### PR TITLE
fix(meshcore): update contact Last Heard on incoming direct message

### DIFF
--- a/src/server/meshcoreManager.dmLastHeard.test.ts
+++ b/src/server/meshcoreManager.dmLastHeard.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Regression for issue #4553: a MeshCore direct message is itself a "we just
+ * heard this contact" event, but the sender contact's `lastSeen` (surfaced as
+ * "Last Heard" in the Contact Details panel) previously only advanced on
+ * `contact_advertised` pushes or the next debounced/manual `refreshContacts()`
+ * poll. A DM arriving between adverts left the panel showing a stale "1 day
+ * ago" moments after a live message came in.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const upsertNode = vi.fn().mockResolvedValue(undefined);
+const insertMessage = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      upsertNode: (...args: unknown[]) => upsertNode(...args),
+      insertMessage: (...args: unknown[]) => insertMessage(...args),
+    },
+  },
+}));
+
+const emitMeshCoreContactUpdated = vi.fn();
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: {
+    emitMeshCoreContactUpdated: (...args: unknown[]) => emitMeshCoreContactUpdated(...args),
+    emitMeshCoreMessage: vi.fn(),
+    emitMeshCoreSelfInfoUpdated: vi.fn(),
+  },
+}));
+
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+interface BridgeEvent {
+  event_type: string;
+  data: Record<string, unknown>;
+}
+
+function dispatchBridgeEvent(m: MeshCoreManager, evt: BridgeEvent): void {
+  // handleBridgeEvent is private; invoking it directly exercises the
+  // contact-message path without standing up the native backend.
+  // @ts-expect-error - exercising private method
+  m.handleBridgeEvent(evt);
+}
+
+describe('MeshCoreManager — DM updates sender Last Heard (#4553)', () => {
+  const SENDER_PUBKEY = 'c'.repeat(64);
+
+  beforeEach(() => {
+    upsertNode.mockClear();
+    insertMessage.mockClear();
+    emitMeshCoreContactUpdated.mockClear();
+    vi.useRealTimers();
+  });
+
+  function makeManagerWithContact(overrides?: Record<string, unknown>): MeshCoreManager {
+    const m = new MeshCoreManager('src-a');
+    (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+    (m as any).localNode = { publicKey: 'a'.repeat(64) };
+    (m as any).contacts.set(SENDER_PUBKEY, {
+      publicKey: SENDER_PUBKEY,
+      advName: 'Cupid_stunt',
+      advType: 1,
+      lastSeen: 1_600_000_000_000, // "1 day ago"-style stale value
+      lastAdvert: 1_600_000_000,
+      pathLen: 4,
+      outPath: '3ed6,86f1,92db,d450',
+      ...overrides,
+    });
+    return m;
+  }
+
+  it('bumps the sender contact lastSeen to now when a direct message arrives', async () => {
+    const fixedNow = 1_800_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNow);
+
+    const manager = makeManagerWithContact();
+
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_message',
+      data: {
+        pubkey_prefix: SENDER_PUBKEY,
+        text: 'test 000',
+        sender_timestamp: 1_700_000_000,
+      },
+    });
+
+    expect(manager.getContact(SENDER_PUBKEY)?.lastSeen).toBe(fixedNow);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(upsertNode).toHaveBeenCalledWith(
+      expect.objectContaining({ publicKey: SENDER_PUBKEY, lastHeard: fixedNow }),
+      'src-a',
+    );
+    expect(emitMeshCoreContactUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ publicKey: SENDER_PUBKEY, lastSeen: fixedNow }),
+      'src-a',
+    );
+  });
+
+  it('does not touch the cached outbound path/hops — those reflect routing, not this message', async () => {
+    const manager = makeManagerWithContact();
+
+    dispatchBridgeEvent(manager, {
+      event_type: 'contact_message',
+      data: {
+        pubkey_prefix: SENDER_PUBKEY,
+        text: 'test 000',
+        sender_timestamp: 1_700_000_000,
+        // This message itself arrived direct (0 hops) — must not overwrite
+        // the contact's separately-tracked outbound routing path.
+        path_len: 0xff,
+      },
+    });
+
+    const contact = manager.getContact(SENDER_PUBKEY);
+    expect(contact?.pathLen).toBe(4);
+    expect(contact?.outPath).toBe('3ed6,86f1,92db,d450');
+  });
+
+  it('is a no-op when the sender is not a known contact', () => {
+    const manager = new MeshCoreManager('src-a');
+    (manager as any).deviceType = MeshCoreDeviceType.COMPANION;
+    (manager as any).localNode = { publicKey: 'a'.repeat(64) };
+
+    expect(() =>
+      dispatchBridgeEvent(manager, {
+        event_type: 'contact_message',
+        data: {
+          pubkey_prefix: 'deadbeef',
+          text: 'orphan dm',
+          sender_timestamp: 1_700_000_000,
+        },
+      }),
+    ).not.toThrow();
+
+    expect(upsertNode).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1699,6 +1699,17 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       logger.debug(`[MeshCore:${this.sourceId}] Contact message from ${data.pubkey_prefix} (${data.text.length} chars)`);
       void this.checkAutoAcknowledge(message, true, undefined, hopCount, ackRoute);
       void this.checkAutoResponder(message, true, undefined, hopCount, ackRoute);
+      // A direct message is itself a "we just heard this contact" event —
+      // without this, Last Heard/Last Seen only advance on `contact_advertised`
+      // pushes or the next refreshContacts() poll, so the Contact Details panel
+      // can show a stale "1 day ago" moments after a live DM arrives (#4553).
+      if (senderContact) {
+        const touchedContact: MeshCoreContact = { ...senderContact, lastSeen: Date.now() };
+        this.contacts.set(senderContact.publicKey, touchedContact);
+        void this.persistContact(touchedContact);
+        this.emit('contacts_updated', { sourceId: this.sourceId, contact: touchedContact });
+        dataEventEmitter.emitMeshCoreContactUpdated(touchedContact, this.sourceId);
+      }
     } else if (event_type === 'channel_message') {
       // MeshCore channel packets have no sender field on the wire — the sender's
       // device prefixes "Name: " onto the text body. Split it out so the UI can


### PR DESCRIPTION
## Summary
- Fixes the "LAST_HEARD time displayed" half of #4553: a MeshCore direct message is itself proof the contact was just heard, but the sender's `lastSeen` (which drives the "Last Heard" field in Contact Details) previously only advanced on `contact_advertised` push events or the next `refreshContacts()` poll. A DM arriving between adverts left the panel showing a stale timestamp (e.g. "1 day ago") moments after a live message came in.
- `handleBridgeEvent`'s `contact_message` handler now bumps the resolved sender contact's `lastSeen` to "now", persists it, and emits `contacts_updated` — the same update/persist/emit pattern already used for `contact_advertised`.
- Deliberately does **not** touch the contact's cached `outPath`/`pathLen` ("Hops Away"/"Path"). Those represent the outbound routing path MeshMonitor would use to *send* to the contact, not the inbound route of a given message — that separation is intentional per #3742 and is the other half of #4553's report (see the issue comment for the full explanation of why "4 hops away" and a "direct" message tag can coexist correctly).

## Test plan
- [x] Added `src/server/meshcoreManager.dmLastHeard.test.ts` (3 new tests): lastSeen bumps to now on a direct message, cached outPath/pathLen are untouched, no-op for an unknown sender.
- [x] `npx vitest run src/server/meshcoreManager*` — 46 files / 448 tests pass.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint:ci` — no new baseline violations.

Fixes #4553 (partially — see issue comment for the "Hops Away"/"Path" discussion, which may warrant a separate feature request).


---
_Generated by [Claude Code](https://claude.ai/code/session_017V91vjhJ3GPhGvBDDv4sa9)_