### PR TITLE
feat(meshcore): receive-only gating UX — Phase 2 frontend (#4547)

### DIFF
--- a/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_EPIC.md
+++ b/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_EPIC.md
@@ -2,9 +2,67 @@
 
 **Epic issue:** #4547
 **Status:**
-- [x] Phase 1 — Backend: setting + central command-aware TX guard (branch `feature/meshcore-receive-only-backend`)
-- [ ] Phase 2 — Frontend: gating UX
+- [x] Phase 1 — Backend: setting + central command-aware TX guard (PR #4550, merged `c41428e6`)
+- [x] Phase 2 — Frontend: gating UX (branch `feature/meshcore-receive-only-ui`)
 - [ ] Phase 3 — Virtual Node gating + docs
+
+## Phase 2 deviations & findings (2026-08-04)
+
+Spec: `docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE2_SPEC.md`. Five work packages,
+7 commits, 58 files, ~3,100 insertions.
+
+- **The deferred tooltip turned out to be a correctness bug, not cosmetics.** The shared
+  `tx_disabled.control_tooltip` reads *"Transmit is disabled on this node's radio. Re-enable TX
+  in the LoRa configuration to use this."* — it names a Meshtastic-only remedy with no MeshCore
+  equivalent, sending a MeshCore operator hunting for a screen their hardware does not have. Now
+  branched via an optional `txDisabledTooltip` prop threaded from `App.tsx` to 24 call sites
+  (`MessagesTab` ×17, `ChannelsTab` ×5, `NodesTab`, `NodePopup` — the last two are
+  `runDisabledReason`, not `title`). Meshtastic copy is asserted byte-identical.
+- **Free win:** `App.tsx`'s existing `txGated` was *already* true for a receive-only MeshCore
+  source, so channels/DM/node-popup controls were already disabled before Phase 2 — WP5 reduced
+  to copy plus the threaded prop.
+- **The latch hazard (highest-risk item).** Three TX paths fire automatically with no user
+  action: the Rooms auto-login effect, `ChannelsView`'s `discoverRegions` mount effect, and
+  `MeshCoreRemoteStatsPanel.load()`. All set a do-not-repeat latch **before** awaiting, so a
+  guard placed after the latch permanently poisons the effect for the session — turning
+  receive-only off would never re-trigger it. Each guard sits before its latch, and each has a
+  "flip the flag off and it fires again" test, the only assertion that catches a mis-placed guard.
+- **Correction to the spec:** `MeshCoreRemoteStatsPanel.load()` has **no** automatic
+  mount/expand trigger — only the two user-initiated buttons call it, and the component's own
+  comment says "No auto-fetch and no polling." The guard was added defensively rather than
+  inventing an auto-load that would have created real unwanted RF calls.
+- **Automations consistency rule (interview decision 5):** configuration inputs stay **editable**;
+  only immediate-transmit controls ("Send Now", "Run now") disable. Saving a setting does not
+  transmit — Phase 1's schedulers skip at tick time — so disabling the forms would protect
+  nothing while looking like config loss. Tests assert *both* directions so a future
+  well-meaning "fix" cannot quietly disable the forms.
+- **Carried-forward Phase 1 review item, fixed here:** `POST /api/settings` did not validate
+  values, so posting `"1"` / `"yes"` / `"TRUE"` / `"on"` persisted something that
+  `refreshReceiveOnly()`'s `raw === 'true'` reads as **false** — receive-only silently OFF while
+  the user believed transmission was blocked. A module-local `STRICT_BOOLEAN_SETTINGS_KEYS`
+  check now rejects with `400 INVALID_BOOLEAN_SETTING` before either write path and before
+  `refreshMeshcoreReceiveOnly` fires. This broke the generic round-trip test in
+  `server.settings-persistence.test.ts`, which posts a placeholder for every valid key; fixed by
+  adding the key to that file's existing `VALID_VALUES` override map (the table any future
+  strict-boolean key should join).
+- **Known gap (accepted):** the `App.tsx` 409-toast regression test was not written. No
+  full-render harness for `<App/>` exists anywhere in the repo (3,933 lines, 78 imports), and
+  building one for a uniform, grep-verified string swap was disproportionate. Flagged rather
+  than silently skipped.
+- **`typecheck:tests` burn-down:** CI runs it non-blocking, to become blocking at zero. This
+  epic had contributed 11 errors (10 from Phase 1, 1 from Phase 2); all fixed properly (no
+  `any`, no suppression directives), taking the repo-wide count 433 → **422**.
+- **Browser-validated live** against a real MeshCore Companion source (`MC-Sandbox`) in the dev
+  container: toggle persists and updates without reload; both `Send Advert` render paths and all
+  four Discover buttons disable with the MeshCore-correct tooltip; `Refresh`, `Disconnect` and
+  the discovery-response checkbox stay enabled; all five automation sections show the paused note
+  while 223/233 inputs stay editable; `GET /contacts/:pk/neighbours` and `GET /admin/status/:pk`
+  both return `409 TX_DISABLED` on the receive-only source while the control source still reaches
+  the radio; a reload with receive-only ON produced **zero** 409s and zero toasts (latch guards
+  holding); disable-confirm cancel aborts and accept re-enables every control immediately;
+  per-source isolation confirmed (sibling MeshCore and both Meshtastic sources unaffected).
+- **Verification:** full Vitest suite 14,149 tests / 0 failures (`success: true` via JSON
+  reporter); `npm run typecheck` clean; `npm run lint:ci` clean of in-repo failures.
 
 ## Phase 1 deviations & findings (2026-08-04)
 

--- a/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE2_SPEC.md
+++ b/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE2_SPEC.md
@@ -1,0 +1,865 @@
+# MeshCore Strict Receive-Only — Phase 2 Implementation Spec (Frontend gating UX)
+
+**Epic:** #4547 (see `MESHCORE_RECEIVE_ONLY_EPIC.md`). **Phase 1 spec:** `MESHCORE_RECEIVE_ONLY_PHASE1_SPEC.md`.
+**Branch:** `feature/meshcore-receive-only-ui` (worktree `/home/yeraze/Development/meshmonitor-mc-rxonly-p2`).
+**Template:** `TX_DISABLED_PHASE2_SPEC.md` (Meshtastic #4294 Phase 2) — same disabled-not-hidden
+philosophy, same `disabled` + `title` idiom, same toast-on-409 fallback.
+
+Phase 1 shipped the enforcement: the `meshcoreReceiveOnly` per-source setting, `isReceiveOnly()` /
+`canTransmit()`, a fail-closed bridge-command denylist, 24 primitive guards, 10 scheduler
+silent-skips, 22 routes returning `409 TX_DISABLED`, and the read contract. **Phase 2 adds no
+enforcement** — every control it disables is already blocked server-side. Phase 2 makes the block
+*visible and explainable* so the user is never left staring at a dead button.
+
+One backend item rides along (§4): `POST /api/settings` does not validate the
+`meshcoreReceiveOnly` value, which is a fail-**open** on malformed input.
+
+> **Anchors.** All `file:line` references below were read against this worktree on 2026-08-04.
+> Line numbers drift as implementers edit above them — **anchor on the quoted code, not the number.**
+
+---
+
+## 1. Reuse inventory (verified — do NOT introduce new primitives for these)
+
+| Concern | What already exists | Location | Verdict for Phase 2 |
+|---|---|---|---|
+| **Per-source TX/receive-only state** | `useTxStatus({ baseUrl, sourceId })` → `{ isTxDisabled, isUdpRelay, ...query }`, TanStack key `['txStatus', baseUrl, sourceId]`, 30 s poll, `staleTime` 25 s, `retry: 1`. `canTransmit ?? txEnabled` fallback for old servers. | `src/hooks/useTxStatus.ts:70-113` | **Serves MeshCore as-is. No extension needed.** Phase 1 made `GET /api/device/tx-status` MeshCore-aware: `deviceStatusRoutes.ts:19-27` narrows via `sourceManagerRegistry.getManager(sourceId)` + `isMeshCoreManager` and returns `{ txEnabled: canTx, udpRelayEnabled: false, canTransmit: canTx }`. So `isTxDisabled === true` **is** "receive-only" for a MeshCore `sourceId`. Do not add a `useMeshCoreReceiveOnly` hook. |
+| **409 detection** | `TX_DISABLED_CODE`, `isTxDisabledBody(status, body)`, `isTxDisabledError(err)` — pure, no React, no I/O. | `src/utils/txDisabled.ts` | Reuse verbatim. Already imported by `App.tsx:50`. |
+| **Global banner** | `AppBanners` renders one TX banner slot from `isTxDisabled` / `isUdpRelay`; offsets in the config-issue and update banners already count it as one. Uses `UiIcon`. | `src/components/AppBanners/AppBanners.tsx` | Reuse the slot; add **one** optional prop to swap the copy (§3.9). Do not add a second banner. |
+| **Banner + tooltip i18n keys** | `banners.tx_disabled`, `banners.tx_disabled_udp_relay`, `tx_disabled.control_tooltip`, `tx_disabled.send_blocked_toast`, `tx_disabled.remote_admin_notice`, `tx_disabled.automation_source_warning`. | `public/locales/en.json:113-131` | Meshtastic-worded, and **one of them is actively misleading on MeshCore** — verbatim strings quoted immediately below. Add a parallel `meshcore.receive_only.*` family (§2); do **not** reword the existing ones (Meshtastic sources still need them verbatim). |
+| **Disabled + tooltip pattern** | Native `disabled={...}` + `title={...}`. No tooltip component exists. Precedent for "explain *why* it is disabled" via an optional reason prop: `TracerouteBody.runDisabledReason` (`map/popups/sections.tsx`, added by #4294 Phase 2). | throughout | Reuse. `MeshCoreMessageStream` and `CliConsoleBody` get the same optional-reason prop treatment (§3.1). |
+| **Danger confirm** | No shared ConfirmDialog. The app-wide danger-confirm is `window.confirm(t('<key>'))` — used at `MeshCoreSettingsView.tsx:81` (purge all messages), `MeshCoreConfigurationView.tsx:616` (import private key), `LoRaConfigSection.tsx` (TX disable, #4294). | — | Reuse `window.confirm`. |
+| **Toast** | `useToast()` → `showToast(message, type, duration?)`, `type ∈ 'success'\|'error'\|'warning'\|'info'`. | `src/components/ToastContainer.tsx` | Reuse. Already in scope in `MeshCoreSettingsView`, `MeshCoreNodesView`, `MeshCoreAutoAnnounceSection`, `MeshCoreTimerTriggersSection`, `App.tsx`. |
+| **Fetch wrapper (components)** | `useCsrfFetch()` → `csrfFetch(url, opts, signal)` returns a raw `Response`, adds `X-CSRF-Token` on mutations, `credentials: 'include'`. This is the MeshCore-tree idiom (`useMeshCore.ts`, every `*Section.tsx`). `useAuthFetch()` is the App.tsx idiom. | `src/hooks/useCsrfFetch.ts`; `src/hooks/useAuthFetch.ts` | **Both are hooks, so the `src/components/**` raw-`fetch()` ban is satisfied.** New code must use one of them — never bare `fetch`. |
+| **Per-source setting save from inside the MeshCore UI** | `MeshCoreNodeDisplaySection.tsx:105-137` — `csrfFetch(\`${baseUrl}/api/settings?sourceId=${encodeURIComponent(sourceId)}\`, { method:'POST', ... })`, then `queryClient.invalidateQueries({ queryKey: nodeDisplaySettingsQueryKey(sourceId) })`, then a success/failure toast. Rendered from `MeshCoreSettingsView.tsx:271`. | `src/components/MeshCore/MeshCoreNodeDisplaySection.tsx` | **This is the idiom for the receive-only toggle**, not the `discoverable` toggle. |
+| *(rejected)* Device-state toggle idiom | `MeshCoreSettingsView.tsx:180-188` `handleToggleDiscoverable` — optimistic `setState`, `await setDiscoverable(next)`, revert on failure. Talks to `/meshcore/config/discoverable`, i.e. **device** state. | — | **Rejected for receive-only.** Receive-only is a MeshMonitor *setting* (`source:{id}:meshcoreReceiveOnly`), not device state; it must go through `/api/settings?sourceId=` so the Phase 1 `refreshMeshcoreReceiveOnly` callback (`settingsRoutes.ts:889-891`) fires. |
+| **Query invalidation after a TX-state change** | `ConfigurationTab.tsx:898` `void queryClient.invalidateQueries({ queryKey: ['txStatus'] })` — prefix match, hits every source's entry. Test precedent: `ConfigurationTab.txDisabled.test.tsx:92-99`. | — | Reuse verbatim after the toggle save. |
+| **Source context** | `useSource()` → `{ sourceId, sourceName, sourceType }`; `sourceType === 'meshcore'` for MeshCore sources. | `src/contexts/SourceContext.tsx` | Reuse in `App.tsx` only (§3.9). MeshCore components already receive `sourceId` as an explicit prop from `MeshCorePage`. |
+| **Client radio summary** | `SourceRadioSummary` already carries `receiveOnly?: boolean` and `canTransmit?: boolean` (Phase 1 WP5). Consumed via `useDashboardData.ts:34` (`DashboardSource.radio`), fetched by `useDashboardSources()` under key `['dashboard', 'sources']`. | `src/types/elevation.ts:40-58`; `src/hooks/useDashboardData.ts:102-107` | **Not the distribution channel for Phase 2** — see §3.0. Available for a future dashboard badge; Phase 2 leaves it untouched. |
+| **App-level gating already flowing** | `App.tsx:249-251`: `const { isTxDisabled, isUdpRelay } = useTxStatus({ baseUrl, sourceId }); const txGated = isTxDisabled && !isMqttBridge;` — threaded to `ChannelsTab` (`:3592`), `MessagesTab` (`:3717`), both `NodePopup`s. `handleRequestNeighborInfo` (`:2068-2115`) already has a `sourceType === 'meshcore'` branch **and** an `isTxDisabledBody` toast. | `src/App.tsx` | **Free win: because `tx-status` is now MeshCore-aware, `txGated` is already `true` for a receive-only MeshCore source, so the unified-view controls are already disabled.** Phase 2 adds **no** gating logic here — it threads a correct tooltip string (§3.9, required: the current one names a nonexistent remedy) and adds a regression test. Do not re-implement the gating. |
+| **Console primitive** | `CliConsoleBody` already has `disabled?: boolean`, `disabledPlaceholder?: string`, `emptyTextDisabled`, and applies `disabled || sending` to the quick-action buttons (`:298`), the input (`:388`) and the Send button (`:395`). Imperative `runCommand` via `CliConsoleBodyHandle`. | `src/components/MeshCore/CliConsoleBody.tsx` | Reuse — **no new props needed** beyond what exists. |
+| **Message-composer primitive** | `MeshCoreMessageStream` has `disabled?: boolean` applied to the input (`:615`) and Send button (`:619`); used by Channels (`:741-745`), DMs (`:513-517`) and Rooms (`:369-373`), all as `disabled={!connected || !canSend}`. | `src/components/MeshCore/MeshCoreMessageStream.tsx` | Reuse; add **one** optional `disabledReason?: string` → `title` (§3.1), mirroring `TracerouteBody.runDisabledReason`. |
+| **ACL form** | `MeshCoreAclManager` already has `disabled?: boolean`; pushes `setperm …` through the parent's `CliConsoleBodyHandle`. | `src/components/MeshCore/MeshCoreAclManager.tsx:44-56` | Reuse the existing prop. Currently rendered with **no** `disabled` at `MeshCoreRemoteConsole.tsx:283` and `MeshCoreLocalConsole.tsx:143`. |
+| **Icons** | `UiIcon` registry, keyed by `UiIconName = keyof typeof UI_ICON_DEFINITIONS`, re-exported from `src/components/icons/index.ts`. **Verified present:** `blocked` (Ban, "ignored and blocked state") `UiIcon.tsx:144`; `pause` (Pause, "pause controls") `:193`; `alert` (AlertTriangle) `:136`; `info` `:176`; `radio` `:198`; `radioSignal` `:204`. | `src/components/icons/UiIcon.tsx` | **Use `UiIcon name="blocked"` for the status-bar chip and `UiIcon name="pause"` for the paused note — both verified to exist.** `UiIconName` is a keyof type, so a wrong name is a `tsc` error, not a silent blank. **No literal emoji in JSX or locale copy.** |
+| **Route test harness / component tests** | 18 existing `src/components/MeshCore/*.test.tsx` files (RTL + Vitest). `createRouteTestApp()` for the one server-side test (§4). | `src/server/test-helpers/routeTestApp.ts` | Reuse both. |
+
+### The existing TX-disabled strings, verbatim (read 2026-08-04, `public/locales/en.json:128-130`)
+
+```
+"tx_disabled.control_tooltip":   "Transmit is disabled on this node's radio. Re-enable TX in the LoRa configuration to use this."
+"tx_disabled.send_blocked_toast": "Transmit is disabled on this source — nothing was sent."
+"tx_disabled.remote_admin_notice": "Remote-node admin is unavailable while Transmit is disabled on this source. Local-node admin still works — you can re-enable TX in the LoRa Config below."
+```
+
+**`control_tooltip` names a Meshtastic-specific remedy ("the LoRa configuration") that does not
+exist on MeshCore hardware.** A MeshCore user shown this tooltip goes hunting for a LoRa Config
+section with a TX checkbox; there is none, and the actual remedy lives in MeshCore → Settings →
+Receive-only mode. That is a correctness problem, not a cosmetic one, so **§3.9 threads the MeshCore
+variant into the unified views** rather than deferring it. `send_blocked_toast` is transport-neutral
+in wording but still says "Transmit is disabled" rather than "receive-only", so it is swapped on the
+same flag for consistency. `remote_admin_notice` belongs to `AdminCommandsTab`, which speaks the
+Meshtastic admin protocol and is not a MeshCore surface at all (MeshCore remote admin is
+`MeshCoreRemoteConsole`) — left alone, noted in §9.
+
+### New code, justified
+
+| New thing | Closest existing | Why new |
+|---|---|---|
+| `MeshCoreReceiveOnlyNote.tsx` + `MeshCoreReceiveOnlyNote.module.css` | An inline `<p className="hint">` | The "Paused — receive-only mode" note appears at **7 sites** (§3.6). Seven copies of the same icon + string + inline style is worse than one 15-line presentational component, and CSS modules are mandatory for new components (the global sheets are frozen). It renders `null` when `receiveOnly` is false, so call sites stay one line. |
+| `disabledReason?: string` on `MeshCoreMessageStream` | `TracerouteBody.runDisabledReason` | Same shape, same reason: a `disabled` control must be able to say *why*. Additive optional prop; existing tests stay green. |
+| `isMeshCore?: boolean` on `AppBanners` | — | One prop to pick between two existing banner strings. Cheaper than a second banner slot (which would break the hard-coded `[showTxBanner]` offset arithmetic). |
+| Everything else | — | **No new hook, no new context, no new CSS in `src/styles/*`, no new API endpoint, no new query key.** |
+
+---
+
+## 2. New i18n keys — `public/locales/en.json` **only**
+
+`en.json` is the source of truth; `de/es/fr/nb_NO/pl/pt_BR/ru/sv/zh_Hans.json` are Weblate-managed
+and `fallbackLng: 'en'` covers the gap. **Do not hand-edit the other locale files.**
+No emoji, no Unicode icon stand-ins in any value.
+
+| Key | English value |
+|---|---|
+| `meshcore.receive_only.title` | `Receive-only mode` |
+| `meshcore.receive_only.toggle_label` | `Strict receive-only (never transmit)` |
+| `meshcore.receive_only.description` | `Block every transmission from this MeshCore node. Messages, adverts, path discovery, remote CLI, logins, telemetry requests and all automations are held. Receiving, the packet log, the Analyzer Observer, contact and telemetry updates, and local serial configuration keep working.` |
+| `meshcore.receive_only.firmware_caveat` | `MeshCore firmware has no radio-level transmit switch, so MeshMonitor enforces this in software. Transmissions the node makes on its own — link-layer acknowledgements, and any advert schedule configured outside MeshMonitor — are not affected.` |
+| `meshcore.receive_only.disable_confirm` | `Allow this MeshCore node to transmit again?\n\nMessages, adverts, path discovery, remote administration and every enabled automation will resume sending over the radio. Continue?` |
+| `meshcore.receive_only.control_tooltip` | `Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.` |
+| `meshcore.receive_only.blocked_toast` | `Receive-only mode is on for this MeshCore source — nothing was sent.` |
+| `meshcore.receive_only.paused_note` | `Paused — receive-only mode. These settings are saved and unchanged; they take effect again when receive-only is turned off.` |
+| `meshcore.receive_only.status_chip` | `Receive-only` |
+| `meshcore.receive_only.saved_on` | `Receive-only mode enabled — this node will not transmit` |
+| `meshcore.receive_only.saved_off` | `Receive-only mode disabled — this node can transmit again` |
+| `meshcore.receive_only.save_failed` | `Failed to change receive-only mode` |
+| `meshcore.receive_only.console_placeholder` | `Local serial commands still work; commands that transmit are blocked.` |
+| `banners.receive_only_meshcore` | `Receive-Only Mode: this MeshCore source will not transmit. Messages, adverts, path discovery, remote administration and automations are held. Turn it off in MeshCore Settings to transmit again.` |
+
+---
+
+## 3. File-by-file changes
+
+### 3.0 Distribution of the receive-only flag — **decision**
+
+**Call `useTxStatus` exactly once, in `MeshCorePage`, and thread one `receiveOnly: boolean` prop
+down.** This is the same shape App.tsx uses for `txGated` (`App.tsx:251`).
+
+Rejected alternatives, for the record:
+- **A new React context.** Rejected: `MeshCorePage` already prop-threads `status`, `loading`,
+  `actions`, `sourceId`, `baseUrl` to every child. One more boolean costs nothing and a context
+  would be a second, parallel source of truth for something TanStack already caches.
+- **`useTxStatus` per component.** Rejected: same query key in ~12 components is deduped by
+  TanStack but multiplies the mock surface in every component test for no benefit.
+- **`GET /api/sources` → `radio.receiveOnly` (`useDashboardSources`, key `['dashboard','sources']`).**
+  Rejected as the *gating* channel: it is a heavier, dashboard-shaped payload on a different
+  cadence, and `useTxStatus` is already the app's established "can this source send?" question with
+  an existing invalidation convention. Phase 1 correctly shipped both; Phase 2 consumes the
+  cheaper, purpose-built one. (The `radio.receiveOnly` field stays available for a future
+  dashboard badge — Phase 2 does not touch it.)
+- **Adding `useTxStatus` inside `useMeshCore`.** Rejected: `useMeshCore` is the API layer and is
+  mocked wholesale in several tests; adding a query there widens the mock surface.
+
+`MeshCorePage.tsx` (`:59-64`):
+```ts
+import { useTxStatus } from '../../hooks/useTxStatus';
+// ...
+const { isTxDisabled: receiveOnly } = useTxStatus({ baseUrl, sourceId });
+```
+Thread `receiveOnly={receiveOnly}` into every child rendered at `:95-211`:
+`MeshCoreStatusBar`, `MeshCoreNodesView`, `MeshCoreChannelsView`, `MeshCoreRoomsView`,
+`MeshCoreDirectMessagesView`, `MeshCoreConfigurationView`, `MeshCoreAutomationsView`,
+`MeshCoreSettingsView`. (`MeshCoreTelemetryView`, `MeshCorePacketMonitorView` and
+`MeshCoreInfoView` are read-only / serial-only — skip them.)
+
+Each of those adds `receiveOnly?: boolean;` (default `false`) to its props interface and
+re-threads to its own children:
+- `MeshCoreDirectMessagesView` → `MeshCoreMessageStream`, `MeshCoreContactDetailPanel`,
+  `MeshCoreNodeTelemetryConfig` (`:554`).
+- `MeshCoreContactDetailPanel` → `MeshCoreRemoteConsole` → `MeshCoreRemoteStatsPanel`,
+  `CliConsoleBody`, `MeshCoreAclManager`.
+- `MeshCoreConfigurationView` → `MeshCoreLocalConsole` (`:526`) → `CliConsoleBody`,
+  `MeshCoreAclManager`.
+- `MeshCoreAutomationsView` → all five sections (`:323-336`).
+- `MeshCoreChannelsView` / `MeshCoreRoomsView` → `MeshCoreMessageStream`.
+
+**Freshness.** The toggle's save invalidates `['txStatus']` (prefix) so every consumer re-reads
+within one tick — no page reload. The 30 s poll is the passive backstop for an out-of-band change
+(another browser tab, a direct API call).
+
+### 3.1 Shared primitives
+
+**`src/components/MeshCore/MeshCoreMessageStream.tsx`**
+- Add `disabledReason?: string;` to the props interface (near `disabled`).
+- Input (`:608-616`): add `title={disabled ? disabledReason : undefined}`.
+- Send button (`:617-622`): same.
+- Wrap the two controls' shared parent `<div className="meshcore-send-bar">` (`:607`) with
+  `title={disabled ? disabledReason : undefined}` as well — a `title` on a `disabled` `<button>`
+  does not fire hover in every browser; the enclosing element's does. (Same trick the #4294 spec
+  called out.)
+- No behavior change when `disabledReason` is omitted.
+
+**`src/components/MeshCore/MeshCoreReceiveOnlyNote.tsx`** (new) + `.module.css`
+```tsx
+interface MeshCoreReceiveOnlyNoteProps { receiveOnly?: boolean; className?: string; }
+```
+Renders `null` unless `receiveOnly`. Otherwise a single `<p role="status" className={...}>` with
+`<UiIcon name="pause" size={14} />` + `{t('meshcore.receive_only.paused_note')}`.
+(`pause` = lucide `Pause`, "pause controls" — verified at `UiIcon.tsx:193`. `UiIconName` is a
+`keyof` type, so a wrong name fails `tsc` rather than rendering blank.)
+Styling in `MeshCoreReceiveOnlyNote.module.css` — muted foreground, small type, `0.5rem` gap.
+**No rule may be added to `src/styles/*.css`.**
+
+### 3.2 The toggle — `src/components/MeshCore/MeshCoreSettingsView.tsx`
+
+Add a **new `form-section` immediately above** the existing "Device actions" section (`:255`), so
+the explanation sits above the buttons it disables.
+
+State + save (model on `MeshCoreNodeDisplaySection.tsx:105-137`):
+```ts
+const queryClient = useQueryClient();          // @tanstack/react-query — new import here
+const csrfFetch = useCsrfFetch();              // new import here
+const [savingReceiveOnly, setSavingReceiveOnly] = useState(false);
+
+const handleToggleReceiveOnly = useCallback(async (next: boolean) => {
+  // Enabling is the safe direction — no confirm. Disabling resumes RF transmission.
+  if (!next && !window.confirm(t('meshcore.receive_only.disable_confirm', '...'))) return;
+  setSavingReceiveOnly(true);
+  try {
+    const res = await csrfFetch(
+      `${baseUrl}/api/settings?sourceId=${encodeURIComponent(sourceId)}`,
+      { method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ meshcoreReceiveOnly: next }) },
+    );
+    if (!res.ok) { showToast(t('meshcore.receive_only.save_failed', '...'), 'error'); return; }
+    await queryClient.invalidateQueries({ queryKey: ['txStatus'] });
+    showToast(t(next ? 'meshcore.receive_only.saved_on' : 'meshcore.receive_only.saved_off', '...'),
+              'success');
+  } finally { setSavingReceiveOnly(false); }
+}, [baseUrl, sourceId, csrfFetch, queryClient, showToast, t]);
+```
+Every value referenced inside the callback is in the dep array — **no new
+`react-hooks/exhaustive-deps` violation.**
+
+Rendering:
+```tsx
+<div className="form-section">
+  <h3>{t('meshcore.receive_only.title', 'Receive-only mode')}</h3>
+  <label style={{ display:'flex', alignItems:'center', gap:'0.5rem' }}>
+    <input type="checkbox" checked={receiveOnly} disabled={savingReceiveOnly}
+           onChange={(e) => void handleToggleReceiveOnly(e.target.checked)} />
+    <span>{t('meshcore.receive_only.toggle_label', '...')}</span>
+  </label>
+  <p className="hint">{t('meshcore.receive_only.description', '...')}</p>
+  <p className="hint">{t('meshcore.receive_only.firmware_caveat', '...')}</p>
+</div>
+```
+`checked` reads the threaded `receiveOnly` prop (server truth via `useTxStatus`), **not** local
+state — so the checkbox and every gated control flip together off one cache entry and cannot
+disagree. No optimistic update: the invalidation lands in well under the ~200 ms it takes a user to
+notice, and an optimistic flip that later reverts would be worse for a safety control.
+
+**Confirm policy — decision and rationale.** Confirm on **disable only**. Unlike Meshtastic
+(`lora_config.tx_disable_confirm`, where *disabling* TX is the dangerous direction because it makes
+the node invisible to the mesh), here the dangerous direction is inverted: enabling receive-only is
+the conservative, reversible choice, while disabling it silently resumes RF transmission — possibly
+releasing queued automations, adverts and auto-acks. The confirm therefore guards the resume.
+Copy is `meshcore.receive_only.disable_confirm`.
+
+Gate the section's own TX buttons (all with `title={receiveOnly ? t('meshcore.receive_only.control_tooltip') : undefined}`):
+- Send advert `:265` → `disabled={!connected || loading || receiveOnly}`.
+- Discover Nearby / Repeaters / Sensors `:282,290,298` → append `|| receiveOnly`.
+- Discover regions `:414` → append `|| receiveOnly`.
+- **Not** gated: Refresh contacts `:262` (serial), Save scope `:405` (serial `set_flood_scope`),
+  saved-region add/delete (DB only), purge messages (DB only).
+- "Respond to discovery requests" toggle `:367-375`: leave settable (it is device state Phase 1
+  neutralises at chokepoint B), but render `<MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />`
+  under it.
+
+### 3.3 The 409 fallback — `src/components/MeshCore/hooks/useMeshCore.ts`
+
+Every MeshCore TX call funnels through this hook, so one helper covers every consumer *and* every
+second render path. Add near the top of the hook body:
+```ts
+const { showToast } = useToast();
+/** True when the response was the Phase 1 409; also raises the toast. */
+const reportTxDisabled = useCallback((status: number, body: unknown): boolean => {
+  if (!isTxDisabledBody(status, body)) return false;
+  showToast(t('meshcore.receive_only.blocked_toast', '...'), 'warning');
+  return true;
+}, [showToast, t]);
+```
+Call it in the failure branch of each TX action, **before** the existing `setError(...)`, and return
+the existing failure value when it returns `true` (so the red inline error does not double up with
+the toast). Actions to patch (all in this file):
+
+`sendMessage`, `sendRoomPost`, `loginRoom`, `loginRoomWithSaved`, `loginRemote`,
+`loginRemoteWithSaved`, `sendCliCommand` (`:1148`), `sendLocalCliCommand` (`:1185`),
+`getRemoteStatus` (`:1241`), `sendAdvert`, `discoverNodes` (`:958`), `discoverRegions` (`:1048`),
+`resetContactPath` (`:911`), `discoverContactPath` (`:940`), `traceContactPath`,
+`pingContactZeroHop`, `shareContact`, `getNeighbours`.
+
+Several of these (`sendCliCommand`, `sendLocalCliCommand`) already read `data.code` and
+`response.status` into their return value — reuse those, do not re-parse the body twice.
+`sendLocalCliCommand` is how a typed `advert` reaches the console: it 409s, the toast fires, and
+the console prints the server's error line as it does today.
+
+Ratchet: `reportTxDisabled` is referenced inside existing `useCallback`s — **add it to each of those
+dep arrays** in the same edit.
+
+### 3.4 Messaging surfaces
+
+| Surface | File:line | Route | Change |
+|---|---|---|---|
+| Channel send box | `MeshCoreChannelsView.tsx:741-745` `disabled={!connected \|\| !canSend}` | POST `/messages/send` | `\|\| receiveOnly` + `disabledReason={receiveOnly ? t('meshcore.receive_only.control_tooltip') : undefined}` |
+| DM send box | `MeshCoreDirectMessagesView.tsx:513-517` | POST `/messages/send` | same |
+| Room post box | `MeshCoreRoomsView.tsx:369-373` | POST `/rooms/post` | same |
+| Room login button | `MeshCoreRoomsView.tsx:308-311` `disabled={loginLoading}` | POST `/rooms/login` | `\|\| receiveOnly` + `title` |
+| Room password input + Enter | `MeshCoreRoomsView.tsx:293-295` | " | `disabled={loginLoading \|\| receiveOnly}`; guard the `onKeyDown` Enter branch with `!receiveOnly` |
+| Room auto-login-with-saved | `MeshCoreRoomsView.tsx:131-147` (effect) | POST `/rooms/login-with-saved` | **§3.4a** — fires from an effect, not a click; a disabled button does not stop it |
+| Room sync-config save | `MeshCoreRoomsView.tsx:362` | settings write (no RF) | **Not gated.** Render `<MeshCoreReceiveOnlyNote />` beside it (the sync *scheduler* logs in over RF and is Phase-1-skipped). |
+
+### 3.4a Automatic / background TX triggers — silent skip, never a toast
+
+Three TX calls fire **without user action**. A disabled button does not stop any of them, and left
+unguarded each produces a 409 on every mount or selection change. Because §3.3 routes those 409s
+through `reportTxDisabled`, an unguarded version means a **toast storm on page load** — the user
+would see warnings for actions they never took.
+
+**Rule — mirror Phase 1's scheduler contract at the UI layer.** *Automatic and background paths
+skip silently: no request is issued, no toast is raised, and no error state is set. Only
+user-initiated actions surface the receive-only toast.* Because the guard returns before the fetch,
+`reportTxDisabled` is never reached — that is the mechanism, and it is what the tests assert.
+
+**Latch hazard — read this before writing the guard.** All three effects set a
+"do not repeat" latch **before** awaiting. Placing the guard after the latch would permanently
+poison the effect for that session: turning receive-only back off would never re-trigger it. **The
+`receiveOnly` early return must come before the latch is set.**
+
+#### (a) Rooms auto-login — `MeshCoreRoomsView.tsx:131-147`
+```ts
+useEffect(() => {
+  if (!selectedRoom) return;
+  if (loggedInRooms.has(selectedRoom)) return;
+  if (!storedCreds.has(selectedRoom)) return;
+  if (receiveOnly) return;                       // ← ADD HERE, before the latch below
+  if (autoLoginAttempted.current.has(selectedRoom)) return;
+  autoLoginAttempted.current.add(selectedRoom);  // the latch
+  // ...
+}, [selectedRoom, loggedInRooms, storedCreds, actions, receiveOnly]);   // ← dep added
+```
+Placed after the cheap identity checks and **before** `autoLoginAttempted.current.add(...)`, so
+selecting the same room again after receive-only is turned off still auto-logs in.
+
+#### (b) ChannelsView region discovery — `MeshCoreChannelsView.tsx:373-390`
+```ts
+useEffect(() => {
+  if (!showScopeOverride || !status?.connected) return;
+  if (receiveOnly) return;                       // ← ADD HERE, before the latch below
+  if (regionsDiscoveredRef.current) return;
+  regionsDiscoveredRef.current = true;           // the latch
+  // ...
+}, [showScopeOverride, status?.connected, discoverRegions, receiveOnly]);   // ← dep added
+```
+The file's own comment at `:372-375` already warns that `discoverRegions()` "emits active radio
+traffic" and must never be tied to `status?.connected` because reconnect flapping would flood the
+mesh (#3704 review) — the same reasoning applies here. Guarding before
+`regionsDiscoveredRef.current = true` means reopening the scope-override panel after receive-only is
+turned off still populates the suggestion datalist. The existing `catch` already resets the latch on
+failure; the guard must not touch it.
+
+#### (c) RemoteStatsPanel auto-load — `MeshCoreRemoteStatsPanel.tsx:44-60`
+`load()` early-returns when `receiveOnly`, before any `fetchStatus(publicKey)` call and before any
+loading state is set; `receiveOnly` joins its dep array (`:60`). Its user-initiated entry points
+(the refresh button `:85-89`, the empty-state button `:144`) are separately disabled in §3.5, so the
+only caller that can reach the guard is the automatic one.
+
+### 3.5 Contact / node / console / telemetry surfaces
+
+**`MeshCoreContactDetailPanel.tsx`** — gate six buttons with `|| receiveOnly` and the tooltip
+`title`; leave two alone.
+
+| Button | Line | Route | Gate? |
+|---|---|---|---|
+| Reset path | `:632-636` (`disabled={resetting}`) | POST `/contacts/:pk/reset-path` | **yes** |
+| Share contact | `:645-649` (`disabled={sharing}`) | POST `/contacts/:pk/share` | **yes** |
+| Trace path | `:668-672` (`disabled={tracing}`) | POST `/contacts/:pk/trace-path` | **yes** |
+| Ping (0 hop) | `:681-685` (`disabled={pinging}`) | POST `/contacts/:pk/ping` | **yes** |
+| Discover path | `:700-704` (`disabled={discovering}`) | POST `/contacts/:pk/discover-path` | **yes** |
+| Neighbours | `:726-730` (`disabled={neighboursLoading}`) | **GET** `/contacts/:pk/neighbours` | **yes** — a GET that transmits |
+| Export contact | `:713-717` | serial `export_contact` | no |
+| Remove contact | `:739-743` | serial `remove_contact` | no |
+| Out-path editor Save | `:1154-1158` | serial `set_out_path` | no |
+
+**`MeshCoreNodesView.tsx` — the second render path for Discover.** The same three discovery actions
+that live in `MeshCoreSettingsView` (§3.2) are *also* rendered as a menu here
+(`:385, :388, :391`, fed by `onDiscoverNodes` from `MeshCorePage.tsx:129`). **This is exactly the
+class of miss that cost #4294 a follow-up patch** (`NodesTab.tsx` rendering `TracerouteBody`
+directly). Add `disabled={receiveOnly}` + `title` to all three `role="menuitem"` buttons, and an
+early return in `handleDiscover` (`:267-287`) with `receiveOnly` added to its dep array.
+
+**`MeshCoreRemoteConsole.tsx`** — every path here is remote-over-RF.
+- "Login with saved" `:241-245` (`disabled={loginBusy}`) → `|| receiveOnly` + `title`.
+- "Login" opener `:251-255` and the fallback opener `:261` → same.
+- Modal submit `:336-340` → same.
+- `CliConsoleBody` `:274-280` `disabled={!loggedIn}` → `disabled={!loggedIn || receiveOnly}` and
+  `disabledPlaceholder={receiveOnly ? t('meshcore.receive_only.control_tooltip') : <existing>}`.
+- `MeshCoreAclManager` `:283` → pass `disabled={receiveOnly}` (the prop already exists).
+- `MeshCoreRemoteStatsPanel` `:268-272` → thread `receiveOnly`.
+
+**`MeshCoreRemoteStatsPanel.tsx`** — GET `/admin/status/:pk` transmits.
+- Refresh button `:85-89` (`disabled={loading}`) → `|| receiveOnly` + `title`.
+- Empty-state fetch button `:144` → `disabled={receiveOnly}` + `title`.
+- `load()` (`:44-60`) — the automatic path; guarded per **§3.4a(c)** (silent skip, no toast).
+
+**`MeshCoreLocalConsole.tsx` — the console stays enabled.** Local serial CLI is explicitly allowed
+(interview decision 2); only the synthetic `advert` verb transmits.
+- Do **not** pass `receiveOnly` into `CliConsoleBody`'s `disabled`.
+- Filter the quick-action catalog: the companion catalog's `advert` entry (`:35`) and the repeater
+  catalog's `advert` entry (`:47`) must be dropped (or rendered `disabled` with the tooltip) when
+  `receiveOnly`. Prefer **disabled + tooltip over removal** — a vanished button teaches the user
+  nothing. `ActionCommand` has no `disabled` field, so filter the array and render a separate
+  disabled placeholder button, or add an optional `disabled?: boolean` to `ActionCommand` and honor
+  it at `CliConsoleBody.tsx:298` (`disabled={disabled || sending || action.disabled}`). **Take the
+  `ActionCommand.disabled` route** — it is 2 lines and keeps the button visible.
+- Append `t('meshcore.receive_only.console_placeholder')` to the console `placeholder` when
+  `receiveOnly`.
+- `MeshCoreAclManager` `:143`: `setperm` over the **local serial** link is allowed → leave enabled.
+
+**`MeshCoreNodeTelemetryConfig.tsx`** — POST `/nodes/:pk/telemetry/poll` transmits.
+- "Poll status" `:278-282` and "Poll LPP" `:288-292` (`disabled={!canPoll || polling !== null}`) →
+  `|| receiveOnly` + `title`.
+- The enable checkbox `:221-222` and interval input `:245-246` write settings only — **leave
+  editable** (§3.6 consistency rule). Render `<MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />`
+  in the section.
+- Also add an `isTxDisabledBody` check to `poll()` (`:152`), which uses `csrfFetch` directly rather
+  than `useMeshCore`.
+
+**Status bar — `MeshCoreStatusBar.tsx`.**
+- Send advert `:46-52` (`disabled={loading}`) → `|| receiveOnly` + `title`.
+  (**Second render path** for the same action as `MeshCoreSettingsView.tsx:265`.)
+- Add a persistent chip next to the connection chip when `receiveOnly`, reusing the existing
+  `mrc-status-chip mrc-status-idle` class family (see `MeshCoreLocalConsole.tsx:106-115`):
+  `<span className="mrc-status-chip mrc-status-idle"><UiIcon name="blocked" size={12} /> {t('meshcore.receive_only.status_chip')}</span>`
+  (`blocked` = lucide `Ban` — verified at `UiIcon.tsx:144`).
+  This guarantees an always-visible indicator on the MeshCore page regardless of whether the global
+  banner renders in that route's tree.
+- Disconnect `:53-57` is not RF → not gated.
+
+### 3.6 Automations — "Paused" notes, editable settings
+
+**Consistency rule (interview decision 5): configuration inputs stay fully editable; only controls
+that cause an *immediate* transmission are disabled.** Rationale: saving an automation setting does
+not transmit — Phase 1's schedulers read the setting and silently skip. Disabling the inputs would
+protect nothing while making a user believe their configuration had been taken away, and the whole
+point of decision 5 is that turning receive-only off restores prior behavior *exactly*. So the note
+explains the pause; the form keeps working.
+
+`MeshCoreAutomationsView.tsx` threads `receiveOnly` to all five sections (`:323-336`).
+
+| Section | Note placement | Immediate-TX control to disable |
+|---|---|---|
+| `MeshCorePathfindingFilterSection.tsx` | under the header/enable row (`:383-388`) | none |
+| `MeshCoreAutoAckSection.tsx` | under the header (`:264-276`) | none |
+| `MeshCoreAutoAnnounceSection.tsx` | under the header (`:315-337`) | **"Send Now" `:327-329`** → `sendNowDisabled \|\| receiveOnly` + `title`; also add an `isTxDisabledBody` check to `sendNow` (`:270-292`, uses `csrfFetch` directly) |
+| `MeshCoreAutoResponderSection.tsx` | under the header (`:268-283`) | none |
+| `MeshCoreTimerTriggersSection.tsx` | under the section header (`~:311`) | **"Run now" `:342-348`** → `!canWrite \|\| runningId === tr.id \|\| !tr.enabled \|\| receiveOnly` + `title`; also add an `isTxDisabledBody` check to `runNow` (`:263-280`) |
+
+Every `disabled={disabled || !canWrite}` input in these five files is left **untouched**.
+
+### 3.7 Surfaces deliberately **not** gated (state this in the PR body)
+
+Serial/DB-only, and therefore still fully usable while receive-only:
+`MeshCoreConfigurationView` name / location / radio params / TX power / telemetry modes;
+`MeshCoreChannelsConfigSection` channel CRUD; `MeshCoreObserverSection` (publishes to MQTT, not
+LoRa); `MeshCoreInfoView` sync-time; `MeshCoreTelemetryView`, `MeshCorePacketMonitorView`,
+`MeshCoreMap` (read-only — verified: no TX call sites); device reboot; private-key import/export;
+contact export/import/remove; out-path editor; connect/disconnect; message purge/delete.
+
+### 3.8 Full TX-surface checklist (verify every row against the running app)
+
+Derived from the epic's route inventory **and** re-verified against the components. Second render
+paths are called out explicitly.
+
+1. `POST /messages/send` — Channels send box · DM send box **(2 paths)**
+2. `POST /rooms/login` — Rooms login button + password Enter
+3. `POST /rooms/login-with-saved` — Rooms auto-login effect **(not a button — §3.4a(a))**
+4. `POST /rooms/post` — Rooms send box
+5. `POST /contacts/:pk/reset-path` — ContactDetailPanel
+6. `POST /contacts/:pk/discover-path` — ContactDetailPanel
+7. `POST /contacts/discover` — SettingsView ×3 · NodesView menu ×3 **(2 paths, 6 buttons)**
+8. `POST /regions/discover` — SettingsView button · ChannelsView mount effect **(2 paths; the effect is §3.4a(b))**
+9. `POST /contacts/:pk/trace-path` — ContactDetailPanel
+10. `POST /contacts/:pk/ping` — ContactDetailPanel
+11. `POST /contacts/:pk/share` — ContactDetailPanel
+12. **`GET` `/contacts/:pk/neighbours`** — ContactDetailPanel
+13. `POST /nodes/:pk/telemetry/poll` — NodeTelemetryConfig ×2 buttons
+14. `POST /neighbors/request` — **`App.tsx:2084-2092`, outside the MeshCore tree.** Already gated by
+    `txGated` and already toasts on 409; needs the copy fix (§3.9) + a regression test only.
+15. `POST /admin/login` — RemoteConsole modal
+16. `POST /admin/login-with-saved` — RemoteConsole button
+17. `POST /admin/cli` — RemoteConsole `CliConsoleBody` + `MeshCoreAclManager`
+18. **`GET` `/admin/status/:pk`** — RemoteStatsPanel refresh + empty-state buttons, plus the auto-load **(§3.4a(c))**
+19. `POST /cli` (`advert` verb only) — LocalConsole quick action + typed input (409 → toast)
+20. `POST /advert` — StatusBar button · SettingsView button **(2 paths)**
+21. `POST /automation/announce/send` — AutoAnnounceSection "Send Now"
+22. `POST /automation/timers/:id/run` — TimerTriggersSection "Run now"
+
+### 3.9 App-level copy — unified views, banner, toasts
+
+`txGated` (`App.tsx:251`) is already `true` for a receive-only MeshCore source, so **no gating logic
+changes here.** What is wrong is the wording, and it is wrong in a way that misdirects the user:
+`tx_disabled.control_tooltip` tells a MeshCore operator to "Re-enable TX in the LoRa configuration",
+a screen that does not exist for their hardware (verbatim string and reasoning in §1). This is
+therefore in scope, not deferred.
+
+**One computed string, threaded — no per-site conditionals.**
+
+`App.tsx` (`sourceType` already destructured at `:109`; `t` and `isTxDisabled` already in scope):
+```ts
+const isMeshCoreSource = sourceType === 'meshcore';
+const txDisabledTooltip = t(
+  isMeshCoreSource ? 'meshcore.receive_only.control_tooltip' : 'tx_disabled.control_tooltip'
+);
+```
+Thread `txDisabledTooltip={txDisabledTooltip}` alongside the existing `txDisabled` prop into:
+- `<ChannelsTab ... txDisabled={txGated} />` (`:3592`)
+- `<MessagesTab ... txDisabled={txGated} />` (`:3717`)
+- `<NodesTab ... />` — carries `txDisabled` already (see `NodesTab.tsx:1833`)
+- both `<NodePopup>` renders (map route and standalone)
+
+In each of those four components add `txDisabledTooltip?: string;` to the props interface, destructure
+it, and replace every `t('tx_disabled.control_tooltip')` with
+`(txDisabledTooltip ?? t('tx_disabled.control_tooltip'))`. **The `??` fallback is load-bearing**: it
+keeps the prop optional so every existing test that renders these components without it is unchanged.
+
+Verified call-site inventory (23 sites, all mechanical `title=` / `runDisabledReason=` swaps):
+
+| File | Lines |
+|---|---|
+| `src/components/MessagesTab.tsx` | `1425, 1457, 1469, 1481, 1523, 1904, 1926, 2037, 2069, 2078, 2350, 2372, 2437, 2459, 2524, 2546, 2610` (17) |
+| `src/components/ChannelsTab.tsx` | `1172, 1232, 1264, 1273, 1282` (5) |
+| `src/components/NodesTab.tsx` | `1833` — `runDisabledReason` on `TracerouteBody` |
+| `src/components/NodePopup/NodePopup.tsx` | `186` — `runDisabledReason` on `TracerouteBody` |
+
+Several sites use the form `title={txDisabled ? t('tx_disabled.control_tooltip') : t('some.other')}` —
+swap only the first branch; leave the non-disabled label alone.
+
+**Toasts.** In the send-handler 409 branches that already call
+`showToast(t('tx_disabled.send_blocked_toast'), 'warning')` (`:1995, :2050, :2112, :2161, :2340,
+:2718, :2760, :2789, :2815, :2920`), switch the key to
+`t(isMeshCoreSource ? 'meshcore.receive_only.blocked_toast' : 'tx_disabled.send_blocked_toast')`.
+These are plain async functions, not `useCallback`s — **no dep-array impact** (same note as #4294).
+
+**Banner.** `AppBanners.tsx`: add `isMeshCore?: boolean` to `AppBannersProps`; in the TX-banner body
+select `t(isMeshCore ? 'banners.receive_only_meshcore' : 'banners.tx_disabled')`. Pass
+`isMeshCore={isMeshCoreSource}` from `App.tsx:3292-3296`. `showTxBanner` and all offset arithmetic
+are unchanged, so the existing banner tests stay green.
+
+**Not in scope here:** `AdminCommandsTab` and `tx_disabled.remote_admin_notice` — that tab speaks the
+Meshtastic admin protocol and is not a MeshCore surface (MeshCore remote admin is
+`MeshCoreRemoteConsole`, handled in §3.5). Noted in §9.
+
+---
+
+## 4. Carried-forward backend item — validate `meshcoreReceiveOnly`
+
+**The bug.** `POST /api/settings` builds `filteredSettings[key] = String(settings[key])`
+(`settingsRoutes.ts:319`) with **no value validation**. `MeshCoreManager.refreshReceiveOnly()`
+(`meshcoreManager.ts:4023-4030`) does `raw === 'true'`. So a caller posting `"1"`, `"yes"`, `"TRUE"`,
+`1` or `"on"` persists a value that reads as **false** — receive-only silently **OFF** while the
+user believes transmission is blocked. That is a fail-open on a safety flag.
+
+**Survey result: there is no existing boolean-validation convention to follow.** Every other boolean
+setting is written unvalidated and read with `=== 'true'`. The closest precedent for
+*value*-validating a settings key is the range check on `maxNodeAgeHours`
+(`settingsRoutes.ts:393-400`), which returns `fail(res, 400, 'INVALID_MAX_NODE_AGE_HOURS', …)` before
+any write. Follow that shape.
+
+**Change** — `src/server/routes/settingsRoutes.ts`, immediately after the filter loop
+(`:320`, before the `autoAckRegex` block and well before either `setSourceSettings` at `:812` or
+`setSettings` at `:897`):
+
+```ts
+/**
+ * Keys whose consumers compare against the exact string 'true'. `String(v)` above
+ * happily stores '1' / 'yes' / 'TRUE', every one of which those consumers read as
+ * FALSE — a silent fail-OPEN for a safety flag (#4547 Phase 1 review). Reject rather
+ * than coerce: a client sending a non-boolean is a client with a bug, and quietly
+ * normalizing it would hide that bug in the one place it matters.
+ */
+const STRICT_BOOLEAN_SETTINGS_KEYS = ['meshcoreReceiveOnly'] as const;
+
+for (const key of STRICT_BOOLEAN_SETTINGS_KEYS) {
+  if (!(key in filteredSettings)) continue;
+  const v = filteredSettings[key];
+  if (v !== 'true' && v !== 'false') {
+    return fail(res, 400, 'INVALID_BOOLEAN_SETTING',
+      `${key} must be the boolean true or false (received "${v}")`);
+  }
+}
+```
+
+Notes:
+- Declare the constant **module-level in `settingsRoutes.ts`**, not in
+  `src/server/constants/settings.ts`. `settings.allowlist.test.ts` makes exact-equality assertions
+  over the key arrays in that file, and Phase 1 already proved that touching it is the way to break
+  a test that should stay unmodified. Keeping the list local also keeps this to one file.
+- `String(true) === 'true'`, so a JSON boolean from the UI passes unchanged.
+- The check sits before **both** write paths, so a rejected request writes nothing and never invokes
+  `callbacks.refreshMeshcoreReceiveOnly` (`:889-891`).
+- `fail` is already imported in this file. Scope stops here — **do not** extend this to other
+  boolean keys in this PR.
+
+---
+
+## 5. Test plan
+
+Standard Vitest + Testing Library files inside the existing suite. **No standalone scripts.**
+No `any`. New MeshCore component tests follow the existing `src/components/MeshCore/*.test.tsx`
+patterns (18 files exist); the one server test uses `createRouteTestApp()`.
+
+### 5.1 Component disabled-state tests
+
+Each renders the component twice — `receiveOnly={false}` and `receiveOnly={true}` — and asserts the
+gated controls flip `disabled` and carry `title === t('meshcore.receive_only.control_tooltip')`,
+**and that the non-gated controls stay enabled** (the negative control is what proves the gate is
+targeted rather than a blanket freeze).
+
+| File (new unless noted) | Asserts |
+|---|---|
+| `MeshCoreSettingsView.receiveOnly.test.tsx` | toggle renders and reflects the prop; Send advert / Discover ×3 / Discover regions disabled + tooltip; Refresh contacts + Save scope **enabled**; paused note under the discoverable toggle |
+| `MeshCoreMessageStream.receiveOnly.test.tsx` (or extend `MeshCoreMessageStream.test.tsx`) | `disabled` + `disabledReason` → input and Send button disabled and both carry the `title`; omitting `disabledReason` leaves `title` undefined |
+| `MeshCoreContactDetailPanel.receiveOnly.test.tsx` | the six RF buttons disabled + tooltip; **Export and Remove still enabled** |
+| `MeshCoreNodesView.receiveOnly.test.tsx` | all three discover menu items disabled + tooltip; `onDiscoverNodes` never called on click |
+| `MeshCoreRemoteConsole.receiveOnly.test.tsx` (extend the existing file) | both login buttons + modal submit disabled; `CliConsoleBody` receives `disabled`; `MeshCoreAclManager` receives `disabled` |
+| `MeshCoreRemoteStatsPanel.receiveOnly.test.tsx` | refresh + empty-state buttons disabled; `fetchStatus` not called on mount/expand while receive-only |
+| `MeshCoreLocalConsole.receiveOnly.test.tsx` | console input/Send **enabled**; `ver` / `stats` / `clock` quick actions **enabled**; `advert` quick action **disabled**; ACL form **enabled** |
+| `MeshCoreNodeTelemetryConfig.receiveOnly.test.tsx` (extend) | both poll buttons disabled; enable checkbox + interval input **enabled**; paused note rendered |
+| `MeshCoreRoomsView.receiveOnly.test.tsx` | login button + password input disabled; send box disabled (auto-login effect covered in §5.3a) |
+| `MeshCoreChannelsView.receiveOnly.test.tsx` (extend) | send box disabled + tooltip (mount effect covered in §5.3a) |
+| `MeshCoreDirectMessagesView.receiveOnly.test.tsx` (extend) | send box disabled; `receiveOnly` threaded to `MeshCoreContactDetailPanel` and `MeshCoreNodeTelemetryConfig` |
+| `MeshCoreStatusBar.receiveOnly.test.tsx` | Send advert disabled + tooltip; Disconnect **enabled**; receive-only chip rendered |
+| `MeshCoreAutoAnnounceSection.receiveOnly.test.tsx` | "Send Now" disabled + tooltip; paused note rendered; **every config input still enabled** |
+| `MeshCoreTimerTriggersSection.receiveOnly.test.tsx` | "Run now" disabled + tooltip; paused note; config inputs enabled |
+| `MeshCoreAutoAckSection.receiveOnly.test.tsx`, `MeshCoreAutoResponderSection.receiveOnly.test.tsx`, `MeshCorePathfindingFilterSection.receiveOnly.test.tsx` | paused note rendered; **no** input disabled by receive-only |
+| `MeshCoreReceiveOnlyNote.test.tsx` | renders `null` when false; renders the string + a `UiIcon` (not a literal emoji) when true |
+| `MeshCorePage.receiveOnly.test.tsx` | with `useTxStatus` mocked to `{ isTxDisabled: true }`, `receiveOnly` reaches every child that declares it |
+
+### 5.2 Toggle save / invalidate path — `MeshCoreSettingsView.receiveOnly.test.tsx`
+
+- Checking the box **does not** call `window.confirm`; POSTs
+  `/api/settings?sourceId=<id>` with body `{ meshcoreReceiveOnly: true }`.
+- Unchecking calls `window.confirm`; mocked `true` → POST with `{ meshcoreReceiveOnly: false }`;
+  mocked `false` → **no** network call and the checkbox stays checked.
+- A successful save calls `queryClient.invalidateQueries({ queryKey: ['txStatus'] })`
+  (mock `useQueryClient`, exactly as `ConfigurationTab.txDisabled.test.tsx:92-99` does).
+- A non-ok save shows the `meshcore.receive_only.save_failed` error toast and does **not** invalidate.
+
+### 5.3 409 toast path
+
+- `useMeshCore.receiveOnly.test.ts` (new; model on `useMeshCore.isLocal.test.ts`): with `csrfFetch`
+  mocked to resolve `{ ok: false, status: 409, json: () => ({ success:false, code:'TX_DISABLED' }) }`,
+  each patched action resolves to its normal failure value (**does not throw**) and `showToast` was
+  called once with the `meshcore.receive_only.blocked_toast` string and `'warning'`.
+- A non-409 failure still takes the existing `setError` path and raises **no** toast.
+- `MeshCoreAutoAnnounceSection` / `MeshCoreTimerTriggersSection` / `MeshCoreNodeTelemetryConfig`:
+  one 409 test each for their direct-`csrfFetch` handlers.
+- `App.tsx` regression: with `sourceType='meshcore'` and `useTxStatus` → `isTxDisabled: true`,
+  `handleRequestNeighborInfo`'s 409 branch raises the **MeshCore-worded** toast.
+
+### 5.3a Automatic-path silence (§3.4a) — one test per effect, **required**
+
+These are the regression net for a toast storm on page load. Each asserts the **absence** of both a
+request and a toast — a disabled-button assertion cannot catch these, because there is no button.
+
+| File | Assertions with `receiveOnly` |
+|---|---|
+| `MeshCoreRoomsView.receiveOnly.test.tsx` | Select a room that has stored credentials → `actions.loginRoomWithSaved` **not called**, `showToast` **not called**, no error state rendered. Then re-render with `receiveOnly={false}` and select the same room again → it **is** called (proves the latch was not poisoned). |
+| `MeshCoreChannelsView.receiveOnly.test.tsx` | Open the scope-override control → `actions.discoverRegions` **not called**, `showToast` **not called**. Re-render with `receiveOnly={false}` and reopen → it **is** called (latch not poisoned). |
+| `MeshCoreRemoteStatsPanel.receiveOnly.test.tsx` | Mount / expand the panel → `fetchStatus` **not called**, `showToast` **not called**, no loading spinner. With `receiveOnly={false}` → it **is** called. |
+
+The "flip the flag off and it works again" half of each test is not optional — it is the only thing
+that catches a guard placed after the latch.
+
+### 5.4 Settings validation — `src/server/routes/settingsRoutes.receiveOnlyValidation.test.ts` (new)
+
+`createRouteTestApp()` with the settings router mounted (**mandatory** for new route tests — no
+`vi.mock('../../services/database.js', …)`).
+
+- `{ meshcoreReceiveOnly: true }` → 200; stored value is `'true'`; the
+  `refreshMeshcoreReceiveOnly` callback fired.
+- `{ meshcoreReceiveOnly: false }` → 200; stored `'false'`.
+- Each of `'1'`, `'yes'`, `'TRUE'`, `'on'`, `1`, `null`, `{}` → **400** with
+  `code === 'INVALID_BOOLEAN_SETTING'`, **nothing written** (the previously-stored value is
+  unchanged), and `refreshMeshcoreReceiveOnly` **not** called.
+- A request carrying a valid `meshcoreReceiveOnly` **plus** other keys still persists the other keys.
+- Global (no `sourceId`) POSTs carrying unrelated keys are unaffected.
+
+### 5.5 Suite requirements
+
+Full Vitest suite green (0 failures) — confirm `success: true` via the JSON reporter, not `rtk`'s
+`PASS/FAIL` summary. `npm run lint:ci 2>&1 | grep '^FAIL' | grep -v '.claude/worktrees'` must be
+empty. `npm run typecheck` clean; run a `tsc` pass **including** test files (`tsconfig.json` excludes
+`src/**/*.test.ts`, so the default run never checks them — Phase 1's reviewer note). No schema
+change, so the PostgreSQL/MySQL containers are not required.
+
+---
+
+## 6. Work packages
+
+**All agents share the one worktree `/home/yeraze/Development/meshmonitor-mc-rxonly-p2`, so file
+overlap forces sequencing.** WP1 touches the props interfaces of the files WP2/WP3/WP4 then modify,
+so **WP1 must be complete and committed before WP2–WP5 start.** After WP1, the four remaining
+packages are file-disjoint and run in parallel.
+
+```
+WP1 ──┬── WP2  (settings toggle + backend validation)
+      ├── WP3  (messaging / contact / console / node surfaces)
+      ├── WP4  (automations)
+      └── WP5  (unified-view tooltip copy + banner + toasts)
+```
+
+Also note the `rtk`-wrapped-`git commit` hazard: parallel agents in one worktree can sweep each
+other's files. **Commit with an explicit pathspec** (`git commit -- <paths>`), never a bare
+`git commit -a`, and audit the per-commit file list.
+
+### WP1 — Foundation: flag distribution, shared primitives, i18n, 409 helper
+**Files:** `public/locales/en.json`; `src/components/MeshCore/MeshCorePage.tsx`;
+`src/components/MeshCore/MeshCoreReceiveOnlyNote.tsx` + `.module.css` (new);
+`src/components/MeshCore/MeshCoreMessageStream.tsx`;
+`src/components/MeshCore/CliConsoleBody.tsx` (optional `ActionCommand.disabled`);
+`src/components/MeshCore/hooks/useMeshCore.ts`; plus a **one-line `receiveOnly?: boolean` prop
+addition + destructure (no behavior)** in `MeshCoreStatusBar`, `MeshCoreNodesView`,
+`MeshCoreChannelsView`, `MeshCoreRoomsView`, `MeshCoreDirectMessagesView`,
+`MeshCoreContactDetailPanel`, `MeshCoreRemoteConsole`, `MeshCoreRemoteStatsPanel`,
+`MeshCoreNodeTelemetryConfig`, `MeshCoreLocalConsole`, `MeshCoreConfigurationView`,
+`MeshCoreAutomationsView`, `MeshCoreSettingsView`, and the five automation sections.
+**Tests:** `MeshCoreReceiveOnlyNote.test.tsx`, `MeshCorePage.receiveOnly.test.tsx`,
+`MeshCoreMessageStream.receiveOnly.test.tsx`, `useMeshCore.receiveOnly.test.ts`.
+
+**Acceptance:**
+- `MeshCorePage` calls `useTxStatus({ baseUrl, sourceId })` once and threads `receiveOnly` to all
+  eight direct children; each re-threads to its own children per §3.0.
+- `MeshCoreMessageStream` accepts `disabledReason` and puts it on the input, the Send button **and**
+  the enclosing `.meshcore-send-bar`.
+- `MeshCoreReceiveOnlyNote` renders `null` when false and uses `UiIcon`, not an emoji; its styling
+  lives in a CSS module — **zero lines added to `src/styles/*.css`**.
+- All 14 `meshcore.receive_only.*` keys + `banners.receive_only_meshcore` exist in `en.json`;
+  **no other locale file is touched.**
+- `useMeshCore.reportTxDisabled` exists and is called from all 18 listed actions; every affected
+  `useCallback` dep array is updated (no new `exhaustive-deps` violation).
+- `tsc` clean including tests; suite green; `lint:ci` clean of in-repo failures.
+
+### WP2 — Receive-only toggle + backend value validation
+**Depends on:** WP1. **Parallel with:** WP3, WP4, WP5.
+**Files:** `src/components/MeshCore/MeshCoreSettingsView.tsx`;
+`src/server/routes/settingsRoutes.ts`.
+**Tests:** `MeshCoreSettingsView.receiveOnly.test.tsx`;
+`src/server/routes/settingsRoutes.receiveOnlyValidation.test.ts`.
+
+**Acceptance:**
+- The toggle renders above "Device actions", reads `checked` from the threaded prop (not local
+  state), and posts to `/api/settings?sourceId=` via `csrfFetch`.
+- **Confirm on disable only**; enabling never prompts.
+- A successful save invalidates `['txStatus']`; a failure toasts and does not invalidate.
+- Send advert / Discover ×3 / Discover regions disabled + tooltip; Refresh contacts and Save scope
+  remain enabled; the paused note renders under the discoverable toggle.
+- `POST /api/settings` rejects any `meshcoreReceiveOnly` that is not exactly `'true'`/`'false'`
+  with `400 INVALID_BOOLEAN_SETTING`, **before any write**, and does not fire
+  `refreshMeshcoreReceiveOnly`. `settings.allowlist.test.ts` passes **unmodified**.
+- No other settings key's validation behavior changes.
+
+### WP3 — Messaging, contact, console and node surfaces
+**Depends on:** WP1. **Parallel with:** WP2, WP4, WP5.
+**Files:** `MeshCoreChannelsView.tsx`, `MeshCoreDirectMessagesView.tsx`, `MeshCoreRoomsView.tsx`,
+`MeshCoreContactDetailPanel.tsx`, `MeshCoreRemoteConsole.tsx`, `MeshCoreRemoteStatsPanel.tsx`,
+`MeshCoreLocalConsole.tsx`, `MeshCoreNodeTelemetryConfig.tsx`, `MeshCoreNodesView.tsx`,
+`MeshCoreStatusBar.tsx`, `MeshCoreConfigurationView.tsx` (thread-through only).
+**Tests:** the eleven files listed in §5.1 for these components, plus the direct-`csrfFetch` 409
+test for `MeshCoreNodeTelemetryConfig`.
+
+**Acceptance:**
+- Every row of the §3.8 checklist owned by this package is disabled + tooltipped, **including both
+  second render paths** (advert: StatusBar *and* SettingsView-owned-by-WP2; discover: NodesView menu
+  *and* SettingsView-owned-by-WP2 — WP3 owns the NodesView and StatusBar halves).
+- **All three §3.4a automatic paths skip silently** — Rooms auto-login, ChannelsView
+  `discoverRegions` mount effect, `MeshCoreRemoteStatsPanel.load()`: no request, **no toast**, no
+  error state, `receiveOnly` in each dep array, and in every case the guard sits **before** the
+  do-not-repeat latch. The §5.3a "flip the flag off and it fires again" assertions must be present
+  and passing; a guard placed after a latch fails this package even if everything else is green.
+- The local console stays usable: input, Send, and the `ver`/`stats`/`clock`/`help` quick actions
+  enabled; only `advert` disabled.
+- Export / Remove / out-path save / sync-time / channel CRUD / device config remain enabled
+  (explicit negative assertions).
+- No new `exhaustive-deps` or `no-explicit-any` violations; no raw `fetch()`.
+
+### WP4 — Automations: paused notes + immediate-send gating
+**Depends on:** WP1. **Parallel with:** WP2, WP3, WP5.
+**Files:** `MeshCoreAutomationsView.tsx`, `MeshCoreAutoAckSection.tsx`,
+`MeshCoreAutoAnnounceSection.tsx`, `MeshCoreAutoResponderSection.tsx`,
+`MeshCorePathfindingFilterSection.tsx`, `MeshCoreTimerTriggersSection.tsx`.
+**Tests:** the five automation `*.receiveOnly.test.tsx` files in §5.1 plus the two direct-`csrfFetch`
+409 tests.
+
+**Acceptance:**
+- All five sections render `<MeshCoreReceiveOnlyNote>` when receive-only.
+- "Send Now" and "Run now" disabled + tooltip; their handlers also detect a 409 and toast.
+- **Every configuration input in all five sections remains enabled and its saved value unchanged** —
+  asserted explicitly, since this is interview decision 5 and the whole point of the phase.
+- No automation setting is written, cleared or defaulted by any code path added here.
+
+### WP5 — Unified-view copy correctness + global banner
+**Depends on:** WP1 (the i18n keys). **Parallel with:** WP2, WP3, WP4.
+**Files:** `src/App.tsx`, `src/components/AppBanners/AppBanners.tsx`, `src/components/MessagesTab.tsx`,
+`src/components/ChannelsTab.tsx`, `src/components/NodesTab.tsx`,
+`src/components/NodePopup/NodePopup.tsx`. (Disjoint from WP2/WP3/WP4 — none of them touch a file
+outside `src/components/MeshCore/` or `src/server/`.)
+**Tests:** extend the `AppBanners` tests for the `isMeshCore` branch; extend the existing
+`*.txDisabled.test.tsx` files for `txDisabledTooltip`; a focused handler test for the MeshCore-worded
+409 toast.
+
+**Acceptance:**
+- `txDisabledTooltip` is computed once in `App.tsx` and threaded to `ChannelsTab`, `MessagesTab`,
+  `NodesTab` and both `NodePopup` renders; **all 23 verified call sites** (§3.9 table) read the prop
+  with an `?? t('tx_disabled.control_tooltip')` fallback, so the prop stays optional.
+- A MeshCore receive-only source shows `meshcore.receive_only.control_tooltip` — which names the
+  MeshCore Settings remedy — and **never** the LoRa-configuration wording. A Meshtastic source's
+  tooltips are byte-identical to today (assert both directions).
+- `AppBanners` shows `banners.receive_only_meshcore` for a MeshCore source and the unchanged
+  `banners.tx_disabled` otherwise; banner-offset arithmetic and existing tests untouched.
+- The App send-handler 409 toasts use the MeshCore string when `sourceType === 'meshcore'`.
+- **No change to `txGated` or to any control-gating logic** — that already works. A regression test
+  proves the MeshCore neighbor-info button is still disabled.
+
+---
+
+## 7. Conventions guardrails
+
+- **No literal emoji or Unicode icon stand-ins** in JSX or in any `en.json` value added here — use
+  `UiIcon`. Only the two verified names: `blocked` (status chip) and `pause` (paused note).
+- **No raw `fetch()`** in `src/components/**` or `src/pages/**` — use `useCsrfFetch` (the MeshCore
+  idiom) or `useAuthFetch`. `useTxStatus` lives in `src/hooks/` and is exempt; do not "fix" it.
+- **No new `any`** (`no-explicit-any` is a ratcheted error).
+- **No new `react-hooks/exhaustive-deps` violations.** Every value newly referenced inside an
+  existing `useCallback`/`useEffect` (`receiveOnly`, `reportTxDisabled`, `queryClient`, `csrfFetch`)
+  must be added to that hook's dep array in the same edit.
+- **New styling goes in a CSS module** (`MeshCoreReceiveOnlyNote.module.css`). Zero additions to
+  `src/styles/nodes.css` or its siblings. Reuse existing `mrc-status-chip` / `hint` /
+  `form-section` classes where they fit.
+- Verify with `npm run lint:ci 2>&1 | grep '^FAIL' | grep -v '.claude/worktrees'` (empty = pass) —
+  plain `npx eslint <file>` exiting 0 does **not** prove the ratchet passes.
+
+---
+
+## 8. Browser validation (live dev container, chrome-devtools)
+
+Prereq: a MeshCore source connected in the dev container (`docker-compose.dev.yml` **plus**
+`docker-compose.dev.local.yml` for the `/dev/ttyUSB*` mappings). Start with receive-only **off**.
+
+1. **Toggle on.** MeshCore → Settings → Receive-only mode. Check the box: **no confirm prompt**,
+   success toast, and within ~1 s (no page reload) the status-bar chip appears, the global banner
+   shows the MeshCore wording, and the Send advert button beside it greys out.
+2. **Messaging.** Channels and DMs: input + Send disabled, hover shows the receive-only tooltip;
+   message history still renders and new inbound messages still arrive.
+3. **Contacts.** Open a contact: Reset path / Share / Trace / Ping / Discover path / Neighbours all
+   disabled with tooltips; **Export and Remove still work.**
+4. **Discovery — both paths.** Settings → Discover Nearby/Repeaters/Sensors disabled; Nodes view →
+   the discover menu's three items disabled. (Regression target for the #4294-class miss.)
+5. **Consoles.** Remote console: login buttons disabled, console body disabled with the explanatory
+   placeholder, ACL form disabled. Local console: still usable — run `ver` and `stats` successfully;
+   the `advert` quick action is disabled; typing `advert` manually returns the server error and the
+   receive-only toast, and does **not** crash the console.
+6. **Automations.** Each of the five sections shows the paused note; "Send Now" and "Run now" are
+   disabled; **change a field, save, reload — the value persisted unchanged.**
+7. **Race toast.** With the UI gated, fire `POST …/messages/send` directly from devtools and confirm
+   the 409 surfaces as the friendly warning toast rather than a red error or a crash.
+7a. **No toast storm (§3.4a).** With receive-only on, hard-reload the MeshCore page, select a room
+   that has saved credentials, open a channel's scope-override control, and expand a remote node's
+   stats panel. **Zero toasts** should appear from any of these — they are automatic paths. Confirm
+   in the Network panel that no `/rooms/login-with-saved`, `/regions/discover` or `/admin/status/:pk`
+   request was issued. Then turn receive-only off and repeat: each now fires normally.
+7b. **Tooltip correctness (§3.9).** On a receive-only MeshCore source, hover a disabled control in
+   the unified Messages/Channels/Nodes views and the map popup's traceroute button. The tooltip must
+   name **MeshCore Settings**, not "the LoRa configuration". Repeat on a TX-disabled Meshtastic
+   source and confirm it still says "Re-enable TX in the LoRa configuration".
+8. **Toggle off.** Uncheck: the confirm prompt **does** appear; accept, and every control above
+   re-enables without a reload. Send a message on the `gauntlet` channel to prove TX resumed.
+9. **Negative control — per-source isolation.** With a second, non-receive-only source configured,
+   switch to it and confirm **nothing** is gated there. Confirm a Meshtastic source still shows the
+   original `banners.tx_disabled` wording, not the MeshCore one.
+
+---
+
+## 9. Out of scope (Phase 3)
+
+- Virtual Node command rejection (the 9 TX commands → `Err` frame).
+- User-facing docs (`docs/features/…`), REST API 409 documentation.
+- Locale propagation beyond `en.json` (Weblate).
+- Mid-retry-chain re-arm: flipping receive-only ON parks that specific DM/channel retry rather than
+  auto-resuming when the flag goes off (Phase 1 known limitation). Phase 2 does not add a re-arm.
+- `AdminCommandsTab` and `tx_disabled.remote_admin_notice`. That tab drives the **Meshtastic** admin
+  protocol (`executeCommand` → Meshtastic AdminMessage) and is not a MeshCore surface at all —
+  MeshCore remote admin is `MeshCoreRemoteConsole`, gated in §3.5. Nothing to gate; the notice string
+  is unreachable for a MeshCore source. Flag it if a future phase exposes that tab to MeshCore.
+  *(Unified-view tooltip copy is **not** deferred — see §3.9, it is required work in WP5.)*
+- A `radio.receiveOnly` badge on the multi-source dashboard (the field exists; nothing consumes it).

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -112,6 +112,7 @@
   "banners.default_password_warning": "Security Warning: The admin account is using the default password. Please change it immediately in the Users tab.",
   "banners.tx_disabled": "Transmit Disabled: Your device cannot send messages. TX is currently disabled in the LoRa configuration. Enable it via the Meshtastic app or re-import your configuration.",
   "banners.tx_disabled_udp_relay": "Radio Transmit Disabled: This device does not transmit over LoRa itself. UDP Broadcast is on, so sends go out over the local network and another node there relays them to the mesh.",
+  "banners.receive_only_meshcore": "Receive-Only Mode: this MeshCore source will not transmit. Messages, adverts, path discovery, remote administration and automations are held. Turn it off in MeshCore Settings to transmit again.",
   "banners.config_error": "Configuration Error",
   "banners.learn_more": "Learn more",
   "banners.update_available": "Update available: v{{version}}",
@@ -5154,5 +5155,19 @@
   "meshcore.automation.pathfinding.filter.preview_count": "{{count}} contacts will be targeted",
   "meshcore.automation.pathfinding.filter.no_match": "No contacts match the current filters",
   "meshcore.automation.autoack.node_ignore_list": "Sender Ignore List",
-  "meshcore.automation.autoack.node_ignore_list_description": "Never auto-acknowledge these senders — use it to break a bot echo loop. One entry per line, or comma-separated. An entry is either a public key (full key or any leading prefix, with or without a leading \"!\") or a contact/sender name. Names are matched ignoring case and extra spaces, and are the only way to exclude a channel sender, because MeshCore channel packets carry no sender key."
+  "meshcore.automation.autoack.node_ignore_list_description": "Never auto-acknowledge these senders — use it to break a bot echo loop. One entry per line, or comma-separated. An entry is either a public key (full key or any leading prefix, with or without a leading \"!\") or a contact/sender name. Names are matched ignoring case and extra spaces, and are the only way to exclude a channel sender, because MeshCore channel packets carry no sender key.",
+
+  "meshcore.receive_only.title": "Receive-only mode",
+  "meshcore.receive_only.toggle_label": "Strict receive-only (never transmit)",
+  "meshcore.receive_only.description": "Block every transmission from this MeshCore node. Messages, adverts, path discovery, remote CLI, logins, telemetry requests and all automations are held. Receiving, the packet log, the Analyzer Observer, contact and telemetry updates, and local serial configuration keep working.",
+  "meshcore.receive_only.firmware_caveat": "MeshCore firmware has no radio-level transmit switch, so MeshMonitor enforces this in software. Transmissions the node makes on its own — link-layer acknowledgements, and any advert schedule configured outside MeshMonitor — are not affected.",
+  "meshcore.receive_only.disable_confirm": "Allow this MeshCore node to transmit again?\n\nMessages, adverts, path discovery, remote administration and every enabled automation will resume sending over the radio. Continue?",
+  "meshcore.receive_only.control_tooltip": "Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.",
+  "meshcore.receive_only.blocked_toast": "Receive-only mode is on for this MeshCore source — nothing was sent.",
+  "meshcore.receive_only.paused_note": "Paused — receive-only mode. These settings are saved and unchanged; they take effect again when receive-only is turned off.",
+  "meshcore.receive_only.status_chip": "Receive-only",
+  "meshcore.receive_only.saved_on": "Receive-only mode enabled — this node will not transmit",
+  "meshcore.receive_only.saved_off": "Receive-only mode disabled — this node can transmit again",
+  "meshcore.receive_only.save_failed": "Failed to change receive-only mode",
+  "meshcore.receive_only.console_placeholder": "Local serial commands still work; commands that transmit are blocked."
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -250,6 +250,17 @@ function App() {
   // MQTT-bridge sources are never gated (different transport, not affected by radio TX state)
   const txGated = isTxDisabled && !isMqttBridge;
 
+  // MeshCore has no LoRa Configuration screen, so the Meshtastic-worded
+  // tooltip/toast point a MeshCore operator at a remedy that does not exist
+  // on their hardware. One computed string, threaded through as an optional
+  // prop (#4547 Phase 2 WP5) — every call site falls back to the existing
+  // Meshtastic copy when the prop is omitted, so Meshtastic behavior is
+  // unchanged.
+  const isMeshCoreSource = sourceType === 'meshcore';
+  const txDisabledTooltip = t(
+    isMeshCoreSource ? 'meshcore.receive_only.control_tooltip' : 'tx_disabled.control_tooltip'
+  );
+
   // Check for version updates. TanStack Query's refetchInterval replaces the
   // hand-rolled setInterval (#3962 Phase 5.1); the hook stops polling on a 404
   // (version checking disabled server-side, env.versionCheckDisabled).
@@ -1993,7 +2004,7 @@ function App() {
         const errorData = await response.json().catch(() => ({}));
         setPositionLoading(null);
         if (isTxDisabledBody(response.status, errorData)) {
-          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          showToast(t(isMeshCoreSource ? 'meshcore.receive_only.blocked_toast' : 'tx_disabled.send_blocked_toast'), 'warning');
         }
         return;
       }
@@ -2048,7 +2059,7 @@ function App() {
         const errorData = await response.json().catch(() => ({}));
         setNodeInfoLoading(null);
         if (isTxDisabledBody(response.status, errorData)) {
-          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          showToast(t(isMeshCoreSource ? 'meshcore.receive_only.blocked_toast' : 'tx_disabled.send_blocked_toast'), 'warning');
         }
         return;
       }
@@ -2110,7 +2121,7 @@ function App() {
         const errorData = await response.json().catch(() => ({}));
         setNeighborInfoLoading(null);
         if (isTxDisabledBody(response.status, errorData)) {
-          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          showToast(t(isMeshCoreSource ? 'meshcore.receive_only.blocked_toast' : 'tx_disabled.send_blocked_toast'), 'warning');
         }
         return;
       }
@@ -2160,7 +2171,7 @@ function App() {
         const detail = await response.json().catch(() => ({}));
         if (isTxDisabledBody(response.status, detail)) {
           setTelemetryRequestLoading(null);
-          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          showToast(t(isMeshCoreSource ? 'meshcore.receive_only.blocked_toast' : 'tx_disabled.send_blocked_toast'), 'warning');
           return;
         }
         throw new Error(detail.error || `Telemetry request failed (${response.status})`);
@@ -2338,7 +2349,7 @@ function App() {
       } else {
         const errorData = await response.json();
         if (isTxDisabledBody(response.status, errorData)) {
-          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          showToast(t(isMeshCoreSource ? 'meshcore.receive_only.blocked_toast' : 'tx_disabled.send_blocked_toast'), 'warning');
           return;
         }
         setError(`Failed to send reaction: ${errorData.error || 'Unknown error'}`);
@@ -2716,7 +2727,7 @@ function App() {
         });
 
         if (isTxDisabledBody(response.status, errorData)) {
-          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          showToast(t(isMeshCoreSource ? 'meshcore.receive_only.blocked_toast' : 'tx_disabled.send_blocked_toast'), 'warning');
           return;
         }
         setError(`Failed to send message: ${errorData.error}`);
@@ -2758,7 +2769,7 @@ function App() {
       } else {
         const errorData = await response.json();
         if (isTxDisabledBody(response.status, errorData)) {
-          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          showToast(t(isMeshCoreSource ? 'meshcore.receive_only.blocked_toast' : 'tx_disabled.send_blocked_toast'), 'warning');
           return;
         }
         setError(`Failed to send bell: ${errorData.error}`);
@@ -2787,7 +2798,7 @@ function App() {
       } else {
         const errorData = await response.json().catch(() => ({}));
         if (isTxDisabledBody(response.status, errorData)) {
-          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          showToast(t(isMeshCoreSource ? 'meshcore.receive_only.blocked_toast' : 'tx_disabled.send_blocked_toast'), 'warning');
           return;
         }
         setError('Failed to send bell DM');
@@ -2813,7 +2824,7 @@ function App() {
       } else {
         const errorData = await response.json();
         if (isTxDisabledBody(response.status, errorData)) {
-          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          showToast(t(isMeshCoreSource ? 'meshcore.receive_only.blocked_toast' : 'tx_disabled.send_blocked_toast'), 'warning');
           return;
         }
         setError(`Failed to send position: ${errorData.error}`);
@@ -2918,7 +2929,7 @@ function App() {
         });
 
         if (isTxDisabledBody(response.status, errorData)) {
-          showToast(t('tx_disabled.send_blocked_toast'), 'warning');
+          showToast(t(isMeshCoreSource ? 'meshcore.receive_only.blocked_toast' : 'tx_disabled.send_blocked_toast'), 'warning');
           return;
         }
         setError(`Failed to resend message: ${errorData.error}`);
@@ -3295,6 +3306,7 @@ function App() {
       <AppBanners
         isTxDisabled={isTxDisabled}
         isUdpRelay={isUdpRelay}
+        isMeshCore={isMeshCoreSource}
         configIssues={configIssues}
         updateAvailable={updateAvailable}
         latestVersion={latestVersion}
@@ -3590,6 +3602,7 @@ function App() {
                   onTraceroute={handleTraceroute}
                   connectionStatus={connectionStatus}
                   txDisabled={txGated}
+                  txDisabledTooltip={txDisabledTooltip}
                   tracerouteLoading={tracerouteLoading}
                   onDeleteNode={handleDeleteNode}
                   onPurgeNodeFromDevice={handlePurgeNodeFromDevice}
@@ -3715,6 +3728,7 @@ function App() {
             onFocusMessageHandled={() => setFocusMessageId(null)}
             mqttReadOnly={isMqttBridge}
             txDisabled={txGated}
+            txDisabledTooltip={txDisabledTooltip}
           />
               </ErrorBoundary>
             }
@@ -3787,6 +3801,7 @@ function App() {
             onFocusMessageHandled={() => setFocusMessageId(null)}
             mqttReadOnly={isMqttBridge}
             txDisabled={txGated}
+            txDisabledTooltip={txDisabledTooltip}
             toggleIgnored={toggleIgnored}
             toggleHideFromMap={toggleHideFromMap}
             toggleFavorite={toggleFavorite}
@@ -3845,6 +3860,7 @@ function App() {
         onPurgeNodeFromDevice={handlePurgeNodeFromDevice}
         currentNodeNum={currentNodeId ? (nodes.find(n => n.user?.id === currentNodeId)?.nodeNum ?? null) : null}
         txDisabled={txGated}
+        txDisabledTooltip={txDisabledTooltip}
       />
 
       {/* News Popup */}

--- a/src/components/AppBanners/AppBanners.test.tsx
+++ b/src/components/AppBanners/AppBanners.test.tsx
@@ -129,6 +129,23 @@ describe('AppBanners — warning banners', () => {
     expect(screen.queryByText(/banners\.tx_disabled/)).not.toBeInTheDocument();
   });
 
+  // #4547 Phase 2 WP5: MeshCore has no LoRa Configuration screen, so a
+  // receive-only MeshCore source gets the MeshCore-worded banner instead of
+  // the Meshtastic "LoRa configuration" copy.
+  it('renders the MeshCore receive-only banner when isMeshCore is true', () => {
+    render(
+      <AppBanners {...baseProps} updateAvailable={false} isTxDisabled isMeshCore deploymentMethod="docker" />
+    );
+    expect(screen.getByText(/banners\.receive_only_meshcore/)).toBeInTheDocument();
+    expect(screen.queryByText(/^banners\.tx_disabled$/)).not.toBeInTheDocument();
+  });
+
+  it('renders the unchanged Meshtastic banner when isMeshCore is false/omitted', () => {
+    render(<AppBanners {...baseProps} updateAvailable={false} isTxDisabled deploymentMethod="docker" />);
+    expect(screen.getByText(/^banners\.tx_disabled$/)).toBeInTheDocument();
+    expect(screen.queryByText(/banners\.receive_only_meshcore/)).not.toBeInTheDocument();
+  });
+
   it('renders a config issue banner with a docs link', () => {
     render(
       <AppBanners

--- a/src/components/AppBanners/AppBanners.tsx
+++ b/src/components/AppBanners/AppBanners.tsx
@@ -20,6 +20,13 @@ interface AppBannersProps {
    * rather than claiming the device cannot send.
    */
   isUdpRelay?: boolean;
+  /**
+   * True when the current source is MeshCore. MeshCore has no LoRa
+   * Configuration screen, so the TX-disabled banner swaps to the
+   * receive-only wording that points at MeshCore Settings instead (#4547
+   * Phase 2 WP5). Does not affect `showTxBanner` or any offset arithmetic.
+   */
+  isMeshCore?: boolean;
   configIssues: ConfigIssue[];
   updateAvailable: boolean;
   latestVersion: string;
@@ -38,6 +45,7 @@ function readDismissedVersion(): string | null {
 export const AppBanners: React.FC<AppBannersProps> = ({
   isTxDisabled,
   isUdpRelay = false,
+  isMeshCore = false,
   configIssues,
   updateAvailable,
   latestVersion,
@@ -112,7 +120,9 @@ export const AppBanners: React.FC<AppBannersProps> = ({
           style={{ top: 'var(--header-height)' }}
         >
           <UiIcon name="alert" />{' '}
-          {isTxDisabled ? t('banners.tx_disabled') : t('banners.tx_disabled_udp_relay')}
+          {isTxDisabled
+            ? t(isMeshCore ? 'banners.receive_only_meshcore' : 'banners.tx_disabled')
+            : t('banners.tx_disabled_udp_relay')}
         </div>
       )}
 

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -92,6 +92,14 @@ export interface ChannelsTabProps {
 
   /** TX disabled on this source (epic #4294 Phase 2) — disable send/request controls with a tooltip, keep reads working. */
   txDisabled?: boolean;
+  /**
+   * Pre-computed tooltip for disabled TX controls (#4547 Phase 2 WP5). App.tsx
+   * picks the MeshCore receive-only wording or the Meshtastic LoRa-config
+   * wording based on source type. Optional — falls back to
+   * `(txDisabledTooltip ?? t('tx_disabled.control_tooltip'))` at each call site when omitted, so
+   * existing callers/tests are unaffected.
+   */
+  txDisabledTooltip?: string;
 
   // Channel selection
   selectedChannel: number;
@@ -174,6 +182,7 @@ export default function ChannelsTab({
   sourceId = null,
   connectionStatus,
   txDisabled = false,
+  txDisabledTooltip,
   selectedChannel,
   setSelectedChannel,
   selectedChannelRef,
@@ -1169,7 +1178,7 @@ export default function ChannelsTab({
                                           className="emoji-picker-button"
                                           onClick={() => setEmojiPickerMessage(msg)}
                                           disabled={txDisabled}
-                                          title={txDisabled ? t('tx_disabled.control_tooltip') : t('channels.emoji_button_title')}
+                                          title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : t('channels.emoji_button_title')}
                                           aria-label={t('channels.emoji_button_title')}
                                         >
                                           <UiIcon name="reaction" size={15} />
@@ -1229,7 +1238,7 @@ export default function ChannelsTab({
                               className="message-input"
                               rows={1}
                               disabled={txDisabled}
-                              title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                              title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                               onKeyDown={e => {
                                 if (
                                   txDisabled ||
@@ -1261,7 +1270,7 @@ export default function ChannelsTab({
                             onClick={() => { void onSendBell?.(selectedChannel, newMessage); setNewMessage(''); }}
                             disabled={txDisabled}
                             className="send-btn channel-action-btn"
-                            title={txDisabled ? t('tx_disabled.control_tooltip') : 'Send alert bell'}
+                            title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : 'Send alert bell'}
                             aria-label="Send alert bell"
                           >
                             <UiIcon name="notifications" size={16} />
@@ -1270,7 +1279,7 @@ export default function ChannelsTab({
                             onClick={() => onSendPosition?.(selectedChannel)}
                             disabled={txDisabled}
                             className="send-btn channel-action-btn"
-                            title={txDisabled ? t('tx_disabled.control_tooltip') : 'Send position'}
+                            title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : 'Send position'}
                             aria-label="Send position"
                           >
                             <UiIcon name="location" size={16} />
@@ -1279,7 +1288,7 @@ export default function ChannelsTab({
                             onClick={() => handleSendMessage(selectedChannel)}
                             disabled={!newMessage.trim() || txDisabled}
                             className="send-btn"
-                            title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                            title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                           >
                             <UiIcon name="send" size={16} />
                           </button>

--- a/src/components/ChannelsTab.txDisabled.test.tsx
+++ b/src/components/ChannelsTab.txDisabled.test.tsx
@@ -185,3 +185,33 @@ describe('ChannelsTab txDisabled gating (#4294 Phase 2)', () => {
     expect(emojiBtn).not.toBeDisabled();
   });
 });
+
+// #4547 Phase 2 WP5: App.tsx computes one MeshCore-or-Meshtastic tooltip
+// string and threads it in as `txDisabledTooltip`. The default-key assertions
+// above already prove the omitted-prop (Meshtastic today) case is
+// byte-identical; this covers the other direction — the prop, when supplied,
+// wins over the default key on every gated control.
+describe('ChannelsTab txDisabledTooltip prop (#4547 Phase 2 WP5)', () => {
+  const MESHCORE_TOOLTIP = 'meshcore.receive_only.control_tooltip';
+
+  it('uses the supplied tooltip on the message textarea instead of the default key', () => {
+    render(<ChannelsTab {...makeProps({ txDisabled: true, txDisabledTooltip: MESHCORE_TOOLTIP })} />);
+    const textarea = document.querySelector('textarea.message-input');
+    expect(textarea?.getAttribute('title')).toBe(MESHCORE_TOOLTIP);
+  });
+
+  it('uses the supplied tooltip on the bell/position buttons and the emoji-picker button', () => {
+    render(<ChannelsTab {...makeProps({ txDisabled: true, txDisabledTooltip: MESHCORE_TOOLTIP })} />);
+    document.querySelectorAll('button.send-btn.channel-action-btn').forEach(btn => {
+      expect(btn.getAttribute('title')).toBe(MESHCORE_TOOLTIP);
+    });
+    const emojiBtn = document.querySelector('button.emoji-picker-button');
+    expect(emojiBtn?.getAttribute('title')).toBe(MESHCORE_TOOLTIP);
+  });
+
+  it('falls back to tx_disabled.control_tooltip when the prop is omitted (Meshtastic default, unchanged)', () => {
+    render(<ChannelsTab {...makeProps({ txDisabled: true })} />);
+    const textarea = document.querySelector('textarea.message-input');
+    expect(textarea?.getAttribute('title')).toBe('tx_disabled.control_tooltip');
+  });
+});

--- a/src/components/MeshCore/CliConsoleBody.tsx
+++ b/src/components/MeshCore/CliConsoleBody.tsx
@@ -39,6 +39,13 @@ export interface ActionCommand {
   defaultLabel: string;
   command: string;
   danger?: boolean;
+  /** When true, this specific quick action renders disabled even though the
+   *  console body itself (and the rest of the catalog) is enabled — e.g. the
+   *  `advert` action while a MeshCore source is in receive-only mode (#4547
+   *  Phase 2). Prefer disabled-with-tooltip over filtering the button out of
+   *  the catalog entirely, per the Phase 2 spec: a vanished button teaches
+   *  the user nothing. */
+  disabled?: boolean;
 }
 
 /** Server-enforced regex for danger commands. Mirrored from
@@ -295,7 +302,7 @@ export const CliConsoleBody = forwardRef<CliConsoleBodyHandle, CliConsoleBodyPro
               type="button"
               className={action.danger ? 'mrc-btn-danger' : 'mrc-btn-quick'}
               onClick={() => handleActionClick(action)}
-              disabled={disabled || sending}
+              disabled={disabled || sending || action.disabled}
               title={action.command}
             >
               {t(action.labelKey, action.defaultLabel)}

--- a/src/components/MeshCore/CliConsoleBody.tsx
+++ b/src/components/MeshCore/CliConsoleBody.tsx
@@ -303,7 +303,9 @@ export const CliConsoleBody = forwardRef<CliConsoleBodyHandle, CliConsoleBodyPro
               className={action.danger ? 'mrc-btn-danger' : 'mrc-btn-quick'}
               onClick={() => handleActionClick(action)}
               disabled={disabled || sending || action.disabled}
-              title={action.command}
+              title={action.disabled
+                ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.')
+                : action.command}
             >
               {t(action.labelKey, action.defaultLabel)}
             </button>

--- a/src/components/MeshCore/MeshCoreAutoAckSection.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAckSection.receiveOnly.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCoreAutoAckSection — receive-only mode (#4547 Phase 2 WP4).
+ *
+ * No immediate-TX control lives in this section (Auto-Ack only fires from
+ * the scheduler on an incoming message, never from a button here), so the
+ * only receive-only behavior is the paused note. Interview decision 5:
+ * configuration inputs stay fully editable while receive-only.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) =>
+      typeof fallback === 'string' ? fallback : key,
+  }),
+}));
+
+const { hasPermissionMock } = vi.hoisted(() => ({ hasPermissionMock: vi.fn() }));
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: hasPermissionMock }),
+}));
+
+const { showToastMock } = vi.hoisted(() => ({ showToastMock: vi.fn() }));
+vi.mock('../ToastContainer', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
+const { csrfFetchMock } = vi.hoisted(() => ({ csrfFetchMock: vi.fn() }));
+vi.mock('../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => csrfFetchMock,
+}));
+
+const { saveBarCapture } = vi.hoisted(() => ({ saveBarCapture: { current: null as unknown } }));
+vi.mock('../../hooks/useSaveBar', () => ({
+  useSaveBar: (options: unknown) => {
+    saveBarCapture.current = options;
+  },
+}));
+
+import { MeshCoreAutoAckSection } from './MeshCoreAutoAckSection';
+
+describe('MeshCoreAutoAckSection receive-only', () => {
+  beforeEach(() => {
+    hasPermissionMock.mockReset().mockReturnValue(true);
+    showToastMock.mockReset();
+    csrfFetchMock.mockReset().mockImplementation((url: string) => {
+      if (url.includes('/automation/autoack')) {
+        return Promise.resolve({ ok: true, json: async () => ({ success: true, data: { enabled: true } }) });
+      }
+      if (url.includes('/channels/all')) {
+        return Promise.resolve({ ok: true, json: async () => ([{ id: 0, name: 'Primary' }]) });
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) });
+    });
+  });
+
+  it('renders the paused note when receiveOnly is true, and nothing when false', async () => {
+    const { rerender } = render(
+      <MeshCoreAutoAckSection baseUrl="" sourceId="src1" receiveOnly={false} />,
+    );
+    await waitFor(() => expect(csrfFetchMock).toHaveBeenCalled());
+    expect(screen.queryByRole('status')).toBeNull();
+
+    rerender(<MeshCoreAutoAckSection baseUrl="" sourceId="src1" receiveOnly />);
+    const note = await screen.findByRole('status');
+    expect(note).toHaveTextContent(/receive-only mode/i);
+  });
+
+  it('leaves the regex trigger-pattern input editable when receive-only and the section is enabled', async () => {
+    render(<MeshCoreAutoAckSection baseUrl="" sourceId="src1" receiveOnly />);
+    await waitFor(() => {
+      const input = document.getElementById('meshcoreAutoAckRegex') as HTMLInputElement | null;
+      expect(input).not.toBeNull();
+      expect(input).not.toBeDisabled();
+    });
+  });
+
+  it('leaves the master enable checkbox editable regardless of receiveOnly', async () => {
+    const { container } = render(<MeshCoreAutoAckSection baseUrl="" sourceId="src1" receiveOnly />);
+    await waitFor(() => expect(csrfFetchMock).toHaveBeenCalled());
+    const master = container.querySelector('.automation-section-header input[type="checkbox"]');
+    expect(master).not.toBeNull();
+    expect(master).not.toBeDisabled();
+  });
+});

--- a/src/components/MeshCore/MeshCoreAutoAckSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAckSection.tsx
@@ -5,6 +5,7 @@ import { useToast } from '../ToastContainer';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSaveBar } from '../../hooks/useSaveBar';
 import { ScopeSelectField, type ScopeMode } from './ScopeSelectField';
+import { MeshCoreReceiveOnlyNote } from './MeshCoreReceiveOnlyNote';
 
 interface MeshCoreAutoAckSectionProps {
   baseUrl: string;
@@ -87,8 +88,6 @@ const generateSample = (template: string): string => {
 };
 
 export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ baseUrl, sourceId, receiveOnly = false }) => {
-  // Not yet consumed here — WP4 renders the paused note.
-  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { showToast } = useToast();
@@ -278,6 +277,8 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
           {t('meshcore.automation.autoack.title', 'Auto-Acknowledge')}
         </h2>
       </div>
+
+      <MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />
 
       <div className="settings-section" style={{ opacity: settings.enabled ? 1 : 0.5, transition: 'opacity 0.2s' }}>
         <p style={{ marginBottom: '1rem', color: '#666', lineHeight: 1.5, marginLeft: '1.75rem' }}>

--- a/src/components/MeshCore/MeshCoreAutoAckSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAckSection.tsx
@@ -9,6 +9,10 @@ import { ScopeSelectField, type ScopeMode } from './ScopeSelectField';
 interface MeshCoreAutoAckSectionProps {
   baseUrl: string;
   sourceId: string;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Plumbed here in WP1; WP4 renders the paused note. This
+   *  section has no immediate-TX control, so no input gates on it. */
+  receiveOnly?: boolean;
 }
 
 interface AutoAckSettings {
@@ -82,7 +86,9 @@ const generateSample = (template: string): string => {
     .replace(/\{VERSION\}/g, '4.8.0');
 };
 
-export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ baseUrl, sourceId }) => {
+export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ baseUrl, sourceId, receiveOnly = false }) => {
+  // Not yet consumed here — WP4 renders the paused note.
+  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { showToast } = useToast();

--- a/src/components/MeshCore/MeshCoreAutoAnnounceSection.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAnnounceSection.receiveOnly.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCoreAutoAnnounceSection — receive-only mode (#4547 Phase 2 WP4).
+ *
+ * "Send Now" is one of the two immediate-TX controls WP4 gates (the other is
+ * Timer Triggers' "Run now"). Everything else in this section is a saved
+ * setting the scheduler reads later, so per interview decision 5 it stays
+ * fully editable — only "Send Now" disables, and only it needs the direct
+ * `csrfFetch` 409 fallback (this handler doesn't go through `useMeshCore`).
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) =>
+      typeof fallback === 'string' ? fallback : key,
+  }),
+}));
+
+const { hasPermissionMock } = vi.hoisted(() => ({ hasPermissionMock: vi.fn() }));
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: hasPermissionMock }),
+}));
+
+const { showToastMock } = vi.hoisted(() => ({ showToastMock: vi.fn() }));
+vi.mock('../ToastContainer', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
+const { csrfFetchMock } = vi.hoisted(() => ({ csrfFetchMock: vi.fn() }));
+vi.mock('../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => csrfFetchMock,
+}));
+
+const { saveBarCapture } = vi.hoisted(() => ({ saveBarCapture: { current: null as unknown } }));
+vi.mock('../../hooks/useSaveBar', () => ({
+  useSaveBar: (options: unknown) => {
+    saveBarCapture.current = options;
+  },
+}));
+
+import { MeshCoreAutoAnnounceSection } from './MeshCoreAutoAnnounceSection';
+
+const CONTROL_TOOLTIP = 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.';
+const BLOCKED_TOAST = 'Receive-only mode is on for this MeshCore source — nothing was sent.';
+
+function mockFetch() {
+  return vi.fn((url: string) => {
+    if (url.includes('/automation/announce/preview')) {
+      return Promise.resolve({ ok: true, json: async () => ({ success: true, preview: '' }) });
+    }
+    if (url.includes('/channels/all')) {
+      return Promise.resolve({ ok: true, json: async () => ([{ id: 0, name: 'Primary' }]) });
+    }
+    if (url.includes('/automation/announce/send')) {
+      return Promise.resolve({ ok: true, json: async () => ({ success: true, data: {} }) });
+    }
+    if (url.includes('/automation/announce')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ success: true, data: { enabled: true, channelIndexes: [0] } }),
+      });
+    }
+    return Promise.resolve({ ok: false, json: async () => ({}) });
+  });
+}
+
+async function waitForSendNowEnabled() {
+  await waitFor(() => {
+    const btn = screen.getByRole('button', { name: /send now/i });
+    expect(btn).not.toBeDisabled();
+  });
+}
+
+describe('MeshCoreAutoAnnounceSection receive-only', () => {
+  beforeEach(() => {
+    hasPermissionMock.mockReset().mockReturnValue(true);
+    showToastMock.mockReset();
+    csrfFetchMock.mockReset().mockImplementation(mockFetch());
+  });
+
+  it('renders the paused note when receiveOnly is true, and nothing when false', async () => {
+    const { rerender } = render(
+      <MeshCoreAutoAnnounceSection baseUrl="" sourceId="src1" receiveOnly={false} />,
+    );
+    await waitFor(() => expect(csrfFetchMock).toHaveBeenCalled());
+    expect(screen.queryByRole('status')).toBeNull();
+
+    rerender(<MeshCoreAutoAnnounceSection baseUrl="" sourceId="src1" receiveOnly />);
+    const note = await screen.findByRole('status');
+    expect(note).toHaveTextContent(/receive-only mode/i);
+  });
+
+  it('disables Send Now with the receive-only tooltip when receiveOnly is true', async () => {
+    render(<MeshCoreAutoAnnounceSection baseUrl="" sourceId="src1" receiveOnly />);
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /send now/i });
+      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute('title', CONTROL_TOOLTIP);
+    });
+  });
+
+  it('enables Send Now (no tooltip) once its own preconditions are met and receiveOnly is false', async () => {
+    render(<MeshCoreAutoAnnounceSection baseUrl="" sourceId="src1" receiveOnly={false} />);
+    await waitForSendNowEnabled();
+    const btn = screen.getByRole('button', { name: /send now/i });
+    expect(btn).not.toHaveAttribute('title');
+  });
+
+  it('leaves the message template textarea editable when receive-only and the section is enabled', async () => {
+    render(<MeshCoreAutoAnnounceSection baseUrl="" sourceId="src1" receiveOnly />);
+    await waitFor(() => {
+      const textarea = document.getElementById('meshcoreAnnounceMessage') as HTMLTextAreaElement | null;
+      expect(textarea).not.toBeNull();
+      expect(textarea).not.toBeDisabled();
+    });
+  });
+
+  it('leaves the master enable checkbox editable regardless of receiveOnly', async () => {
+    const { container } = render(<MeshCoreAutoAnnounceSection baseUrl="" sourceId="src1" receiveOnly />);
+    await waitFor(() => expect(csrfFetchMock).toHaveBeenCalled());
+    const master = container.querySelector('.automation-section-header input[type="checkbox"]');
+    expect(master).not.toBeNull();
+    expect(master).not.toBeDisabled();
+  });
+
+  it('sendNow: a 409 TX_DISABLED response raises the receive-only toast, not the generic failure toast', async () => {
+    csrfFetchMock.mockReset().mockImplementation((url: string) => {
+      if (url.includes('/automation/announce/send')) {
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          json: async () => ({ success: false, code: 'TX_DISABLED' }),
+        });
+      }
+      return mockFetch()(url);
+    });
+    render(<MeshCoreAutoAnnounceSection baseUrl="" sourceId="src1" receiveOnly={false} />);
+    await waitForSendNowEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /send now/i }));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(BLOCKED_TOAST, 'warning');
+    });
+    expect(showToastMock).not.toHaveBeenCalledWith(
+      expect.stringMatching(/failed to send announcement/i),
+      'error',
+    );
+  });
+});

--- a/src/components/MeshCore/MeshCoreAutoAnnounceSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAnnounceSection.tsx
@@ -7,6 +7,8 @@ import { useAuth } from '../../contexts/AuthContext';
 import { useSaveBar } from '../../hooks/useSaveBar';
 import { ScopeSelectField, type ScopeMode } from './ScopeSelectField';
 import { MESHCORE_AUTOMATION_TOKENS } from './meshcoreAutomationTokens';
+import { MeshCoreReceiveOnlyNote } from './MeshCoreReceiveOnlyNote';
+import { isTxDisabledBody } from '../../utils/txDisabled';
 
 interface MeshCoreAutoAnnounceSectionProps {
   baseUrl: string;
@@ -64,8 +66,6 @@ const arraysEqual = (a: number[], b: number[]): boolean => {
 };
 
 export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionProps> = ({ baseUrl, sourceId, receiveOnly = false }) => {
-  // Not yet consumed here — WP4 renders the paused note + Send Now gating.
-  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { showToast } = useToast();
@@ -285,6 +285,14 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
           showToast(t('automation.insufficient_permissions', 'Insufficient permissions'), 'error');
           return;
         }
+        const errBody = await res.json().catch(() => null);
+        if (isTxDisabledBody(res.status, errBody)) {
+          showToast(
+            t('meshcore.receive_only.blocked_toast', 'Receive-only mode is on for this MeshCore source — nothing was sent.'),
+            'warning',
+          );
+          return;
+        }
         throw new Error(`Server returned ${res.status}`);
       }
       const json = await res.json();
@@ -332,7 +340,8 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
         </h2>
         <button
           onClick={sendNow}
-          disabled={sendNowDisabled}
+          disabled={sendNowDisabled || receiveOnly}
+          title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
           className="meshcore-btn meshcore-btn-primary meshcore-send-now"
         >
           {isSendingNow
@@ -340,6 +349,8 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
             : t('meshcore.automation.announce.send_now', 'Send Now')}
         </button>
       </div>
+
+      <MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />
 
       <div className="settings-section" style={{ opacity: settings.enabled ? 1 : 0.5, transition: 'opacity 0.2s' }}>
         <p style={{ marginBottom: '1rem', color: '#666', lineHeight: 1.5, marginLeft: '1.75rem' }}>

--- a/src/components/MeshCore/MeshCoreAutoAnnounceSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAnnounceSection.tsx
@@ -11,6 +11,10 @@ import { MESHCORE_AUTOMATION_TOKENS } from './meshcoreAutomationTokens';
 interface MeshCoreAutoAnnounceSectionProps {
   baseUrl: string;
   sourceId: string;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Plumbed here in WP1; WP4 renders the paused note and gates
+   *  "Send Now". */
+  receiveOnly?: boolean;
 }
 
 interface AutoAnnounceSettings {
@@ -59,7 +63,9 @@ const arraysEqual = (a: number[], b: number[]): boolean => {
   return aSorted.every((v, i) => v === bSorted[i]);
 };
 
-export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionProps> = ({ baseUrl, sourceId }) => {
+export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionProps> = ({ baseUrl, sourceId, receiveOnly = false }) => {
+  // Not yet consumed here — WP4 renders the paused note + Send Now gating.
+  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { showToast } = useToast();

--- a/src/components/MeshCore/MeshCoreAutoResponderSection.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreAutoResponderSection.receiveOnly.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCoreAutoResponderSection — receive-only mode (#4547 Phase 2 WP4).
+ *
+ * No immediate-TX control lives in this section (Auto-Responder only fires
+ * from the scheduler on an incoming message match, never from a button
+ * here), so the only receive-only behavior is the paused note. Interview
+ * decision 5: configuration inputs stay fully editable while receive-only.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) =>
+      typeof fallback === 'string' ? fallback : key,
+  }),
+}));
+
+const { hasPermissionMock } = vi.hoisted(() => ({ hasPermissionMock: vi.fn() }));
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: hasPermissionMock }),
+}));
+
+const { showToastMock } = vi.hoisted(() => ({ showToastMock: vi.fn() }));
+vi.mock('../ToastContainer', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
+const { csrfFetchMock } = vi.hoisted(() => ({ csrfFetchMock: vi.fn() }));
+vi.mock('../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => csrfFetchMock,
+}));
+
+const { saveBarCapture } = vi.hoisted(() => ({ saveBarCapture: { current: null as unknown } }));
+vi.mock('../../hooks/useSaveBar', () => ({
+  useSaveBar: (options: unknown) => {
+    saveBarCapture.current = options;
+  },
+}));
+
+import { MeshCoreAutoResponderSection } from './MeshCoreAutoResponderSection';
+
+const ONE_TRIGGER = [{
+  id: 't1',
+  name: 'Ping',
+  enabled: true,
+  pattern: '^ping',
+  responseType: 'text',
+  response: 'pong',
+  channels: [],
+  listenDMs: true,
+  replyAsDM: false,
+  cooldownSeconds: 0,
+  preSendDelaySeconds: 0,
+  scopeMode: 'inherit',
+  scopeName: '',
+}];
+
+describe('MeshCoreAutoResponderSection receive-only', () => {
+  beforeEach(() => {
+    hasPermissionMock.mockReset().mockReturnValue(true);
+    showToastMock.mockReset();
+    csrfFetchMock.mockReset().mockImplementation((url: string) => {
+      if (url.includes('/automation/responder')) {
+        return Promise.resolve({ ok: true, json: async () => ({ success: true, data: { enabled: true, triggers: ONE_TRIGGER } }) });
+      }
+      if (url.includes('/channels/all')) {
+        return Promise.resolve({ ok: true, json: async () => ([{ id: 0, name: 'Primary' }]) });
+      }
+      if (url.includes('/api/scripts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ scripts: [] }) });
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) });
+    });
+  });
+
+  it('renders the paused note when receiveOnly is true, and nothing when false', async () => {
+    const { rerender } = render(
+      <MeshCoreAutoResponderSection baseUrl="" sourceId="src1" receiveOnly={false} />,
+    );
+    await waitFor(() => expect(csrfFetchMock).toHaveBeenCalled());
+    expect(screen.queryByRole('status')).toBeNull();
+
+    rerender(<MeshCoreAutoResponderSection baseUrl="" sourceId="src1" receiveOnly />);
+    const note = await screen.findByRole('status');
+    expect(note).toHaveTextContent(/receive-only mode/i);
+  });
+
+  it('leaves an existing trigger\'s pattern input editable when receive-only', async () => {
+    render(<MeshCoreAutoResponderSection baseUrl="" sourceId="src1" receiveOnly />);
+    await waitFor(() => {
+      const input = screen.queryByDisplayValue('^ping') as HTMLInputElement | null;
+      expect(input).not.toBeNull();
+      expect(input).not.toBeDisabled();
+    });
+  });
+
+  it('leaves the master enable checkbox editable regardless of receiveOnly', async () => {
+    const { container } = render(<MeshCoreAutoResponderSection baseUrl="" sourceId="src1" receiveOnly />);
+    await waitFor(() => expect(csrfFetchMock).toHaveBeenCalled());
+    const master = container.querySelector('.automation-section-header input[type="checkbox"]');
+    expect(master).not.toBeNull();
+    expect(master).not.toBeDisabled();
+  });
+});

--- a/src/components/MeshCore/MeshCoreAutoResponderSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoResponderSection.tsx
@@ -9,6 +9,10 @@ import { ScopeSelectField, type ScopeMode } from './ScopeSelectField';
 interface MeshCoreAutoResponderSectionProps {
   baseUrl: string;
   sourceId: string;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Plumbed here in WP1; WP4 renders the paused note. This
+   *  section has no immediate-TX control, so no input gates on it. */
+  receiveOnly?: boolean;
 }
 
 /**
@@ -85,7 +89,9 @@ const newTrigger = (): MeshCoreAutoResponderTrigger => ({
   scopeName: '',
 });
 
-export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSectionProps> = ({ baseUrl, sourceId }) => {
+export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSectionProps> = ({ baseUrl, sourceId, receiveOnly = false }) => {
+  // Not yet consumed here — WP4 renders the paused note.
+  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { showToast } = useToast();

--- a/src/components/MeshCore/MeshCoreAutoResponderSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoResponderSection.tsx
@@ -5,6 +5,7 @@ import { useToast } from '../ToastContainer';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSaveBar } from '../../hooks/useSaveBar';
 import { ScopeSelectField, type ScopeMode } from './ScopeSelectField';
+import { MeshCoreReceiveOnlyNote } from './MeshCoreReceiveOnlyNote';
 
 interface MeshCoreAutoResponderSectionProps {
   baseUrl: string;
@@ -90,8 +91,6 @@ const newTrigger = (): MeshCoreAutoResponderTrigger => ({
 });
 
 export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSectionProps> = ({ baseUrl, sourceId, receiveOnly = false }) => {
-  // Not yet consumed here — WP4 renders the paused note.
-  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { showToast } = useToast();
@@ -285,6 +284,8 @@ export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSection
           {t('meshcore.automation.responder.count', '{{count}} triggers', { count: triggers.length })}
         </span>
       </div>
+
+      <MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />
 
       <div className="settings-section" style={{ opacity: enabled ? 1 : 0.5, transition: 'opacity 0.2s' }}>
         <p style={{ marginBottom: '1rem', color: '#666', lineHeight: 1.5, marginLeft: '1.75rem' }}>

--- a/src/components/MeshCore/MeshCoreAutomationsView.tsx
+++ b/src/components/MeshCore/MeshCoreAutomationsView.tsx
@@ -16,6 +16,11 @@ import { UiIcon } from '../icons';
 interface MeshCoreAutomationsViewProps {
   baseUrl: string;
   sourceId: string;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Threaded to all five automation sections; each renders a
+   *  paused note while keeping its configuration inputs editable (interview
+   *  decision 5) — only "Send Now" / "Run now" get disabled, wired in WP4. */
+  receiveOnly?: boolean;
 }
 
 interface PathfindingSettings {
@@ -38,7 +43,7 @@ const DEFAULTS: PathfindingSettings = {
   lastRunAt: null,
 };
 
-export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = ({ baseUrl, sourceId }) => {
+export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = ({ baseUrl, sourceId, receiveOnly = false }) => {
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { hasPermission } = useAuth();
@@ -320,20 +325,20 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
         ) : null}
 
         {/* Target Filter (#4024) */}
-        <MeshCorePathfindingFilterSection baseUrl={baseUrl} sourceId={sourceId} canWrite={canWrite} />
+        <MeshCorePathfindingFilterSection baseUrl={baseUrl} sourceId={sourceId} canWrite={canWrite} receiveOnly={receiveOnly} />
       </div>
 
       {/* Auto-Acknowledge Section */}
-      <MeshCoreAutoAckSection baseUrl={baseUrl} sourceId={sourceId} />
+      <MeshCoreAutoAckSection baseUrl={baseUrl} sourceId={sourceId} receiveOnly={receiveOnly} />
 
       {/* Auto-Announce Section */}
-      <MeshCoreAutoAnnounceSection baseUrl={baseUrl} sourceId={sourceId} />
+      <MeshCoreAutoAnnounceSection baseUrl={baseUrl} sourceId={sourceId} receiveOnly={receiveOnly} />
 
       {/* Auto-Responder Section */}
-      <MeshCoreAutoResponderSection baseUrl={baseUrl} sourceId={sourceId} />
+      <MeshCoreAutoResponderSection baseUrl={baseUrl} sourceId={sourceId} receiveOnly={receiveOnly} />
 
       {/* Timer Triggers Section */}
-      <MeshCoreTimerTriggersSection baseUrl={baseUrl} sourceId={sourceId} />
+      <MeshCoreTimerTriggersSection baseUrl={baseUrl} sourceId={sourceId} receiveOnly={receiveOnly} />
     </div>
   );
 };

--- a/src/components/MeshCore/MeshCoreChannelsView.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.test.tsx
@@ -1015,3 +1015,104 @@ describe('MeshCoreChannelsView — read-only viewers skip send-side lookups', ()
     expect(getDefaultScope).toHaveBeenCalled();
   });
 });
+
+describe('MeshCoreChannelsView — receive-only mode (#4547 Phase 2 WP3)', () => {
+  function routedFetch() {
+    return vi.fn((url: string) => {
+      if (url.includes('/api/channels/all')) {
+        return Promise.resolve(jsonResponse([{ id: 0, name: 'Public' }]));
+      }
+      if (url.includes('/messages/channel-counts')) {
+        return Promise.resolve(jsonResponse({ success: true, counts: { 0: 0 } }));
+      }
+      if (/\/messages\/channel\/\d+/.test(url)) {
+        return Promise.resolve(jsonResponse({ success: true, data: [], count: 0 }));
+      }
+      return Promise.resolve(jsonResponse({ success: true, data: [] }));
+    });
+  }
+
+  beforeEach(() => {
+    permissionFn = () => true;
+    csrfFetchMock.mockImplementation(routedFetch());
+  });
+
+  it('disables the send box with a tooltip', async () => {
+    render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+        receiveOnly
+      />,
+    );
+    await waitFor(() => screen.getByText('# Public'));
+    const input = screen.getByPlaceholderText('Type a message…');
+    expect(input).toBeDisabled();
+    expect(input).toHaveAttribute(
+      'title',
+      'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.',
+    );
+  });
+
+  it(
+    'discoverRegions mount effect: silently skips while receiveOnly (no call) — ' +
+    'then fires once the scope-override control is reopened after receiveOnly is turned off (latch not poisoned)',
+    async () => {
+      const discoverRegions = vi.fn().mockResolvedValue({ regions: ['alpha'] });
+      const actions = makeActions({ discoverRegions });
+      const { rerender } = render(
+        <MeshCoreChannelsView
+          messages={[]}
+          contacts={contacts}
+          status={makeStatus()}
+          actions={actions}
+          baseUrl=""
+          sourceId="src-a"
+          receiveOnly
+        />,
+      );
+      await waitFor(() => screen.getByText('# Public'));
+
+      // Open the scope-override control (user-initiated).
+      fireEvent.click(screen.getByText('Scope: unscoped'));
+      await new Promise(resolve => setTimeout(resolve, 20));
+      expect(discoverRegions).not.toHaveBeenCalled();
+
+      // Flip receive-only off without closing the control — the effect's own
+      // dep array (receiveOnly included) must re-fire it.
+      rerender(
+        <MeshCoreChannelsView
+          messages={[]}
+          contacts={contacts}
+          status={makeStatus()}
+          actions={actions}
+          baseUrl=""
+          sourceId="src-a"
+          receiveOnly={false}
+        />,
+      );
+      await waitFor(() => expect(discoverRegions).toHaveBeenCalled());
+    },
+  );
+
+  it('leaves the send box enabled and untitled when receiveOnly is false', async () => {
+    render(
+      <MeshCoreChannelsView
+        messages={[]}
+        contacts={contacts}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+      />,
+    );
+    await waitFor(() => screen.getByText('# Public'));
+    const input = screen.getByPlaceholderText('Type a message…');
+    expect(input).not.toBeDisabled();
+    expect(input).not.toHaveAttribute('title');
+  });
+});

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -104,9 +104,6 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   onNodeNameClick,
   receiveOnly = false,
 }) => {
-  // Not yet consumed here — WP3 wires the send-box gate + discover-regions
-  // mount-effect silent skip.
-  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { hasPermission } = useAuth();
@@ -383,6 +380,11 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   // to status?.connected — reconnect flapping would flood the mesh (#3704 review).
   useEffect(() => {
     if (!showScopeOverride || !status?.connected) return;
+    // Receive-only mode: silently skip — no request, no toast, no error state.
+    // Must sit BEFORE the do-not-repeat latch below so turning receive-only
+    // back off re-enables discovery the next time the panel is opened (#4547
+    // Phase 2 §3.4a).
+    if (receiveOnly) return;
     if (regionsDiscoveredRef.current) return;
     regionsDiscoveredRef.current = true;
     let cancelled = false;
@@ -396,7 +398,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
       }
     })();
     return () => { cancelled = true; };
-  }, [showScopeOverride, status?.connected, discoverRegions]);
+  }, [showScopeOverride, status?.connected, discoverRegions, receiveOnly]);
 
   // Reset the one-off override when switching channels so it never leaks across
   // channels, and collapse the control back to its unobtrusive default.
@@ -751,7 +753,8 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
           messages={filtered}
           contacts={contacts}
           selfPublicKey={selfKey}
-          disabled={!connected || !canSend}
+          disabled={!connected || !canSend || receiveOnly}
+          disabledReason={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
           emptyText={t('meshcore.no_messages', 'No messages on this channel yet')}
           onDeleteMessage={canSend ? handleDeleteMessage : undefined}
           onSend={async text => {

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -37,6 +37,11 @@ interface MeshCoreChannelsViewProps {
   baseUrl: string;
   sourceId: string;
   onNodeNameClick?: (publicKey: string) => void;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Plumbed here in WP1; WP3 wires the actual gating (send box
+   *  disabled + tooltip, and the region-discovery mount effect's silent
+   *  skip). */
+  receiveOnly?: boolean;
 }
 
 interface ChannelRow {
@@ -97,7 +102,11 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   baseUrl,
   sourceId,
   onNodeNameClick,
+  receiveOnly = false,
 }) => {
+  // Not yet consumed here — WP3 wires the send-box gate + discover-regions
+  // mount-effect silent skip.
+  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { hasPermission } = useAuth();

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -381,9 +381,9 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
   useEffect(() => {
     if (!showScopeOverride || !status?.connected) return;
     // Receive-only mode: silently skip — no request, no toast, no error state.
-    // Must sit BEFORE the do-not-repeat latch below so turning receive-only
-    // back off re-enables discovery the next time the panel is opened (#4547
-    // Phase 2 §3.4a).
+    // Must sit BEFORE the do-not-repeat latch below so that turning
+    // receive-only off re-enables discovery the next time the panel is
+    // opened (#4547 Phase 2 §3.4a).
     if (receiveOnly) return;
     if (regionsDiscoveredRef.current) return;
     regionsDiscoveredRef.current = true;

--- a/src/components/MeshCore/MeshCoreConfigurationView.tsx
+++ b/src/components/MeshCore/MeshCoreConfigurationView.tsx
@@ -21,6 +21,11 @@ interface MeshCoreConfigurationViewProps {
   baseUrl?: string;
   /** Source UUID — required for the channels sub-section's API calls. */
   sourceId?: string;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Threaded to MeshCoreLocalConsole; the rest of this view
+   *  (name/location/radio params/TX power/telemetry modes/channel CRUD) is
+   *  serial/DB-only and deliberately not gated (§3.7 of the Phase 2 spec). */
+  receiveOnly?: boolean;
 }
 
 export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps> = ({
@@ -28,6 +33,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
   actions,
   baseUrl,
   sourceId,
+  receiveOnly = false,
 }) => {
   const { t } = useTranslation();
   const { hasPermission } = useAuth();
@@ -529,6 +535,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
           deviceType={local?.advType}
           connected={connected}
           actions={{ sendLocalCliCommand: actions.sendLocalCliCommand }}
+          receiveOnly={receiveOnly}
         />
       )}
 

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.receiveOnly.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCoreContactDetailPanel — receive-only gating (#4547 Phase 2 WP3).
+ *
+ * Six of the panel's action buttons transmit (Reset path, Share, Trace,
+ * Ping, Discover path, Neighbours — the last a GET that still transmits).
+ * Export and Remove are serial/local-DB operations and must stay enabled.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MeshCoreContactDetailPanel } from './MeshCoreContactDetailPanel';
+import type { MeshCoreContact } from '../../utils/meshcoreHelpers';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) => {
+      if (typeof fallback === 'string') return fallback;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('../../contexts/SettingsContext', () => ({
+  useSettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
+}));
+
+vi.mock('../../contexts/SourceContext', () => ({
+  useSource: () => ({ sourceId: 'test-source', sourceName: 'Test' }),
+}));
+
+vi.mock('./MeshCoreRemoteConsole', () => ({
+  MeshCoreRemoteConsole: () => null,
+}));
+
+const PK = 'a'.repeat(64);
+const TOOLTIP = 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.';
+
+function renderPanel(receiveOnly: boolean) {
+  const contact: MeshCoreContact = {
+    publicKey: PK,
+    advName: 'Repeater One',
+    advType: 2,
+    pathLen: 2,
+    outPath: 'a3,7f',
+  };
+  return render(
+    <MeshCoreContactDetailPanel
+      contact={contact}
+      publicKey={PK}
+      onResetPath={vi.fn().mockResolvedValue(true)}
+      onShareContact={vi.fn().mockResolvedValue({ ok: true })}
+      onTracePath={vi.fn().mockResolvedValue({ hops: [], lastSnr: 0 })}
+      onPingZeroHop={vi.fn().mockResolvedValue({ ok: true, rttMs: 1, snrToTarget: 1, snrFromTarget: 1 })}
+      onDiscoverPath={vi.fn().mockResolvedValue(true)}
+      onGetNeighbours={vi.fn().mockResolvedValue({ total: 0, neighbours: [] })}
+      onRemoveContact={vi.fn().mockResolvedValue(true)}
+      onExportContact={vi.fn().mockResolvedValue([1, 2, 3])}
+      canWriteNodes
+      isCompanion
+      receiveOnly={receiveOnly}
+    />,
+  );
+}
+
+describe('MeshCoreContactDetailPanel receive-only mode', () => {
+  it('disables the six RF action buttons with a tooltip', () => {
+    renderPanel(true);
+    for (const name of [
+      'Reset Path', 'Share Contact', 'Trace Path', 'Ping (0 hop)', 'Discover Path', 'Neighbours',
+    ]) {
+      const btn = screen.getByRole('button', { name });
+      expect(btn, `${name} should be disabled`).toBeDisabled();
+      expect(btn, `${name} should carry the receive-only tooltip`).toHaveAttribute('title', TOOLTIP);
+    }
+  });
+
+  it('leaves Export and Remove enabled (serial/local-DB operations)', () => {
+    renderPanel(true);
+    const exportBtn = screen.getByRole('button', { name: 'Export' });
+    const removeBtn = screen.getByRole('button', { name: 'Remove' });
+    expect(exportBtn).not.toBeDisabled();
+    expect(removeBtn).not.toBeDisabled();
+  });
+
+  it('leaves all six RF buttons enabled and untitled when receiveOnly is false', () => {
+    renderPanel(false);
+    for (const name of [
+      'Reset Path', 'Share Contact', 'Trace Path', 'Discover Path', 'Neighbours',
+    ]) {
+      const btn = screen.getByRole('button', { name });
+      expect(btn).not.toBeDisabled();
+      expect(btn).not.toHaveAttribute('title', TOOLTIP);
+    }
+    // The Ping button carries its own explanatory hint when not receive-only
+    // — assert only that it's enabled and the tooltip is not the RO one.
+    const pingBtn = screen.getByRole('button', { name: 'Ping (0 hop)' });
+    expect(pingBtn).not.toBeDisabled();
+    expect(pingBtn).not.toHaveAttribute('title', TOOLTIP);
+  });
+});

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -89,6 +89,11 @@ interface MeshCoreContactDetailPanelProps {
    *  `remote_admin` resource. When false the console is hidden even if
    *  `remoteAdminActions` is supplied. */
   canRemoteAdmin?: boolean;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Threaded to MeshCoreRemoteConsole; WP3 wires the actual
+   *  gating of the six RF buttons on this panel (Reset/Share/Trace/Ping/
+   *  Discover path/Neighbours). */
+  receiveOnly?: boolean;
 }
 
 const COLLAPSED_KEY = 'meshcoreContactDetailsCollapsed';
@@ -110,6 +115,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
   isCompanion = true,
   remoteAdminActions,
   canRemoteAdmin = false,
+  receiveOnly = false,
 }) => {
   const { t } = useTranslation();
   const { timeFormat, dateFormat } = useSettings();
@@ -1174,6 +1180,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
           publicKey={publicKey}
           contactName={name}
           actions={remoteAdminActions}
+          receiveOnly={receiveOnly}
         />
       )}
     </div>

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -639,7 +639,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     type="button"
                     className="btn-secondary"
                     onClick={handleResetPath}
-                    disabled={resetting}
+                    disabled={resetting || receiveOnly}
+                    title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
                     aria-label={t('meshcore.contact_details.reset_path_button', 'Reset Path')}
                   >
                     {resetting
@@ -652,7 +653,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     type="button"
                     className="btn-secondary"
                     onClick={handleShareContact}
-                    disabled={sharing}
+                    disabled={sharing || receiveOnly}
+                    title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
                     aria-label={t('meshcore.contact_details.share_contact_button', 'Share Contact')}
                   >
                     {sharing
@@ -675,7 +677,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     type="button"
                     className="btn-secondary"
                     onClick={handleTracePath}
-                    disabled={tracing}
+                    disabled={tracing || receiveOnly}
+                    title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
                     aria-label={t('meshcore.contact_details.trace_path_button', 'Trace Path')}
                   >
                     {tracing
@@ -688,8 +691,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     type="button"
                     className="btn-secondary"
                     onClick={handlePingZeroHop}
-                    disabled={pinging}
-                    title={t(
+                    disabled={pinging || receiveOnly}
+                    title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : t(
                       'meshcore.contact_details.ping_zero_hop_hint',
                       'Send a zero-hop trace. A reply means this node is in direct radio range (repeaters and room servers only — companions do not repeat traces).',
                     )}
@@ -707,7 +710,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     type="button"
                     className="btn-secondary"
                     onClick={handleDiscoverPath}
-                    disabled={discovering}
+                    disabled={discovering || receiveOnly}
+                    title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
                     aria-label={t('meshcore.contact_details.discover_path_button', 'Discover Path')}
                   >
                     {discovering
@@ -733,7 +737,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     type="button"
                     className="btn-secondary"
                     onClick={handleGetNeighbours}
-                    disabled={neighboursLoading}
+                    disabled={neighboursLoading || receiveOnly}
+                    title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
                     aria-label={t('meshcore.contact_details.neighbours_button', 'Neighbours')}
                   >
                     {neighboursLoading

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -32,6 +32,13 @@ vi.mock('../../hooks/useCsrfFetch', () => ({
   useCsrfFetch: () => csrfFetchMock,
 }));
 
+// MeshCoreNodeTelemetryConfig (mounted inside the DM detail pane) uses
+// useToast() to surface the receive-only 409 toast (#4547 Phase 2 WP3).
+const showToastMock = vi.fn();
+vi.mock('../ToastContainer', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
 // TelemetryGraphs is exercised by its own tests; here we only need to
 // confirm the DM view mounts it with the right props when conditions are
 // met. Stub the heavy graphs component with a sentinel so we don't need
@@ -646,5 +653,64 @@ describe('MeshCoreDirectMessagesView — DM unread marking (#3891)', () => {
       expect(raw).toBeTruthy();
       expect(JSON.parse(raw as string)[REAL_PK]).toBeGreaterThan(0);
     });
+  });
+});
+
+describe('MeshCoreDirectMessagesView — receive-only mode (#4547 Phase 2 WP3)', () => {
+  it('disables the DM send box with a tooltip', () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[realContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+        receiveOnly
+      />,
+    );
+    fireEvent.click(screen.getByText('Remote Bob'));
+    const input = screen.getByPlaceholderText('Type a message…');
+    expect(input).toBeDisabled();
+    expect(input).toHaveAttribute(
+      'title',
+      'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.',
+    );
+  });
+
+  it('threads receiveOnly to MeshCoreContactDetailPanel and MeshCoreNodeTelemetryConfig', async () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[realContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+        baseUrl=""
+        sourceId="src-a"
+        receiveOnly
+      />,
+    );
+    fireEvent.click(screen.getByText('Remote Bob'));
+
+    // ContactDetailPanel: Share Contact is one of the six gated RF buttons.
+    const shareBtn = await screen.findByRole('button', { name: 'Share Contact' });
+    expect(shareBtn).toBeDisabled();
+
+    // NodeTelemetryConfig: Poll Status is gated too.
+    const pollBtn = await screen.findByText('Poll Status');
+    expect(pollBtn.closest('button')).toBeDisabled();
+  });
+
+  it('leaves the DM send box enabled and untitled when receiveOnly is false', () => {
+    render(
+      <MeshCoreDirectMessagesView
+        messages={messages}
+        contacts={[realContact]}
+        status={makeStatus()}
+        actions={makeActions()}
+      />,
+    );
+    fireEvent.click(screen.getByText('Remote Bob'));
+    const input = screen.getByPlaceholderText('Type a message…');
+    expect(input).not.toBeDisabled();
+    expect(input).not.toHaveAttribute('title');
   });
 });

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -519,7 +519,8 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                   messages={filtered}
                   contacts={contacts}
                   selfPublicKey={selfKey}
-                  disabled={!connected || !canSend}
+                  disabled={!connected || !canSend || receiveOnly}
+                  disabledReason={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
                   emptyText={t('meshcore.no_messages', 'No messages with this contact yet')}
                   onSend={text => actions.sendMessage(text, selected)}
                   onDeleteMessage={canSend ? handleDeleteMessage : undefined}

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -45,6 +45,10 @@ interface MeshCoreDirectMessagesViewProps {
   sourceId?: string;
   /** When set, auto-selects this contact on mount or when the value changes. */
   initialSelectedContact?: string | null;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Threaded to MeshCoreContactDetailPanel and
+   *  MeshCoreNodeTelemetryConfig; WP3 wires the DM send-box gate itself. */
+  receiveOnly?: boolean;
 }
 
 /** True when the publicKey is a real 64-char hex (i.e. not a synthetic / prefix key). */
@@ -74,6 +78,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
   baseUrl,
   sourceId,
   initialSelectedContact,
+  receiveOnly = false,
 }) => {
   const { t } = useTranslation();
   const { hasPermission } = useAuth();
@@ -548,6 +553,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                   forgetRemoteCredential: actions.forgetRemoteCredential,
                   getRemoteStatus: actions.getRemoteStatus,
                 }}
+                receiveOnly={receiveOnly}
               />
               {!!sourceId && typeof baseUrl === 'string' && isRealNodeKey(selected) && (
                 <>
@@ -555,6 +561,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                     baseUrl={baseUrl}
                     sourceId={sourceId}
                     publicKey={selected}
+                    receiveOnly={receiveOnly}
                   />
                   <TelemetryGraphs
                     nodeId={selected}

--- a/src/components/MeshCore/MeshCoreLocalConsole.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreLocalConsole.receiveOnly.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCoreLocalConsole — receive-only mode (#4547 Phase 2 WP3).
+ *
+ * The local console stays usable while receive-only: local serial CLI is
+ * explicitly allowed (interview decision 2). Only the synthetic `advert`
+ * quick action transmits, so it alone is disabled (with a tooltip) via
+ * `ActionCommand.disabled`, not by disabling the console body wholesale.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MeshCoreLocalConsole } from './MeshCoreLocalConsole';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) =>
+      typeof fallback === 'string' ? fallback : key,
+  }),
+}));
+
+function makeActions() {
+  return { sendLocalCliCommand: vi.fn().mockResolvedValue({ ok: true, reply: 'ok' }) };
+}
+
+describe('MeshCoreLocalConsole receive-only mode — Companion device', () => {
+  let actions: ReturnType<typeof makeActions>;
+
+  beforeEach(() => {
+    actions = makeActions();
+  });
+
+  it('keeps the input, Send button, and non-advert quick actions enabled', () => {
+    render(
+      <MeshCoreLocalConsole
+        sourceId="src-1"
+        deviceType={1}
+        connected
+        actions={actions}
+        receiveOnly
+      />,
+    );
+    const input = screen.getByPlaceholderText(/Type a command/);
+    expect(input).not.toBeDisabled();
+
+    for (const label of ['Version', 'Stats', 'Clock', 'Help']) {
+      const btn = screen.getByText(label).closest('button');
+      expect(btn).not.toBeDisabled();
+    }
+  });
+
+  it('disables only the "Send advert" quick action, with a tooltip', () => {
+    render(
+      <MeshCoreLocalConsole
+        sourceId="src-1"
+        deviceType={1}
+        connected
+        actions={actions}
+        receiveOnly
+      />,
+    );
+    const advertBtn = screen.getByText('Send advert').closest('button');
+    expect(advertBtn).toBeDisabled();
+    expect(advertBtn).toHaveAttribute('title', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.');
+  });
+
+  it('runs a non-transmitting quick action (ver) successfully while receive-only', async () => {
+    render(
+      <MeshCoreLocalConsole
+        sourceId="src-1"
+        deviceType={1}
+        connected
+        actions={actions}
+        receiveOnly
+      />,
+    );
+    fireEvent.click(screen.getByText('Version'));
+    // Quick actions pre-fill the input rather than auto-sending — press Send.
+    const sendBtn = screen.getByText('Send');
+    fireEvent.click(sendBtn);
+    await waitFor(() => expect(actions.sendLocalCliCommand).toHaveBeenCalledWith('ver', undefined));
+  });
+
+  it('appends the receive-only hint to the input placeholder', () => {
+    render(
+      <MeshCoreLocalConsole
+        sourceId="src-1"
+        deviceType={1}
+        connected
+        actions={actions}
+        receiveOnly
+      />,
+    );
+    const input = screen.getByPlaceholderText(
+      /Type a command \(ver, stats, clock, advert, help\).*Local serial commands still work/,
+    );
+    expect(input).toBeInTheDocument();
+  });
+
+  it('leaves the advert action enabled and untitled when receiveOnly is false', () => {
+    render(
+      <MeshCoreLocalConsole
+        sourceId="src-1"
+        deviceType={1}
+        connected
+        actions={actions}
+      />,
+    );
+    const advertBtn = screen.getByText('Send advert').closest('button');
+    expect(advertBtn).not.toBeDisabled();
+    expect(advertBtn).toHaveAttribute('title', 'advert');
+  });
+});
+
+describe('MeshCoreLocalConsole receive-only mode — Repeater device (ACL form)', () => {
+  it('leaves the ACL setperm form enabled — local serial is allowed even while receive-only', () => {
+    const actions = makeActions();
+    const { container } = render(
+      <MeshCoreLocalConsole
+        sourceId="src-1"
+        deviceType={2}
+        connected
+        actions={actions}
+        receiveOnly
+      />,
+    );
+    // MeshCoreAclManager renders a "setperm" submit control; assert it's not
+    // disabled by checking the pubkey input (the form's own required field).
+    const pubkeyInput = container.querySelector('.acl-pubkey-input');
+    expect(pubkeyInput).not.toBeDisabled();
+
+    // The "Send advert" quick action, part of the Repeater catalog, is still
+    // the one gated control.
+    const advertBtn = screen.getByText('Send advert').closest('button');
+    expect(advertBtn).toBeDisabled();
+  });
+});

--- a/src/components/MeshCore/MeshCoreLocalConsole.tsx
+++ b/src/components/MeshCore/MeshCoreLocalConsole.tsx
@@ -77,8 +77,6 @@ export const MeshCoreLocalConsole: React.FC<MeshCoreLocalConsoleProps> = ({
   actions,
   receiveOnly = false,
 }) => {
-  // Not yet consumed here — WP3 wires the `advert` quick-action gating.
-  void receiveOnly;
   const { t } = useTranslation();
 
   const targetName = deviceName || t('meshcore.localConsole.default_target', 'this device');
@@ -86,11 +84,20 @@ export const MeshCoreLocalConsole: React.FC<MeshCoreLocalConsoleProps> = ({
   // Repeater (2) and RoomServer (3) share the same catalog. Companion (1)
   // gets the synthetic catalog. Unknown (0) shows no quick actions —
   // the user can still type free-form commands.
+  //
+  // The console itself stays enabled while receive-only (local serial CLI is
+  // explicitly allowed — interview decision 2); only the synthetic `advert`
+  // verb transmits, so it alone is disabled (with a tooltip) via
+  // ActionCommand.disabled rather than being filtered out of the catalog —
+  // a vanished button teaches the user nothing (#4547 Phase 2 §3.5).
   const actionCatalog = useMemo<ActionCommand[]>(() => {
-    if (deviceType === 2 || deviceType === 3) return REPEATER_ACTION_CATALOG;
-    if (deviceType === 1) return COMPANION_ACTION_CATALOG;
-    return [];
-  }, [deviceType]);
+    const base =
+      deviceType === 2 || deviceType === 3 ? REPEATER_ACTION_CATALOG :
+      deviceType === 1 ? COMPANION_ACTION_CATALOG :
+      [];
+    if (!receiveOnly) return base;
+    return base.map(action => action.key === 'advert' ? { ...action, disabled: true } : action);
+  }, [deviceType, receiveOnly]);
 
   const runCommand = useCallback(
     (text: string, opts?: { confirm?: boolean }) => actions.sendLocalCliCommand(text, opts),
@@ -98,9 +105,21 @@ export const MeshCoreLocalConsole: React.FC<MeshCoreLocalConsoleProps> = ({
   );
 
   // ACL management is meaningful on Repeater (2) and Room Server (3)
-  // local firmware. Companion has no ACL concept.
+  // local firmware. Companion has no ACL concept. `setperm` over the local
+  // serial link is allowed even while receive-only (only over-the-air
+  // transmissions are blocked), so this is NOT gated by receiveOnly.
   const showAcl = connected && (deviceType === 2 || deviceType === 3);
   const bodyRef = useRef<CliConsoleBodyHandle | null>(null);
+
+  const basePlaceholder = deviceType === 1
+    ? t('meshcore.localConsole.companion_placeholder', 'Type a command (ver, stats, clock, advert, help)')
+    : t('meshcore.localConsole.repeater_placeholder', 'Type a CLI command (ver, stats, neighbors, advert…)');
+  const enabledPlaceholder = receiveOnly
+    ? `${basePlaceholder} ${t(
+        'meshcore.receive_only.console_placeholder',
+        'Local serial commands still work; commands that transmit are blocked.',
+      )}`
+    : basePlaceholder;
 
   return (
     <section className="meshcore-remote-console" aria-label={t('meshcore.localConsole.title', 'Device console')}>
@@ -127,17 +146,7 @@ export const MeshCoreLocalConsole: React.FC<MeshCoreLocalConsoleProps> = ({
         actionCatalog={connected ? actionCatalog : []}
         disabled={!connected}
         disabledPlaceholder={t('meshcore.localConsole.disconnected_placeholder', 'Connect the source to send commands')}
-        placeholder={
-          deviceType === 1
-            ? t(
-                'meshcore.localConsole.companion_placeholder',
-                'Type a command (ver, stats, clock, advert, help)',
-              )
-            : t(
-                'meshcore.localConsole.repeater_placeholder',
-                'Type a CLI command (ver, stats, neighbors, advert…)',
-              )
-        }
+        placeholder={enabledPlaceholder}
         emptyTextDisabled={t(
           'meshcore.localConsole.empty_disconnected',
           'Connect the source to begin sending commands.',

--- a/src/components/MeshCore/MeshCoreLocalConsole.tsx
+++ b/src/components/MeshCore/MeshCoreLocalConsole.tsx
@@ -62,6 +62,11 @@ interface MeshCoreLocalConsoleProps {
    *  when false — sending to a disconnected source would just timeout. */
   connected: boolean;
   actions: Pick<MeshCoreActions, 'sendLocalCliCommand'>;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Plumbed here in WP1; WP3 wires the actual gating — the
+   *  console itself stays enabled (local serial CLI is allowed), only the
+   *  synthetic `advert` quick action is disabled. */
+  receiveOnly?: boolean;
 }
 
 export const MeshCoreLocalConsole: React.FC<MeshCoreLocalConsoleProps> = ({
@@ -70,7 +75,10 @@ export const MeshCoreLocalConsole: React.FC<MeshCoreLocalConsoleProps> = ({
   deviceType,
   connected,
   actions,
+  receiveOnly = false,
 }) => {
+  // Not yet consumed here — WP3 wires the `advert` quick-action gating.
+  void receiveOnly;
   const { t } = useTranslation();
 
   const targetName = deviceName || t('meshcore.localConsole.default_target', 'this device');

--- a/src/components/MeshCore/MeshCoreMessageStream.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.receiveOnly.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCoreMessageStream.disabledReason (#4547 Phase 2 WP1) — the composer's
+ * `disabled` control must be able to say *why*, mirroring
+ * `TracerouteBody.runDisabledReason`. The `disabledReason` prop puts a
+ * `title` on the input, the Send button, and their shared `.meshcore-send-bar`
+ * parent (a `title` on a disabled <button> does not reliably fire hover).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) => {
+      if (typeof fallback === 'string') return fallback;
+      return key;
+    },
+  }),
+  Trans: ({ children }: { children?: unknown }) => children,
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+import { MeshCoreMessageStream } from './MeshCoreMessageStream';
+
+const REASON = 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.';
+
+describe('MeshCoreMessageStream disabledReason', () => {
+  it('puts the title on the input, the Send button, and the send-bar parent when disabled', () => {
+    const { container } = render(
+      <MeshCoreMessageStream messages={[]} disabled disabledReason={REASON} onSend={async () => true} />,
+    );
+    const bar = container.querySelector('.meshcore-send-bar');
+    const input = container.querySelector('input');
+    const button = container.querySelector('.meshcore-send-bar button');
+
+    expect(bar).toHaveAttribute('title', REASON);
+    expect(input).toHaveAttribute('title', REASON);
+    expect(button).toHaveAttribute('title', REASON);
+    expect(input).toBeDisabled();
+    expect(button).toBeDisabled();
+  });
+
+  it('leaves title undefined when disabledReason is omitted (no behavior change)', () => {
+    const { container } = render(
+      <MeshCoreMessageStream messages={[]} disabled onSend={async () => true} />,
+    );
+    const bar = container.querySelector('.meshcore-send-bar');
+    const input = container.querySelector('input');
+    const button = container.querySelector('.meshcore-send-bar button');
+
+    expect(bar).not.toHaveAttribute('title');
+    expect(input).not.toHaveAttribute('title');
+    expect(button).not.toHaveAttribute('title');
+  });
+
+  it('does not set title when not disabled, even if disabledReason is provided', () => {
+    const { container } = render(
+      <MeshCoreMessageStream messages={[]} disabledReason={REASON} onSend={async () => true} />,
+    );
+    const bar = container.querySelector('.meshcore-send-bar');
+    const input = container.querySelector('input');
+
+    expect(bar).not.toHaveAttribute('title');
+    expect(input).not.toHaveAttribute('title');
+    expect(input).not.toBeDisabled();
+  });
+});

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -14,6 +14,12 @@ interface MeshCoreMessageStreamProps {
   selfPublicKey?: string;
   emptyText?: string;
   disabled?: boolean;
+  /** Why the composer is disabled (e.g. MeshCore receive-only mode). Applied
+   *  as the `title` on the input, the Send button and their shared parent
+   *  (#4547 Phase 2 WP1) — a `title` on a disabled `<button>` does not fire
+   *  hover in every browser, so the enclosing element carries it too. Only
+   *  meaningful while `disabled` is true; ignored otherwise. */
+  disabledReason?: string;
   onSend: (text: string) => Promise<boolean>;
   onNodeNameClick?: (publicKey: string) => void;
   /** When provided, received channel messages show a Reply button (#3851). The
@@ -85,6 +91,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
   selfPublicKey,
   emptyText,
   disabled,
+  disabledReason,
   onSend,
   onNodeNameClick,
   onReply,
@@ -604,7 +611,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
           );
         })}
       </div>
-      <div className="meshcore-send-bar">
+      <div className="meshcore-send-bar" title={disabled ? disabledReason : undefined}>
         <input
           ref={inputRef}
           type="text"
@@ -613,10 +620,12 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
           onKeyDown={handleKeyDown}
           placeholder={t('meshcore.type_message', 'Type a message…')}
           disabled={disabled || sending}
+          title={disabled ? disabledReason : undefined}
         />
         <button
           onClick={() => void handleSend()}
           disabled={disabled || sending || !draft.trim() || overLimit}
+          title={disabled ? disabledReason : undefined}
         >
           {sending ? t('meshcore.sending', 'Sending…') : t('meshcore.send', 'Send')}
         </button>

--- a/src/components/MeshCore/MeshCoreNodeTelemetryConfig.test.tsx
+++ b/src/components/MeshCore/MeshCoreNodeTelemetryConfig.test.tsx
@@ -8,9 +8,10 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MeshCoreNodeTelemetryConfig } from './MeshCoreNodeTelemetryConfig';
 
-const { csrfFetchMock, hasPermissionMock } = vi.hoisted(() => ({
+const { csrfFetchMock, hasPermissionMock, showToastMock } = vi.hoisted(() => ({
   csrfFetchMock: vi.fn(),
   hasPermissionMock: vi.fn(),
+  showToastMock: vi.fn(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -28,16 +29,21 @@ vi.mock('../../hooks/useCsrfFetch', () => ({
   useCsrfFetch: () => csrfFetchMock,
 }));
 
+vi.mock('../ToastContainer', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
 const PK = 'a'.repeat(64);
 
 const okResponse = (body: unknown) => ({ ok: true, json: async () => body });
 
-const renderPanel = () =>
-  render(<MeshCoreNodeTelemetryConfig baseUrl="" sourceId="test-source" publicKey={PK} />);
+const renderPanel = (receiveOnly = false) =>
+  render(<MeshCoreNodeTelemetryConfig baseUrl="" sourceId="test-source" publicKey={PK} receiveOnly={receiveOnly} />);
 
 describe('MeshCoreNodeTelemetryConfig — manual poll buttons', () => {
   beforeEach(() => {
     hasPermissionMock.mockReset().mockReturnValue(true);
+    showToastMock.mockReset();
     csrfFetchMock.mockReset().mockImplementation((_url: string, opts?: { method?: string; body?: string }) => {
       if (opts?.method === 'POST') {
         const type = JSON.parse(opts.body ?? '{}').type;
@@ -106,5 +112,74 @@ describe('MeshCoreNodeTelemetryConfig — manual poll buttons', () => {
     renderPanel();
     const btn = await screen.findByText('Poll Status');
     expect(btn.closest('button')).toBeDisabled();
+  });
+});
+
+describe('MeshCoreNodeTelemetryConfig — receive-only mode (#4547 Phase 2 WP3)', () => {
+  beforeEach(() => {
+    hasPermissionMock.mockReset().mockReturnValue(true);
+    showToastMock.mockReset();
+    csrfFetchMock.mockReset().mockImplementation((_url: string, opts?: { method?: string }) => {
+      if (opts?.method === 'POST') {
+        return Promise.resolve(okResponse({ success: true, data: { type: 'status', written: 0 } }));
+      }
+      return Promise.resolve(
+        okResponse({ success: true, data: { enabled: false, intervalMinutes: 60, lastRequestAt: null } }),
+      );
+    });
+  });
+
+  it('disables both poll buttons with a tooltip; the enable checkbox and interval input stay enabled', async () => {
+    renderPanel(true);
+    const pollStatus = (await screen.findByText('Poll Status')).closest('button');
+    const pollLpp = screen.getByText('Poll Environment (LPP)').closest('button');
+    expect(pollStatus).toBeDisabled();
+    expect(pollStatus).toHaveAttribute('title', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.');
+    expect(pollLpp).toBeDisabled();
+    expect(pollLpp).toHaveAttribute('title', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.');
+
+    // Negative control: the settings-only controls are NOT gated (interview
+    // decision 5 — only immediate-TX controls are disabled).
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toBeDisabled();
+    const intervalInput = screen.getByDisplayValue('60');
+    expect(intervalInput).not.toBeDisabled();
+  });
+
+  it('does not disable the poll buttons when receiveOnly is false', async () => {
+    renderPanel(false);
+    const pollStatus = (await screen.findByText('Poll Status')).closest('button');
+    expect(pollStatus).not.toBeDisabled();
+    expect(pollStatus).not.toHaveAttribute('title', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.');
+  });
+
+  it('renders the paused note when receiveOnly', async () => {
+    renderPanel(true);
+    await screen.findByText('Poll Status');
+    expect(screen.getByText(/Paused — receive-only mode/)).toBeInTheDocument();
+  });
+
+  it('poll() detects a 409 TX_DISABLED response and toasts instead of setting the inline error', async () => {
+    csrfFetchMock.mockImplementation((_url: string, opts?: { method?: string }) => {
+      if (opts?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          json: async () => ({ success: false, code: 'TX_DISABLED', error: 'Transmit is disabled' }),
+        });
+      }
+      return Promise.resolve(
+        okResponse({ success: true, data: { enabled: false, intervalMinutes: 60, lastRequestAt: null } }),
+      );
+    });
+    // Render enabled so the button is clickable — a direct 409 from the
+    // server (e.g. a race with another tab flipping the setting) must still
+    // surface the friendly toast rather than a raw error.
+    renderPanel(false);
+    fireEvent.click(await screen.findByText('Poll Status'));
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(
+      'Receive-only mode is on for this MeshCore source — nothing was sent.', 'warning',
+    ));
+    expect(screen.queryByText('Transmit is disabled')).not.toBeInTheDocument();
   });
 });

--- a/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
+++ b/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
@@ -22,6 +22,11 @@ interface MeshCoreNodeTelemetryConfigProps {
   sourceId: string;
   /** 64-char hex pubkey of the remote MeshCore node. */
   publicKey: string;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Plumbed here in WP1; WP3 wires the actual gating (Poll
+   *  status / Poll LPP disabled; the enable checkbox and interval input
+   *  stay editable per interview decision 5). */
+  receiveOnly?: boolean;
 }
 
 interface TelemetryConfigState {
@@ -43,7 +48,10 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
   baseUrl,
   sourceId,
   publicKey,
+  receiveOnly = false,
 }) => {
+  // Not yet consumed here — WP3 wires the poll-button gating.
+  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { hasPermission } = useAuth();

--- a/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
+++ b/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
@@ -14,6 +14,9 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../contexts/AuthContext';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
+import { useToast } from '../ToastContainer';
+import { isTxDisabledBody } from '../../utils/txDisabled';
+import { MeshCoreReceiveOnlyNote } from './MeshCoreReceiveOnlyNote';
 
 interface MeshCoreNodeTelemetryConfigProps {
   /** Frontend basename (e.g. '' or '/meshmonitor'). */
@@ -50,10 +53,9 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
   publicKey,
   receiveOnly = false,
 }) => {
-  // Not yet consumed here — WP3 wires the poll-button gating.
-  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
+  const { showToast } = useToast();
   const { hasPermission } = useAuth();
   const canWriteConfig = hasPermission('configuration', 'write');
   // A manual poll is a user-initiated read that happens to transmit, so it's
@@ -172,6 +174,10 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
               ? t('meshcore.telemetry_config.poll_wrote', `Wrote ${written} telemetry row(s).`)
               : t('meshcore.telemetry_config.poll_empty', 'Request sent — no telemetry returned.'),
         });
+      } else if (isTxDisabledBody(response.status, data)) {
+        // Receive-only 409 — the friendly warning toast covers this; don't
+        // also paint the red inline error (#4547 Phase 2 §3.3).
+        showToast(t('meshcore.receive_only.blocked_toast', 'Receive-only mode is on for this MeshCore source — nothing was sent.'), 'warning');
       } else {
         setPollMsg({
           kind: 'err',
@@ -282,12 +288,14 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
             'Request telemetry immediately, outside the scheduled interval. Subject to the same 60-second mesh-TX spacing. Status applies to repeaters; Environment (LPP) to nodes with sensors.',
           )}
         </p>
+        <MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />
         <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
           <button
             type="button"
             className="btn-secondary"
             onClick={() => void poll('status')}
-            disabled={!canPoll || polling !== null}
+            disabled={!canPoll || polling !== null || receiveOnly}
+            title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
           >
             {polling === 'status'
               ? t('meshcore.telemetry_config.polling', 'Polling…')
@@ -297,7 +305,8 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
             type="button"
             className="btn-secondary"
             onClick={() => void poll('lpp')}
-            disabled={!canPoll || polling !== null}
+            disabled={!canPoll || polling !== null || receiveOnly}
+            title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
           >
             {polling === 'lpp'
               ? t('meshcore.telemetry_config.polling', 'Polling…')

--- a/src/components/MeshCore/MeshCoreNodesView.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.receiveOnly.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCoreNodesView — the Discover menu is the second render path for
+ * discover-nodes (#4547 Phase 2 WP3 §3.5): the same three actions also live
+ * in MeshCoreSettingsView (WP2). Missing this half is exactly the class of
+ * bug that cost the Meshtastic TX-disabled epic (#4294) a follow-up patch.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) => {
+      if (typeof fallback === 'string') return fallback;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('./MeshCoreMap', () => ({
+  MeshCoreMap: () => <div data-testid="mc-map" />,
+}));
+
+const showToast = vi.fn();
+vi.mock('../ToastContainer', () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock('../../contexts/SettingsContext', () => ({
+  useSettings: () => ({ timeFormat: '24', dateFormat: 'MM/DD/YYYY' }),
+}));
+
+vi.mock('../../contexts/SourceContext', () => ({
+  useSource: () => ({ sourceId: 'test-source', sourceName: 'Test Source', sourceType: 'meshcore' }),
+}));
+
+vi.mock('../../hooks/useNodeDisplaySettings', () => ({
+  useNodeDisplaySettings: () => ({ maxNodeAgeHours: null }),
+}));
+
+import { MeshCoreNodesView } from './MeshCoreNodesView';
+
+const TOOLTIP = 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.';
+
+describe('MeshCoreNodesView receive-only mode', () => {
+  beforeEach(() => {
+    showToast.mockReset();
+  });
+
+  it('disables all three discover menu items with a tooltip, and clicking one does not call onDiscoverNodes', () => {
+    const onDiscoverNodes = vi.fn().mockResolvedValue({ returned: 2, newCount: 1 });
+    render(
+      <MeshCoreNodesView
+        nodes={[]}
+        contacts={[]}
+        onDiscoverNodes={onDiscoverNodes}
+        canDiscover
+        receiveOnly
+      />,
+    );
+    fireEvent.click(screen.getByText('Discover'));
+
+    for (const label of ['Discover Nearby Nodes', 'Discover Repeaters', 'Discover Sensors']) {
+      const item = screen.getByRole('menuitem', { name: label });
+      expect(item).toBeDisabled();
+      expect(item).toHaveAttribute('title', TOOLTIP);
+      fireEvent.click(item);
+    }
+    expect(onDiscoverNodes).not.toHaveBeenCalled();
+  });
+
+  it('leaves the discover menu items enabled and untitled when receiveOnly is false', () => {
+    const onDiscoverNodes = vi.fn().mockResolvedValue({ returned: 0, newCount: 0 });
+    render(
+      <MeshCoreNodesView
+        nodes={[]}
+        contacts={[]}
+        onDiscoverNodes={onDiscoverNodes}
+        canDiscover
+      />,
+    );
+    fireEvent.click(screen.getByText('Discover'));
+    const item = screen.getByRole('menuitem', { name: 'Discover Nearby Nodes' });
+    expect(item).not.toBeDisabled();
+    expect(item).not.toHaveAttribute('title');
+
+    fireEvent.click(item);
+    expect(onDiscoverNodes).toHaveBeenCalledWith('nearby');
+  });
+});

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -154,8 +154,6 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
   mapIsLoading,
   receiveOnly = false,
 }) => {
-  // Not yet consumed here — WP3 wires the Discover menu gating.
-  void receiveOnly;
   const { t } = useTranslation();
   const { showToast } = useToast();
   const { timeFormat, dateFormat } = useSettings();
@@ -273,6 +271,7 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
   // surface here too because responders land directly in this list.
   const handleDiscover = useCallback(async (mode: DiscoverMode) => {
     if (!onDiscoverNodes || discovering) return;
+    if (receiveOnly) return;
     setDiscoverMenuOpen(false);
     setDiscovering(mode);
     try {
@@ -291,7 +290,7 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
     } finally {
       setDiscovering(null);
     }
-  }, [onDiscoverNodes, discovering, showToast, t]);
+  }, [onDiscoverNodes, discovering, receiveOnly, showToast, t]);
 
   const merged = useMemo(() => mergeNodesAndContacts(nodes, contacts), [nodes, contacts]);
 
@@ -389,13 +388,31 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
                     onClick={() => setDiscoverMenuOpen(false)}
                   />
                   <div className="mc-discover-menu" role="menu">
-                    <button type="button" role="menuitem" onClick={() => void handleDiscover('nearby')}>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => void handleDiscover('nearby')}
+                      disabled={receiveOnly}
+                      title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
+                    >
                       {t('meshcore.discover.nearby', 'Discover Nearby Nodes')}
                     </button>
-                    <button type="button" role="menuitem" onClick={() => void handleDiscover('repeaters')}>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => void handleDiscover('repeaters')}
+                      disabled={receiveOnly}
+                      title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
+                    >
                       {t('meshcore.discover.repeaters', 'Discover Repeaters')}
                     </button>
-                    <button type="button" role="menuitem" onClick={() => void handleDiscover('sensors')}>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => void handleDiscover('sensors')}
+                      disabled={receiveOnly}
+                      title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
+                    >
                       {t('meshcore.discover.sensors', 'Discover Sensors')}
                     </button>
                   </div>

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -44,6 +44,10 @@ interface MeshCoreNodesViewProps {
    * instead of an apparently-empty map during initial connect.
    */
   mapIsLoading?: boolean;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Plumbed here in WP1; WP3 wires the actual gating (the
+   *  Discover menu's three items disabled + tooltip). */
+  receiveOnly?: boolean;
 }
 
 interface MergedRow {
@@ -148,7 +152,10 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
   onDiscoverNodes,
   canDiscover,
   mapIsLoading,
+  receiveOnly = false,
 }) => {
+  // Not yet consumed here — WP3 wires the Discover menu gating.
+  void receiveOnly;
   const { t } = useTranslation();
   const { showToast } = useToast();
   const { timeFormat, dateFormat } = useSettings();

--- a/src/components/MeshCore/MeshCorePage.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCorePage.receiveOnly.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCorePage — receive-only flag distribution (#4547 Phase 2 WP1, §3.0).
+ *
+ * Phase 1 made GET /api/device/tx-status MeshCore-aware, so `isTxDisabled`
+ * for a MeshCore sourceId already means "receive-only is on" — no separate
+ * hook. This test proves MeshCorePage calls `useTxStatus` exactly once and
+ * threads the resulting boolean, renamed `receiveOnly`, into each of its
+ * eight direct children (per §3.0's decision — a plain prop, not a new
+ * context, not a per-component query).
+ *
+ * Every child component is replaced with a lightweight stub that renders
+ * the `receiveOnly` prop it received, and `MeshCoreSubToolbar` is replaced
+ * with plain buttons so the test can switch views without needing the real
+ * sidebar markup.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => (typeof fallback === 'string' ? fallback : key),
+  }),
+}));
+
+const txStatus = { isTxDisabled: true };
+vi.mock('../../hooks/useTxStatus', () => ({
+  useTxStatus: (...args: unknown[]) => {
+    useTxStatusCalls.push(args);
+    return txStatus;
+  },
+}));
+let useTxStatusCalls: unknown[][] = [];
+
+vi.mock('./hooks/useMeshCore', () => ({
+  useMeshCore: () => ({
+    status: { connected: true, deviceType: 1 },
+    nodes: [],
+    contacts: [],
+    messages: [],
+    loading: false,
+    hasLoadedOnce: true,
+    error: null,
+    actions: { discoverNodes: vi.fn(), setNodeFavorite: vi.fn(), importContact: vi.fn(), clearError: vi.fn(), syncDeviceTime: vi.fn() },
+  }),
+  ConnectionStatus: {},
+}));
+
+vi.mock('./hooks/useMeshCoreUnread', () => ({
+  useMeshCoreUnread: () => ({ channels: false, dms: false }),
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ authStatus: { user: { isAdmin: false } } }),
+}));
+
+vi.mock('../NotificationsTab', () => ({ default: () => null }));
+
+// Real SaveBarProvider/SaveBarGroup/SaveBar — plain context, safe to mount.
+
+vi.mock('./MeshCoreSubToolbar', () => ({
+  MeshCoreSubToolbar: (props: { onSelect: (v: string) => void }) => (
+    <div>
+      {['nodes', 'channels', 'rooms', 'dms', 'configuration', 'automations', 'settings'].map(v => (
+        <button key={v} type="button" onClick={() => props.onSelect(v)}>
+          go-{v}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+function stub(testId: string) {
+  return (props: { receiveOnly?: boolean }) => (
+    <div data-testid={testId}>{String(props.receiveOnly)}</div>
+  );
+}
+
+vi.mock('./MeshCoreStatusBar', () => ({ MeshCoreStatusBar: stub('statusbar-receiveOnly') }));
+vi.mock('./MeshCoreNodesView', () => ({ MeshCoreNodesView: stub('nodesview-receiveOnly') }));
+vi.mock('./MeshCoreChannelsView', () => ({ MeshCoreChannelsView: stub('channelsview-receiveOnly') }));
+vi.mock('./MeshCoreRoomsView', () => ({ MeshCoreRoomsView: stub('roomsview-receiveOnly') }));
+vi.mock('./MeshCoreDirectMessagesView', () => ({ MeshCoreDirectMessagesView: stub('dmsview-receiveOnly') }));
+vi.mock('./MeshCoreInfoView', () => ({ MeshCoreInfoView: () => null }));
+vi.mock('./MeshCoreTelemetryView', () => ({ MeshCoreTelemetryView: () => null }));
+vi.mock('./MeshCorePacketMonitorView', () => ({ MeshCorePacketMonitorView: () => null }));
+vi.mock('./MeshCoreConfigurationView', () => ({ MeshCoreConfigurationView: stub('configview-receiveOnly') }));
+vi.mock('./MeshCoreSettingsView', () => ({ MeshCoreSettingsView: stub('settingsview-receiveOnly') }));
+vi.mock('./MeshCoreAutomationsView', () => ({ MeshCoreAutomationsView: stub('automationsview-receiveOnly') }));
+
+import { MeshCorePage } from './MeshCorePage';
+
+describe('MeshCorePage — receive-only flag distribution (#4547 Phase 2 WP1)', () => {
+  it('calls useTxStatus exactly once with { baseUrl, sourceId }', () => {
+    useTxStatusCalls = [];
+    render(<MeshCorePage baseUrl="/mm" sourceId="src-1" />);
+    expect(useTxStatusCalls).toHaveLength(1);
+    expect(useTxStatusCalls[0][0]).toEqual({ baseUrl: '/mm', sourceId: 'src-1' });
+  });
+
+  it('threads receiveOnly=true (from isTxDisabled) into MeshCoreStatusBar and the default nodes view', () => {
+    render(<MeshCorePage baseUrl="" sourceId="src-1" />);
+    expect(screen.getByTestId('statusbar-receiveOnly')).toHaveTextContent('true');
+    expect(screen.getByTestId('nodesview-receiveOnly')).toHaveTextContent('true');
+  });
+
+  it('threads receiveOnly into every remaining direct child as the view switches', () => {
+    render(<MeshCorePage baseUrl="" sourceId="src-1" />);
+
+    fireEvent.click(screen.getByText('go-channels'));
+    expect(screen.getByTestId('channelsview-receiveOnly')).toHaveTextContent('true');
+
+    fireEvent.click(screen.getByText('go-rooms'));
+    expect(screen.getByTestId('roomsview-receiveOnly')).toHaveTextContent('true');
+
+    fireEvent.click(screen.getByText('go-dms'));
+    expect(screen.getByTestId('dmsview-receiveOnly')).toHaveTextContent('true');
+
+    fireEvent.click(screen.getByText('go-configuration'));
+    expect(screen.getByTestId('configview-receiveOnly')).toHaveTextContent('true');
+
+    fireEvent.click(screen.getByText('go-automations'));
+    expect(screen.getByTestId('automationsview-receiveOnly')).toHaveTextContent('true');
+
+    fireEvent.click(screen.getByText('go-settings'));
+    expect(screen.getByTestId('settingsview-receiveOnly')).toHaveTextContent('true');
+  });
+
+  it('threads receiveOnly=false when isTxDisabled is false (Meshtastic/non-gated source)', () => {
+    txStatus.isTxDisabled = false;
+    try {
+      render(<MeshCorePage baseUrl="" sourceId="src-2" />);
+      expect(screen.getByTestId('statusbar-receiveOnly')).toHaveTextContent('false');
+      expect(screen.getByTestId('nodesview-receiveOnly')).toHaveTextContent('false');
+    } finally {
+      txStatus.isTxDisabled = true;
+    }
+  });
+});

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -14,6 +14,7 @@
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useTxStatus } from '../../hooks/useTxStatus';
 import { useMeshCore, ConnectionStatus } from './hooks/useMeshCore';
 import { useMeshCoreUnread } from './hooks/useMeshCoreUnread';
 import { MeshCoreStatusBar } from './MeshCoreStatusBar';
@@ -63,6 +64,16 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
   const meshCore = useMeshCore({ baseUrl, sourceId, enabled });
   const { status, nodes, contacts, messages, loading, hasLoadedOnce, error, actions } = meshCore;
 
+  // MeshCore strict receive-only mode (#4547 Phase 2 WP1). Phase 1 made
+  // GET /api/device/tx-status MeshCore-aware, so `isTxDisabled` for a
+  // MeshCore sourceId already means "receive-only is on" — no separate hook
+  // needed (see MESHCORE_RECEIVE_ONLY_PHASE2_SPEC.md §3.0). Called exactly
+  // once here and threaded down as a plain boolean prop; every consumer
+  // shares the same TanStack cache entry, so the toggle save's
+  // `invalidateQueries({ queryKey: ['txStatus'] })` updates them all in one
+  // tick with no page reload.
+  const { isTxDisabled: receiveOnly } = useTxStatus({ baseUrl, sourceId });
+
   const [view, setView] = useState<MeshCoreView>('nodes');
   const [toolbarExpanded, setToolbarExpanded] = useState(false);
   const [pendingDmContact, setPendingDmContact] = useState<string | null>(null);
@@ -98,6 +109,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
         onOpenSettings={() => setView('settings')}
         actions={actions}
         hideConnectionText={!!onStatusChange}
+        receiveOnly={receiveOnly}
       />
 
       {error && (
@@ -129,6 +141,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
               onDiscoverNodes={actions.discoverNodes}
               canDiscover={(status?.connected ?? false) && status?.deviceType === DEVICE_TYPE_COMPANION}
               mapIsLoading={!hasLoadedOnce}
+              receiveOnly={receiveOnly}
             />
           )}
           {view === 'channels' && (
@@ -140,6 +153,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
               baseUrl={baseUrl}
               sourceId={sourceId}
               onNodeNameClick={navigateToDm}
+              receiveOnly={receiveOnly}
             />
           )}
           {view === 'rooms' && (
@@ -151,6 +165,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
               baseUrl={baseUrl}
               sourceId={sourceId}
               onNodeNameClick={navigateToDm}
+              receiveOnly={receiveOnly}
             />
           )}
           {view === 'dms' && (
@@ -163,6 +178,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
               baseUrl={baseUrl}
               sourceId={sourceId}
               initialSelectedContact={pendingDmContact}
+              receiveOnly={receiveOnly}
             />
           )}
           {view === 'telemetry' && (
@@ -180,6 +196,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
               actions={actions}
               baseUrl={baseUrl}
               sourceId={sourceId}
+              receiveOnly={receiveOnly}
             />
           )}
           {view === 'automations' && (
@@ -188,6 +205,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
                 <MeshCoreAutomationsView
                   baseUrl={baseUrl}
                   sourceId={sourceId}
+                  receiveOnly={receiveOnly}
                 />
               </SaveBarGroup>
               <SaveBar />
@@ -207,6 +225,7 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
                   actions={actions}
                   baseUrl={baseUrl}
                   sourceId={sourceId}
+                  receiveOnly={receiveOnly}
                 />
               </SaveBarGroup>
               <SaveBar />

--- a/src/components/MeshCore/MeshCorePathfindingFilterSection.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCorePathfindingFilterSection.receiveOnly.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCorePathfindingFilterSection — receive-only mode (#4547 Phase 2 WP4).
+ *
+ * This section has no immediate-TX control (the filter only narrows which
+ * contacts Auto-Pathfinding targets; it never sends anything itself), so the
+ * only receive-only behavior is the paused note (interview decision 5:
+ * configuration inputs stay fully editable while receive-only).
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) =>
+      typeof fallback === 'string' ? fallback : key,
+  }),
+}));
+
+const { csrfFetchMock } = vi.hoisted(() => ({ csrfFetchMock: vi.fn() }));
+vi.mock('../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => csrfFetchMock,
+}));
+
+const { saveBarCapture } = vi.hoisted(() => ({ saveBarCapture: { current: null as unknown } }));
+vi.mock('../../hooks/useSaveBar', () => ({
+  useSaveBar: (options: unknown) => {
+    saveBarCapture.current = options;
+  },
+}));
+
+import { MeshCorePathfindingFilterSection } from './MeshCorePathfindingFilterSection';
+
+describe('MeshCorePathfindingFilterSection receive-only', () => {
+  beforeEach(() => {
+    csrfFetchMock.mockReset().mockImplementation((url: string) => {
+      if (url.includes('/automation/pathfinding/filter')) {
+        return Promise.resolve({ ok: true, json: async () => ({ success: true, data: {} }) });
+      }
+      if (url.includes('/contacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ success: true, data: [] }) });
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) });
+    });
+  });
+
+  it('renders the paused note when receiveOnly is true, and nothing when false', async () => {
+    const { rerender } = render(
+      <MeshCorePathfindingFilterSection baseUrl="" sourceId="src1" canWrite receiveOnly={false} />,
+    );
+    await waitFor(() => expect(csrfFetchMock).toHaveBeenCalled());
+    expect(screen.queryByRole('status')).toBeNull();
+
+    rerender(<MeshCorePathfindingFilterSection baseUrl="" sourceId="src1" canWrite receiveOnly />);
+    const note = await screen.findByRole('status');
+    expect(note).toHaveTextContent(/receive-only mode/i);
+  });
+
+  it('leaves the filter enable checkbox editable — receive-only does not gate configuration', async () => {
+    render(<MeshCorePathfindingFilterSection baseUrl="" sourceId="src1" canWrite receiveOnly />);
+    await waitFor(() => expect(csrfFetchMock).toHaveBeenCalled());
+    const checkbox = document.getElementById('pathfindingFilterEnabled') as HTMLInputElement | null;
+    expect(checkbox).not.toBeNull();
+    expect(checkbox).not.toBeDisabled();
+  });
+
+  it('still gates configuration inputs on !canWrite, independent of receiveOnly', async () => {
+    render(<MeshCorePathfindingFilterSection baseUrl="" sourceId="src1" canWrite={false} receiveOnly />);
+    await waitFor(() => expect(csrfFetchMock).toHaveBeenCalled());
+    const checkbox = document.getElementById('pathfindingFilterEnabled') as HTMLInputElement | null;
+    expect(checkbox).toBeDisabled();
+  });
+});

--- a/src/components/MeshCore/MeshCorePathfindingFilterSection.tsx
+++ b/src/components/MeshCore/MeshCorePathfindingFilterSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { useSaveBar } from '../../hooks/useSaveBar';
 import { meshcoreAgeCutoffMs, isWithinMeshcoreAge } from '../../utils/meshcoreAge';
+import { MeshCoreReceiveOnlyNote } from './MeshCoreReceiveOnlyNote';
 
 interface MeshCorePathfindingFilterSectionProps {
   baseUrl: string;
@@ -137,8 +138,6 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
   canWrite,
   receiveOnly = false,
 }) => {
-  // Not yet consumed here — WP4 renders the paused note.
-  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
 
@@ -396,6 +395,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
           {t('meshcore.automation.pathfinding.filter.master_toggle', 'Filter target contacts')}
         </label>
       </div>
+      <MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />
       <p style={{ margin: '0 0 1rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)', lineHeight: '1.5' }}>
         {t(
           'meshcore.automation.pathfinding.filter.description',

--- a/src/components/MeshCore/MeshCorePathfindingFilterSection.tsx
+++ b/src/components/MeshCore/MeshCorePathfindingFilterSection.tsx
@@ -8,6 +8,10 @@ interface MeshCorePathfindingFilterSectionProps {
   baseUrl: string;
   sourceId: string;
   canWrite: boolean;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Plumbed here in WP1; WP4 renders the paused note. This
+   *  section has no immediate-TX control, so no input gates on it. */
+  receiveOnly?: boolean;
 }
 
 // Mirrors MeshcorePathfindingFilterSettings in src/services/database.ts (#4024).
@@ -131,7 +135,10 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
   baseUrl,
   sourceId,
   canWrite,
+  receiveOnly = false,
 }) => {
+  // Not yet consumed here — WP4 renders the paused note.
+  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
 

--- a/src/components/MeshCore/MeshCoreReceiveOnlyNote.module.css
+++ b/src/components/MeshCore/MeshCoreReceiveOnlyNote.module.css
@@ -1,0 +1,15 @@
+/*
+ * MeshCoreReceiveOnlyNote (#4547 Phase 2 WP1). CSS module — do not add these
+ * rules to the global sheets (CLAUDE.md CSS containment rule). Small, muted
+ * inline note shown at every gated section while a MeshCore source is in
+ * receive-only mode.
+ */
+
+.note {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--ctp-subtext0);
+  font-size: 0.85em;
+  margin: 0.35rem 0;
+}

--- a/src/components/MeshCore/MeshCoreReceiveOnlyNote.test.tsx
+++ b/src/components/MeshCore/MeshCoreReceiveOnlyNote.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => (typeof fallback === 'string' ? fallback : key),
+  }),
+}));
+
+import { MeshCoreReceiveOnlyNote } from './MeshCoreReceiveOnlyNote';
+
+describe('MeshCoreReceiveOnlyNote', () => {
+  it('renders null when receiveOnly is false', () => {
+    const { container } = render(<MeshCoreReceiveOnlyNote receiveOnly={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders null when receiveOnly is omitted', () => {
+    const { container } = render(<MeshCoreReceiveOnlyNote />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the paused-note string and a UiIcon (not an emoji) when receiveOnly is true', () => {
+    render(<MeshCoreReceiveOnlyNote receiveOnly />);
+    const note = screen.getByRole('status');
+    expect(note).toHaveTextContent(
+      'Paused — receive-only mode. These settings are saved and unchanged; they take effect again when receive-only is turned off.',
+    );
+    // Default icon style is lucide (SVG), never a literal emoji glyph.
+    expect(note.querySelector('svg')).not.toBeNull();
+  });
+});

--- a/src/components/MeshCore/MeshCoreReceiveOnlyNote.tsx
+++ b/src/components/MeshCore/MeshCoreReceiveOnlyNote.tsx
@@ -1,0 +1,41 @@
+/**
+ * MeshCoreReceiveOnlyNote — shared "paused" note (#4547 Phase 2 WP1).
+ *
+ * The receive-only-mode explanation shows up at every section whose
+ * configuration inputs stay editable but whose effect is paused while
+ * transmission is blocked (interview decision 5 — see
+ * docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE2_SPEC.md §3.1). Seven
+ * call sites would otherwise each hand-roll the same icon + string + inline
+ * style, so this renders `null` when not receive-only and a single
+ * `role="status"` line otherwise, keeping every call site to one line.
+ */
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { UiIcon } from '../icons';
+import styles from './MeshCoreReceiveOnlyNote.module.css';
+
+interface MeshCoreReceiveOnlyNoteProps {
+  /** When falsy, the component renders nothing. */
+  receiveOnly?: boolean;
+  className?: string;
+}
+
+export const MeshCoreReceiveOnlyNote: React.FC<MeshCoreReceiveOnlyNoteProps> = ({
+  receiveOnly,
+  className,
+}) => {
+  const { t } = useTranslation();
+  if (!receiveOnly) return null;
+
+  return (
+    <p role="status" className={className ? `${styles.note} ${className}` : styles.note}>
+      <UiIcon name="pause" size={14} />
+      {t(
+        'meshcore.receive_only.paused_note',
+        'Paused — receive-only mode. These settings are saved and unchanged; they take effect again when receive-only is turned off.',
+      )}
+    </p>
+  );
+};
+
+export default MeshCoreReceiveOnlyNote;

--- a/src/components/MeshCore/MeshCoreRemoteConsole.test.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.test.tsx
@@ -21,15 +21,28 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-// Stub the heavy children — we're only exercising the console's own UI.
+// Stub the heavy children — we're only exercising the console's own UI. Each
+// stub reflects the props relevant to receive-only gating as data attributes
+// so tests can assert what was threaded through without rendering the real
+// (much heavier) child.
 vi.mock('./MeshCoreRemoteStatsPanel', () => ({
-  MeshCoreRemoteStatsPanel: () => null,
+  MeshCoreRemoteStatsPanel: (props: { receiveOnly?: boolean }) => (
+    <div data-testid="stats-panel" data-receive-only={String(!!props.receiveOnly)} />
+  ),
 }));
 vi.mock('./MeshCoreAclManager', () => ({
-  MeshCoreAclManager: () => null,
+  MeshCoreAclManager: (props: { disabled?: boolean }) => (
+    <div data-testid="acl-manager" data-disabled={String(!!props.disabled)} />
+  ),
 }));
 vi.mock('./CliConsoleBody', () => ({
-  CliConsoleBody: () => null,
+  CliConsoleBody: (props: { disabled?: boolean; disabledPlaceholder?: string }) => (
+    <div
+      data-testid="cli-console-body"
+      data-disabled={String(!!props.disabled)}
+      data-disabled-placeholder={props.disabledPlaceholder ?? ''}
+    />
+  ),
 }));
 
 const PK = 'a'.repeat(64);
@@ -102,5 +115,69 @@ describe('MeshCoreRemoteConsole credential handling', () => {
     await waitFor(() => expect(actions.getRemoteAdminCapability).toHaveBeenCalled());
     expect(screen.queryByText('Saved password')).not.toBeInTheDocument();
     expect(screen.queryByText('Log in with saved password')).not.toBeInTheDocument();
+  });
+});
+
+describe('MeshCoreRemoteConsole receive-only mode (#4547 Phase 2 WP3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables "Log in with saved password" + "Use a different password" with a tooltip when a credential is stored', async () => {
+    const actions = makeActions();
+    render(
+      <MeshCoreRemoteConsole publicKey={PK} contactName="Repeater" actions={actions as any} receiveOnly />,
+    );
+
+    const savedBtn = await screen.findByText('Log in with saved password');
+    const differentBtn = screen.getByText('Use a different password');
+    expect(savedBtn.closest('button')).toBeDisabled();
+    expect(savedBtn.closest('button')).toHaveAttribute('title', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.');
+    expect(differentBtn.closest('button')).toBeDisabled();
+
+    fireEvent.click(savedBtn);
+    expect(actions.loginRemoteWithSaved).not.toHaveBeenCalled();
+  });
+
+  it('disables the plain "Log in to {name}" opener when nothing is stored', async () => {
+    const actions = makeActions({
+      getRemoteAdminCapability: vi.fn().mockResolvedValue({
+        canRemember: true,
+        rotatedCount: 0,
+        rotated: [],
+        stored: [],
+      }),
+    });
+    render(
+      <MeshCoreRemoteConsole publicKey={PK} contactName="Repeater" actions={actions as any} receiveOnly />,
+    );
+
+    const openBtn = await screen.findByText('Log in to {{name}}');
+    expect(openBtn.closest('button')).toBeDisabled();
+    expect(openBtn.closest('button')).toHaveAttribute('title', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.');
+  });
+
+  it('threads disabled (and the placeholder) into CliConsoleBody even before login', async () => {
+    // CliConsoleBody is unconditionally rendered (its own `disabled` prop
+    // covers both !loggedIn and receiveOnly), so this doesn't require
+    // driving the console into a logged-in state first.
+    const actions = makeActions();
+    render(
+      <MeshCoreRemoteConsole publicKey={PK} contactName="Repeater" actions={actions as any} receiveOnly />,
+    );
+    await waitFor(() => expect(actions.getRemoteAdminCapability).toHaveBeenCalled());
+    expect(screen.getByTestId('cli-console-body')).toHaveAttribute('data-disabled', 'true');
+    expect(screen.getByTestId('cli-console-body')).toHaveAttribute(
+      'data-disabled-placeholder', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.',
+    );
+  });
+
+  it('leaves the login buttons enabled and untitled when receiveOnly is false', async () => {
+    const actions = makeActions();
+    render(<MeshCoreRemoteConsole publicKey={PK} contactName="Repeater" actions={actions as any} />);
+
+    const savedBtn = await screen.findByText('Log in with saved password');
+    expect(savedBtn.closest('button')).not.toBeDisabled();
+    expect(savedBtn.closest('button')).not.toHaveAttribute('title');
   });
 });

--- a/src/components/MeshCore/MeshCoreRemoteConsole.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.tsx
@@ -70,12 +70,17 @@ interface MeshCoreRemoteConsoleProps {
     | 'forgetRemoteCredential'
     | 'getRemoteStatus'
   >;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Threaded to MeshCoreRemoteStatsPanel; WP3 wires the actual
+   *  gating of the login buttons, the console body, and the ACL form. */
+  receiveOnly?: boolean;
 }
 
 export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
   publicKey,
   contactName,
   actions,
+  receiveOnly = false,
 }) => {
   const { t } = useTranslation();
   const [capability, setCapability] = useState<CapabilitySnapshot | null>(null);
@@ -268,6 +273,7 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
         <MeshCoreRemoteStatsPanel
           publicKey={publicKey}
           fetchStatus={actions.getRemoteStatus}
+          receiveOnly={receiveOnly}
         />
       )}
 

--- a/src/components/MeshCore/MeshCoreRemoteConsole.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.tsx
@@ -247,7 +247,8 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
               type="button"
               className="mrc-btn-primary"
               onClick={() => void handleLoginWithSaved()}
-              disabled={loginBusy}
+              disabled={loginBusy || receiveOnly}
+              title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
             >
               {loginBusy
                 ? t('meshcore.remoteConsole.logging_in', 'Logging in…')
@@ -257,13 +258,20 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
               type="button"
               className="mrc-btn-secondary"
               onClick={() => setShowLogin(true)}
-              disabled={loginBusy}
+              disabled={loginBusy || receiveOnly}
+              title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
             >
               {t('meshcore.remoteConsole.login_different', 'Use a different password')}
             </button>
           </>
         ) : (
-          <button type="button" className="mrc-btn-primary" onClick={() => setShowLogin(true)}>
+          <button
+            type="button"
+            className="mrc-btn-primary"
+            onClick={() => setShowLogin(true)}
+            disabled={receiveOnly}
+            title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
+          >
             {t('meshcore.remoteConsole.login_button', 'Log in to {{name}}', { name: contactName })}
           </button>
         )}
@@ -283,10 +291,13 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
         targetName={contactName}
         runCommand={runCommand}
         actionCatalog={loggedIn ? REMOTE_ACTION_CATALOG : []}
-        disabled={!loggedIn}
+        disabled={!loggedIn || receiveOnly}
+        disabledPlaceholder={receiveOnly
+          ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.')
+          : undefined}
       />
 
-      {loggedIn && <MeshCoreAclManager bodyRef={bodyRef} />}
+      {loggedIn && <MeshCoreAclManager bodyRef={bodyRef} disabled={receiveOnly} />}
 
       {showLogin && (
         <div
@@ -343,7 +354,8 @@ export const MeshCoreRemoteConsole: React.FC<MeshCoreRemoteConsoleProps> = ({
                 type="button"
                 className="mrc-btn-primary"
                 onClick={() => void handleLogin()}
-                disabled={loginBusy}
+                disabled={loginBusy || receiveOnly}
+                title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
               >
                 {loginBusy
                   ? t('meshcore.remoteConsole.logging_in', 'Logging in…')

--- a/src/components/MeshCore/MeshCoreRemoteStatsPanel.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteStatsPanel.receiveOnly.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCoreRemoteStatsPanel — receive-only gating (#4547 Phase 2 WP3).
+ *
+ * GET /admin/status/:pk transmits (SendStatusReq), so both user-initiated
+ * entry points (the header "Refresh"/"Fetch stats" button and the
+ * empty-state "Fetch stats" button) are disabled while receive-only, and
+ * `load()` itself early-returns before calling `fetchStatus` or setting any
+ * loading state — the defensive guard the spec's §3.4a(c) calls the
+ * "automatic path" contract, verified here for every caller of `load()`.
+ *
+ * Note: as of this worktree, MeshCoreRemoteStatsPanel has no actual
+ * mount/expand-triggered auto-load (the component's own comment states
+ * "No auto-fetch and no polling — status is loaded only when the user
+ * asks"); only the two buttons below invoke `load()`. The guard inside
+ * `load()` is still added per the spec so any future automatic caller is
+ * covered for free, and the mount-time assertion below locks in that
+ * mounting the panel never fetches on its own, in either mode.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MeshCoreRemoteStatsPanel } from './MeshCoreRemoteStatsPanel';
+import type { MeshCoreRemoteStatus } from './hooks/useMeshCore';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) => {
+      if (typeof fallback === 'string') return fallback;
+      return key;
+    },
+  }),
+}));
+
+const PK = 'a'.repeat(64);
+
+type FetchStatusFn = (publicKey: string) => Promise<MeshCoreRemoteStatus | null>;
+
+describe('MeshCoreRemoteStatsPanel receive-only mode', () => {
+  let fetchStatus: ReturnType<typeof vi.fn<FetchStatusFn>>;
+
+  beforeEach(() => {
+    fetchStatus = vi.fn<FetchStatusFn>().mockResolvedValue({ uptimeSecs: 100 } as MeshCoreRemoteStatus);
+  });
+
+  it('does not call fetchStatus on mount, regardless of receiveOnly', () => {
+    render(<MeshCoreRemoteStatsPanel publicKey={PK} fetchStatus={fetchStatus} receiveOnly />);
+    expect(fetchStatus).not.toHaveBeenCalled();
+  });
+
+  it('disables the header refresh/fetch button with a tooltip when receiveOnly', () => {
+    const { container } = render(
+      <MeshCoreRemoteStatsPanel publicKey={PK} fetchStatus={fetchStatus} receiveOnly />,
+    );
+    const btn = container.querySelector('.mrs-refresh-btn');
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('title', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.');
+
+    fireEvent.click(btn!);
+    expect(fetchStatus).not.toHaveBeenCalled();
+  });
+
+  it('disables the empty-state fetch button with a tooltip when receiveOnly', () => {
+    const { container } = render(
+      <MeshCoreRemoteStatsPanel publicKey={PK} fetchStatus={fetchStatus} receiveOnly />,
+    );
+    // Both the header button and the empty-state button render the same
+    // "Fetch stats" label before any status has loaded — assert both by class.
+    const headerBtn = container.querySelector('.mrs-refresh-btn');
+    const emptyBtn = container.querySelector('.mrs-fetch-btn');
+    for (const btn of [headerBtn, emptyBtn]) {
+      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute('title', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.');
+    }
+  });
+
+  it('load() itself skips silently when receiveOnly — no fetch, no loading state', async () => {
+    // Force a click through even though the button is disabled, to prove
+    // the guard lives inside load() too (defense in depth), not just on the
+    // button's disabled attribute.
+    const { rerender } = render(
+      <MeshCoreRemoteStatsPanel publicKey={PK} fetchStatus={fetchStatus} receiveOnly={false} />,
+    );
+    // Re-render as receive-only without ever having fetched.
+    rerender(<MeshCoreRemoteStatsPanel publicKey={PK} fetchStatus={fetchStatus} receiveOnly />);
+    expect(screen.queryByText('Loading status…')).not.toBeInTheDocument();
+    expect(fetchStatus).not.toHaveBeenCalled();
+  });
+
+  it('fetches normally (button enabled, no tooltip) when receiveOnly is false', async () => {
+    const { container } = render(
+      <MeshCoreRemoteStatsPanel publicKey={PK} fetchStatus={fetchStatus} receiveOnly={false} />,
+    );
+    const btn = container.querySelector('.mrs-refresh-btn')!;
+    expect(btn).not.toBeDisabled();
+    expect(btn).not.toHaveAttribute('title');
+
+    fireEvent.click(btn);
+    await waitFor(() => expect(fetchStatus).toHaveBeenCalledWith(PK));
+  });
+});

--- a/src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx
@@ -23,12 +23,19 @@ interface Props {
   publicKey: string;
   /** Pulled from the same useMeshCore actions bundle the console uses. */
   fetchStatus: MeshCoreActions['getRemoteStatus'];
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Plumbed here in WP1; WP3 wires the actual gating (refresh /
+   *  empty-state buttons disabled, and the auto-load silently skipped). */
+  receiveOnly?: boolean;
 }
 
 export const MeshCoreRemoteStatsPanel: React.FC<Props> = ({
   publicKey,
   fetchStatus,
+  receiveOnly = false,
 }) => {
+  // Not yet consumed here — WP3 wires the button gating + auto-load silent skip.
+  void receiveOnly;
   const { t } = useTranslation();
   const [status, setStatus] = useState<MeshCoreRemoteStatus | null>(null);
   const [loading, setLoading] = useState(false);

--- a/src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx
@@ -34,8 +34,6 @@ export const MeshCoreRemoteStatsPanel: React.FC<Props> = ({
   fetchStatus,
   receiveOnly = false,
 }) => {
-  // Not yet consumed here — WP3 wires the button gating + auto-load silent skip.
-  void receiveOnly;
   const { t } = useTranslation();
   const [status, setStatus] = useState<MeshCoreRemoteStatus | null>(null);
   const [loading, setLoading] = useState(false);
@@ -49,6 +47,12 @@ export const MeshCoreRemoteStatsPanel: React.FC<Props> = ({
 
   const load = useCallback(async () => {
     if (inFlightRef.current) return;
+    // Receive-only mode: silently skip — no request, no toast, no loading
+    // state. Guards every caller of `load()` (both the manual Refresh /
+    // Fetch-stats buttons below, which are also separately disabled, and any
+    // future automatic caller), before any fetchStatus() call and before any
+    // loading state is set (#4547 Phase 2 §3.4a(c)).
+    if (receiveOnly) return;
     inFlightRef.current = true;
     setLoading(true);
     setError(null);
@@ -64,7 +68,7 @@ export const MeshCoreRemoteStatsPanel: React.FC<Props> = ({
       inFlightRef.current = false;
       setLoading(false);
     }
-  }, [fetchStatus, publicKey, t]);
+  }, [fetchStatus, publicKey, receiveOnly, t]);
 
   // No auto-fetch and no polling — status is loaded only when the user asks
   // (the "Fetch stats" / "Refresh" buttons below), to avoid spending radio
@@ -93,7 +97,8 @@ export const MeshCoreRemoteStatsPanel: React.FC<Props> = ({
           type="button"
           className="mrs-refresh-btn"
           onClick={(e) => { e.stopPropagation(); void load(); }}
-          disabled={loading}
+          disabled={loading || receiveOnly}
+          title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
         >
           {loading
             ? t('meshcore.remoteStats.refreshing', 'Refreshing…')
@@ -148,7 +153,13 @@ export const MeshCoreRemoteStatsPanel: React.FC<Props> = ({
               <p className="mrs-empty-hint">
                 {t('meshcore.remoteStats.empty_hint', 'Status is not fetched automatically.')}
               </p>
-              <button type="button" className="mrs-fetch-btn" onClick={() => void load()}>
+              <button
+                type="button"
+                className="mrs-fetch-btn"
+                onClick={() => void load()}
+                disabled={receiveOnly}
+                title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
+              >
                 {t('meshcore.remoteStats.fetch', 'Fetch stats')}
               </button>
             </div>

--- a/src/components/MeshCore/MeshCoreRoomsView.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreRoomsView.receiveOnly.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCoreRoomsView — receive-only gating (#4547 Phase 2 WP3), including the
+ * auto-login latch hazard (§3.4a(a)).
+ *
+ * The auto-login effect sets `autoLoginAttempted.current.add(selectedRoom)`
+ * (a do-not-repeat latch) BEFORE awaiting. The receiveOnly guard must sit
+ * before that latch line, or turning receive-only back off would never
+ * re-trigger auto-login for a room already visited once this session. The
+ * "flip receiveOnly off and it fires" half of the test below is the only
+ * thing that catches a guard placed after the latch.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MeshCoreRoomsView } from './MeshCoreRoomsView';
+import type { MeshCoreContact } from '../../utils/meshcoreHelpers';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) => {
+      if (typeof fallback === 'string') return fallback;
+      return key;
+    },
+  }),
+  Trans: ({ children }: { children?: unknown }) => children,
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: () => true }),
+}));
+
+const ROOM_PK = 'b'.repeat(64);
+
+function makeActions(overrides?: Record<string, unknown>) {
+  return {
+    getRoomCredentials: vi.fn().mockResolvedValue({
+      canRemember: true,
+      stored: [{ publicKey: ROOM_PK }],
+    }),
+    loginRoomWithSaved: vi.fn().mockResolvedValue({ success: true }),
+    loginRoom: vi.fn().mockResolvedValue({ success: true }),
+    sendRoomPost: vi.fn().mockResolvedValue(true),
+    getRoomSyncConfig: vi.fn().mockResolvedValue(null),
+    setRoomSyncConfig: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+const roomContact: MeshCoreContact = {
+  publicKey: ROOM_PK,
+  advName: 'Test Room',
+  advType: 3,
+};
+
+describe('MeshCoreRoomsView receive-only mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables the login button and password input, with a tooltip', async () => {
+    const actions = makeActions();
+    render(
+      <MeshCoreRoomsView
+        messages={[]}
+        contacts={[roomContact]}
+        status={{ connected: true } as any}
+        actions={actions as any}
+        baseUrl=""
+        sourceId="src-1"
+        receiveOnly
+      />,
+    );
+    fireEvent.click(screen.getByText('Test Room'));
+
+    const loginBtn = await screen.findByText('Login');
+    expect(loginBtn.closest('button')).toBeDisabled();
+    const passwordInput = screen.getByPlaceholderText(/Password/);
+    expect(passwordInput).toBeDisabled();
+    expect(passwordInput).toHaveAttribute(
+      'title',
+      'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.',
+    );
+  });
+
+  it('auto-login: silently skips while receiveOnly (no call, no error) — then fires once receiveOnly is turned off (latch not poisoned)', async () => {
+    const actions = makeActions();
+    const { rerender } = render(
+      <MeshCoreRoomsView
+        messages={[]}
+        contacts={[roomContact]}
+        status={{ connected: true } as any}
+        actions={actions as any}
+        baseUrl=""
+        sourceId="src-1"
+        receiveOnly
+      />,
+    );
+
+    // Let the credential-capability fetch resolve (mount effect).
+    await waitFor(() => expect(actions.getRoomCredentials).toHaveBeenCalled());
+    fireEvent.click(screen.getByText('Test Room'));
+
+    // Give any (incorrectly unguarded) effect a chance to fire.
+    await new Promise(resolve => setTimeout(resolve, 20));
+    expect(actions.loginRoomWithSaved).not.toHaveBeenCalled();
+    expect(screen.queryByText('Login failed')).not.toBeInTheDocument();
+
+    // Flip receive-only off without touching the selection — the effect's
+    // own dep array (receiveOnly included) must re-fire it.
+    rerender(
+      <MeshCoreRoomsView
+        messages={[]}
+        contacts={[roomContact]}
+        status={{ connected: true } as any}
+        actions={actions as any}
+        baseUrl=""
+        sourceId="src-1"
+        receiveOnly={false}
+      />,
+    );
+
+    await waitFor(() => expect(actions.loginRoomWithSaved).toHaveBeenCalledWith(ROOM_PK));
+  });
+
+  it('disables the send box (with a tooltip) once logged in, when receiveOnly', async () => {
+    const actions = makeActions();
+    const { rerender } = render(
+      <MeshCoreRoomsView
+        messages={[]}
+        contacts={[roomContact]}
+        status={{ connected: true } as any}
+        actions={actions as any}
+        baseUrl=""
+        sourceId="src-1"
+        receiveOnly={false}
+      />,
+    );
+    fireEvent.click(screen.getByText('Test Room'));
+    await waitFor(() => expect(actions.loginRoomWithSaved).toHaveBeenCalled());
+    const input = await screen.findByPlaceholderText('Type a message…');
+    expect(input).not.toBeDisabled();
+
+    // Now that the room is logged in, re-render as receive-only and confirm
+    // the send box gates without needing to log in again.
+    rerender(
+      <MeshCoreRoomsView
+        messages={[]}
+        contacts={[roomContact]}
+        status={{ connected: true } as any}
+        actions={actions as any}
+        baseUrl=""
+        sourceId="src-1"
+        receiveOnly
+      />,
+    );
+    const gatedInput = screen.getByPlaceholderText('Type a message…');
+    expect(gatedInput).toBeDisabled();
+    expect(gatedInput).toHaveAttribute(
+      'title',
+      'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.',
+    );
+  });
+});

--- a/src/components/MeshCore/MeshCoreRoomsView.tsx
+++ b/src/components/MeshCore/MeshCoreRoomsView.tsx
@@ -19,6 +19,7 @@ import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
 import { useAuth } from '../../contexts/AuthContext';
 import { UiIcon } from '../icons';
+import { MeshCoreReceiveOnlyNote } from './MeshCoreReceiveOnlyNote';
 
 const MOBILE_BREAKPOINT = 768;
 const isMobileViewport = (): boolean =>
@@ -62,9 +63,6 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
   onNodeNameClick,
   receiveOnly = false,
 }) => {
-  // Not yet consumed here — WP3 wires the login/send gating + auto-login
-  // effect's silent skip.
-  void receiveOnly;
   const { t } = useTranslation();
   const { hasPermission } = useAuth();
   const canSend = hasPermission('messages', 'write');
@@ -142,6 +140,11 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
     if (!selectedRoom) return;
     if (loggedInRooms.has(selectedRoom)) return;
     if (!storedCreds.has(selectedRoom)) return;
+    // Receive-only mode: silently skip — no request, no toast, no error
+    // state. Must sit BEFORE the do-not-repeat latch below so turning
+    // receive-only back off re-triggers auto-login the next time the room is
+    // selected (#4547 Phase 2 §3.4a).
+    if (receiveOnly) return;
     if (autoLoginAttempted.current.has(selectedRoom)) return;
 
     autoLoginAttempted.current.add(selectedRoom);
@@ -153,7 +156,7 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
       }
       setLoginLoading(false);
     })();
-  }, [selectedRoom, loggedInRooms, storedCreds, actions]);
+  }, [selectedRoom, loggedInRooms, storedCreds, actions, receiveOnly]);
 
   const loadSyncConfig = useCallback(async (pubkey: string) => {
     const config = await actions.getRoomSyncConfig(pubkey);
@@ -299,9 +302,10 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
                 className="meshcore-room-login-input"
                 value={loginPassword}
                 onChange={e => setLoginPassword(e.target.value)}
-                onKeyDown={e => e.key === 'Enter' && !loginLoading && handleLogin()}
+                onKeyDown={e => e.key === 'Enter' && !loginLoading && !receiveOnly && handleLogin()}
                 placeholder={t('meshcore.rooms.password_placeholder', 'Password (empty for guest)')}
-                disabled={loginLoading}
+                disabled={loginLoading || receiveOnly}
+                title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
                 autoFocus
               />
               {canRemember && (
@@ -317,7 +321,8 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
               <button
                 className="meshcore-room-login-btn"
                 onClick={handleLogin}
-                disabled={loginLoading}
+                disabled={loginLoading || receiveOnly}
+                title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
               >
                 {loginLoading
                   ? t('meshcore.rooms.logging_in', 'Logging in…')
@@ -372,6 +377,7 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
                       {t('meshcore.rooms.save_sync', 'Save')}
                     </button>
                   )}
+                  <MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />
                 </span>
               )}
             </div>
@@ -379,7 +385,8 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
               messages={filtered}
               contacts={contacts}
               selfPublicKey={selfKey}
-              disabled={!connected || !canSend}
+              disabled={!connected || !canSend || receiveOnly}
+              disabledReason={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
               emptyText={t('meshcore.rooms.no_messages', 'No posts in this room yet')}
               onSend={handleSend}
               onNodeNameClick={onNodeNameClick}

--- a/src/components/MeshCore/MeshCoreRoomsView.tsx
+++ b/src/components/MeshCore/MeshCoreRoomsView.tsx
@@ -32,6 +32,11 @@ interface MeshCoreRoomsViewProps {
   baseUrl: string;
   sourceId: string;
   onNodeNameClick?: (publicKey: string) => void;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Plumbed here in WP1; WP3 wires the actual gating (login
+   *  button + password input + send box disabled, and the auto-login
+   *  effect's silent skip). */
+  receiveOnly?: boolean;
 }
 
 function buildRoomFilter(roomPubkey: string): (m: MeshCoreMessage) => boolean {
@@ -55,7 +60,11 @@ export const MeshCoreRoomsView: React.FC<MeshCoreRoomsViewProps> = ({
   actions,
   sourceId: _sourceId,
   onNodeNameClick,
+  receiveOnly = false,
 }) => {
+  // Not yet consumed here — WP3 wires the login/send gating + auto-login
+  // effect's silent skip.
+  void receiveOnly;
   const { t } = useTranslation();
   const { hasPermission } = useAuth();
   const canSend = hasPermission('messages', 'write');

--- a/src/components/MeshCore/MeshCoreSettingsView.discoverResults.test.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.discoverResults.test.tsx
@@ -29,6 +29,11 @@ vi.mock('../../contexts/AuthContext', () => ({ useAuth: () => ({ hasPermission: 
 vi.mock('./MeshCoreNodeDisplaySection', () => ({
   MeshCoreNodeDisplaySection: () => null,
 }));
+// The receive-only toggle (#4547 Phase 2 WP2) reads useCsrfFetch/useQueryClient,
+// which throw outside their real providers — this file renders the component
+// bare, so both need a stub. Discovery flow itself never touches either.
+vi.mock('../../hooks/useCsrfFetch', () => ({ useCsrfFetch: () => vi.fn() }));
+vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ invalidateQueries: vi.fn() }) }));
 
 const NEARBY = 'Discover Nearby Nodes';
 

--- a/src/components/MeshCore/MeshCoreSettingsView.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.receiveOnly.test.tsx
@@ -221,4 +221,28 @@ describe('MeshCoreSettingsView — toggle save / invalidate path (#4547 Phase 2 
     ));
     expect(h.invalidateQueries).not.toHaveBeenCalled();
   });
+
+  it('a non-ok save (400, with a json body) toasts the error, does not invalidate, and leaves the checkbox not claiming the new state', async () => {
+    h.csrfFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: vi.fn().mockResolvedValue({ success: false, error: 'Invalid request', code: 'VALIDATION_ERROR' }),
+    });
+    const user = userEvent.setup();
+    renderView(false);
+
+    const checkbox = screen.getByRole('checkbox', { name: /Strict receive-only/i });
+    await user.click(checkbox);
+
+    await waitFor(() => expect(h.showToast).toHaveBeenCalledWith(
+      expect.stringMatching(/Failed to change receive-only mode/),
+      'error',
+    ));
+    expect(h.invalidateQueries).not.toHaveBeenCalled();
+    // receiveOnly is server-truth via the prop, not local state — a failed
+    // save must not leave the checkbox claiming the toggled (unpersisted)
+    // state. Since the prop never changed (still false), the box must still
+    // read unchecked.
+    expect(checkbox).not.toBeChecked();
+  });
 });

--- a/src/components/MeshCore/MeshCoreSettingsView.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.receiveOnly.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * MeshCoreSettingsView — receive-only toggle (#4547 Phase 2 WP2).
+ *
+ * Covers: the toggle renders and reflects the threaded `receiveOnly` prop
+ * (not local state), confirm-on-disable-only, the save/invalidate/toast
+ * path, and the button gating owned by this package (Send advert, Discover
+ * x3, Discover regions — with Refresh contacts and Save scope left enabled
+ * as the negative control, per spec §5.1/§5.2).
+ *
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MeshCoreSettingsView } from './MeshCoreSettingsView';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>, opts?: Record<string, unknown>) => {
+      const base = typeof fallback === 'string' ? fallback : key;
+      const vars = (typeof fallback === 'object' ? fallback : opts) ?? {};
+      return base.replace(/\{\{(\w+)\}\}/g, (_m, k) => String((vars as Record<string, unknown>)[k] ?? ''));
+    },
+  }),
+}));
+
+const h = vi.hoisted(() => ({
+  showToast: vi.fn(),
+  invalidateQueries: vi.fn(),
+  csrfFetch: vi.fn(),
+}));
+
+vi.mock('../ToastContainer', () => ({ useToast: () => ({ showToast: h.showToast }) }));
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: () => ({ hasPermission: () => true }) }));
+vi.mock('../../hooks/useCsrfFetch', () => ({ useCsrfFetch: () => h.csrfFetch }));
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: h.invalidateQueries }),
+}));
+// Not under test; it fetches on mount.
+vi.mock('./MeshCoreNodeDisplaySection', () => ({
+  MeshCoreNodeDisplaySection: () => null,
+}));
+
+function makeActions(overrides: Record<string, unknown> = {}) {
+  return {
+    discoverNodes: vi.fn().mockResolvedValue({ returned: 0, newCount: 0, nodes: [] }),
+    getDiscoverable: vi.fn().mockResolvedValue(false),
+    setDiscoverable: vi.fn().mockResolvedValue(true),
+    getDefaultScope: vi.fn().mockResolvedValue(''),
+    setDefaultScope: vi.fn().mockResolvedValue('region-x'),
+    discoverRegions: vi.fn().mockResolvedValue(null),
+    fetchSavedRegions: vi.fn().mockResolvedValue([]),
+    addSavedRegion: vi.fn().mockResolvedValue(true),
+    deleteSavedRegion: vi.fn().mockResolvedValue(true),
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    purgeAllMessages: vi.fn().mockResolvedValue(true),
+    refreshContacts: vi.fn().mockResolvedValue(undefined),
+    sendAdvert: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  } as never;
+}
+
+function renderView(receiveOnly: boolean, overrides: Record<string, unknown> = {}) {
+  render(
+    <MeshCoreSettingsView
+      status={{ connected: true, deviceType: 1 } as never}
+      loading={false}
+      actions={makeActions(overrides)}
+      baseUrl=""
+      sourceId="src-a"
+      receiveOnly={receiveOnly}
+    />,
+  );
+}
+
+const TOOLTIP = 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.csrfFetch.mockResolvedValue({ ok: true });
+});
+
+describe('MeshCoreSettingsView — receive-only toggle rendering', () => {
+  it('renders unchecked and reflects false when receiveOnly is false', () => {
+    renderView(false);
+    const checkbox = screen.getByRole('checkbox', { name: /Strict receive-only/i });
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('renders checked when receiveOnly is true — reads the threaded prop, not local state', () => {
+    renderView(true);
+    const checkbox = screen.getByRole('checkbox', { name: /Strict receive-only/i });
+    expect(checkbox).toBeChecked();
+  });
+});
+
+describe('MeshCoreSettingsView — receive-only button gating', () => {
+  it('disables Send advert, Discover x3 and Discover regions, all with the control tooltip', () => {
+    renderView(true);
+
+    const gated = [
+      screen.getByRole('button', { name: 'Send advert' }),
+      screen.getByRole('button', { name: 'Discover Nearby Nodes' }),
+      screen.getByRole('button', { name: 'Discover Repeaters' }),
+      screen.getByRole('button', { name: 'Discover Sensors' }),
+      screen.getByRole('button', { name: 'Discover regions from repeaters' }),
+    ];
+    for (const btn of gated) {
+      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute('title', TOOLTIP);
+    }
+  });
+
+  it('leaves Refresh contacts and Save scope enabled — the negative control', () => {
+    renderView(true);
+
+    expect(screen.getByRole('button', { name: 'Refresh contacts' })).not.toBeDisabled();
+    // Save scope is disabled by its own dirty-check (scopeInput === defaultScope
+    // on mount), never by receiveOnly — assert it carries no receive-only tooltip.
+    const saveScope = screen.getByRole('button', { name: 'Save' });
+    expect(saveScope).not.toHaveAttribute('title', TOOLTIP);
+  });
+
+  it('enables every gated button again once receiveOnly flips back to false', () => {
+    renderView(false);
+
+    const gated = [
+      screen.getByRole('button', { name: 'Send advert' }),
+      screen.getByRole('button', { name: 'Discover Nearby Nodes' }),
+      screen.getByRole('button', { name: 'Discover Repeaters' }),
+      screen.getByRole('button', { name: 'Discover Sensors' }),
+      screen.getByRole('button', { name: 'Discover regions from repeaters' }),
+    ];
+    for (const btn of gated) {
+      expect(btn).not.toBeDisabled();
+    }
+  });
+
+  it('renders the paused note under the discoverable toggle only while receive-only', () => {
+    renderView(true);
+    expect(screen.getByRole('status')).toHaveTextContent(/Paused — receive-only mode/);
+  });
+
+  it('does not render the paused note when receiveOnly is false', () => {
+    renderView(false);
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+});
+
+describe('MeshCoreSettingsView — toggle save / invalidate path (#4547 Phase 2 WP2 §5.2)', () => {
+  it('checking the box does not call window.confirm and POSTs { meshcoreReceiveOnly: true }', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm');
+    const user = userEvent.setup();
+    renderView(false);
+
+    await user.click(screen.getByRole('checkbox', { name: /Strict receive-only/i }));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    await waitFor(() => expect(h.csrfFetch).toHaveBeenCalledTimes(1));
+    const [url, opts] = h.csrfFetch.mock.calls[0];
+    expect(url).toBe('/api/settings?sourceId=src-a');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ meshcoreReceiveOnly: true });
+    confirmSpy.mockRestore();
+  });
+
+  it('a successful save invalidates the ["txStatus"] query key and toasts success', async () => {
+    const user = userEvent.setup();
+    renderView(false);
+
+    await user.click(screen.getByRole('checkbox', { name: /Strict receive-only/i }));
+
+    await waitFor(() => expect(h.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['txStatus'] }));
+    expect(h.showToast).toHaveBeenCalledWith(
+      expect.stringMatching(/Receive-only mode enabled/),
+      'success',
+    );
+  });
+
+  it('unchecking calls window.confirm; accepting POSTs { meshcoreReceiveOnly: false }', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const user = userEvent.setup();
+    renderView(true);
+
+    await user.click(screen.getByRole('checkbox', { name: /Strict receive-only/i }));
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(h.csrfFetch).toHaveBeenCalledTimes(1));
+    const [, opts] = h.csrfFetch.mock.calls[0];
+    expect(JSON.parse(opts.body)).toEqual({ meshcoreReceiveOnly: false });
+    confirmSpy.mockRestore();
+  });
+
+  it('unchecking, when confirm is declined, makes no network call and the checkbox stays checked', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const user = userEvent.setup();
+    renderView(true);
+
+    const checkbox = screen.getByRole('checkbox', { name: /Strict receive-only/i });
+    await user.click(checkbox);
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(h.csrfFetch).not.toHaveBeenCalled();
+    // receiveOnly is server-truth via the prop, unchanged (still true) → still checked.
+    expect(checkbox).toBeChecked();
+    confirmSpy.mockRestore();
+  });
+
+  it('a non-ok save shows the save_failed error toast and does not invalidate', async () => {
+    h.csrfFetch.mockResolvedValue({ ok: false, status: 500 });
+    const user = userEvent.setup();
+    renderView(false);
+
+    await user.click(screen.getByRole('checkbox', { name: /Strict receive-only/i }));
+
+    await waitFor(() => expect(h.showToast).toHaveBeenCalledWith(
+      expect.stringMatching(/Failed to change receive-only mode/),
+      'error',
+    ));
+    expect(h.invalidateQueries).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/MeshCore/MeshCoreSettingsView.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.tsx
@@ -17,6 +17,10 @@ interface MeshCoreSettingsViewProps {
   baseUrl: string;
   /** Source UUID — passed through to MeshCoreNodeDisplaySection (#4412 Phase 4 WP2). */
   sourceId: string;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Plumbed here in WP1; WP2 wires the toggle itself plus the
+   *  gating of Send advert / Discover ×3 / Discover regions. */
+  receiveOnly?: boolean;
 }
 
 export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
@@ -25,7 +29,10 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
   actions,
   baseUrl,
   sourceId,
+  receiveOnly = false,
 }) => {
+  // Not yet consumed here — WP2 wires the toggle + button gating.
+  void receiveOnly;
   const { t } = useTranslation();
   const { showToast } = useToast();
   const { hasPermission } = useAuth();

--- a/src/components/MeshCore/MeshCoreSettingsView.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.tsx
@@ -270,7 +270,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
   }, [baseUrl, sourceId, csrfFetch, queryClient, showToast, t]);
 
   const receiveOnlyTooltip = receiveOnly
-    ? (t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') as string)
+    ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.')
     : undefined;
 
   return (

--- a/src/components/MeshCore/MeshCoreSettingsView.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.tsx
@@ -1,10 +1,13 @@
 import React, { useCallback, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
 import { ConnectionStatus, DiscoveredNode, MeshCoreActions, SavedRegion } from './hooks/useMeshCore';
 import { useToast } from '../ToastContainer';
 import { useAuth } from '../../contexts/AuthContext';
+import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { UiIcon } from '../icons';
 import { MeshCoreNodeDisplaySection } from './MeshCoreNodeDisplaySection';
+import { MeshCoreReceiveOnlyNote } from './MeshCoreReceiveOnlyNote';
 
 // MeshCoreDeviceType.COMPANION — active discovery is companion-only.
 const DEVICE_TYPE_COMPANION = 1;
@@ -31,11 +34,12 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
   sourceId,
   receiveOnly = false,
 }) => {
-  // Not yet consumed here — WP2 wires the toggle + button gating.
-  void receiveOnly;
   const { t } = useTranslation();
   const { showToast } = useToast();
   const { hasPermission } = useAuth();
+  const csrfFetch = useCsrfFetch();
+  const queryClient = useQueryClient();
+  const [savingReceiveOnly, setSavingReceiveOnly] = useState(false);
   const canPurgeMessages = hasPermission('messages', 'write');
   const [purgingMessages, setPurgingMessages] = useState(false);
   const connected = status?.connected ?? false;
@@ -222,6 +226,53 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
     await actions.connect();
   };
 
+  // Receive-only toggle (#4547 Phase 2 WP2). Enabling is the safe direction —
+  // no confirm. Disabling resumes RF transmission, so that direction is
+  // gated behind window.confirm (interview decision — see spec §3.2).
+  const handleToggleReceiveOnly = useCallback(async (next: boolean) => {
+    if (!next && !window.confirm(t(
+      'meshcore.receive_only.disable_confirm',
+      'Allow this MeshCore node to transmit again?\n\nMessages, adverts, path discovery, remote administration and every enabled automation will resume sending over the radio. Continue?',
+    ))) {
+      return;
+    }
+    setSavingReceiveOnly(true);
+    try {
+      const res = await csrfFetch(
+        `${baseUrl}/api/settings?sourceId=${encodeURIComponent(sourceId)}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ meshcoreReceiveOnly: next }),
+        },
+      );
+      if (!res.ok) {
+        showToast(t('meshcore.receive_only.save_failed', 'Failed to change receive-only mode'), 'error');
+        return;
+      }
+      // Prefix match — hits this source's txStatus entry (and every other
+      // source's, harmlessly) so every consumer of useTxStatus re-reads
+      // within one tick. Same idiom as ConfigurationTab.tsx after a TX
+      // config change.
+      await queryClient.invalidateQueries({ queryKey: ['txStatus'] });
+      showToast(
+        t(
+          next ? 'meshcore.receive_only.saved_on' : 'meshcore.receive_only.saved_off',
+          next
+            ? 'Receive-only mode enabled — this node will not transmit'
+            : 'Receive-only mode disabled — this node can transmit again',
+        ),
+        'success',
+      );
+    } finally {
+      setSavingReceiveOnly(false);
+    }
+  }, [baseUrl, sourceId, csrfFetch, queryClient, showToast, t]);
+
+  const receiveOnlyTooltip = receiveOnly
+    ? (t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') as string)
+    : undefined;
+
   return (
     <div className="meshcore-form-view">
       <h2 style={{ color: 'var(--ctp-text)', marginBottom: '1rem' }}>
@@ -260,6 +311,31 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
       </div>
 
       <div className="form-section">
+        <h3>{t('meshcore.receive_only.title', 'Receive-only mode')}</h3>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <input
+            type="checkbox"
+            checked={receiveOnly}
+            disabled={savingReceiveOnly}
+            onChange={(e) => void handleToggleReceiveOnly(e.target.checked)}
+          />
+          <span>{t('meshcore.receive_only.toggle_label', 'Strict receive-only (never transmit)')}</span>
+        </label>
+        <p className="hint">
+          {t(
+            'meshcore.receive_only.description',
+            'Block every transmission from this MeshCore node. Messages, adverts, path discovery, remote CLI, logins, telemetry requests and all automations are held. Receiving, the packet log, the Analyzer Observer, contact and telemetry updates, and local serial configuration keep working.',
+          )}
+        </p>
+        <p className="hint">
+          {t(
+            'meshcore.receive_only.firmware_caveat',
+            'MeshCore firmware has no radio-level transmit switch, so MeshMonitor enforces this in software. Transmissions the node makes on its own — link-layer acknowledgements, and any advert schedule configured outside MeshMonitor — are not affected.',
+          )}
+        </p>
+      </div>
+
+      <div className="form-section">
         <h3>{t('meshcore.settings.actions', 'Device actions')}</h3>
         <p className="hint">
           {t('meshcore.settings.actions_hint',
@@ -269,7 +345,11 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
           <button onClick={() => void actions.refreshContacts()} disabled={!connected || loading}>
             {t('meshcore.refresh', 'Refresh contacts')}
           </button>
-          <button onClick={() => void actions.sendAdvert()} disabled={!connected || loading}>
+          <button
+            onClick={() => void actions.sendAdvert()}
+            disabled={!connected || loading || receiveOnly}
+            title={receiveOnlyTooltip}
+          >
             {t('meshcore.send_advert', 'Send advert')}
           </button>
         </div>
@@ -288,7 +368,8 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
           <div style={{ display: 'flex', gap: '0.5rem' }}>
             <button
               onClick={() => void handleDiscover('nearby')}
-              disabled={!connected || loading || discovering !== null || discoveringRegions}
+              disabled={!connected || loading || discovering !== null || discoveringRegions || receiveOnly}
+              title={receiveOnlyTooltip}
             >
               {discovering === 'nearby'
                 ? t('meshcore.discover.running', 'Discovering…')
@@ -296,7 +377,8 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
             </button>
             <button
               onClick={() => void handleDiscover('repeaters')}
-              disabled={!connected || loading || discovering !== null || discoveringRegions}
+              disabled={!connected || loading || discovering !== null || discoveringRegions || receiveOnly}
+              title={receiveOnlyTooltip}
             >
               {discovering === 'repeaters'
                 ? t('meshcore.discover.running', 'Discovering…')
@@ -304,7 +386,8 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
             </button>
             <button
               onClick={() => void handleDiscover('sensors')}
-              disabled={!connected || loading || discovering !== null || discoveringRegions}
+              disabled={!connected || loading || discovering !== null || discoveringRegions || receiveOnly}
+              title={receiveOnlyTooltip}
             >
               {discovering === 'sensors'
                 ? t('meshcore.discover.running', 'Discovering…')
@@ -385,6 +468,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
               'MeshCore companion firmware does not answer discovery on its own, so other nodes can only ' +
               'find this one when this is enabled. Replies are zero-hop (direct range) and rate-limited.')}
           </p>
+          <MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />
         </div>
       )}
 
@@ -420,7 +504,8 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
           <div style={{ marginTop: '0.75rem' }}>
             <button
               onClick={() => void handleDiscoverRegions()}
-              disabled={!connected || loading || discoveringRegions || discovering !== null}
+              disabled={!connected || loading || discoveringRegions || discovering !== null || receiveOnly}
+              title={receiveOnlyTooltip}
             >
               {discoveringRegions
                 ? t('meshcore.scope.discovering', 'Discovering regions…')

--- a/src/components/MeshCore/MeshCoreStatusBar.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreStatusBar.receiveOnly.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCoreStatusBar — receive-only gating (#4547 Phase 2 WP3).
+ *
+ * Send advert is the SECOND render path for the same action gated in
+ * MeshCoreSettingsView (WP2). Disconnect is not RF and must stay enabled.
+ * A persistent status chip renders whenever receiveOnly is true, giving an
+ * always-visible indicator on the MeshCore page regardless of the global
+ * banner.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MeshCoreStatusBar } from './MeshCoreStatusBar';
+import type { ConnectionStatus } from './hooks/useMeshCore';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) => {
+      if (typeof fallback === 'string') return fallback;
+      return key;
+    },
+  }),
+}));
+
+const TOOLTIP = 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.';
+
+function makeActions() {
+  return {
+    sendAdvert: vi.fn().mockResolvedValue(true),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const connectedStatus: ConnectionStatus = {
+  connected: true,
+  localNode: { publicKey: 'a'.repeat(64), name: 'Local Node' },
+} as ConnectionStatus;
+
+describe('MeshCoreStatusBar receive-only mode', () => {
+  it('disables Send advert with a tooltip, leaves Disconnect enabled', () => {
+    const actions = makeActions();
+    render(
+      <MeshCoreStatusBar
+        status={connectedStatus}
+        loading={false}
+        onOpenSettings={vi.fn()}
+        actions={actions as any}
+        receiveOnly
+      />,
+    );
+    const advertBtn = screen.getByText('Send advert').closest('button');
+    const disconnectBtn = screen.getByText('Disconnect').closest('button');
+    expect(advertBtn).toBeDisabled();
+    expect(advertBtn).toHaveAttribute('title', TOOLTIP);
+    expect(disconnectBtn).not.toBeDisabled();
+  });
+
+  it('renders a persistent receive-only status chip', () => {
+    const actions = makeActions();
+    render(
+      <MeshCoreStatusBar
+        status={connectedStatus}
+        loading={false}
+        onOpenSettings={vi.fn()}
+        actions={actions as any}
+        receiveOnly
+      />,
+    );
+    expect(screen.getByText('Receive-only')).toBeInTheDocument();
+  });
+
+  it('leaves Send advert enabled and untitled, and does not render the chip, when receiveOnly is false', () => {
+    const actions = makeActions();
+    render(
+      <MeshCoreStatusBar
+        status={connectedStatus}
+        loading={false}
+        onOpenSettings={vi.fn()}
+        actions={actions as any}
+      />,
+    );
+    const advertBtn = screen.getByText('Send advert').closest('button');
+    expect(advertBtn).not.toBeDisabled();
+    expect(advertBtn).toHaveAttribute('title', 'Send advert');
+    expect(screen.queryByText('Receive-only')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/MeshCore/MeshCoreStatusBar.tsx
+++ b/src/components/MeshCore/MeshCoreStatusBar.tsx
@@ -10,6 +10,10 @@ interface MeshCoreStatusBarProps {
   /** When true, the parent renders the connection chip in its own header
    *  and we suppress the duplicate "Connected to X" text + dot here. */
   hideConnectionText?: boolean;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Plumbed here in WP1; WP3 wires the actual gating (Send advert
+   *  disabled + tooltip, receive-only status chip). */
+  receiveOnly?: boolean;
 }
 
 export const MeshCoreStatusBar: React.FC<MeshCoreStatusBarProps> = ({
@@ -18,7 +22,10 @@ export const MeshCoreStatusBar: React.FC<MeshCoreStatusBarProps> = ({
   onOpenSettings,
   actions,
   hideConnectionText,
+  receiveOnly = false,
 }) => {
+  // Not yet consumed here — WP3 wires the Send-advert gate + status chip.
+  void receiveOnly;
   const { t } = useTranslation();
   const connected = status?.connected ?? false;
   const localName = status?.localNode?.name || t('meshcore.unknown', 'Unknown');

--- a/src/components/MeshCore/MeshCoreStatusBar.tsx
+++ b/src/components/MeshCore/MeshCoreStatusBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ConnectionStatus, MeshCoreActions } from './hooks/useMeshCore';
+import { UiIcon } from '../icons';
 
 interface MeshCoreStatusBarProps {
   status: ConnectionStatus | null;
@@ -24,8 +25,6 @@ export const MeshCoreStatusBar: React.FC<MeshCoreStatusBarProps> = ({
   hideConnectionText,
   receiveOnly = false,
 }) => {
-  // Not yet consumed here — WP3 wires the Send-advert gate + status chip.
-  void receiveOnly;
   const { t } = useTranslation();
   const connected = status?.connected ?? false;
   const localName = status?.localNode?.name || t('meshcore.unknown', 'Unknown');
@@ -46,14 +45,19 @@ export const MeshCoreStatusBar: React.FC<MeshCoreStatusBarProps> = ({
             )}
           </>
         )}
+        {receiveOnly && (
+          <span className="mrc-status-chip mrc-status-idle">
+            <UiIcon name="blocked" size={12} /> {t('meshcore.receive_only.status_chip', 'Receive-only')}
+          </span>
+        )}
       </div>
       <div className="meshcore-status-bar-right">
         {connected ? (
           <>
             <button
               onClick={() => void actions.sendAdvert()}
-              disabled={loading}
-              title={t('meshcore.send_advert', 'Send advert')}
+              disabled={loading || receiveOnly}
+              title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : t('meshcore.send_advert', 'Send advert')}
             >
               {t('meshcore.send_advert', 'Send advert')}
             </button>

--- a/src/components/MeshCore/MeshCoreTimerTriggersSection.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreTimerTriggersSection.receiveOnly.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCoreTimerTriggersSection — receive-only mode (#4547 Phase 2 WP4).
+ *
+ * "Run now" is the second of the two immediate-TX controls WP4 gates (the
+ * first is Auto-Announce's "Send Now"). Everything else in this section is
+ * a saved trigger definition the scheduler reads later, so per interview
+ * decision 5 it stays fully editable — only "Run now" disables, and only it
+ * needs the direct `csrfFetch` 409 fallback (this handler doesn't go
+ * through `useMeshCore`).
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) =>
+      typeof fallback === 'string' ? fallback : key,
+  }),
+}));
+
+const { hasPermissionMock } = vi.hoisted(() => ({ hasPermissionMock: vi.fn() }));
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: hasPermissionMock }),
+}));
+
+const { showToastMock } = vi.hoisted(() => ({ showToastMock: vi.fn() }));
+vi.mock('../ToastContainer', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
+const { csrfFetchMock } = vi.hoisted(() => ({ csrfFetchMock: vi.fn() }));
+vi.mock('../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => csrfFetchMock,
+}));
+
+const { saveBarCapture } = vi.hoisted(() => ({ saveBarCapture: { current: null as unknown } }));
+vi.mock('../../hooks/useSaveBar', () => ({
+  useSaveBar: (options: unknown) => {
+    saveBarCapture.current = options;
+  },
+}));
+
+import { MeshCoreTimerTriggersSection } from './MeshCoreTimerTriggersSection';
+
+const CONTROL_TOOLTIP = 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.';
+const BLOCKED_TOAST = 'Receive-only mode is on for this MeshCore source — nothing was sent.';
+
+const ONE_TRIGGER = [{
+  id: 'tr1',
+  name: 'Beacon',
+  enabled: true,
+  scheduleType: 'cron',
+  cronExpression: '0 */6 * * *',
+  responseType: 'text',
+  response: 'hello',
+  destination: 'channel',
+  channelIndex: 0,
+  scopeMode: 'inherit',
+  scopeName: '',
+}];
+
+function mockFetch() {
+  return vi.fn((url: string) => {
+    if (url.includes('/automation/timers')) {
+      return Promise.resolve({ ok: true, json: async () => ({ success: true, data: { triggers: ONE_TRIGGER } }) });
+    }
+    if (url.includes('/channels/all')) {
+      return Promise.resolve({ ok: true, json: async () => ([{ id: 0, name: 'Primary' }]) });
+    }
+    if (url.includes('/api/scripts')) {
+      return Promise.resolve({ ok: true, json: async () => ({ scripts: [] }) });
+    }
+    if (url.includes('/contacts')) {
+      return Promise.resolve({ ok: true, json: async () => ({ success: true, data: [] }) });
+    }
+    return Promise.resolve({ ok: false, json: async () => ({}) });
+  });
+}
+
+async function waitForRunNowEnabled() {
+  await waitFor(() => {
+    const btn = screen.getByRole('button', { name: /run now/i });
+    expect(btn).not.toBeDisabled();
+  });
+}
+
+describe('MeshCoreTimerTriggersSection receive-only', () => {
+  beforeEach(() => {
+    hasPermissionMock.mockReset().mockReturnValue(true);
+    showToastMock.mockReset();
+    csrfFetchMock.mockReset().mockImplementation(mockFetch());
+  });
+
+  it('renders the paused note when receiveOnly is true, and nothing when false', async () => {
+    const { rerender } = render(
+      <MeshCoreTimerTriggersSection baseUrl="" sourceId="src1" receiveOnly={false} />,
+    );
+    await waitFor(() => expect(csrfFetchMock).toHaveBeenCalled());
+    expect(screen.queryByRole('status')).toBeNull();
+
+    rerender(<MeshCoreTimerTriggersSection baseUrl="" sourceId="src1" receiveOnly />);
+    const note = await screen.findByRole('status');
+    expect(note).toHaveTextContent(/receive-only mode/i);
+  });
+
+  it('disables Run now with the receive-only tooltip when receiveOnly is true', async () => {
+    render(<MeshCoreTimerTriggersSection baseUrl="" sourceId="src1" receiveOnly />);
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /run now/i });
+      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute('title', CONTROL_TOOLTIP);
+    });
+  });
+
+  it('enables Run now (no tooltip) once its own preconditions are met and receiveOnly is false', async () => {
+    render(<MeshCoreTimerTriggersSection baseUrl="" sourceId="src1" receiveOnly={false} />);
+    await waitForRunNowEnabled();
+    const btn = screen.getByRole('button', { name: /run now/i });
+    expect(btn).not.toHaveAttribute('title');
+  });
+
+  it('leaves the trigger name input editable when receive-only', async () => {
+    render(<MeshCoreTimerTriggersSection baseUrl="" sourceId="src1" receiveOnly />);
+    await waitFor(() => {
+      const input = screen.queryByDisplayValue('Beacon') as HTMLInputElement | null;
+      expect(input).not.toBeNull();
+      expect(input).not.toBeDisabled();
+    });
+  });
+
+  it('leaves the cron expression input editable when receive-only', async () => {
+    render(<MeshCoreTimerTriggersSection baseUrl="" sourceId="src1" receiveOnly />);
+    await waitFor(() => {
+      const input = screen.queryByDisplayValue('0 */6 * * *') as HTMLInputElement | null;
+      expect(input).not.toBeNull();
+      expect(input).not.toBeDisabled();
+    });
+  });
+
+  it('runNow: a 409 TX_DISABLED response raises the receive-only toast, not the generic run-failed toast', async () => {
+    csrfFetchMock.mockReset().mockImplementation((url: string) => {
+      if (url.includes('/run')) {
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          json: async () => ({ success: false, code: 'TX_DISABLED' }),
+        });
+      }
+      return mockFetch()(url);
+    });
+    render(<MeshCoreTimerTriggersSection baseUrl="" sourceId="src1" receiveOnly={false} />);
+    await waitForRunNowEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /run now/i }));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith(BLOCKED_TOAST, 'warning');
+    });
+    expect(showToastMock).not.toHaveBeenCalledWith(
+      expect.stringMatching(/run failed/i),
+      'error',
+    );
+  });
+});

--- a/src/components/MeshCore/MeshCoreTimerTriggersSection.tsx
+++ b/src/components/MeshCore/MeshCoreTimerTriggersSection.tsx
@@ -10,6 +10,10 @@ import { ScopeSelectField, type ScopeMode } from './ScopeSelectField';
 interface MeshCoreTimerTriggersSectionProps {
   baseUrl: string;
   sourceId: string;
+  /** True when this MeshCore source is in strict receive-only mode (#4547
+   *  Phase 2). Plumbed here in WP1; WP4 renders the paused note and gates
+   *  "Run now". */
+  receiveOnly?: boolean;
 }
 
 /**
@@ -79,7 +83,9 @@ const triggersEqual = (a: MeshCoreTimerTrigger[], b: MeshCoreTimerTrigger[]): bo
   return JSON.stringify(a) === JSON.stringify(b);
 };
 
-export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSectionProps> = ({ baseUrl, sourceId }) => {
+export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSectionProps> = ({ baseUrl, sourceId, receiveOnly = false }) => {
+  // Not yet consumed here — WP4 renders the paused note + Run now gating.
+  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { showToast } = useToast();

--- a/src/components/MeshCore/MeshCoreTimerTriggersSection.tsx
+++ b/src/components/MeshCore/MeshCoreTimerTriggersSection.tsx
@@ -6,6 +6,8 @@ import { useToast } from '../ToastContainer';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSaveBar } from '../../hooks/useSaveBar';
 import { ScopeSelectField, type ScopeMode } from './ScopeSelectField';
+import { MeshCoreReceiveOnlyNote } from './MeshCoreReceiveOnlyNote';
+import { isTxDisabledBody } from '../../utils/txDisabled';
 
 interface MeshCoreTimerTriggersSectionProps {
   baseUrl: string;
@@ -84,8 +86,6 @@ const triggersEqual = (a: MeshCoreTimerTrigger[], b: MeshCoreTimerTrigger[]): bo
 };
 
 export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSectionProps> = ({ baseUrl, sourceId, receiveOnly = false }) => {
-  // Not yet consumed here — WP4 renders the paused note + Run now gating.
-  void receiveOnly;
   const { t } = useTranslation();
   const csrfFetch = useCsrfFetch();
   const { showToast } = useToast();
@@ -276,6 +276,11 @@ export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSection
       const json = await res.json();
       if (res.ok && json.success) {
         showToast(t('meshcore.automation.timers.ran', 'Trigger fired'), 'success');
+      } else if (isTxDisabledBody(res.status, json)) {
+        showToast(
+          t('meshcore.receive_only.blocked_toast', 'Receive-only mode is on for this MeshCore source — nothing was sent.'),
+          'warning',
+        );
       } else {
         showToast(json?.data?.reason || json?.error || t('meshcore.automation.timers.run_failed', 'Run failed'), 'error');
       }
@@ -309,6 +314,8 @@ export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSection
           {t('meshcore.automation.timers.count', '{{count}} triggers', { count: triggers.length })}
         </span>
       </div>
+
+      <MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />
 
       <div className="settings-section">
         <p style={{ marginBottom: '1rem', color: '#666', lineHeight: 1.5, marginLeft: '1.75rem' }}>
@@ -348,7 +355,8 @@ export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSection
               <button
                 type="button"
                 onClick={() => runNow(tr.id)}
-                disabled={!canWrite || runningId === tr.id || !tr.enabled}
+                disabled={!canWrite || runningId === tr.id || !tr.enabled || receiveOnly}
+                title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
                 className="meshcore-btn meshcore-btn-secondary"
               >
                 {runningId === tr.id ? t('meshcore.automation.timers.running', 'Running…') : t('meshcore.automation.timers.run_now', 'Run now')}

--- a/src/components/MeshCore/hooks/useMeshCore.isLocal.test.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.isLocal.test.ts
@@ -30,6 +30,12 @@ vi.mock('../../../contexts/MapContext', () => ({
   useMapContext: () => ({ setMeshCoreNodes: vi.fn() }),
 }));
 
+// useMeshCore now calls useToast() (#4547 Phase 2 WP1, reportTxDisabled) —
+// mock it so this hook-only render doesn't need a real ToastProvider ancestor.
+vi.mock('../../ToastContainer', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
 /** Minimal fake Socket.io client: records handlers by event name and lets
  *  the test fire them directly, exactly like a real push event arriving. */
 function createFakeSocket() {

--- a/src/components/MeshCore/hooks/useMeshCore.receiveOnly.test.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.receiveOnly.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useMeshCore — `reportTxDisabled` 409 toast wiring (#4547 Phase 2 WP1, §3.3).
+ *
+ * Every MeshCore TX-primitive action funnels through this hook, so one
+ * helper (`reportTxDisabled`) covers every consumer and every second render
+ * path. When a server call fails with the Phase 1 409 (`TX_DISABLED`), the
+ * helper raises a single warning toast and the action still resolves to its
+ * normal failure value (never throws). A non-409 failure must NOT raise the
+ * toast — it takes the existing inline-error path unchanged.
+ *
+ * Modeled on useMeshCore.isLocal.test.ts for the mock shape (csrfFetch,
+ * MapContext, WebSocketContext).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const showToast = vi.fn();
+
+vi.mock('../../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => (globalThis as any).fetch,
+}));
+
+vi.mock('../../../contexts/MapContext', () => ({
+  useMapContext: () => ({ setMeshCoreNodes: vi.fn() }),
+}));
+
+vi.mock('../../../contexts/WebSocketContext', () => ({
+  useWebSocketContext: () => ({ state: { socket: { connected: true, on: vi.fn(), off: vi.fn(), emit: vi.fn(), io: { on: vi.fn(), off: vi.fn() } } } }),
+}));
+
+vi.mock('../../ToastContainer', () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => (typeof fallback === 'string' ? fallback : key),
+  }),
+}));
+
+import { useMeshCore } from './useMeshCore';
+
+const LOCAL_PK = 'a'.repeat(64);
+const CONTACT_PK = 'b'.repeat(64);
+const SOURCE_ID = 'src-1';
+
+function snapshotResponse() {
+  return {
+    success: true,
+    data: {
+      status: { connected: true, deviceType: 1, deviceTypeName: 'Companion', config: null, localNode: { publicKey: LOCAL_PK, name: 'Me', advType: 1 } },
+      contacts: [],
+      nodes: [],
+      messages: [],
+      seqCursor: 0,
+    },
+  };
+}
+
+const TX_DISABLED_BODY = { success: false, code: 'TX_DISABLED', error: 'Transmit is disabled on this source' };
+const GENERIC_FAILURE_BODY = { success: false, code: 'SOME_OTHER_ERROR', error: 'boom' };
+
+/** One entry per action §3.3 requires `reportTxDisabled` wired into. */
+const PATCHED_ACTIONS: Array<{
+  name: string;
+  invoke: (actions: ReturnType<typeof useMeshCore>['actions']) => Promise<unknown>;
+}> = [
+  { name: 'resetContactPath', invoke: a => a.resetContactPath(CONTACT_PK) },
+  { name: 'discoverContactPath', invoke: a => a.discoverContactPath(CONTACT_PK) },
+  { name: 'discoverNodes', invoke: a => a.discoverNodes('nearby') },
+  { name: 'discoverRegions', invoke: a => a.discoverRegions() },
+  { name: 'loginRemote', invoke: a => a.loginRemote(CONTACT_PK, 'pw') },
+  { name: 'sendCliCommand', invoke: a => a.sendCliCommand(CONTACT_PK, 'ver') },
+  { name: 'sendLocalCliCommand', invoke: a => a.sendLocalCliCommand('ver') },
+  { name: 'loginRemoteWithSaved', invoke: a => a.loginRemoteWithSaved(CONTACT_PK) },
+  { name: 'getRemoteStatus', invoke: a => a.getRemoteStatus(CONTACT_PK) },
+  { name: 'shareContact', invoke: a => a.shareContact(CONTACT_PK) },
+  { name: 'traceContactPath', invoke: a => a.traceContactPath(CONTACT_PK) },
+  { name: 'pingContactZeroHop', invoke: a => a.pingContactZeroHop(CONTACT_PK) },
+  { name: 'getNeighbours', invoke: a => a.getNeighbours(CONTACT_PK) },
+  { name: 'sendAdvert', invoke: a => a.sendAdvert() },
+  { name: 'sendMessage', invoke: a => a.sendMessage('hello', CONTACT_PK) },
+  { name: 'sendRoomPost', invoke: a => a.sendRoomPost(CONTACT_PK, 'hello') },
+  { name: 'loginRoom', invoke: a => a.loginRoom(CONTACT_PK, 'pw') },
+  { name: 'loginRoomWithSaved', invoke: a => a.loginRoomWithSaved(CONTACT_PK) },
+];
+
+async function renderConnectedHook() {
+  const { result } = renderHook(() => useMeshCore({ baseUrl: '', sourceId: SOURCE_ID, enabled: true }));
+  await waitFor(() => expect(result.current.hasLoadedOnce).toBe(true));
+  return result;
+}
+
+describe('useMeshCore — reportTxDisabled 409 toast (#4547 Phase 2 WP1)', () => {
+  beforeEach(() => {
+    showToast.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('409 TX_DISABLED response', () => {
+    beforeEach(() => {
+      (globalThis as any).fetch = vi.fn().mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/snapshot')) {
+          return { ok: true, status: 200, json: async () => snapshotResponse() };
+        }
+        return { ok: false, status: 409, json: async () => TX_DISABLED_BODY };
+      });
+    });
+
+    it.each(PATCHED_ACTIONS)('$name resolves without throwing and raises exactly one blocked-toast warning', async ({ invoke }) => {
+      const result = await renderConnectedHook();
+      showToast.mockClear();
+
+      // Resolving (rather than rejecting) is itself part of the assertion —
+      // every action catches its own fetch/parse errors, so a TX_DISABLED
+      // 409 must surface as a normal failure value, never a thrown error.
+      await invoke(result.current.actions);
+
+      expect(showToast).toHaveBeenCalledTimes(1);
+      expect(showToast).toHaveBeenCalledWith(
+        'Receive-only mode is on for this MeshCore source — nothing was sent.',
+        'warning',
+      );
+    });
+  });
+
+  describe('non-409 failure', () => {
+    beforeEach(() => {
+      (globalThis as any).fetch = vi.fn().mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/snapshot')) {
+          return { ok: true, status: 200, json: async () => snapshotResponse() };
+        }
+        return { ok: false, status: 500, json: async () => GENERIC_FAILURE_BODY };
+      });
+    });
+
+    it.each(PATCHED_ACTIONS)('$name does not raise the receive-only toast on a non-409 failure', async ({ invoke }) => {
+      const result = await renderConnectedHook();
+      showToast.mockClear();
+
+      await invoke(result.current.actions);
+
+      expect(showToast).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -17,9 +17,12 @@
  * gates that should suppress polling entirely.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useCsrfFetch } from '../../../hooks/useCsrfFetch';
 import { useMapContext } from '../../../contexts/MapContext';
 import { useWebSocketContext } from '../../../contexts/WebSocketContext';
+import { useToast } from '../../ToastContainer';
+import { isTxDisabledBody } from '../../../utils/txDisabled';
 import type {
   MeshCoreMessageEvent,
   MeshCoreContactUpdateEvent,
@@ -459,6 +462,29 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
   const seqCursorRef = useRef<number>(0);
   const localNodeRef = useRef<MeshCoreNode | null>(null);
   const contactsRef = useRef<Map<string, MeshCoreContact>>(new Map());
+
+  const { t } = useTranslation();
+  const { showToast } = useToast();
+  /**
+   * True when the response was the Phase 1 409 (`TX_DISABLED`) raised by
+   * MeshCore strict receive-only mode (#4547 Phase 1). Also raises the
+   * warning toast as a side effect. Every TX-primitive action below calls
+   * this in its failure branch, before the existing `setError(...)`, and
+   * skips `setError` when it returns true — the toast is the user-facing
+   * signal for this specific failure, so a red inline error would double up
+   * with it. Automatic/background call sites (not wired through this
+   * component) must guard with `receiveOnly` BEFORE ever calling the action,
+   * so this helper is never reached for those paths and never raises an
+   * unsolicited toast (§3.4a of the Phase 2 spec).
+   */
+  const reportTxDisabled = useCallback((status: number, body: unknown): boolean => {
+    if (!isTxDisabledBody(status, body)) return false;
+    showToast(
+      t('meshcore.receive_only.blocked_toast', 'Receive-only mode is on for this MeshCore source — nothing was sent.'),
+      'warning',
+    );
+    return true;
+  }, [showToast, t]);
 
   /**
    * Belt-and-braces re-stamp of `isLocal` (#4438). The server already sets
@@ -916,6 +942,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       );
       const data = await response.json();
       if (!data.success) {
+        if (reportTxDisabled(response.status, data)) return false;
         setError(data.error || 'Failed to reset path');
         return false;
       }
@@ -935,7 +962,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       setError('Failed to reset path');
       return false;
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const discoverContactPath = useCallback(async (publicKey: string): Promise<boolean> => {
     try {
@@ -945,6 +972,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       );
       const data = await response.json();
       if (!data.success) {
+        if (reportTxDisabled(response.status, data)) return false;
         setError(data.error || 'Failed to discover path');
         return false;
       }
@@ -953,7 +981,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       setError('Failed to discover path');
       return false;
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const discoverNodes = useCallback(async (
     mode: 'nearby' | 'repeaters' | 'sensors',
@@ -966,6 +994,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       });
       const data = await response.json();
       if (!data.success) {
+        if (reportTxDisabled(response.status, data)) return null;
         setError(data.error || 'Failed to discover nodes');
         return null;
       }
@@ -985,7 +1014,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       setError('Failed to discover nodes');
       return null;
     }
-  }, [mcPrefix, csrfFetch, refreshContacts]);
+  }, [mcPrefix, csrfFetch, refreshContacts, reportTxDisabled]);
 
   const getDiscoverable = useCallback(async (): Promise<boolean> => {
     try {
@@ -1050,6 +1079,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       const response = await csrfFetch(`${mcPrefix}/regions/discover`, { method: 'POST' });
       const data = await response.json();
       if (!data.success) {
+        if (reportTxDisabled(response.status, data)) return null;
         setError(data.error || 'Failed to discover regions');
         return null;
       }
@@ -1062,7 +1092,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       setError('Failed to discover regions');
       return null;
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   /**
    * Saved-regions catalog for the scope-override datalist.
@@ -1133,6 +1163,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
         body: JSON.stringify({ publicKey, password, rememberPassword }),
       });
       const data = await response.json();
+      reportTxDisabled(response.status, data);
       return {
         success: !!data.success,
         persisted: data.persisted,
@@ -1143,7 +1174,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     } catch (err) {
       return { success: false, error: err instanceof Error ? err.message : 'Network error' };
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const sendCliCommand = useCallback(async (
     publicKey: string,
@@ -1165,11 +1196,12 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       if (data.success && data.data) {
         return { ok: true as const, reply: data.data.reply, elapsedMs: data.data.elapsedMs };
       }
+      reportTxDisabled(response.status, data);
       return { ok: false as const, error: data.error || 'Unknown error', code: data.code, status: response.status };
     } catch (err) {
       return { ok: false as const, error: err instanceof Error ? err.message : 'Network error' };
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const getRemoteAdminCapability = useCallback(async () => {
     try {
@@ -1200,11 +1232,12 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       if (data.success && data.data) {
         return { ok: true as const, reply: data.data.reply, elapsedMs: data.data.elapsedMs };
       }
+      reportTxDisabled(response.status, data);
       return { ok: false as const, error: data.error || 'Unknown error', code: data.code, status: response.status };
     } catch (err) {
       return { ok: false as const, error: err instanceof Error ? err.message : 'Network error' };
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const loginRemoteWithSaved = useCallback(async (publicKey: string) => {
     try {
@@ -1214,6 +1247,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
         body: JSON.stringify({ publicKey }),
       });
       const data = await response.json();
+      reportTxDisabled(response.status, data);
       return {
         success: !!data.success,
         usedStored: data.usedStored,
@@ -1223,7 +1257,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     } catch (err) {
       return { success: false, error: err instanceof Error ? err.message : 'Network error' };
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const forgetRemoteCredential = useCallback(async (publicKey: string): Promise<boolean> => {
     try {
@@ -1245,11 +1279,12 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       );
       const data = await response.json();
       if (data.success && data.data) return data.data as MeshCoreRemoteStatus;
+      reportTxDisabled(response.status, data);
       return null;
     } catch (_err) {
       return null;
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const shareContact = useCallback(async (publicKey: string): Promise<{ ok: boolean; error?: string }> => {
     try {
@@ -1260,6 +1295,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       const data = await response.json();
       if (!data.success) {
         const error = data.error || 'Failed to share contact';
+        if (reportTxDisabled(response.status, data)) return { ok: false, error };
         setError(error);
         return { ok: false, error };
       }
@@ -1269,7 +1305,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       setError(error);
       return { ok: false, error };
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const setContactOutPath = useCallback(async (publicKey: string, outPath: string, hashBytes: 1 | 2 | 3 = 1): Promise<boolean> => {
     try {
@@ -1314,6 +1350,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       );
       const data = await response.json();
       if (!data.success) {
+        if (reportTxDisabled(response.status, data)) return null;
         setError(data.error || 'Trace path failed');
         return null;
       }
@@ -1322,7 +1359,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       setError('Trace path failed');
       return null;
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const pingContactZeroHop = useCallback(async (publicKey: string): Promise<ZeroHopPingResult> => {
     try {
@@ -1332,6 +1369,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       );
       const data = await response.json();
       if (!data.success) {
+        reportTxDisabled(response.status, data);
         return { ok: false, error: data.error || 'Ping failed' };
       }
       return {
@@ -1344,7 +1382,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     } catch (_err) {
       return { ok: false, error: 'Ping failed' };
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const removeContact = useCallback(async (publicKey: string): Promise<boolean> => {
     try {
@@ -1460,12 +1498,15 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
         `${mcPrefix}/contacts/${encodeURIComponent(publicKey)}/neighbours${qs ? '?' + qs : ''}`,
       );
       const data = await response.json();
-      if (!data.success) return null;
+      if (!data.success) {
+        reportTxDisabled(response.status, data);
+        return null;
+      }
       return data.data as { total: number; neighbours: { publicKeyPrefix: string; heardSecondsAgo: number; snr: number }[] };
     } catch (_err) {
       return null;
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const rebootDevice = useCallback(async (opts?: { confirm?: boolean }): Promise<boolean> => {
     try {
@@ -1524,11 +1565,14 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
     try {
       const response = await csrfFetch(`${mcPrefix}/advert`, { method: 'POST' });
       const data = await response.json();
-      if (!data.success) setError(data.error || 'Failed to send advert');
+      if (!data.success) {
+        if (reportTxDisabled(response.status, data)) return;
+        setError(data.error || 'Failed to send advert');
+      }
     } catch (_err) {
       setError('Failed to send advert');
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const sendMessage = useCallback(async (text: string, toPublicKey?: string, channelIdx?: number, scope?: string | null): Promise<boolean> => {
     if (!text.trim()) return false;
@@ -1550,13 +1594,14 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
         await fetchMessages();
         return true;
       }
+      if (reportTxDisabled(response.status, data)) return false;
       setError(data.error || 'Failed to send message');
       return false;
     } catch (_err) {
       setError('Failed to send message');
       return false;
     }
-  }, [mcPrefix, csrfFetch, fetchMessages]);
+  }, [mcPrefix, csrfFetch, fetchMessages, reportTxDisabled]);
 
   // ----- Message deletion / purge (#3981) -----
   // Each does an optimistic local prune; the server also broadcasts a
@@ -1792,11 +1837,12 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
         body: JSON.stringify({ publicKey, password, rememberPassword }),
       });
       const data = await response.json();
+      reportTxDisabled(response.status, data);
       return { success: !!data.success, persisted: data.persisted, error: data.error };
     } catch (_err) {
       return { success: false, error: 'Room login request failed' };
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const loginRoomWithSaved = useCallback(async (publicKey: string): Promise<{ success: boolean; usedStored?: boolean; error?: string; code?: string }> => {
     try {
@@ -1806,11 +1852,12 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
         body: JSON.stringify({ publicKey }),
       });
       const data = await response.json();
+      reportTxDisabled(response.status, data);
       return { success: !!data.success, usedStored: data.usedStored, error: data.error, code: data.code };
     } catch (_err) {
       return { success: false, error: 'Room auto-login request failed' };
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const sendRoomPost = useCallback(async (roomPublicKey: string, text: string): Promise<boolean> => {
     try {
@@ -1821,6 +1868,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       });
       const data = await response.json();
       if (!data.success) {
+        if (reportTxDisabled(response.status, data)) return false;
         setError(data.error || 'Failed to send room post');
         return false;
       }
@@ -1829,7 +1877,7 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       setError('Failed to send room post');
       return false;
     }
-  }, [mcPrefix, csrfFetch]);
+  }, [mcPrefix, csrfFetch, reportTxDisabled]);
 
   const getRoomCredentials = useCallback(async (): Promise<{ canRemember: boolean; stored: Array<{ publicKey: string }> } | null> => {
     try {

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -151,6 +151,14 @@ export interface MessagesTabProps {
 
   /** TX disabled on this source (epic #4294 Phase 2) — disable send/request controls with a tooltip, keep reads working. */
   txDisabled?: boolean;
+  /**
+   * Pre-computed tooltip for disabled TX controls (#4547 Phase 2 WP5). App.tsx
+   * picks the MeshCore receive-only wording or the Meshtastic LoRa-config
+   * wording based on source type. Optional — falls back to
+   * `(txDisabledTooltip ?? t('tx_disabled.control_tooltip'))` at each call site when omitted, so
+   * existing callers/tests are unaffected.
+   */
+  txDisabledTooltip?: string;
 
   // Selected state
   selectedDMNode: string | null;
@@ -266,6 +274,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   currentNodeId,
   connectionStatus,
   txDisabled = false,
+  txDisabledTooltip,
   selectedDMNode,
   setSelectedDMNode,
   pendingComposeFocus = null,
@@ -1422,7 +1431,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                   setShowActionsMenu(false);
                                 }}
                                 disabled={connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode || txDisabled}
-                                title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                                title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                               >
                                 <UiIcon name="route" /> {t('messages.traceroute_button')}
                                 {tracerouteLoading === selectedDMNode && <span className="spinner"></span>}
@@ -1454,7 +1463,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                 setShowActionsMenu(false);
                               }}
                               disabled={connectionStatus !== 'connected' || positionLoading === selectedDMNode || txDisabled}
-                              title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                              title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                             >
                               <UiIcon name="location" /> {t('messages.exchange_position')}
                               {positionLoading === selectedDMNode && <span className="spinner"></span>}
@@ -1466,7 +1475,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                 setShowActionsMenu(false);
                               }}
                               disabled={connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode || txDisabled}
-                              title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                              title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                             >
                               <UiIcon name="key" /> {t('messages.exchange_node_info')}
                               {nodeInfoLoading === selectedDMNode && <span className="spinner"></span>}
@@ -1478,7 +1487,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                 setShowActionsMenu(false);
                               }}
                               disabled={connectionStatus !== 'connected' || telemetryRequestLoading === selectedDMNode || txDisabled}
-                              title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                              title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                             >
                               <UiIcon name="telemetry" /> {t('messages.request_telemetry')}
                               {telemetryRequestLoading === selectedDMNode && <span className="spinner"></span>}
@@ -1520,7 +1529,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                               setShowActionsMenu(false);
                             }}
                             disabled={connectionStatus !== 'connected' || adminScanLoading === selectedDMNode || txDisabled}
-                            title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                            title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                           >
                             <UiIcon name="search" /> {t('messages.scan_for_admin')}
                             {adminScanLoading === selectedDMNode && <span className="spinner"></span>}
@@ -1901,7 +1910,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                   className="resend-button"
                                   onClick={() => handleResendMessage(msg)}
                                   disabled={txDisabled}
-                                  title={txDisabled ? t('tx_disabled.control_tooltip') : t('messages.resend_button_title')}
+                                  title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : t('messages.resend_button_title')}
                                   aria-label={t('messages.resend_button_title')}
                                 >
                                   ↻
@@ -1923,7 +1932,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                 className="emoji-picker-button"
                                 onClick={() => setEmojiPickerMessage(msg)}
                                 disabled={txDisabled}
-                                title={txDisabled ? t('tx_disabled.control_tooltip') : t('messages.emoji_button_title')}
+                                title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : t('messages.emoji_button_title')}
                                 aria-label={t('messages.emoji_button_title')}
                               >
                                 <UiIcon name="reaction" size={15} />
@@ -2034,7 +2043,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         className="message-input"
                         rows={1}
                         disabled={txDisabled}
-                        title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                        title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                         onKeyDown={e => {
                           if (
                             txDisabled ||
@@ -2066,7 +2075,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       onClick={() => { void onSendBell?.(selectedDMNode, newMessage); setNewMessage(''); }}
                       disabled={txDisabled}
                       className="send-btn channel-action-btn"
-                      title={txDisabled ? t('tx_disabled.control_tooltip') : 'Send alert bell'}
+                      title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : 'Send alert bell'}
                       aria-label="Send alert bell"
                     >
                       <UiIcon name="notifications" size={16} />
@@ -2075,7 +2084,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       onClick={() => handleSendDirectMessage(selectedDMNode)}
                       disabled={!newMessage.trim() || txDisabled}
                       className="send-btn"
-                      title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                      title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                       aria-label={t('common.send')}
                     >
                       <UiIcon name="send" size={16} />
@@ -2347,7 +2356,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                   <button
                     onClick={() => handleTraceroute(selectedDMNode)}
                     disabled={connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode || txDisabled}
-                    title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                    title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                     style={{
                       flex: 1,
                       padding: '0.5rem 1rem',
@@ -2369,7 +2378,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         setShowTracerouteChannelDropdown(prev => !prev);
                       }}
                       disabled={connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode || txDisabled}
-                      title={txDisabled ? t('tx_disabled.control_tooltip') : t('messages.traceroute_channel')}
+                      title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : t('messages.traceroute_channel')}
                       aria-label={t('messages.traceroute_channel')}
                       style={{
                         padding: '0.5rem 0.5rem',
@@ -2434,7 +2443,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                   <button
                     onClick={() => handleExchangeNodeInfo(selectedDMNode)}
                     disabled={connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode || txDisabled}
-                    title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                    title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                     style={{
                       flex: 1,
                       padding: '0.5rem 1rem',
@@ -2456,7 +2465,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         setShowNodeInfoChannelDropdown(prev => !prev);
                       }}
                       disabled={connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode || txDisabled}
-                      title={txDisabled ? t('tx_disabled.control_tooltip') : t('messages.exchange_node_info_channel')}
+                      title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : t('messages.exchange_node_info_channel')}
                       aria-label={t('messages.exchange_node_info_channel')}
                       style={{
                         padding: '0.5rem 0.5rem',
@@ -2521,7 +2530,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                   <button
                     onClick={() => handleExchangePosition(selectedDMNode)}
                     disabled={connectionStatus !== 'connected' || positionLoading === selectedDMNode || txDisabled}
-                    title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                    title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                     style={{
                       flex: 1,
                       padding: '0.5rem 1rem',
@@ -2543,7 +2552,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         setShowPositionChannelDropdown(prev => !prev);
                       }}
                       disabled={connectionStatus !== 'connected' || positionLoading === selectedDMNode || txDisabled}
-                      title={txDisabled ? t('tx_disabled.control_tooltip') : t('messages.exchange_position_channel')}
+                      title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : t('messages.exchange_position_channel')}
                       aria-label={t('messages.exchange_position_channel')}
                       style={{
                         padding: '0.5rem 0.5rem',
@@ -2607,7 +2616,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                 <button
                   onClick={() => handleRequestNeighborInfo(selectedDMNode)}
                   disabled={connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode || txDisabled}
-                  title={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                  title={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                   style={{
                     flex: '1 1 auto',
                     minWidth: '120px',

--- a/src/components/MessagesTab.txDisabled.test.tsx
+++ b/src/components/MessagesTab.txDisabled.test.tsx
@@ -295,3 +295,39 @@ describe('MessagesTab txDisabled gating (#4294 Phase 2)', () => {
     expect(screen.getByText('hi back')).toBeTruthy();
   });
 });
+
+// #4547 Phase 2 WP5: App.tsx computes one MeshCore-or-Meshtastic tooltip
+// string and threads it in as `txDisabledTooltip`. The `?? t('tx_disabled.control_tooltip')`
+// fallback above already proves the omitted-prop (Meshtastic today) case is
+// byte-identical; this covers the other direction — the prop, when supplied,
+// wins over the default key on every gated control.
+describe('MessagesTab txDisabledTooltip prop (#4547 Phase 2 WP5)', () => {
+  const MESHCORE_TOOLTIP = 'meshcore.receive_only.control_tooltip';
+
+  it('uses the supplied tooltip on the DM textarea instead of the default key', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true, txDisabledTooltip: MESHCORE_TOOLTIP })} />);
+    const textarea = document.querySelector('textarea.message-input');
+    expect(textarea?.getAttribute('title')).toBe(MESHCORE_TOOLTIP);
+  });
+
+  it('uses the supplied tooltip on the DM bell and resend buttons', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true, txDisabledTooltip: MESHCORE_TOOLTIP })} />);
+    const bellBtn = document.querySelector('button.send-btn.channel-action-btn');
+    expect(bellBtn?.getAttribute('title')).toBe(MESHCORE_TOOLTIP);
+    const resendBtn = document.querySelector('button.resend-button');
+    expect(resendBtn?.getAttribute('title')).toBe(MESHCORE_TOOLTIP);
+  });
+
+  it('uses the supplied tooltip in the actions dropdown', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true, txDisabledTooltip: MESHCORE_TOOLTIP })} />);
+    fireEvent.click(screen.getByTitle('messages.actions_menu_title'));
+    const btn = screen.getByText('messages.scan_for_admin').closest('button');
+    expect(btn?.getAttribute('title')).toBe(MESHCORE_TOOLTIP);
+  });
+
+  it('falls back to tx_disabled.control_tooltip when the prop is omitted (Meshtastic default, unchanged)', () => {
+    render(<MessagesTab {...makeProps({ txDisabled: true })} />);
+    const textarea = document.querySelector('textarea.message-input');
+    expect(textarea?.getAttribute('title')).toBe('tx_disabled.control_tooltip');
+  });
+});

--- a/src/components/NodePopup/NodePopup.tsx
+++ b/src/components/NodePopup/NodePopup.tsx
@@ -50,6 +50,14 @@ interface NodePopupProps {
   currentNodeNum?: number | null;
   /** TX disabled on this source (epic #4294 Phase 2) — ORed into the traceroute run button's disabled state. */
   txDisabled?: boolean;
+  /**
+   * Pre-computed tooltip for disabled TX controls (#4547 Phase 2 WP5). App.tsx
+   * picks the MeshCore receive-only wording or the Meshtastic LoRa-config
+   * wording based on source type. Optional — falls back to
+   * `t('tx_disabled.control_tooltip')` at each call site when omitted, so
+   * existing callers/tests are unaffected.
+   */
+  txDisabledTooltip?: string;
 }
 
 export const NodePopup: React.FC<NodePopupProps> = ({
@@ -72,6 +80,7 @@ export const NodePopup: React.FC<NodePopupProps> = ({
   onPurgeNodeFromDevice,
   currentNodeNum,
   txDisabled = false,
+  txDisabledTooltip,
 }) => {
   const { t } = useTranslation();
 
@@ -183,7 +192,7 @@ export const NodePopup: React.FC<NodePopupProps> = ({
             onRunTraceroute={node.user?.id && onTraceroute ? () => onTraceroute(node.user!.id) : undefined}
             running={tracerouteLoading === node.user?.id}
             runDisabled={connectionStatus !== 'connected' || tracerouteLoading === node.user?.id || txDisabled}
-            runDisabledReason={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+            runDisabledReason={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
           />
         ) : undefined}
       />

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -90,6 +90,14 @@ interface NodesTabProps {
   connectionStatus?: string;
   /** TX disabled on this source (epic #4294 Phase 2) — ORed into the traceroute run button's disabled state. */
   txDisabled?: boolean;
+  /**
+   * Pre-computed tooltip for disabled TX controls (#4547 Phase 2 WP5). App.tsx
+   * picks the MeshCore receive-only wording or the Meshtastic LoRa-config
+   * wording based on source type. Optional — falls back to
+   * `t('tx_disabled.control_tooltip')` at each call site when omitted, so
+   * existing callers/tests are unaffected.
+   */
+  txDisabledTooltip?: string;
   /** Node ID currently being tracerouted (for loading state) */
   tracerouteLoading?: string | null;
   /** Handler for deleting a node from local database */
@@ -411,6 +419,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   onTraceroute,
   connectionStatus,
   txDisabled = false,
+  txDisabledTooltip,
   tracerouteLoading,
   onDeleteNode,
   onPurgeNodeFromDevice,
@@ -1830,7 +1839,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                           onRunTraceroute={node.user?.id && onTraceroute ? () => onTraceroute(node.user!.id) : undefined}
                           running={tracerouteLoading === node.user?.id}
                           runDisabled={isTracerouteRunDisabled(connectionStatus, tracerouteLoading, node.user?.id, txDisabled)}
-                          runDisabledReason={txDisabled ? t('tx_disabled.control_tooltip') : undefined}
+                          runDisabledReason={txDisabled ? (txDisabledTooltip ?? t('tx_disabled.control_tooltip')) : undefined}
                         />
                       ) : undefined}
                     />

--- a/src/server/meshcoreManager.receiveOnly.perSource.test.ts
+++ b/src/server/meshcoreManager.receiveOnly.perSource.test.ts
@@ -23,7 +23,7 @@ const SOURCE_B = 'source-b';
 /** Only source-a's meshcoreReceiveOnly setting is 'true'; everything else reads null. */
 function mockPerSourceReceiveOnly(): void {
   vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
-    async (sourceId: string, key: string) => {
+    async (sourceId: string | null | undefined, key: string) => {
       if (sourceId === SOURCE_A && key === 'meshcoreReceiveOnly') return 'true';
       return null;
     },

--- a/src/server/meshcoreManager.receiveOnlySchedulers.test.ts
+++ b/src/server/meshcoreManager.receiveOnlySchedulers.test.ts
@@ -262,7 +262,7 @@ describe('MeshCoreManager scheduler silent skips (#4547 WP3)', () => {
         meshcoreAutoAnnounceAdvertEnabled: 'false',
       };
       vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
-        async (_sourceId: string, key: string) => (key in announceSettings ? announceSettings[key] : null),
+        async (_sourceId: string | null | undefined, key: string) => (key in announceSettings ? announceSettings[key] : null),
       );
       const sendMessage = vi.fn().mockResolvedValue(true);
       (manager as any).sendMessage = sendMessage;
@@ -282,7 +282,7 @@ describe('MeshCoreManager scheduler silent skips (#4547 WP3)', () => {
         meshcoreAutoAnnounceAdvertDelaySeconds: '30',
       };
       vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
-        async (_sourceId: string, key: string) => (key in announceSettings ? announceSettings[key] : null),
+        async (_sourceId: string | null | undefined, key: string) => (key in announceSettings ? announceSettings[key] : null),
       );
       (manager as any).sendMessage = vi.fn().mockResolvedValue(true);
       const sendAdvert = vi.fn().mockResolvedValue(true);
@@ -309,7 +309,7 @@ describe('MeshCoreManager scheduler silent skips (#4547 WP3)', () => {
         meshcoreAutoAnnounceAdvertDelaySeconds: '30',
       };
       vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
-        async (_sourceId: string, key: string) => (key in announceSettings ? announceSettings[key] : null),
+        async (_sourceId: string | null | undefined, key: string) => (key in announceSettings ? announceSettings[key] : null),
       );
       (manager as any).sendMessage = vi.fn().mockResolvedValue(true);
       const sendAdvert = vi.fn().mockResolvedValue(true);
@@ -430,7 +430,7 @@ describe('MeshCoreManager scheduler silent skips (#4547 WP3)', () => {
     it('receive-only OFF: a matching trigger reaches sendMessage', async () => {
       const { manager } = makeManager();
       vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
-        async (_sourceId: string, key: string) => {
+        async (_sourceId: string | null | undefined, key: string) => {
           if (key === 'meshcoreAutoResponderEnabled') return 'true';
           if (key === 'meshcoreAutoResponderTriggers') return JSON.stringify([trigger]);
           return null;
@@ -477,7 +477,7 @@ describe('MeshCoreManager scheduler silent skips (#4547 WP3)', () => {
         meshcoreAutoAckPreSendDelaySeconds: '0',
       };
       vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
-        async (_sourceId: string, key: string) => (key in autoAckSettings ? autoAckSettings[key] : null),
+        async (_sourceId: string | null | undefined, key: string) => (key in autoAckSettings ? autoAckSettings[key] : null),
       );
       const sendMessage = vi.fn().mockResolvedValue(true);
       (manager as any).sendMessage = sendMessage;

--- a/src/server/meshcoreNativeBackend.receiveOnly.test.ts
+++ b/src/server/meshcoreNativeBackend.receiveOnly.test.ts
@@ -36,11 +36,24 @@ const TxtTypes = { Plain: 0, CliData: 1, SignedPlain: 2 };
 class MockConnection extends EventEmitter {
   sentFrames: Uint8Array[] = [];
   addOrUpdateContact = vi.fn().mockResolvedValue(undefined);
-  getContacts = vi.fn<[], Promise<any[]>>().mockResolvedValue([]);
+  getContacts = vi.fn<() => Promise<any[]>>().mockResolvedValue([]);
   async connect() { /* no-op */ }
   async close() { /* no-op */ }
   async getSelfInfo() {
     return { type: AdvType.Chat, publicKey: Uint8Array.from(Array(32).fill(0)), name: 'TestNode' };
+  }
+  /**
+   * Node's `EventEmitter` typings constrain event names to `string | symbol`,
+   * but the real meshcore.js connection (untyped in production code) emits
+   * and listens on the numeric ResponseCodes/PushCodes constants directly.
+   * Numeric event names behave identically to their string form at runtime
+   * (JS coerces numeric object keys to strings internally), so this override
+   * widens just the event-name parameter to `PropertyKey` to match production
+   * usage — the cast on the delegating call reflects that equivalence rather
+   * than suppressing a real type mismatch.
+   */
+  emit(eventName: PropertyKey, ...args: unknown[]): boolean {
+    return super.emit(eventName as string | symbol, ...args);
   }
   sendToRadioFrame(frame: Uint8Array) {
     this.sentFrames.push(frame);

--- a/src/server/routes/settingsRoutes.receiveOnlyValidation.test.ts
+++ b/src/server/routes/settingsRoutes.receiveOnlyValidation.test.ts
@@ -1,0 +1,128 @@
+/**
+ * POST /api/settings — meshcoreReceiveOnly strict-boolean validation
+ * (#4547 Phase 2 WP2 §4).
+ *
+ * `filteredSettings[key] = String(settings[key])` (settingsRoutes.ts) has no
+ * value validation, and MeshCoreManager.refreshReceiveOnly() reads the stored
+ * value with `raw === 'true'`. So posting `'1'`, `'yes'`, `'TRUE'`, `'on'`,
+ * `1`, `null` or `{}` would previously persist a value that reads back as
+ * `false` — receive-only silently OFF while the user believes transmission
+ * is blocked. This is a fail-open on a safety flag.
+ *
+ * Uses the real-middleware harness (createRouteTestApp) per CLAUDE.md — "New
+ * or changed route tests MUST use the harness" — rather than mocking
+ * services/database.js. See settingsRoutes.perSource.test.ts (sibling file)
+ * for the same pattern applied to a different key.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import settingsRoutes, { setSettingsCallbacks } from './settingsRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+describe('POST /api/settings — meshcoreReceiveOnly strict-boolean validation (#4547 Phase 2 WP2)', () => {
+  let harness: RouteTestHarness;
+  const refreshSpy = vi.fn();
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/api/settings', settingsRoutes),
+    });
+    setSettingsCallbacks({ refreshMeshcoreReceiveOnly: refreshSpy });
+    refreshSpy.mockClear();
+  });
+
+  afterEach(async () => {
+    setSettingsCallbacks({});
+    await harness.db.settings.deleteSourceSettings(harness.sourceA).catch(() => {});
+    await harness.db.settings.deleteSetting('maxNodeAgeHours').catch(() => {});
+    await harness.cleanup();
+  });
+
+  it('accepts { meshcoreReceiveOnly: true } → 200, stores the string "true", and fires the refresh callback', async () => {
+    const agent = await harness.loginAs(harness.admin);
+
+    const res = await agent
+      .post(`/api/settings?sourceId=${harness.sourceA}`)
+      .send({ meshcoreReceiveOnly: true });
+
+    expect(res.status).toBe(200);
+    const stored = await harness.db.settings.getSettingForSource(harness.sourceA, 'meshcoreReceiveOnly');
+    expect(stored).toBe('true');
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(refreshSpy).toHaveBeenCalledWith(harness.sourceA);
+  });
+
+  it('accepts { meshcoreReceiveOnly: false } → 200 and stores the string "false"', async () => {
+    const agent = await harness.loginAs(harness.admin);
+
+    const res = await agent
+      .post(`/api/settings?sourceId=${harness.sourceA}`)
+      .send({ meshcoreReceiveOnly: false });
+
+    expect(res.status).toBe(200);
+    const stored = await harness.db.settings.getSettingForSource(harness.sourceA, 'meshcoreReceiveOnly');
+    expect(stored).toBe('false');
+  });
+
+  it.each([
+    ['1', '1'],
+    ['yes', 'yes'],
+    ['TRUE', 'TRUE'],
+    ['on', 'on'],
+    [1, 1],
+    [null, null],
+    [{}, {}],
+  ])('rejects meshcoreReceiveOnly=%p with 400 INVALID_BOOLEAN_SETTING, writes nothing, and never fires the refresh callback', async (value) => {
+    const agent = await harness.loginAs(harness.admin);
+
+    // Prove "nothing written" against a real prior value, not just absence.
+    await harness.db.settings.setSourceSettings(harness.sourceA, { meshcoreReceiveOnly: 'true' });
+
+    const res = await agent
+      .post(`/api/settings?sourceId=${harness.sourceA}`)
+      .send({ meshcoreReceiveOnly: value });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_BOOLEAN_SETTING');
+
+    const stored = await harness.db.settings.getSettingForSource(harness.sourceA, 'meshcoreReceiveOnly');
+    expect(stored).toBe('true'); // unchanged from the pre-seeded value
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('a valid meshcoreReceiveOnly alongside other keys still persists the other keys', async () => {
+    const agent = await harness.loginAs(harness.admin);
+
+    const res = await agent
+      .post(`/api/settings?sourceId=${harness.sourceA}`)
+      .send({ meshcoreReceiveOnly: true, maxNodeAgeHours: '48' });
+
+    expect(res.status).toBe(200);
+    const receiveOnly = await harness.db.settings.getSettingForSource(harness.sourceA, 'meshcoreReceiveOnly');
+    const maxAge = await harness.db.settings.getSettingForSource(harness.sourceA, 'maxNodeAgeHours');
+    expect(receiveOnly).toBe('true');
+    expect(maxAge).toBe('48');
+  });
+
+  it('an invalid meshcoreReceiveOnly rejects the whole request — sibling keys in the same payload are not persisted either', async () => {
+    const agent = await harness.loginAs(harness.admin);
+
+    const res = await agent
+      .post(`/api/settings?sourceId=${harness.sourceA}`)
+      .send({ meshcoreReceiveOnly: '1', maxNodeAgeHours: '48' });
+
+    expect(res.status).toBe(400);
+    const maxAge = await harness.db.settings.getSettingForSource(harness.sourceA, 'maxNodeAgeHours');
+    expect(maxAge).toBeNull();
+  });
+
+  it('a global (no sourceId) POST carrying unrelated keys is unaffected by this validation', async () => {
+    const agent = await harness.loginAs(harness.admin);
+
+    const res = await agent.post('/api/settings').send({ maxNodeAgeHours: '48' });
+
+    expect(res.status).toBe(200);
+    const stored = await harness.db.settings.getSetting('maxNodeAgeHours');
+    expect(stored).toBe('48');
+  });
+});

--- a/src/server/routes/settingsRoutes.receiveOnlyValidation.test.ts
+++ b/src/server/routes/settingsRoutes.receiveOnlyValidation.test.ts
@@ -72,7 +72,7 @@ describe('POST /api/settings — meshcoreReceiveOnly strict-boolean validation (
     [1, 1],
     [null, null],
     [{}, {}],
-  ])('rejects meshcoreReceiveOnly=%p with 400 INVALID_BOOLEAN_SETTING, writes nothing, and never fires the refresh callback', async (value) => {
+  ])('rejects meshcoreReceiveOnly=%p with 400 INVALID_BOOLEAN_SETTING, writes nothing, and never fires the refresh callback', async (value, _sameValue) => {
     const agent = await harness.loginAs(harness.admin);
 
     // Prove "nothing written" against a real prior value, not just absence.

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -325,6 +325,28 @@ router.post('/', requirePermission('settings', 'write', { sourceIdFrom: 'query' 
       );
     }
 
+    // Keys whose consumers compare against the exact string 'true'. `String(v)` above
+    // happily stores '1' / 'yes' / 'TRUE', every one of which those consumers read as
+    // FALSE — a silent fail-OPEN for a safety flag (#4547 Phase 1 review). Reject rather
+    // than coerce: a client sending a non-boolean is a client with a bug, and quietly
+    // normalizing it would hide that bug in the one place it matters.
+    //
+    // Declared module-locally (not in src/server/constants/settings.ts) so
+    // settings.allowlist.test.ts's exact-equality assertions over that file's key
+    // arrays stay unmodified (#4547 Phase 2 WP2). Sits before both write paths
+    // (setSourceSettings below and setSettings further down) and before
+    // callbacks.refreshMeshcoreReceiveOnly fires, so a rejected request writes nothing.
+    const STRICT_BOOLEAN_SETTINGS_KEYS = ['meshcoreReceiveOnly'] as const;
+
+    for (const key of STRICT_BOOLEAN_SETTINGS_KEYS) {
+      if (!(key in filteredSettings)) continue;
+      const v = filteredSettings[key];
+      if (v !== 'true' && v !== 'false') {
+        return fail(res, 400, 'INVALID_BOOLEAN_SETTING',
+          `${key} must be the boolean true or false (received "${v}")`);
+      }
+    }
+
     // Validate autoAckRegex pattern.
     //
     // The pattern is validated with RE2 (compileUserRegex), which — unlike the

--- a/src/server/server.settings-persistence.test.ts
+++ b/src/server/server.settings-persistence.test.ts
@@ -173,6 +173,14 @@ function validTestValue(key: string, suffix = ''): string {
     autoDeleteByDistanceLon: '-74.006',
     appriseApiServerUrl: 'http://apprise.example.com:8000',
     externalUrl: 'https://mesh.example.com',
+
+    // Strict-boolean keys (settingsRoutes.ts's module-local
+    // STRICT_BOOLEAN_SETTINGS_KEYS, #4547 Phase 2 WP2 §4): these reject
+    // anything except the exact strings 'true'/'false' — the generic
+    // `test-${key}` fallback below 400s for them. Add every future entry in
+    // STRICT_BOOLEAN_SETTINGS_KEYS here too, or this round-trip test breaks
+    // the same way meshcoreReceiveOnly did.
+    meshcoreReceiveOnly: 'true',
   };
 
   if (key in VALID_VALUES) {


### PR DESCRIPTION
## Phase 2 of 3 — Frontend gating UX for MeshCore strict receive-only mode

Part of #4547. Follows #4550 (Phase 1 backend enforcement).
Epic plan: `docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_EPIC.md` · Spec: `…_PHASE2_SPEC.md`.

Adds the user-facing half: a per-source toggle, disabled-with-reason states across every MeshCore
transmit surface, "paused" notes on the automation sections, and MeshCore-correct wording
everywhere the old Meshtastic copy was wrong.

**No Virtual Node gating in this PR** (Phase 3).

### A copy bug worth calling out

The shared tooltip read:

> "Transmit is disabled on this node's radio. **Re-enable TX in the LoRa configuration** to use this."

That names a Meshtastic-only remedy. A MeshCore operator seeing it would go hunting for a LoRa
Configuration screen their hardware does not have — the real switch is MeshCore → Settings. So this
is a correctness fix, not cosmetics. Branched via an optional `txDisabledTooltip` prop threaded from
`App.tsx` to 24 call sites; the Meshtastic wording is asserted **byte-identical**.

### The subtle part: three auto-firing TX paths

The Rooms auto-login effect, `ChannelsView`'s `discoverRegions` mount effect, and
`MeshCoreRemoteStatsPanel.load()` all transmit with no user action — and all set a do-not-repeat
latch **before** awaiting. A guard placed after the latch would permanently poison the effect for
the session: turning receive-only back off would never re-trigger it. Each guard sits before its
latch, and each has a "flip the flag off and it fires again" test, which is the only assertion that
catches a mis-placed guard. Automatic paths skip **silently** — no request, no toast; only
user-initiated actions surface the 409.

(Spec correction: `RemoteStatsPanel.load()` turned out to have no auto-trigger at all — its own
comment says "No auto-fetch and no polling". Guard added defensively rather than inventing an
auto-load that would have caused real unwanted RF calls.)

### Automations: settings stay editable

Config inputs remain **fully editable**; only immediate-transmit controls ("Send Now", "Run now")
disable. Saving an automation setting does not transmit — Phase 1's schedulers read it and skip at
tick time — so disabling the forms would protect nothing while looking like config loss. Tests
assert both directions, so a future well-meaning "fix" can't quietly disable them.

### Carried-forward Phase 1 review item (fixed here)

`POST /api/settings` did not validate values. Posting `"1"` / `"yes"` / `"TRUE"` / `"on"` persisted
something `refreshReceiveOnly()`'s `raw === 'true'` reads as **false** — receive-only silently OFF
while the user believed transmission was blocked. A fail-open on a safety flag. Now rejected with
`400 INVALID_BOOLEAN_SETTING` before either write path and before `refreshMeshcoreReceiveOnly` fires.

### Browser-validated against real hardware

Driven live in the dev container against a MeshCore Companion source, with a second MeshCore source
and two Meshtastic sources as controls:

- Toggle persists and updates **without a reload**; per-source isolation confirmed (siblings unaffected).
- Both `Send Advert` render paths (status bar + Device actions) and all four Discover buttons disable
  with the MeshCore-correct tooltip; `Refresh`, `Disconnect` and the discovery-response checkbox stay enabled.
- All five automation sections show the paused note while **223/233 inputs stay editable**.
- `GET /contacts/:pk/neighbours` and `GET /admin/status/:pk` both return `409 TX_DISABLED` on the
  receive-only source, while the control source still reaches the radio — so the 409 is specific,
  not a blanket failure.
- **A reload with receive-only ON produced zero 409s and zero toasts** — the latch guards holding.
- Disable-confirm: cancel aborts, accept re-enables every control immediately.
- Console clean (only an unrelated link-preview fetch).

### Testing

- Full Vitest suite: **14,149 tests, 0 failures** (`success: true` via JSON reporter).
- `npm run typecheck` clean; `npm run lint:ci` clean of in-repo failures.
- Also took the non-blocking `typecheck:tests` burn-down from **433 → 422** by properly fixing the
  11 errors this epic had contributed (10 from Phase 1) — no `any`, no suppression directives.

### Known gap

The `App.tsx` 409-toast regression test was not written: no full-render harness for `<App/>` exists
anywhere in the repo (3,933 lines, 78 imports), and building one for a uniform, grep-verified string
swap was disproportionate. Flagging rather than silently skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf
