### PR TITLE
feat(meshcore): Virtual Node receive-only gating + docs — Phase 3 (closes #4547)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -154,6 +154,7 @@ export default defineConfig({
           collapsed: true,
           items: [
             { text: 'MeshCore', link: '/features/meshcore' },
+            { text: 'MeshCore Receive-Only Mode', link: '/features/meshcore-receive-only' },
             { text: 'MeshCore Analyzer Observer', link: '/features/meshcore-analyzer-observer' }
           ]
         }

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -728,6 +728,11 @@ Update automation and system settings.
 - **Auto Welcome**: `autoWelcomeEnabled`, `autoWelcomeMessage`, etc.
 - **Display Preferences**: `temperatureUnit`, `distanceUnit`, `timeFormat`, `dateFormat`, etc.
 - **Traceroute**: `tracerouteIntervalMinutes` (1-60)
+- **MeshCore** (per-source — pass `?sourceId=<id>`): `meshcoreReceiveOnly` (string: exact
+  `"true"`/`"false"` — see the strict-boolean note below). Blocks every transmission from that
+  MeshCore source; see [MeshCore Receive-Only Mode](/docs/features/meshcore-receive-only.md).
+  Current state is also readable from `GET /api/sources` (`radio.receiveOnly` /
+  `radio.canTransmit` on the MeshCore entry) and `GET /api/device/tx-status?sourceId=<id>`.
 
 **Response:**
 ```json
@@ -739,6 +744,24 @@ Update automation and system settings.
   }
 }
 ```
+
+**Errors:**
+- `400 INVALID_BOOLEAN_SETTING` — a strict-boolean setting was sent a value other than the exact
+  string `"true"` or `"false"`. Currently applies to `meshcoreReceiveOnly`
+  (`src/server/routes/settingsRoutes.ts`). This is stricter than the general "everything is a
+  string" rule above on purpose: the server reads this setting back with `raw === 'true'`, so a
+  coerced truthy value like `"1"`, `"yes"`, `"TRUE"`, or `"on"` would persist successfully and
+  then evaluate to **false** on every subsequent check — silently leaving transmission enabled on
+  a source the operator believed was receive-only. Rejecting the request outright surfaces that
+  bug immediately instead of hiding it behind a safety setting.
+
+  ```json
+  {
+    "success": false,
+    "error": "meshcoreReceiveOnly must be the boolean true or false (received \"1\")",
+    "code": "INVALID_BOOLEAN_SETTING"
+  }
+  ```
 
 **Notes:**
 - All settings values are strings for database storage compatibility
@@ -1103,8 +1126,13 @@ v1 API endpoints use the envelope format:
 
 **Transmit-disabled sources (`409 TX_DISABLED`):** any transmit action — message send, traceroute,
 position/nodeinfo/neighbor/telemetry request, or remote-node admin command — returns the envelope
-format above with `code: "TX_DISABLED"` and HTTP `409` when the target source's LoRa radio has
-`lora.txEnabled = false` (receive-only mode; see [Receive-Only Mode](/docs/features/receive-only-mode.md)):
+format above with `code: "TX_DISABLED"` and HTTP `409`. Two independent causes trigger it, one per
+source type:
+
+- **Meshtastic** — the target source's LoRa radio has `lora.txEnabled = false` (receive-only mode;
+  see [Receive-Only Mode](/docs/features/receive-only-mode.md)).
+- **MeshCore** — the target source has the per-source `meshcoreReceiveOnly` setting turned on
+  (see [MeshCore Receive-Only Mode](/docs/features/meshcore-receive-only.md)).
 
 ```json
 {
@@ -1114,7 +1142,41 @@ format above with `code: "TX_DISABLED"` and HTTP `409` when the target source's 
 }
 ```
 
-Nothing is transmitted. Re-enable **TX Enabled** in the source's LoRa configuration to clear it.
+Nothing is transmitted. For Meshtastic, re-enable **TX Enabled** in the source's LoRa configuration
+to clear it. For MeshCore, turn off receive-only mode for the source (MeshCore Settings, or
+`POST /api/settings?sourceId=<id>` with `meshcoreReceiveOnly: "false"`). The MeshCore message is:
+
+```json
+{
+  "success": false,
+  "error": "Transmission blocked: this MeshCore source is configured for receive-only operation.",
+  "code": "TX_DISABLED"
+}
+```
+
+MeshCore routes gated behind `409 TX_DISABLED` (mounted under `/api/sources/:id/meshcore`):
+
+```
+POST /messages/send
+POST /rooms/login | /rooms/login-with-saved | /rooms/post
+POST /contacts/:publicKey/reset-path | /discover-path | /discover | /regions/discover
+POST /contacts/:publicKey/trace-path | /ping | /share
+POST /nodes/:publicKey/telemetry/poll
+POST /neighbors/request                       (only the remote-node branch; the
+                                                local/no-key branch is unaffected)
+GET  /contacts/:publicKey/neighbours           ← GET, not POST
+POST /admin/login | /admin/login-with-saved
+POST /admin/cli
+GET  /admin/status/:publicKey                  ← GET, not POST
+POST /cli                                      (only the `advert` verb; every
+                                                 other local CLI verb still works)
+POST /advert
+POST /automation/announce/send | /automation/timers/:triggerId/run
+```
+
+Two of these are **`GET`** requests that transmit — `GET /contacts/:publicKey/neighbours` (asks a
+remote repeater for its neighbour table) and `GET /admin/status/:publicKey` (polls a remote node for
+status). An API consumer scanning only `POST` routes for transmit side effects will miss both.
 
 **Common Status Codes:**
 - `200` - Success

--- a/docs/api/REST_API.md
+++ b/docs/api/REST_API.md
@@ -103,8 +103,12 @@ Per-source v1 endpoints return `400 MISSING_SOURCE_ID` when `sourceId` is absent
 
 **Transmit-disabled sources (`409 TX_DISABLED`):** any transmit action — message send, traceroute,
 position/nodeinfo/neighbor/telemetry request, or remote-node admin command — returns `409` with
-`code: "TX_DISABLED"` when the target source's LoRa radio has `lora.txEnabled = false` (receive-only
-mode; see [Receive-Only Mode](/docs/features/receive-only-mode.md)):
+`code: "TX_DISABLED"`. Two independent causes trigger it, one per source type:
+
+- **Meshtastic** — the target source's LoRa radio has `lora.txEnabled = false` (receive-only mode;
+  see [Receive-Only Mode](/docs/features/receive-only-mode.md)).
+- **MeshCore** — the target source has the per-source `meshcoreReceiveOnly` setting turned on
+  (see [MeshCore Receive-Only Mode](/docs/features/meshcore-receive-only.md)).
 
 ```json
 {
@@ -114,10 +118,47 @@ mode; see [Receive-Only Mode](/docs/features/receive-only-mode.md)):
 }
 ```
 
-Nothing is transmitted. Re-enable **TX Enabled** in the source's LoRa configuration to clear it. This
-applies to both the v1 endpoints above and the equivalent main-API routes (`/api/messages/send`,
-`/api/traceroute`, `/api/position/request`, `/api/nodeinfo/request`, `/api/neighborinfo/request`,
-`/api/telemetry/request`, `/api/admin/commands`).
+Nothing is transmitted. For Meshtastic, re-enable **TX Enabled** in the source's LoRa configuration
+to clear it. This applies to both the v1 endpoints above and the equivalent main-API routes
+(`/api/messages/send`, `/api/traceroute`, `/api/position/request`, `/api/nodeinfo/request`,
+`/api/neighborinfo/request`, `/api/telemetry/request`, `/api/admin/commands`).
+
+For MeshCore, turn off receive-only mode for the source (MeshCore Settings, or
+`POST /api/settings?sourceId=<id>` with `meshcoreReceiveOnly: "false"`) to clear it. The MeshCore
+message is:
+
+```json
+{
+  "success": false,
+  "error": "Transmission blocked: this MeshCore source is configured for receive-only operation.",
+  "code": "TX_DISABLED"
+}
+```
+
+MeshCore routes gated behind `409 TX_DISABLED` (mounted under
+`/api/sources/:id/meshcore`):
+
+```
+POST /messages/send
+POST /rooms/login | /rooms/login-with-saved | /rooms/post
+POST /contacts/:publicKey/reset-path | /discover-path | /discover | /regions/discover
+POST /contacts/:publicKey/trace-path | /ping | /share
+POST /nodes/:publicKey/telemetry/poll
+POST /neighbors/request                       (only the remote-node branch; the
+                                                local/no-key branch is unaffected)
+GET  /contacts/:publicKey/neighbours           ← GET, not POST
+POST /admin/login | /admin/login-with-saved
+POST /admin/cli
+GET  /admin/status/:publicKey                  ← GET, not POST
+POST /cli                                      (only the `advert` verb; every
+                                                 other local CLI verb still works)
+POST /advert
+POST /automation/announce/send | /automation/timers/:triggerId/run
+```
+
+Two of these are **`GET`** requests that transmit — `GET /contacts/:publicKey/neighbours` (asks a
+remote repeater for its neighbour table) and `GET /admin/status/:publicKey` (polls a remote node for
+status). An API consumer scanning only `POST` routes for transmit side effects will miss both.
 
 **Common Status Codes:**
 - `200` - Success

--- a/docs/configuration/virtual-node.md
+++ b/docs/configuration/virtual-node.md
@@ -454,7 +454,7 @@ MeshCore App 3 ┘
 - **Identity & device info** — the app connects, shows the node's identity, and reads device/firmware info.
 - **Contacts** — served from the durable per-source contact list (so the app sees the full set even when the live companion read is flaky).
 - **Channels & battery** — channel info (including PSK) and the local node's battery level.
-- **Messaging** — incoming channel and direct messages are pushed to the app; outgoing **direct** and **channel** text messages are forwarded to the real node.
+- **Messaging** — incoming channel and direct messages are pushed to the app; outgoing **direct** and **channel** text messages are forwarded to the real node, unless the source is in [receive-only mode](#safety-receive-only-mode).
 
 ### Enabling MeshCore Virtual Node on a Source
 
@@ -503,6 +503,12 @@ In the MeshCore mobile app, add a new device using the **TCP / network** connect
 By default the MeshCore Virtual Node is **read-and-message only**: read operations and sending text messages are allowed, but configuration-mutating commands (set radio params, set advert name, import private key, reboot, set channel, set TX power, etc.) are **blocked** and rejected back to the app. Exporting the device's private key is **always blocked**, regardless of settings.
 
 Enabling **Allow admin commands** forwards those configuration commands through to the real node. Only enable it on a trusted LAN where you control every device that can reach the port — any connected app would then be able to reconfigure your node.
+
+### Safety: receive-only mode
+
+*New in 4.14 (#4547).* When the source has [Receive-only mode](/features/meshcore-receive-only) turned on, the Virtual Node keeps serving reads — identity, contacts, channels, message sync, device info, battery, time, config setters, PKI export where enabled, and the live OTA packet feed — but refuses the nine commands that would transmit (sending messages, self-adverts, remote logins, trace path, telemetry and status requests, and neighbour requests). A connected app gets a clean, immediate refusal instead of a silent drop or a hung request.
+
+This is independent of **Allow admin commands** and **Allow PKI export** — receive-only blocks *transmission*, those two gate *configuration and key export*. All three can be set independently.
 
 ### Status & Troubleshooting
 

--- a/docs/features/meshcore-analyzer-observer.md
+++ b/docs/features/meshcore-analyzer-observer.md
@@ -16,6 +16,8 @@ The Analyzer Observer relays every packet your MeshCore Companion hears to a Mes
 
 It publishes what the radio already heard. Nothing more.
 
+Because it only ever publishes outbound to a broker over the network, the Analyzer Observer keeps running unaffected when a source is in [receive-only mode](/features/meshcore-receive-only) — receive-only blocks the radio path, not this one.
+
 ## Requirements
 
 - A **Companion** source (not a Repeater, not a Room Server) — the Analyzer Observer needs the device's signing key, and only Companions can export one.

--- a/docs/features/meshcore-receive-only.md
+++ b/docs/features/meshcore-receive-only.md
@@ -57,6 +57,10 @@ The [MeshCore Virtual Node](/configuration/virtual-node#meshcore-virtual-node) p
 
 The nine transmit-causing companion commands are refused instead: `SendChannelTxtMsg`, `SendTxtMsg` (including the CLI relay), `SendSelfAdvert`, `SendLogin`, `SendTracePath`, `SendTelemetryReq`, `SendStatusReq`, and `SendBinaryReq` (neighbour requests). A third-party MeshCore client connected to the Virtual Node gets a prompt, well-formed refusal on each of these — not a silent drop, and not a timeout.
 
+::: warning The Virtual Node port is unauthenticated
+Keeping reads available cuts both ways: the Virtual Node port has no authentication, so any client that can reach it can read your identity, contacts, channels and messages. That is existing Virtual Node behaviour and receive-only mode does not change it — but it is worth restating here, because "receive-only" means *this node will not transmit*, not *this node will not disclose anything*. If that distinction matters for your deployment, restrict access to the port, or turn the Virtual Node off.
+:::
+
 ## How to enable / disable it
 
 1. Open the source's **MeshCore Settings**.
@@ -78,7 +82,7 @@ Any MeshCore route that would transmit returns:
 }
 ```
 
-with HTTP status `409`. This is the same `TX_DISABLED` code Meshtastic sources use for `lora.txEnabled = false` — see the [REST API reference](https://github.com/Yeraze/meshmonitor/blob/main/docs/api/API_REFERENCE.md) for the full route list. Two of the gated routes are `GET` requests (fetching neighbours and remote admin status), which is easy to miss if you're only checking `POST` routes.
+with HTTP status `409`. This is the same `TX_DISABLED` code Meshtastic sources use for `lora.txEnabled = false` — see the [REST API reference](/api/API_REFERENCE) for the full route list. Two of the gated routes are `GET` requests (fetching neighbours and remote admin status), which is easy to miss if you're only checking `POST` routes.
 
 ## Per-source scope
 
@@ -90,4 +94,4 @@ Receive-only applies to **one source only**. A sibling MeshCore source, or any M
 - [MeshCore Virtual Node](/configuration/virtual-node#meshcore-virtual-node) — what read-only access covers
 - [MeshCore Analyzer Observer](/features/meshcore-analyzer-observer) — keeps publishing under receive-only
 - [Receive-Only Mode](/features/receive-only-mode) — the Meshtastic equivalent, which **is** a firmware kill switch
-- [REST API Reference](https://github.com/Yeraze/meshmonitor/blob/main/docs/api/API_REFERENCE.md) — `409 TX_DISABLED` error shape
+- [REST API Reference](/api/API_REFERENCE) — `409 TX_DISABLED` error shape

--- a/docs/features/meshcore-receive-only.md
+++ b/docs/features/meshcore-receive-only.md
@@ -1,0 +1,93 @@
+# MeshCore Receive-Only Mode
+
+::: tip Added in 4.14 (#4547)
+A per-source strict receive-only setting for MeshCore sources — the node keeps listening, but MeshMonitor blocks every transmission it controls.
+:::
+
+::: danger MeshCore firmware has no transmit kill switch
+MeshCore firmware exposes **no radio-level transmit switch**. We checked: the companion protocol client `@liamcottle/meshcore.js` (v1.13.0) has no `txEnabled`, `disableTx`, or `radioOff` command anywhere in its command set. `SetTxPower` only lowers transmit power — it never stops transmission.
+
+So MeshMonitor enforces receive-only **in software**, by refusing every send it controls: the web UI, the REST API, schedulers, automations, and the Virtual Node port. It **cannot** stop transmissions the node makes on its own — link-layer acknowledgements, and any advert schedule you configured on the device outside MeshMonitor.
+
+**MeshMonitor's guarantee is "MeshMonitor will not key the radio," not "this radio is silent."** If you need this for a regulatory or site-policy reason, read that sentence again before you rely on it. Contrast this with Meshtastic's [`lora.txEnabled`](/features/receive-only-mode), which **is** a firmware kill switch — Meshtastic hardware drops outbound packets at the radio driver, before they reach the air.
+:::
+
+## What it is
+
+Receive-only mode is a per-source setting (`meshcoreReceiveOnly`) that applies to a single MeshCore source — Companion or Repeater. Turn it on and MeshMonitor stops sending anything to that node's radio: no messages, no adverts, no remote admin, no path discovery, and no automation transmits. Everything the node hears keeps flowing in as normal.
+
+Good reasons to run a MeshCore source this way:
+
+- A dedicated **Analyzer Observer** box that should only listen and report, never key up
+- A **passive monitoring station** watching mesh activity without participating in it
+- A **regulatory or site-policy** environment that requires a listen-only radio
+- A **shared install** — a kiosk, a public terminal, a lab node — where accidental transmission by any user must be prevented
+
+## What still works
+
+- **Receiving and decoding** every packet the radio hears
+- The **Analyzer Observer** — it publishes heard packets outbound to an MQTT broker, which is a network path, not a radio path (see [MeshCore Analyzer Observer](/features/meshcore-analyzer-observer))
+- The **MeshCore Packet Monitor** (raw OTA capture)
+- Contact, route, telemetry, and dashboard updates learned from RF traffic
+- The connection itself, over USB or TCP — the source stays connected
+- **Local serial configuration**: device name, radio parameters, TX power, coordinates, channel create/edit/delete, RTC sync, device stats, reboot, and contact import/export
+- The **local serial CLI**, except the synthetic `advert` verb (see [What is blocked](#what-is-blocked))
+- **Read-only Virtual Node access** — see [below](#virtual-node-access)
+
+## What is blocked
+
+Anything that puts a packet on the air from this node:
+
+- Channel messages and direct messages
+- Self-adverts
+- Remote CLI and remote logins
+- Path discovery and traceroute
+- Telemetry and status requests to other nodes
+- Neighbour requests
+- Node and region discovery
+- Contact sharing
+- Discovery auto-responses (the node no longer answers other nodes' discovery requests)
+- Every automation that transmits: auto-acknowledge, the auto-responder, auto-announce, auto-pathfinding, and timer triggers
+
+Automation settings are **preserved, not cleared**. Each affected automation section shows a "Paused — receive-only mode" note; the configuration stays exactly as you left it and resumes on its own configured schedule the moment you turn receive-only off. Turning it on never discards a saved automation.
+
+## Virtual Node access
+
+The [MeshCore Virtual Node](/configuration/virtual-node#meshcore-virtual-node) port stays up and keeps serving reads while a source is receive-only: identity, contacts, channels, message sync, device info, battery, time, local config setters, and PKI export (where enabled) all keep working, along with the live packet feed. This matters because the Virtual Node port is a raw TCP socket that bypasses MeshMonitor's HTTP API entirely — closing it off is what makes receive-only complete.
+
+The nine transmit-causing companion commands are refused instead: `SendChannelTxtMsg`, `SendTxtMsg` (including the CLI relay), `SendSelfAdvert`, `SendLogin`, `SendTracePath`, `SendTelemetryReq`, `SendStatusReq`, and `SendBinaryReq` (neighbour requests). A third-party MeshCore client connected to the Virtual Node gets a prompt, well-formed refusal on each of these — not a silent drop, and not a timeout.
+
+## How to enable / disable it
+
+1. Open the source's **MeshCore Settings**.
+2. Toggle **Receive-only mode**.
+3. Turning it **on** takes effect immediately — no confirmation needed.
+4. Turning it **off** shows a confirmation dialog, because it resumes RF: messages, adverts, remote admin, and every enabled automation will start transmitting again. Confirm to apply.
+
+The change applies with no reload and no reconnect.
+
+## API behaviour
+
+Any MeshCore route that would transmit returns:
+
+```json
+{
+  "success": false,
+  "error": "Transmission blocked: this MeshCore source is configured for receive-only operation.",
+  "code": "TX_DISABLED"
+}
+```
+
+with HTTP status `409`. This is the same `TX_DISABLED` code Meshtastic sources use for `lora.txEnabled = false` — see the [REST API reference](https://github.com/Yeraze/meshmonitor/blob/main/docs/api/API_REFERENCE.md) for the full route list. Two of the gated routes are `GET` requests (fetching neighbours and remote admin status), which is easy to miss if you're only checking `POST` routes.
+
+## Per-source scope
+
+Receive-only applies to **one source only**. A sibling MeshCore source, or any Meshtastic source, keeps transmitting normally. There is no global switch — set it per source, on the sources that need it.
+
+## Related
+
+- [MeshCore Support](/features/meshcore) — source setup and configuration
+- [MeshCore Virtual Node](/configuration/virtual-node#meshcore-virtual-node) — what read-only access covers
+- [MeshCore Analyzer Observer](/features/meshcore-analyzer-observer) — keeps publishing under receive-only
+- [Receive-Only Mode](/features/receive-only-mode) — the Meshtastic equivalent, which **is** a firmware kill switch
+- [REST API Reference](https://github.com/Yeraze/meshmonitor/blob/main/docs/api/API_REFERENCE.md) — `409 TX_DISABLED` error shape

--- a/docs/features/meshcore-receive-only.md
+++ b/docs/features/meshcore-receive-only.md
@@ -82,7 +82,7 @@ Any MeshCore route that would transmit returns:
 }
 ```
 
-with HTTP status `409`. This is the same `TX_DISABLED` code Meshtastic sources use for `lora.txEnabled = false` — see the [REST API reference](/api/API_REFERENCE) for the full route list. Two of the gated routes are `GET` requests (fetching neighbours and remote admin status), which is easy to miss if you're only checking `POST` routes.
+with HTTP status `409`. This is the same `TX_DISABLED` code Meshtastic sources use for `lora.txEnabled = false` — see the [REST API reference](https://github.com/Yeraze/meshmonitor/blob/main/docs/api/API_REFERENCE.md) for the full route list. Two of the gated routes are `GET` requests (fetching neighbours and remote admin status), which is easy to miss if you're only checking `POST` routes.
 
 ## Per-source scope
 
@@ -94,4 +94,4 @@ Receive-only applies to **one source only**. A sibling MeshCore source, or any M
 - [MeshCore Virtual Node](/configuration/virtual-node#meshcore-virtual-node) — what read-only access covers
 - [MeshCore Analyzer Observer](/features/meshcore-analyzer-observer) — keeps publishing under receive-only
 - [Receive-Only Mode](/features/receive-only-mode) — the Meshtastic equivalent, which **is** a firmware kill switch
-- [REST API Reference](/api/API_REFERENCE) — `409 TX_DISABLED` error shape
+- [REST API Reference](https://github.com/Yeraze/meshmonitor/blob/main/docs/api/API_REFERENCE.md) — `409 TX_DISABLED` error shape

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -518,6 +518,17 @@ Write controls in the MeshCore UI are now **disabled in place** for users withou
 
 See [Per-Source Permissions](/features/per-source-permissions) for the full model.
 
+## Receive-Only Mode
+
+*New in 4.14.* A per-source **Receive-only mode** toggle in MeshCore Settings blocks every
+transmission from that source — messages, adverts, remote admin, path discovery, and every
+transmitting automation — while receiving, the packet log, the Analyzer Observer, and local
+serial configuration keep working. MeshCore firmware has no radio-level transmit switch, so
+MeshMonitor enforces this in software; it cannot stop link-layer acknowledgements or an
+on-device advert schedule configured outside MeshMonitor. See
+[MeshCore Receive-Only Mode](/features/meshcore-receive-only) for the full picture, including
+Virtual Node behavior and the firmware limitation.
+
 ## Radio Configuration
 
 Use the Configuration view's **Preset** dropdown to pick from the official MeshCore preset list, or choose **Custom** to manually set:

--- a/docs/features/receive-only-mode.md
+++ b/docs/features/receive-only-mode.md
@@ -62,7 +62,9 @@ rest of the mesh** over time, even though it can still hear everything happening
   run history rather than failing the run; the automation builder also shows an inline warning
   badge next to any explicitly-selected source that currently has TX disabled.
 - **Not gated:** the embedded MQTT bridge downlink (it publishes to a broker, bypassing the radio
-  entirely) and MeshCore sources (a different protocol with no equivalent flag).
+  entirely). MeshCore sources have their own equivalent — see
+  [MeshCore Receive-Only Mode](/features/meshcore-receive-only) — enforced in software, because
+  MeshCore firmware has no transmit kill switch.
 
 ## How to enable / disable it
 
@@ -89,3 +91,5 @@ itself after you disable it, that's a device-side quirk, not MeshMonitor overrid
   checkbox
 - [REST API Reference](https://github.com/Yeraze/meshmonitor/blob/main/docs/api/API_REFERENCE.md) — `409 TX_DISABLED` error shape
 - [Multi-Source](/features/multi-source) — TX state is tracked per source
+- [MeshCore Receive-Only Mode](/features/meshcore-receive-only) — the MeshCore equivalent,
+  enforced in software rather than by a firmware kill switch

--- a/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_EPIC.md
+++ b/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_EPIC.md
@@ -3,8 +3,58 @@
 **Epic issue:** #4547
 **Status:**
 - [x] Phase 1 — Backend: setting + central command-aware TX guard (PR #4550, merged `c41428e6`)
-- [x] Phase 2 — Frontend: gating UX (branch `feature/meshcore-receive-only-ui`)
-- [ ] Phase 3 — Virtual Node gating + docs
+- [x] Phase 2 — Frontend: gating UX (PR #4552, merged `d818768f`)
+- [x] Phase 3 — Virtual Node gating + docs (branch `feature/meshcore-receive-only-vn`)
+
+**EPIC COMPLETE.** Every MeshMonitor-controlled transmit path for a MeshCore source is now
+gated: HTTP routes (409), manager primitives (throw), schedulers and automations (silent skip),
+the discovery auto-responder, and the Virtual Node port. The one thing MeshMonitor cannot stop
+is firmware-autonomous TX — see the hard constraint at the top of this document, documented for
+users in `docs/features/meshcore-receive-only.md`.
+
+## Phase 3 deviations & findings (2026-08-04)
+
+Spec: `docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE3_SPEC.md`. Four work packages,
+4 commits, 10 files.
+
+- **The refusal shape was the whole phase, and the obvious choice was wrong.** Refusing with
+  `Disabled(15)` would have hung real clients: in `@liamcottle/meshcore.js` v1.13.0 only
+  `exportPrivateKey()` listens for `Disabled` (`connection.js:1576`), and `sendTextMessage` /
+  `sendChannelTextMessage` / `sendAdvert` have **no timeout at all** — so a `Disabled` reply to
+  those emits an event nobody is listening for and the promise never settles. `Err(1)` with
+  `ErrorCodes.BadState(4)` is the only refusal every command wrapper terminates on.
+  `BadState` over `UnsupportedCmd` because the latter is a *capability* claim a client may cache,
+  whereas receive-only is runtime state.
+- **The guard must precede the `Sent` frame — relying on Phase 1's throw was structurally
+  impossible.** Six of the nine handlers wrote `Sent(6)` before reaching the manager, and the
+  client wrappers for `login` and `tracePath` do `onSent → this.off(Err, onErr)`
+  (`connection.js:1641`, `:2373`) — they tear down the error listener the instant `Sent` arrives.
+  Any refusal emitted after that point is silently discarded. Before this phase those six
+  commands did not transmit (Phase 1 blocked them downstream) but never refused either: the
+  client simply hung 12–30 s to its own timeout. Three handlers already replied `Err(BadState)`
+  correctly, so for those the change is byte-identical.
+- **8 guard sites cover 9 commands.** `handleSendCliTxtMsg` is private with a single caller
+  (`handleSendTxtMsg`), so a separate guard there would be dead code — documented in a JSDoc note
+  so a future reader doesn't "fix" the apparent omission. Guards run before payload parsing, so
+  `SendBinaryReq` is refused at the envelope and future sub-types are covered automatically.
+- **`isReceiveOnly()` is a required interface member, deliberately.** An optional one would
+  default to "allowed" — the wrong direction for a safety gate. Making it required meant the
+  existing `FakeManager` stopped compiling and 41 tests failed until WP2 updated the harness;
+  that noisy failure is the intended behaviour and was not silenced with a cast.
+- **Regression net:** an inventory test fires every `CommandCodes` value with receive-only ON and
+  asserts no TX manager mock is reached, so a future unguarded handler fails on day one — the
+  same shape as Phase 1's fail-closed denylist test. Plus a decode test using the real
+  `meshcore.js` client, proving a genuine client parses the refusal rather than desyncing.
+- **Doc bug fixed:** `docs/features/receive-only-mode.md` still claimed MeshCore had "no
+  equivalent flag" — true before this epic, false now.
+- **Correction to this document:** the telemetry-poll route is
+  `POST /nodes/:publicKey/telemetry/poll`, not `/contacts/:pk/telemetry/poll` as the Phase 1
+  inventory above originally recorded. Fixed inline.
+- **i18n:** all 14 receive-only keys present and referenced in `public/locales/en.json`;
+  non-English locales are Weblate-managed and were not touched.
+- **Verification:** full Vitest suite 14,168 tests / 0 failures (`success: true` via JSON
+  reporter); VN suite 104/104; `npm run typecheck` clean; `npm run lint:ci` clean of in-repo
+  failures; `npm run docs:build` succeeds with no dead links.
 
 ## Phase 2 deviations & findings (2026-08-04)
 
@@ -217,7 +267,7 @@ guard must hold across reconnects, not just at arm time.
 /rooms/login-with-saved · :474 /rooms/post
 `meshcoreContactsRoutes.ts` :167 reset-path · :205 discover-path · :247 /discover · :290
 /regions/discover · :313 trace-path · :358 ping · :486 share · **:652 `GET`
-/contacts/:pk/neighbours** · :757 telemetry/poll · :1011 /neighbors/request
+/contacts/:pk/neighbours** · :757 `POST /nodes/:publicKey/telemetry/poll` · :1011 /neighbors/request
 `meshcoreAdminRoutes.ts` :44 /admin/login · :127 /admin/cli · :360 /admin/login-with-saved ·
 **:433 `GET` /admin/status/:pk** · :230 /cli (only the `advert` verb)
 `meshcoreDeviceRoutes.ts` :262 /advert

--- a/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE3_SPEC.md
+++ b/docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE3_SPEC.md
@@ -1,0 +1,773 @@
+# MeshCore Strict Receive-Only Mode — Phase 3 Spec
+
+**Epic issue:** #4547 · **Epic plan:** `MESHCORE_RECEIVE_ONLY_EPIC.md`
+**Branch:** `feature/meshcore-receive-only-vn` · **Worktree:** `/home/yeraze/Development/meshmonitor-mc-rxonly-p3`
+**Depends on:** Phase 1 (`c41428e6`) and Phase 2 (`d818768f`), both on `origin/main`.
+
+Phase 3 closes the last transmit path (the Virtual Node TCP port) and ships the
+documentation. Two independent halves:
+
+- **Part A** — refuse the 9 TX-causing Virtual Node companion commands.
+- **Part B** — user doc, sidebar, cross-links, API docs, i18n audit.
+
+All line numbers below were re-verified against the current worktree on 2026-08-04.
+The epic's Phase-3 inventory (`MESHCORE_RECEIVE_ONLY_EPIC.md:230-236`) proved
+accurate — no drift.
+
+---
+
+## 1. Reuse inventory (read this before writing anything)
+
+Everything Phase 3 needs already exists. The only genuinely new artifacts are one
+private helper method, one interface method, and one docs page.
+
+### 1.1 Receive-only state
+
+| Mechanism | Location | Phase 3 use |
+|---|---|---|
+| `MeshCoreManager.isReceiveOnly(): boolean` | `src/server/meshcoreManager.ts:3989` | **The** state read. Sync, cached, no DB hit. |
+| `MeshCoreManager.canTransmit(): boolean` | `meshcoreManager.ts:3998` | Inverse of the above; routes use `isReceiveOnly()`, so the VN matches routes. |
+| `setReceiveOnly()` / `refreshReceiveOnly()` | `meshcoreManager.ts:4007`, `:4023` | Already keeps the cache fresh on settings write and on `connect()` (`:1207`). Phase 3 adds nothing here. |
+| `MESHCORE_RECEIVE_ONLY_MESSAGE` | `src/server/constants/meshcoreTx.ts:58` | Not used on the wire (companion protocol carries no error string) — but referenced in log lines so grep finds every refusal site. |
+| `TxDisabledError` / `isTxDisabledError()` | `src/server/errors/txDisabledError.ts` | **Not** newly consumed by the VN. See §2.6 for why the pre-check does not rely on the downstream throw. |
+
+### 1.2 Route-layer refusal idiom being mirrored
+
+`src/server/routes/meshcoreRouteShared.ts`:
+
+- `requireMeshcoreTx()` (`:79`) — middleware, fails **closed** when the manager is missing.
+- `rejectIfReceiveOnly(req, res): boolean` (`:100`) — inline guard, **returns `true` when it has
+  already written the response.**
+- `failIfTxDisabled(res, error): boolean` (`:113`) — catch-block mapping.
+
+Phase 3's VN helper (`§2.3`) is the transport-shifted twin of `rejectIfReceiveOnly`: same name
+shape, same boolean-means-already-replied contract, same fail-closed posture. Reviewers should be
+able to read one and recognise the other.
+
+### 1.3 Virtual Node server — existing primitives (all reused, none replaced)
+
+`src/server/meshcoreVirtualNodeServer.ts`:
+
+| Primitive | Line | Note |
+|---|---|---|
+| `MeshCoreVirtualNodeManager` interface | `:68` | Deliberately narrow so the server is testable with a fake. Phase 3 widens it by exactly one method. |
+| `send(clientId, payload)` | `:1437` | The single socket-write path. Frames via `frameNodeToApp`. Never bypass it. |
+| `encodeErr(errCode?)` | `meshcoreCompanionCodec.ts:997` | `[0x01][errCode]`. |
+| `ErrorCodes` | `meshcoreCompanionCodec.ts:127` | `UnsupportedCmd:1, NotFound:2, TableFull:3, BadState:4, FileIoError:5, IllegalArg:6`. |
+| `encodeDisabled()` | `meshcoreCompanionCodec.ts:992` | `Disabled(15)`. **Rejected** for this phase — see §2.2. |
+| `COMMAND_NAMES` reverse map | `:192` | Human-readable command name for the refusal log line. Already used by `handleConfigCommand:726`. |
+| `handleConfigCommand`'s `allowAdminCommands` refusal | `:727-733` | The precedent for a policy refusal on this port: `logger.debug(...)` + `Err`. Phase 3 copies the shape exactly. |
+| `handleExportPrivateKey`'s `allowPkiExport` refusal | `:650-656` | The *other* precedent — and the one case that correctly uses `Disabled(15)`. §2.2 explains why it is the exception, not the rule. |
+
+### 1.4 Test harness — existing, reused as-is
+
+`src/server/meshcoreVirtualNodeServer.test.ts` (1,500+ lines, 12 describe blocks):
+
+| Harness piece | Line | Phase 3 use |
+|---|---|---|
+| `FakeManager implements MeshCoreVirtualNodeManager` | `:61` | Gains one method + one mock (§3.1). |
+| `makeManager(overrides)` | `:179` | `makeManager({ isReceiveOnly: () => true })` is the whole per-test setup. |
+| `TestClient` (`request`, `expectFrames`, `send`, `close`) | `:198` | Byte-level frame assertions over a real socket. |
+| `frameCommand(payload)` | `:187` | Builds app→node frames. |
+| Real `meshcore.js` decoder driven directly (`conn.onFrameReceived`) | `:277-283` | The existing pattern for "prove a real client parses our frame". Phase 3 reuses it — see §3.4 for the no-`any` variant. |
+| `vi.mock('../services/database.js')` stub | `:24-29` | Already stubs `auditLogAsync` + `settings.getSetting`. No change needed. |
+
+**Decision: new tests go in the existing file, not a new one.** The sibling Meshtastic VN tests
+(`virtualNodeServer.*.test.ts`) each build their own harness, but that harness is ~180 lines here
+and `FakeManager` must be edited in this file regardless. A separate file would either duplicate
+the harness or export it. One new `describe` block, zero duplication.
+
+### 1.5 Docs surfaces
+
+| Surface | Location | Phase 3 action |
+|---|---|---|
+| VitePress sidebar | `docs/.vitepress/config.mts` — `Protocol-Specific` group at `:152-160` (`text:` at `:153`, items at `:155-158`) | Add one entry. |
+| Meshtastic analogue page | `docs/features/receive-only-mode.md` (91 lines) | Model for structure **and** contains a now-false claim to fix (`:65`). |
+| MeshCore feature page | `docs/features/meshcore.md` (583 lines) | Cross-link + a short section. |
+| MeshCore VN docs | `docs/configuration/virtual-node.md` — `## MeshCore Virtual Node` at `:434`, `### What works` at `:452`, `### Safety: admin commands` at `:501` | Add a sibling safety subsection. |
+| API shared 409 block | `docs/api/REST_API.md:104-118` and `docs/api/API_REFERENCE.md:1104-1118` | Extend to MeshCore. |
+| `POST /api/settings` | `docs/api/API_REFERENCE.md:698` | Document `400 INVALID_BOOLEAN_SETTING`. |
+| `docs/api/API.md` | `:3-10` carries an explicit "This document is outdated" warning | **Leave alone** (same call the Meshtastic TX-disabled epic made). |
+| Locales | `public/locales/en.json` — 13 `meshcore.receive_only.*` keys at `:5160-5172`, `banners.receive_only_meshcore` at `:115` | Verified present. Non-English is Weblate-managed — see §5.4. |
+
+**Nothing new is proposed that an existing mechanism covers.** The three new things and why:
+
+1. `MeshCoreVirtualNodeManager.isReceiveOnly()` — the VN's manager interface is intentionally
+   narrow and does not currently expose it. No alternative: the server has no other handle on the
+   manager.
+2. `MeshCoreVirtualNodeServer.refuseIfReceiveOnly()` — the route-layer helper takes
+   `(req, res)`; the VN speaks `(clientId, commandName)` over a socket. Not shareable.
+3. `docs/features/meshcore-receive-only.md` — the epic mandates a user doc; the Meshtastic page
+   documents a firmware kill switch and would be actively misleading if reused.
+
+---
+
+## 2. Part A design — what "refuse" looks like on the wire
+
+This is the crux of the phase. The conclusions below are derived from
+`node_modules/@liamcottle/meshcore.js@1.13.0/src/connection/connection.js`, which is both the
+library MeshMonitor itself uses and the reference implementation of the companion protocol client.
+
+### 2.1 What actually happens today (receive-only ON, no Phase 3)
+
+Every VN handler is already inside a `try/catch` (WP2's Phase 1 audit was right about that), and
+Phase 1 made every manager method these handlers call throw `TxDisabledError`. But the catch
+blocks fall into **two different shapes**, and only one of them is safe:
+
+| # | Command | Handler | Manager method (Phase 1 guard) | Today's reply | Client-visible result |
+|---|---|---|---|---|---|
+| 1 | `SendChannelTxtMsg` | `:1143` | `sendMessage` (`mgr:3072`) | `Err(BadState)` | ✅ promise rejects immediately |
+| 2 | `SendTxtMsg` (Plain) | `:1172` | `sendMessageWithResult` (`mgr:3083`) | `Err(BadState)` | ✅ promise rejects immediately |
+| 4 | `SendSelfAdvert` | `:768` | `sendAdvert` (`mgr:3669`) | `Err(BadState)` | ✅ promise rejects immediately |
+| 3 | `SendTxtMsg` (CliData) → `handleSendCliTxtMsg` | `:1264` | `sendCliCommand` (`mgr:5185`) | `Sent(6)` at `:1272`, then **silence** | ❌ hangs to the app's own timeout |
+| 5 | `SendLogin` | `:803` | `loginToNode` (`mgr:4787`) | `Sent(6)` at `:814`, then **silence** | ❌ hangs ~12 s → `reject("timeout")` |
+| 6 | `SendTracePath` | `:846` | `tracePathRaw` (`mgr:4171`) | `Sent(6)` at `:855`, then **silence** | ❌ hangs ~30 s |
+| 7 | `SendTelemetryReq` | `:882` | `requestRemoteTelemetryRaw` (`mgr:5725`) | `Sent(6)` at `:892`, then **silence** | ❌ hangs ~30 s |
+| 8 | `SendStatusReq` | `:927` | `requestNodeStatus` (`mgr:4825`) | `Sent(6)` at `:937`, then **silence** | ❌ hangs ~30 s |
+| 9 | `SendBinaryReq` → `handleGetNeighboursReq` | `:963` / `:1005` | `getNeighbours` (`mgr:4667`) | `Sent(6)` at `:1017`, then **silence** | ❌ hangs ~30 s |
+
+So the honest current state is: **nothing transmits, but 6 of 9 commands leave the client waiting
+out a timeout.** No frame is malformed and no desync occurs — but "hangs for 30 seconds" is not a
+refusal, and the epic's exit criterion is a client that is *told* it cannot transmit.
+
+### 2.2 The refusal frame: `Err(1)` with `ErrorCodes.BadState(4)`
+
+**Evidence for `Err` over `Disabled`.** `connection.js:349-425` (`onFrameReceived`) routes each
+response code to a handler that re-emits it as an event. Every command wrapper then registers
+listeners for the codes it cares about:
+
+- `sendTextMessage` (`:1047-1048`): `once(Sent)`, `once(Err)`.
+- `sendChannelTextMessage` (`:1083-1084`): `once(Ok)`, `once(Err)`.
+- `sendAdvert` (`:835-836`): `once(Ok)`, `once(Err)`.
+- `login` (`:1682-1684`): `once(Err)`, `once(Sent)`, `once(LoginSuccess)`.
+- `tracePath` (`:2414-2416`): `once(Sent)`, `on(TraceData)`, `once(Err)`.
+- `getStatus` / `getTelemetry` / `sendBinaryRequest`: same three-listener shape.
+- `exportPrivateKey` (`:1574-1576`): `once(PrivateKey)`, `once(Err)`, **`once(Disabled)`**.
+
+`Disabled(15)` is listened for by **exactly one** wrapper — `exportPrivateKey`. Reply `Disabled`
+to any of the 9 and the client emits an event with no listener; the promise never settles. Worse,
+`sendTextMessage`, `sendChannelTextMessage` and `sendAdvert` have **no timeout of any kind**, so
+those three would hang *forever*, not merely for the est-timeout. `Err` is the only refusal every
+wrapper terminates on. `Disabled` stays where it belongs: `handleExportPrivateKey:654`.
+
+**Evidence for `BadState(4)` over `UnsupportedCmd(1)`.** `onErrResponse` (`:556-561`) reads the
+optional code byte and emits `{ errCode }`, but every `onErr` handler in the library is
+`() => reject()` — the code is informational for meshcore.js and rendered (at most) by richer apps
+such as meshcore-flutter. Three arguments settle it:
+
+1. **Semantics.** `UnsupportedCmd` means "this device does not implement that command" — a
+   capability statement an app may reasonably cache and use to hide a feature permanently.
+   Receive-only is a *runtime state* that an operator flips off at will. `BadState` means "the
+   device cannot do that right now", which is exactly true.
+2. **Zero-delta on 3 handlers.** Commands 1, 2 and 4 already emit `Err(BadState)` today via their
+   catch blocks. Choosing `BadState` makes the Phase 3 pre-check **byte-identical** to current
+   behaviour for those three — the change is purely *when* the frame is written, not what it says.
+   No app that works today can regress on them.
+3. **Repo consistency.** `Err(BadState)` is already this file's "the node would not / could not do
+   it" answer (`:750`, `:757`, `:773`, `:780`, `:1157`, `:1203`). `Err(UnsupportedCmd)` is reserved
+   for "this port does not offer that command at all" (`:619` unknown command, `:731`
+   admin-disabled, `:980` unknown binary sub-type). Receive-only is the former.
+
+**Framing safety.** `encodeErr(ErrorCodes.BadState)` produces a 2-byte payload, written through
+`send()` → `frameNodeToApp` → `[0x3e][0x02 0x00][0x01 0x04]`. The node→app framing is
+length-prefixed and every payload is self-delimiting, so a refusal cannot desync a client's parser
+regardless of what it was expecting. Exactly one frame is written per refused command.
+
+### 2.3 The guard must run **before** the `Sent` frame
+
+This is the structural reason an explicit pre-check is required and relying on the downstream
+`TxDisabledError` throw is not merely untidy but *incapable* of working:
+
+```js
+// connection.js:1638-1641  (login)          // connection.js:2370-2373 (tracePath)
+const onSent = (response) => {
+    // remove error listener since we received sent response
+    this.off(Constants.ResponseCodes.Err, onErr);
+    …arm setTimeout(estTimeout)…
+}
+```
+
+The client **tears down its `Err` listener the moment `Sent` arrives.** An `Err` written after the
+`Sent` is emitted into the void. `getStatus`, `getTelemetry` and `sendBinaryRequest` follow the
+identical pattern. Therefore:
+
+> **Invariant (test-enforced):** for a refused command, the `Err` frame must be the **first and
+> only** frame the server writes. No `Sent` may precede it.
+
+Since the 6 Sent-first handlers write `Sent` *before* awaiting the manager, the throw physically
+cannot be converted into a client-visible refusal at the catch site. The pre-check is not a
+stylistic preference.
+
+### 2.4 Placement: 8 call sites covering 9 commands
+
+`handleSendCliTxtMsg` (`:1264`) is `private` and has exactly **one** caller —
+`handleSendTxtMsg:1183`. A guard at the top of `handleSendTxtMsg` therefore covers both the Plain
+DM and the CliData relay. Adding a second guard inside `handleSendCliTxtMsg` would be unreachable
+code. Do not add it; add a one-line comment pointing at the caller's guard instead.
+
+Guard sites, in file order:
+
+| Handler | Insert immediately after the opening brace at | Command name for the log |
+|---|---|---|
+| `handleSendSelfAdvert` | `:768` (before the `try` at `:769`) | `SendSelfAdvert` |
+| `handleSendLogin` | `:803` (before `let parsed;` at `:804`) | `SendLogin` |
+| `handleSendTracePath` | `:846` (before `:847`) | `SendTracePath` |
+| `handleSendTelemetryReq` | `:882` (before `:883`) | `SendTelemetryReq` |
+| `handleSendStatusReq` | `:927` (before `:928`) | `SendStatusReq` |
+| `handleSendBinaryReq` | `:963` (before `let parsed:` at `:964`) | `SendBinaryReq` |
+| `handleSendChannelTxtMsg` | `:1143` (before `:1144`) | `SendChannelTxtMsg` |
+| `handleSendTxtMsg` | `:1172` (before `:1173`) | `SendTxtMsg` |
+
+**Guard-first ordering, deliberately.** Each guard runs *before* payload parsing and before
+`resolveContactKey`. Consequences, all intended:
+
+- A malformed payload on a refused command yields `Err(BadState)` rather than `Err(IllegalArg)`.
+  The receive-only state is the more relevant fact, and both are `Err`.
+- `SendTxtMsg` to an unknown contact prefix yields `Err(BadState)` rather than `Err(NotFound)`.
+- `SendBinaryReq` is refused for **all** sub-types, including ones added later. Guarding after the
+  sub-type dispatch would leave a future RF sub-type unguarded; guarding the envelope cannot.
+- No parser runs on input from a client that is not permitted to act. Small hardening win.
+
+### 2.5 The helper
+
+Insert after `auditPkiExport()` (which ends at `:706`), before the `handleConfigCommand` JSDoc at
+`:708`, so the three policy gates on this port — receive-only, `allowAdminCommands`, `allowPkiExport`
+— sit together.
+
+```ts
+  /**
+   * Receive-only refusal for the 9 TX-causing companion commands (#4547 Phase 3).
+   * Returns true when it has ALREADY replied and the caller must return —
+   * same contract as `rejectIfReceiveOnly()` in routes/meshcoreRouteShared.ts.
+   *
+   * MUST be called before the handler writes anything, in particular before the
+   * `Sent(6)` that six of these handlers emit up front: meshcore.js drops its
+   * `Err` listener the instant `Sent` arrives (connection.js:1641, :2373), so an
+   * error written afterwards is silently discarded and the client waits out its
+   * estimated timeout instead.
+   *
+   * Replies Err(BadState) — the only refusal every meshcore.js command wrapper
+   * terminates on. Disabled(15) is listened for by exportPrivateKey() alone
+   * (connection.js:1576) and would hang the untimed send/advert promises forever.
+   *
+   * Fails CLOSED: a manager that cannot answer is treated as receive-only, in
+   * line with `isRfBridgeCommand()`'s fail-closed default (constants/meshcoreTx.ts).
+   *
+   * Logged at debug, matching the sibling `allowAdminCommands` refusal — a
+   * companion app retries sends on its own schedule, so an info-level line here
+   * would be a log flood. The operator-facing signal is the single state-change
+   * info line from `MeshCoreManager.setReceiveOnly()`.
+   */
+  private refuseIfReceiveOnly(clientId: string, commandName: string): boolean {
+    let receiveOnly: boolean;
+    try {
+      receiveOnly = this.options.manager.isReceiveOnly() !== false;
+    } catch (err) {
+      logger.warn(
+        `[MeshCore VN ${this.sourceId}] receive-only check threw, refusing ${commandName}: ${(err as Error).message}`,
+      );
+      receiveOnly = true;
+    }
+    if (!receiveOnly) return false;
+    logger.debug(
+      `[MeshCore VN ${this.sourceId}] ${commandName} refused from ${clientId} (receive-only mode)`,
+    );
+    this.send(clientId, encodeErr(ErrorCodes.BadState));
+    return true;
+  }
+```
+
+`!== false` rather than `=== true` is the fail-closed shape: a manager that returns `undefined`
+(an incomplete double, a stale build) blocks rather than transmits.
+
+Call shape at each site:
+
+```ts
+    if (this.refuseIfReceiveOnly(clientId, 'SendTracePath')) return;
+```
+
+### 2.6 What is *not* changed, and why
+
+- **The 6 `catch` blocks stay as they are.** If receive-only is flipped ON between the pre-check
+  and the `await`, the manager still throws `TxDisabledError`, the catch logs a warning, and the
+  client times out. Nothing transmits; the window is microseconds; adding a second refusal path
+  after `Sent` cannot help because the client is no longer listening for `Err`. Documented as an
+  accepted residual rather than engineered around.
+- **`SetFloodScope` (`:531-535`) is untouched.** It replies `Ok` without applying and never
+  transmits. Its inline comment warns that an `Err` here can be treated as a fatal handshake
+  failure — a good reason not to widen the refusal surface beyond the 9.
+- **Every read path is untouched:** `AppStart`, `DeviceQuery`, `GetContacts`, `GetChannel`,
+  `GetBatteryVoltage`, `GetDeviceTime`, `SetDeviceTime`, `SyncNextMessage`, `ExportPrivateKey`,
+  and all six `Set*` config commands (interview decision 2 explicitly allows local serial config,
+  including `SetTxPower`). The live pushes — `MsgWaiting`, `ContactMsgRecv`/`ChannelMsgRecv`,
+  `LogRxData(0x88)` OTA feed, `SendConfirmed` — all keep flowing.
+- **The command surface is closed by construction.** `dispatchCommand`'s `default` branch (`:617-620`)
+  answers every unhandled code with `Err(UnsupportedCmd)`. `ResetPath`, `ShareContact`,
+  `SendRawData`, `AddUpdateContact`, `ImportContact`, `Reboot`, `GetStats` and the signing commands
+  are not in the switch and are already refused. The 9 guarded handlers are the complete TX surface
+  — and §3.5's inventory test keeps it that way.
+
+### 2.7 Interface change
+
+`MeshCoreVirtualNodeManager` (`:68`) gains, after `getContacts()` at `:72`:
+
+```ts
+  /**
+   * True when this source is configured strictly receive-only (#4547). Sync and
+   * cached on the manager — no DB read on the command path. The server refuses
+   * the 9 TX-causing companion commands while this is true.
+   */
+  isReceiveOnly(): boolean;
+```
+
+`MeshCoreManager` already implements it (`meshcoreManager.ts:3989`) and is passed as
+`manager: this` (`meshcoreManager.ts:1362`), so the production wiring needs **no** change. The
+method is **required, not optional** — an optional method would default to "allowed", which is
+fail-open and unacceptable for a safety gate. The only fallout is the test `FakeManager` (§3.1).
+
+---
+
+## 3. Part A test plan
+
+All standard Vitest. All additions go in `src/server/meshcoreVirtualNodeServer.test.ts`.
+
+### 3.1 Harness changes
+
+`FakeManager` (`:61`) gains:
+
+```ts
+  receiveOnlyMock = vi.fn().mockReturnValue(false);
+  isReceiveOnly() { return this.receiveOnlyMock() as boolean; }
+```
+
+Default `false` keeps all 12 existing describe blocks green unmodified — verify that before
+writing new tests. Per-test override: `makeManager({ isReceiveOnly: () => true })`.
+
+### 3.2 Refusal tests — one per command (9 tests)
+
+New block: `describe('MeshCoreVirtualNodeServer — receive-only mode (#4547)', …)`, server built
+with `makeManager({ isReceiveOnly: () => true })` and `allowAdminCommands: true` (so the CLI test
+proves receive-only wins over an *enabled* admin flag, not that admin-off happened to block it).
+
+For each of the 9, assert **all three**:
+
+1. `payload[0] === ResponseCodes.Err` and `payload[1] === ErrorCodes.BadState`.
+2. The frame is the **first** frame written — i.e. `client.request(...)` resolves with the `Err`,
+   never with a `Sent`. This is the §2.3 invariant and the single most important assertion in the
+   phase; a guard mistakenly placed after `encodeSent` passes assertion 1 and fails this one.
+3. The corresponding manager mock was **not called** (`expect(manager.sendAdvertMock).not.toHaveBeenCalled()`).
+
+| Test | Command frame | Mock asserted un-called |
+|---|---|---|
+| refuses SendChannelTxtMsg | `SendChannelTxtMsg` | `sendMessageMock` |
+| refuses SendTxtMsg (Plain DM) | `SendTxtMsg`, `txtType=Plain`, known contact prefix | `sendMessageWithResultMock` |
+| refuses SendTxtMsg (CliData / CLI relay) | `SendTxtMsg`, `txtType=CliData`, known prefix, `allowAdminCommands: true` | `sendCliCommandMock` |
+| refuses SendSelfAdvert | `SendSelfAdvert` | `sendAdvertMock` |
+| refuses SendLogin | `SendLogin` + 32-byte key + password | `loginToNodeMock` |
+| refuses SendTracePath | `SendTracePath` + tag/auth/path | `tracePathRawMock` |
+| refuses SendTelemetryReq | `SendTelemetryReq` + 32-byte key | `requestRemoteTelemetryRawMock` |
+| refuses SendStatusReq | `SendStatusReq` + 32-byte key | `requestNodeStatusMock` |
+| refuses SendBinaryReq/GetNeighbours | `SendBinaryReq` + key + `GetNeighbours` blob | `getNeighboursMock` |
+
+Reuse the exact frame builders the existing per-command describe blocks already use (`:753`,
+`:874`, `:938`, `:998`, `:1098`, `:1263`) — do not re-derive the byte layouts.
+
+Plus two edge tests:
+
+- **`SendBinaryReq` with an unknown sub-type is still refused as `BadState`, not `UnsupportedCmd`** —
+  proves the envelope-level guard (§2.4) covers future sub-types.
+- **`SendTxtMsg` to an unknown contact prefix returns `BadState`, not `NotFound`** — pins the
+  documented guard-first ordering so a later "fix" that moves the guard below `resolveContactKey`
+  is caught.
+
+### 3.3 Read-path regression test (the "VN stays up" guarantee)
+
+One test, same receive-only server, walking a full app session and asserting each read still works:
+
+- `AppStart` → `SelfInfo` (not `Err`)
+- `DeviceQuery` → `DeviceInfo`
+- `GetDeviceTime` → `CurrTime`; `SetDeviceTime` → `Ok`
+- `GetContacts` → `ContactsStart` / `Contact` / `EndOfContacts`
+- `GetChannel(0)` → `ChannelInfo`
+- `GetBatteryVoltage` → `BatteryVoltage`
+- `SyncNextMessage` → `NoMoreMessages`
+- `SetFloodScope` → `Ok`
+- one `Set*` config command with `allowAdminCommands: true` → `Ok` (local serial config stays
+  allowed per interview decision 2)
+- `ExportPrivateKey` with `allowPkiExport: true` → `PrivateKey(14)`
+
+Plus a live-push test: `manager.emitMessage(...)` still produces `MsgWaiting`, and
+`manager.emitOtaPacket(...)` still produces `LogRxData(0x88)`, while receive-only is ON.
+
+### 3.4 Wire-shape test with the real meshcore.js decoder
+
+Mirrors the existing `:277-283` pattern but **without `any`** (`@typescript-eslint/no-explicit-any`
+is an error and this file must not grow its baseline count):
+
+```ts
+interface DecoderLike {
+  once(code: number, cb: (event: { errCode?: number }) => void): void;
+  onFrameReceived(frame: Uint8Array): void;
+}
+const conn = new (Connection as unknown as new () => DecoderLike)();
+```
+
+Assert that feeding the refusal payload into a real `Connection` emits `ResponseCodes.Err` with
+`errCode === ErrorCodes.BadState` — i.e. a real client parses the refusal through its normal
+dispatch rather than hitting `onFrameReceived`'s `console.log("unhandled frame")` fallback
+(`connection.js:424`).
+
+### 3.5 Inventory test — the future-proofing guard
+
+The analogue of Phase 1's denylist-coverage test. With receive-only ON, iterate
+`Object.values(CommandCodes)`, send each as a bare one-byte frame, then assert that **none** of the
+TX-capable manager mocks was called:
+
+```
+sendMessageMock, sendMessageWithResultMock, sendAdvertMock, loginToNodeMock,
+tracePathRawMock, requestRemoteTelemetryRawMock, requestNodeStatusMock,
+getNeighboursMock, sendCliCommandMock
+```
+
+Bare frames make most handlers reply `Err(IllegalArg)` on parse — that is fine and irrelevant; the
+assertion is only "no TX method was reached". A new VN handler that transmits without a guard fails
+this test the day it lands. Give it a comment saying so.
+
+### 3.6 Receive-only OFF regression
+
+The 12 existing describe blocks already cover the happy paths with the default `false`. Add one
+explicit test that flips the flag at runtime — `receiveOnlyMock.mockReturnValue(true)`, assert a
+`SendSelfAdvert` refusal, then `mockReturnValue(false)` and assert the same command now reaches
+`sendAdvertMock` and replies `Ok`. This proves the guard reads live state and is not latched
+(the Phase 2 latch hazard, in the VN's shape).
+
+### 3.7 Fail-closed test
+
+`makeManager({ isReceiveOnly: () => { throw new Error('boom'); } })` → `SendSelfAdvert` still gets
+`Err(BadState)` and `sendAdvertMock` is not called.
+
+---
+
+## 4. Part B — documentation
+
+### 4.1 New page: `docs/features/meshcore-receive-only.md`
+
+Modeled on `docs/features/receive-only-mode.md` but **must not** copy its central claim — the
+Meshtastic page says "It isn't a MeshMonitor-side restriction"; here the opposite is true and that
+is the single most important thing on the page.
+
+Required structure:
+
+```
+# MeshCore Receive-Only Mode
+
+::: tip Added in 4.14 (#4547)
+[one-sentence framing: per-source strict receive-only for MeshCore sources]
+:::
+
+::: danger MeshCore firmware has no transmit kill switch
+[THE limitation, stated first, in plain words — see 4.2]
+:::
+
+## What it is
+## What still works
+## What is blocked
+## Virtual Node access
+## How to enable / disable it
+## API behaviour
+## Related
+```
+
+Content requirements per section:
+
+- **What it is** — per-source setting `meshcoreReceiveOnly`, applies to *all* MeshCore source
+  types (Companion and Repeater — interview decision 4), enforced across HTTP routes, schedulers,
+  automations and the Virtual Node port.
+- **What still works** — receiving and decoding; the packet log; the Analyzer Observer; contact,
+  telemetry and route updates; local serial configuration (name, radio params, TX power, coords,
+  channel CRUD, RTC sync, device query, reboot, contact import/export); read-only Virtual Node
+  access; the local UART CLI except the `advert` verb.
+- **What is blocked** — channel messages and DMs, self-adverts, remote CLI/admin, logins, path
+  discovery and traceroute, telemetry and status requests, neighbour queries, node discovery,
+  ANON_REQ, share-contact, discovery auto-responses, room posts, and every scheduler/automation
+  that transmits (auto-pathfinding, auto-announce, timer triggers, auto-responder, auto-acknowledge,
+  remote-telemetry and room-sync schedulers). State explicitly that automation **settings are
+  preserved untouched** and resume exactly as configured when receive-only is turned off
+  (interview decision 5) — with a "Paused — receive-only mode" note in the UI.
+- **Virtual Node access** — the VN port stays up and serves reads (contacts, channels, message
+  sync, device info, battery, time, config setters, PKI export where enabled) plus the live OTA
+  packet feed. The 9 transmit commands are refused with a companion-protocol error, so a
+  third-party MeshCore client sees a clean failure instead of a silent drop. Name the 9. State that
+  this closes the last transmit path, since the VN port bypasses the HTTP API entirely.
+- **How to enable / disable it** — MeshCore Settings → Receive-only mode. Note the confirmation
+  dialog on **disable** (turning transmission back on) and that the change takes effect immediately
+  without a reload.
+- **API behaviour** — `409` with `code: "TX_DISABLED"` on the MeshCore transmit routes; the exact
+  message string; a pointer to the API reference. Mention that two of them are `GET`
+  (`GET /contacts/:pk/neighbours`, `GET /admin/status/:pk`) since that surprises people.
+
+### 4.2 The firmware limitation — required wording constraints
+
+Must appear **above the fold**, in a `::: danger` block, and must state, in short words:
+
+1. MeshCore firmware exposes **no** radio-level transmit kill switch. Verified against
+   `@liamcottle/meshcore.js` v1.13.0: the full `CommandCodes` set has no `txEnabled`, `disableTx`
+   or `radioOff` equivalent; `SetTxPower(12)` lowers power but never stops transmission;
+   `SetOtherParams(38)` carries only manual-add-contacts, telemetry modes and advert-location policy.
+2. MeshMonitor therefore enforces receive-only **in software only**.
+3. It **cannot** stop transmissions the node makes on its own, specifically:
+   - link-layer acknowledgements, and
+   - any advert schedule configured on the device outside MeshMonitor.
+4. Anyone deploying this for a **regulatory or site-policy** reason must not treat it as a
+   guarantee that the radio is silent. Contrast it, in one sentence, with the Meshtastic
+   `lora.txEnabled` mode, which *is* a firmware kill switch — and link to that page.
+
+Do not soften this into "may not stop". Do not bury it under "What it is".
+
+### 4.3 Sidebar
+
+`docs/.vitepress/config.mts`, `Protocol-Specific` group items (`:155-158`):
+
+```ts
+            { text: 'MeshCore', link: '/features/meshcore' },
+            { text: 'MeshCore Receive-Only Mode', link: '/features/meshcore-receive-only' },
+            { text: 'MeshCore Analyzer Observer', link: '/features/meshcore-analyzer-observer' }
+```
+
+### 4.4 Cross-links (4 files)
+
+1. **`docs/features/receive-only-mode.md:65` — a factual correction, not a link.** It currently
+   reads: *"**Not gated:** … and MeshCore sources (a different protocol with no equivalent flag)."*
+   That has been false since Phase 1. Rewrite to point at the new page, e.g. *"MeshCore sources
+   have their own equivalent — see [MeshCore Receive-Only Mode](/features/meshcore-receive-only) —
+   enforced in software, because MeshCore firmware has no transmit kill switch."* Also add the page
+   to that file's `## Related` list (`:86-91`).
+2. **`docs/features/meshcore.md`** — add a short `## Receive-Only Mode` section (4-6 lines +
+   the link). Place it near `## Radio Configuration` (`:521`) or `## Permissions` (`:502`);
+   implementer's judgement, but it must be findable from the page's heading list.
+3. **`docs/configuration/virtual-node.md`** — add `### Safety: receive-only mode` immediately after
+   `### Safety: admin commands` (`:501`), inside the `## MeshCore Virtual Node` section (`:434`).
+   Explain that when the source is receive-only, the VN keeps serving reads and the live packet
+   feed while the 9 transmit commands are refused, and that this is independent of the
+   `allowAdminCommands` and `allowPkiExport` toggles. Also add one line to `### What works` (`:452`)
+   noting the receive-only caveat.
+4. **`docs/features/meshcore-analyzer-observer.md`** — one line confirming the Observer keeps
+   publishing under receive-only (it is an outbound MQTT/network publisher, not a radio path). Only
+   if the page has a natural home for it; skip rather than force it.
+
+### 4.5 API docs
+
+**`docs/api/REST_API.md:104-118`** and the mirrored block in **`docs/api/API_REFERENCE.md:1104-1118`**
+currently scope `409 TX_DISABLED` to Meshtastic only ("when the target source's LoRa radio has
+`lora.txEnabled = false`"). Extend both blocks to name the second trigger, keeping the existing
+JSON example and adding the MeshCore message string:
+
+```
+"error": "Transmission blocked: this MeshCore source is configured for receive-only operation.",
+"code": "TX_DISABLED"
+```
+
+State the two causes side by side: Meshtastic — `lora.txEnabled = false`; MeshCore — the per-source
+`meshcoreReceiveOnly` setting. Link both feature pages.
+
+Add the MeshCore route list (from the epic's route inventory, verified against
+`src/server/routes/meshcore*Routes.ts`), calling out the two `GET`s:
+
+```
+POST /api/sources/:id/meshcore/messages/send
+POST /api/sources/:id/meshcore/rooms/login | /rooms/login-with-saved | /rooms/post
+POST …/contacts/:pk/reset-path | /discover-path | /discover | /regions/discover
+POST …/contacts/:pk/trace-path | /ping | /share | /telemetry/poll | /neighbors/request
+GET  …/contacts/:pk/neighbours          ← GET
+POST …/admin/login | /admin/cli | /admin/login-with-saved
+GET  …/admin/status/:pk                 ← GET
+POST …/cli                              (only the `advert` verb)
+POST …/advert
+POST …/automation/announce/send | /automation/timers/:triggerId/run
+```
+
+**`docs/api/API_REFERENCE.md:698` (`POST /api/settings`)** — add to that endpoint's error section:
+
+- `400 INVALID_BOOLEAN_SETTING` — a strict-boolean setting was sent a value other than the exact
+  strings `"true"` or `"false"`. Currently applies to `meshcoreReceiveOnly`
+  (`src/server/routes/settingsRoutes.ts:339`). Note *why* it is strict: the server reads these with
+  `raw === 'true'`, so `"1"` / `"yes"` / `"TRUE"` / `"on"` would persist and then read back as
+  **false** — silently leaving transmission enabled on a source the operator believed was
+  receive-only. Also add `meshcoreReceiveOnly` to the "Supported Settings" list as a per-source
+  key.
+
+If `REST_API.md` has its own `POST /api/settings` section, apply the same edit there; if it does
+not (grep found none), leave it.
+
+**`docs/api/API.md` — do not touch.** It carries an explicit outdated banner (`:3-10`) and the
+Meshtastic TX-disabled epic deliberately left it alone. Same call here.
+
+### 4.6 i18n
+
+**Verified — no new keys are required for Part A.** The refusal is wire-level and has no UI string.
+Phase 2's 13 keys are present in `public/locales/en.json`:
+`meshcore.receive_only.{title,toggle_label,description,firmware_caveat,disable_confirm,control_tooltip,blocked_toast,paused_note,status_chip,saved_on,saved_off,save_failed,console_placeholder}`
+(`:5160-5172`) plus `banners.receive_only_meshcore` (`:115`).
+
+**Non-English locales are Weblate-managed** (`docs/features/translations.md:3, :36, :109` — "Weblate
+will automatically detect the new string"; the repo has Weblate-authored translation PRs, e.g.
+`4af8d1b3`). Confirmed: `meshcore.receive_only.*` appears **0 times** in `de.json` and `fr.json`,
+which is the expected steady state for keys added days ago. **Do not hand-add translations to any
+non-English locale file** — that conflicts with Weblate's round-trip.
+
+Deliverable for this item is an audit, not an edit: confirm all 14 keys exist in `en.json`, confirm
+every one is actually referenced from a component (grep), and report anything orphaned. Fix only
+`en.json` if something is missing.
+
+*Optional, only if it costs nothing:* one new English key noting in the MeshCore Virtual Node
+settings section that VN clients cannot transmit while receive-only is on. Nice-to-have; skip if it
+means restructuring the settings component.
+
+---
+
+## 5. Work packages
+
+Four packages. WP2 depends on WP1. WP3 and WP4 are independent of everything and of each other, so
+all three of WP1, WP3, WP4 can start immediately in parallel.
+
+All agents share the one worktree — **file overlaps are listed per package and there are none
+between packages.** Follow the repo's parallel-agent commit rule: use the pathspec form of
+`git commit` (or `rtk proxy git`), never a bare `git commit -a`, so concurrent agents do not sweep
+each other's files.
+
+### WP1 — Virtual Node receive-only gate (production code)
+
+**Files (exclusive):** `src/server/meshcoreVirtualNodeServer.ts`
+
+1. Add `isReceiveOnly(): boolean` to `MeshCoreVirtualNodeManager` after `:72` (§2.7).
+2. Add `refuseIfReceiveOnly()` after `auditPkiExport()` (`:706`) (§2.5).
+3. Add the 8 guard calls at the sites in §2.4, each as the first statement of its handler.
+4. Add the "guarded by the caller" comment in `handleSendCliTxtMsg` (`:1264`).
+5. Update the class-level JSDoc (`:259-273`) with a one-line note that the 9 TX commands are
+   refused under receive-only.
+
+**Acceptance**
+- `npm run typecheck` clean.
+- `npx eslint src/server/meshcoreVirtualNodeServer.ts` reports nothing new, **and**
+  `npm run lint:ci 2>&1 | grep '^FAIL' | grep -v '.claude/worktrees'` is empty.
+- No `any` introduced (`no-explicit-any` count for this file must not grow in the baseline).
+- Every guard is the **first statement** of its handler and precedes any `this.send(...)`
+  — reviewer greps for `encodeSent` and confirms each is below a `refuseIfReceiveOnly` line.
+- Existing VN test suite still passes (it will, once WP2 lands `FakeManager.isReceiveOnly`; until
+  then a type error in the test file is expected and is WP2's to fix — WP1 must not silence it with
+  a cast).
+
+### WP2 — Virtual Node receive-only tests
+
+**Depends on:** WP1 (needs the interface method and the guards).
+**Files (exclusive):** `src/server/meshcoreVirtualNodeServer.test.ts`
+
+1. `FakeManager.isReceiveOnly` + `receiveOnlyMock`, default `false` (§3.1). Confirm all 12 existing
+   describe blocks pass **unmodified** before writing anything new.
+2. New describe block with: 9 refusal tests (§3.2) each asserting Err-code, first-frame, and
+   mock-not-called; the 2 edge tests; the read-path regression (§3.3); the live-push test; the
+   meshcore.js decoder test (§3.4); the inventory test (§3.5); the flag-flip test (§3.6); the
+   fail-closed test (§3.7).
+
+**Acceptance**
+- Full Vitest suite: 0 failures, `success: true` via the JSON reporter (per CLAUDE.md — the
+  summary line alone is not sufficient).
+- The first-frame assertion is present in all 9 refusal tests. Sanity-check it by temporarily
+  moving one guard below its `encodeSent` and confirming the test fails; revert.
+- The inventory test fails if a guard is removed. Verify by deleting one guard, running, reverting.
+- No `any` in new test code (§3.4 gives the typed decoder pattern).
+- `npx tsc --noEmit` with test files included reports no new errors (`tsconfig.json` excludes
+  `*.test.ts`, so the normal `typecheck` will not catch these — Phase 1's reviewer note).
+
+### WP3 — User documentation
+
+**Files (exclusive):** `docs/features/meshcore-receive-only.md` (new),
+`docs/.vitepress/config.mts`, `docs/features/receive-only-mode.md`, `docs/features/meshcore.md`,
+`docs/configuration/virtual-node.md`, optionally `docs/features/meshcore-analyzer-observer.md`
+
+1. Write the new page to §4.1's structure, with §4.2's limitation block above the fold.
+2. Sidebar entry (§4.3).
+3. The four cross-links (§4.4) — **including the `receive-only-mode.md:65` factual correction,
+   which is a bug fix, not a nicety.**
+
+**Acceptance**
+- `npm run docs:build` (or the repo's VitePress build script) succeeds with no dead links.
+- The firmware-limitation block is in a `::: danger` container, appears before the first `##`
+  heading, and states all four points in §4.2.
+- No emoji added to the page body beyond what sibling feature pages already use in headings.
+- The blocked/allowed lists match Phase 1's actual behaviour — cross-check against
+  `src/server/constants/meshcoreTx.ts` (`RF_BRIDGE_COMMANDS` / `SERIAL_ONLY_BRIDGE_COMMANDS` /
+  `RF_LOCAL_CLI_VERBS`), not against this spec's prose.
+- `grep -n "no equivalent flag" docs/features/receive-only-mode.md` returns nothing.
+
+### WP4 — API documentation + i18n audit
+
+**Files (exclusive):** `docs/api/REST_API.md`, `docs/api/API_REFERENCE.md`
+**Read-only:** `public/locales/en.json` (edit only if a key is genuinely missing)
+
+1. Extend both `409 TX_DISABLED` blocks to cover MeshCore, with the MeshCore message string and the
+   route list (§4.5).
+2. Document `400 INVALID_BOOLEAN_SETTING` on `POST /api/settings` and add `meshcoreReceiveOnly` to
+   the supported-settings list (§4.5).
+3. i18n audit per §4.6 — verify the 14 keys, verify each is referenced from a component, report
+   orphans. **No non-English locale edits.**
+
+**Acceptance**
+- Every route listed in the API docs actually returns `409 TX_DISABLED` — spot-check at least the
+  two `GET` routes against `src/server/routes/meshcoreContactsRoutes.ts` and
+  `meshcoreAdminRoutes.ts`.
+- `docs/api/API.md` is unmodified (`git diff --name-only` must not list it).
+- `git diff --name-only public/locales/` lists at most `en.json`.
+- The audit result is reported in the PR description, not written to a new file.
+
+---
+
+## 6. Exit criteria (Phase 3 / epic)
+
+- A third-party MeshCore client connected to the VN port of a receive-only source **cannot
+  transmit**, and receives a well-formed `Err(BadState)` as the first and only reply to each of the
+  9 transmit commands — no hang, no timeout wait, no framing desync.
+- The same client's reads all keep working: handshake, contacts, channels, message sync, device
+  info, battery, time, config setters, PKI export (where enabled), and the live OTA packet feed.
+- Full Vitest suite green (`success: true` via JSON reporter); `npm run typecheck` clean;
+  `npm run lint:ci` clean of in-repo failures; `tsc` including test files clean.
+- Docs shipped: new user page in the sidebar, the firmware limitation stated plainly and above the
+  fold, `receive-only-mode.md`'s false "no equivalent flag" claim corrected, API docs covering
+  `409 TX_DISABLED` on the MeshCore routes and `400 INVALID_BOOLEAN_SETTING` on `POST /settings`.
+
+### Live validation (before the PR is marked ready)
+
+Deploy to the dev container (`docker-compose.dev.yml` + `docker-compose.dev.local.yml`) against the
+`MC-Sandbox` MeshCore source used for Phase 2, enable its Virtual Node, and connect a real MeshCore
+client to the port. Confirm:
+
+1. Handshake completes normally with receive-only ON (this is the one residual risk — the
+   `SetFloodScope` comment at `:532` warns that an `Err` at the wrong point can be read as a fatal
+   handshake failure; the 9 guarded commands are all post-handshake, but an app that auto-adverts
+   on connect will get a refusal early and must not drop the socket).
+2. Contacts, channels and message history load; the packet feed streams.
+3. Sending a channel message and a DM both fail **promptly** in the app's UI, not after a timeout.
+4. Turning receive-only off in MeshMonitor makes the same client transmit again with no reconnect.
+
+Record the outcome in the epic doc's "Phase 3 deviations & findings" section, following the Phase 1
+and Phase 2 precedent.
+
+---
+
+## 7. Risks / easy misses
+
+1. **Guard placed after `encodeSent`.** Passes a naive "returns Err" test and is invisible in
+   review. The first-frame assertion (§3.2 point 2) is the only thing that catches it.
+2. **Using `Disabled(15)` because `handleExportPrivateKey` does.** Hangs 8 of 9 wrappers, three of
+   them forever (no timeout).
+3. **Making `isReceiveOnly` optional on the interface** to avoid touching `FakeManager`. That is
+   fail-open on a safety gate.
+4. **Guarding `handleGetNeighboursReq` instead of `handleSendBinaryReq`.** Leaves every future
+   binary sub-type unguarded.
+5. **Adding a second guard inside `handleSendCliTxtMsg`.** Unreachable; it has exactly one caller,
+   already guarded.
+6. **Info-level refusal logging.** A companion app retries on its own schedule; this is a log flood
+   in production. Debug only.
+7. **Hand-adding non-English translations.** Conflicts with Weblate's round-trip.
+8. **Leaving `receive-only-mode.md:65` alone.** It actively tells users MeshCore has no equivalent
+   flag, which this epic made false three phases ago.

--- a/src/components/MeshCore/MeshCoreChannelsView.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.test.tsx
@@ -439,6 +439,26 @@ describe('MeshCoreChannelsView — infinite scroll pagination (#4460)', () => {
     await waitFor(() => expect(screen.getByText('recent message')).toBeTruthy());
     expect(screen.queryByText('much older message')).toBeNull();
 
+    // The render that made "recent message" assertable is the SAME render that
+    // flips `hasMoreHistory` true, but the child's scroll-listener effect
+    // (MeshCoreMessageStream's `addEventListener('scroll', handleScroll)`,
+    // keyed on `hasMoreOlder`) is a passive effect — it flushes on its own
+    // schedule, not synchronously with the DOM mutation `waitFor` just
+    // observed. Firing the scroll event immediately risked hitting a stale
+    // listener still closed over `hasMoreOlder: false` from the initial
+    // mount, which silently no-ops (confirmed empirically: instrumenting the
+    // listener showed `scroll listener (re)attached { hasMoreOlder: false }`
+    // → `handleScroll fired { hasMoreOlder: false }` → `scroll listener
+    // (re)attached { hasMoreOlder: true }`, i.e. the fresh listener attached
+    // AFTER the stale one had already consumed the one-and-only scroll event
+    // this test dispatches). An empty `act()` flushes any passive effects
+    // still pending from that render before we dispatch the scroll, so the
+    // listener is guaranteed current. This is a test-only race — real users
+    // fire many scroll events while scrolling, so a real browser self-heals
+    // on the next one; only a single synthetic dispatch right after the race
+    // window can observe it.
+    await act(async () => {});
+
     const list = container.querySelector('.meshcore-message-list') as HTMLElement;
     fireEvent.scroll(list);
 

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -67,6 +67,11 @@ class FakeManager extends EventEmitter implements MeshCoreVirtualNodeManager {
     this.localNode = localNode;
     this.contacts = contacts;
   }
+  // Receive-only state (#4547 Phase 3). Default false keeps every pre-existing
+  // describe block green unmodified; flip per-test via `makeManager({ isReceiveOnly: () => true })`
+  // or `manager.receiveOnlyMock.mockReturnValue(true)` on an already-built FakeManager.
+  receiveOnlyMock = vi.fn().mockReturnValue(false);
+  isReceiveOnly() { return this.receiveOnlyMock() as boolean; }
   sendMessageMock = vi.fn().mockResolvedValue(true);
   sendMessageWithResultMock = vi.fn().mockResolvedValue({ ok: true });
   // Config-mutation mocks (issue #3904).
@@ -1518,5 +1523,389 @@ describe('MeshCoreVirtualNodeServer — getClientDetails (status endpoint contra
     expect(details[0].ip.length).toBeGreaterThan(0);
     expect(details[0].connectedAt).toBeInstanceOf(Date);
     expect(details[0].lastActivity).toBeInstanceOf(Date);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Receive-only mode (#4547 Phase 3 WP2)
+//
+// WP1 (c15192b5) added `isReceiveOnly()` to the manager interface and a
+// fail-closed `refuseIfReceiveOnly()` guard at the top of the 8 handlers that
+// cover the 9 TX-causing companion commands. This block proves the guard's
+// wire contract end to end: Err(BadState) as the FIRST and ONLY frame (never
+// a Sent — six of these handlers used to write Sent before awaiting the
+// manager, and meshcore.js drops its Err listener the instant Sent arrives),
+// the underlying manager TX method never invoked, every read path and the
+// live OTA feed unaffected, a real meshcore.js client actually parses the
+// refusal, and a denylist-style inventory test that fails the day a future
+// handler transmits without a guard.
+// ─────────────────────────────────────────────────────────────────────────
+describe('MeshCoreVirtualNodeServer — receive-only mode (#4547)', () => {
+  let server: MeshCoreVirtualNodeServer;
+  let client: TestClient;
+  let manager: FakeManager;
+
+  // Matches SAMPLE_CONTACTS' publicKey so prefix-resolution succeeds for the
+  // DM/CLI refusal tests (guard fires before contact resolution anyway, but
+  // using a real prefix keeps these tests honest about what they exercise).
+  const REMOTE_KEY = 'b1'.repeat(32);
+  const REMOTE_KEY_BYTES = Buffer.from(REMOTE_KEY, 'hex');
+  const REMOTE_PREFIX = REMOTE_KEY_BYTES.subarray(0, 6);
+
+  // allowAdminCommands defaults to true here so the CLI-relay refusal test
+  // proves receive-only wins over an ENABLED admin flag, not that admin-off
+  // happened to block it (§3.2 of the spec).
+  async function startReceiveOnly(
+    opts: { allowAdminCommands?: boolean; allowPkiExport?: boolean } = {},
+  ): Promise<void> {
+    manager = new FakeManager();
+    manager.receiveOnlyMock.mockReturnValue(true);
+    server = new MeshCoreVirtualNodeServer({
+      port: 0,
+      manager,
+      databaseService: CHANNELS_DB,
+      allowAdminCommands: opts.allowAdminCommands ?? true,
+      allowPkiExport: opts.allowPkiExport ?? false,
+    });
+    await server.start();
+    client = new TestClient();
+    await client.connect(server.getListeningPort()!);
+  }
+
+  afterEach(async () => {
+    client?.close();
+    await server?.stop();
+  });
+
+  // ── frame builders — byte layouts mirror the per-command describe blocks
+  // above verbatim; not re-derived here (spec §3.2). ──
+  const channelFrame = (text: string, channelIdx = 1): number[] => [
+    CommandCodes.SendChannelTxtMsg, 0, channelIdx, 0, 0, 0, 0, ...Buffer.from(text, 'utf8'),
+  ];
+  const dmFrame = (prefix: Buffer, text: string): number[] => [
+    CommandCodes.SendTxtMsg, 0, 0, 0, 0, 0, 0, ...prefix, ...Buffer.from(text, 'utf8'),
+  ];
+  const cliFrame = (text: string): number[] => [
+    CommandCodes.SendTxtMsg, 1, 0, 0, 0, 0, 0, ...REMOTE_PREFIX, ...Buffer.from(text, 'utf8'),
+  ];
+  const advertFrame: number[] = [CommandCodes.SendSelfAdvert, 1];
+  const loginFrame = (publicKeyHex: string, password: string): number[] => [
+    CommandCodes.SendLogin, ...Buffer.from(publicKeyHex, 'hex'), ...Buffer.from(password, 'utf8'),
+  ];
+  function traceFrame(tag: number, auth: number, path: number[]): number[] {
+    const head = Buffer.alloc(8);
+    head.writeUInt32LE(tag >>> 0, 0);
+    head.writeUInt32LE(auth >>> 0, 4);
+    return [CommandCodes.SendTracePath, ...head, 0, ...path];
+  }
+  const telemetryFrame = (publicKeyHex: string): number[] => [
+    CommandCodes.SendTelemetryReq, 0, 0, 0, ...Buffer.from(publicKeyHex, 'hex'),
+  ];
+  const statusFrame = (publicKeyHex: string): number[] => [
+    CommandCodes.SendStatusReq, ...Buffer.from(publicKeyHex, 'hex'),
+  ];
+  function neighboursFrame(
+    publicKeyHex: string,
+    opts: { count?: number; offset?: number; orderBy?: number; prefixLen?: number; tag?: number } = {},
+  ): number[] {
+    const { count = 10, offset = 0, orderBy = 0, prefixLen = 8, tag = 0x11223344 } = opts;
+    const req = Buffer.alloc(11);
+    req[0] = BinaryRequestTypes.GetNeighbours;
+    req[1] = 0;
+    req[2] = count;
+    req.writeUInt16LE(offset, 3);
+    req[5] = orderBy;
+    req[6] = prefixLen;
+    req.writeUInt32LE(tag >>> 0, 7);
+    return [CommandCodes.SendBinaryReq, ...Buffer.from(publicKeyHex, 'hex'), ...req];
+  }
+
+  // ── 9 refusal tests. Each asserts all three of: Err(BadState), that it is
+  // the FIRST frame written (client.request() resolves with exactly one
+  // payload — if a guard were mistakenly placed after encodeSent, payload[0]
+  // would be ResponseCodes.Sent here and the Err/BadState assertion would
+  // fail), and that the underlying manager TX method was never called. ──
+
+  it('refuses SendChannelTxtMsg with Err(BadState) as the first frame, without calling sendMessage', async () => {
+    await startReceiveOnly();
+    const payload = await client.request(channelFrame('hi chan'));
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(ErrorCodes.BadState);
+    expect(manager.sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses SendTxtMsg (Plain DM) with Err(BadState) as the first frame, without calling sendMessageWithResult', async () => {
+    await startReceiveOnly();
+    const payload = await client.request(dmFrame(REMOTE_PREFIX, 'hi dm'));
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(ErrorCodes.BadState);
+    expect(manager.sendMessageWithResultMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses SendTxtMsg (CliData / CLI relay) with Err(BadState) even with allowAdminCommands on, without calling sendCliCommand', async () => {
+    await startReceiveOnly({ allowAdminCommands: true });
+    const payload = await client.request(cliFrame('get name'));
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(ErrorCodes.BadState);
+    expect(manager.sendCliCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses SendSelfAdvert with Err(BadState) as the first frame, without calling sendAdvert', async () => {
+    await startReceiveOnly();
+    const payload = await client.request(advertFrame);
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(ErrorCodes.BadState);
+    expect(manager.sendAdvertMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses SendLogin with Err(BadState) as the first frame — never a Sent — without calling loginToNode', async () => {
+    await startReceiveOnly();
+    const payload = await client.request(loginFrame(REMOTE_KEY, 'hunter2'));
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(ErrorCodes.BadState);
+    expect(manager.loginToNodeMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses SendTracePath with Err(BadState) as the first frame — never a Sent — without calling tracePathRaw', async () => {
+    await startReceiveOnly();
+    const payload = await client.request(traceFrame(0xdeadbeef, 0, [0xa3, 0x7f]));
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(ErrorCodes.BadState);
+    expect(manager.tracePathRawMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses SendTelemetryReq with Err(BadState) as the first frame — never a Sent — without calling requestRemoteTelemetryRaw', async () => {
+    await startReceiveOnly();
+    const payload = await client.request(telemetryFrame(REMOTE_KEY));
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(ErrorCodes.BadState);
+    expect(manager.requestRemoteTelemetryRawMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses SendStatusReq with Err(BadState) as the first frame — never a Sent — without calling requestNodeStatus', async () => {
+    await startReceiveOnly();
+    const payload = await client.request(statusFrame(REMOTE_KEY));
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(ErrorCodes.BadState);
+    expect(manager.requestNodeStatusMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses SendBinaryReq/GetNeighbours with Err(BadState) as the first frame — never a Sent — without calling getNeighbours', async () => {
+    await startReceiveOnly();
+    const payload = await client.request(neighboursFrame(REMOTE_KEY));
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(ErrorCodes.BadState);
+    expect(manager.getNeighboursMock).not.toHaveBeenCalled();
+  });
+
+  // ── 2 edge tests pinning the guard-first ordering (§2.4) ──
+
+  it('refuses SendBinaryReq with an unknown inner sub-type as BadState, not UnsupportedCmd (envelope-level guard covers future sub-types)', async () => {
+    await startReceiveOnly();
+    const frame = [CommandCodes.SendBinaryReq, ...REMOTE_KEY_BYTES, BinaryRequestTypes.GetTelemetryData, 0, 0];
+    const payload = await client.request(frame);
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(ErrorCodes.BadState);
+    expect(manager.getNeighboursMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses a DM to an unknown contact prefix as BadState, not NotFound (guard runs before contact resolution)', async () => {
+    await startReceiveOnly();
+    const unknownPrefix = Buffer.from('ff'.repeat(6), 'hex');
+    const payload = await client.request(dmFrame(unknownPrefix, 'x'));
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(ErrorCodes.BadState);
+    expect(manager.sendMessageWithResultMock).not.toHaveBeenCalled();
+  });
+
+  // ── Read-path regression: the VN stays fully usable while receive-only ──
+
+  it('serves every read path normally while receive-only is ON (AppStart, contacts, channels, sync, config, PKI export)', async () => {
+    await startReceiveOnly({ allowAdminCommands: true, allowPkiExport: true });
+
+    const appStart = await client.request([CommandCodes.AppStart, 1, 0, 0, 0, 0, 0, 0]);
+    expect(appStart[0]).toBe(ResponseCodes.SelfInfo);
+
+    const deviceQuery = await client.request([CommandCodes.DeviceQuery, 1]);
+    expect(deviceQuery[0]).toBe(ResponseCodes.DeviceInfo);
+
+    const currTime = await client.request([CommandCodes.GetDeviceTime]);
+    expect(currTime[0]).toBe(ResponseCodes.CurrTime);
+
+    const setTime = await client.request([CommandCodes.SetDeviceTime, 0, 0, 0, 0]);
+    expect(setTime[0]).toBe(ResponseCodes.Ok);
+
+    client.send([CommandCodes.GetContacts, 0, 0, 0, 0]);
+    const [contactsStart, contact, endOfContacts] = await client.expectFrames(3);
+    expect(contactsStart[0]).toBe(ResponseCodes.ContactsStart);
+    expect(contact[0]).toBe(ResponseCodes.Contact);
+    expect(endOfContacts[0]).toBe(ResponseCodes.EndOfContacts);
+
+    const channel = await client.request([CommandCodes.GetChannel, 0]);
+    expect(channel[0]).toBe(ResponseCodes.ChannelInfo);
+
+    const battery = await client.request([CommandCodes.GetBatteryVoltage]);
+    expect(battery[0]).toBe(ResponseCodes.BatteryVoltage);
+
+    const sync = await client.request([CommandCodes.SyncNextMessage]);
+    expect(sync[0]).toBe(ResponseCodes.NoMoreMessages);
+
+    const floodScope = await client.request([CommandCodes.SetFloodScope, 0]);
+    expect(floodScope[0]).toBe(ResponseCodes.Ok);
+
+    // Local serial config stays allowed under receive-only (interview decision 2).
+    const setName = await client.request([CommandCodes.SetAdvertName, ...Buffer.from('Rover', 'utf8')]);
+    expect(setName[0]).toBe(ResponseCodes.Ok);
+    expect(manager.setNameMock).toHaveBeenCalledWith('Rover');
+
+    const exportKey = await client.request([CommandCodes.ExportPrivateKey]);
+    expect(exportKey[0]).toBe(ResponseCodes.PrivateKey);
+
+    // None of the 9 TX-capable methods were reached by any of the above.
+    expect(manager.sendMessageMock).not.toHaveBeenCalled();
+    expect(manager.sendMessageWithResultMock).not.toHaveBeenCalled();
+    expect(manager.sendAdvertMock).not.toHaveBeenCalled();
+    expect(manager.loginToNodeMock).not.toHaveBeenCalled();
+    expect(manager.tracePathRawMock).not.toHaveBeenCalled();
+    expect(manager.requestRemoteTelemetryRawMock).not.toHaveBeenCalled();
+    expect(manager.requestNodeStatusMock).not.toHaveBeenCalled();
+    expect(manager.getNeighboursMock).not.toHaveBeenCalled();
+    expect(manager.sendCliCommandMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the live OTA packet feed and MsgWaiting push flowing while receive-only is ON', async () => {
+    await startReceiveOnly();
+
+    const msgPush = new Promise<Buffer>((resolve) => (client as unknown as { waiters: Array<(p: Buffer) => void> }).waiters.push(resolve));
+    manager.emitMessage({
+      id: 'ro-1',
+      fromPublicKey: 'b1'.repeat(32),
+      toPublicKey: undefined,
+      text: 'incoming while receive-only',
+      timestamp: 1_750_000_000_000,
+    });
+    expect((await msgPush)[0]).toBe(PushCodes.MsgWaiting);
+
+    const otaPush = client.expectFrames(1);
+    manager.emitOtaPacket({ snr: -7.25, rssi: -95, raw_hex: '0102030405aabbccddeeff' });
+    const [ota] = await otaPush;
+    expect(ota[0]).toBe(PushCodes.LogRxData);
+  });
+
+  // ── Wire-shape test with the real meshcore.js decoder (§3.4, no `any`) ──
+
+  it('a real meshcore.js client parses the refusal via its normal Err dispatch (not the unhandled-frame fallback)', async () => {
+    await startReceiveOnly();
+    const payload = await client.request(advertFrame);
+    expect(payload[0]).toBe(ResponseCodes.Err);
+
+    interface DecoderLike {
+      once(code: number, cb: (event: { errCode?: number }) => void): void;
+      onFrameReceived(frame: Uint8Array): void;
+    }
+    const conn = new (Connection as unknown as new () => DecoderLike)();
+    const decoded = await new Promise<{ errCode?: number }>((resolve) => {
+      conn.once(ResponseCodes.Err, (event) => resolve(event));
+      conn.onFrameReceived(new Uint8Array(payload));
+    });
+    expect(decoded.errCode).toBe(ErrorCodes.BadState);
+  });
+
+  // ── Inventory test: the future-proofing guard (§3.5) ──
+  // Mirrors Phase 1's fail-closed denylist-coverage test. Fires every known
+  // CommandCode as a bare one-byte frame with receive-only ON and asserts
+  // that NONE of the TX-capable manager mocks was ever reached. Malformed
+  // frames mostly reply Err(IllegalArg) — irrelevant; the only thing that
+  // matters is that no TX method fires. A future handler that transmits
+  // without a `refuseIfReceiveOnly()` guard fails this test on day one.
+  it('never reaches a TX-capable manager method for ANY known CommandCode while receive-only (future-proofing inventory guard)', async () => {
+    await startReceiveOnly();
+
+    for (const code of Object.values(CommandCodes)) {
+      client.send([code]);
+    }
+    // Bare frames are processed synchronously up to each guard's early return
+    // (no `await` precedes it in any of the 9 guarded handlers), but give the
+    // real socket round-trip a moment to land before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(manager.sendMessageMock).not.toHaveBeenCalled();
+    expect(manager.sendMessageWithResultMock).not.toHaveBeenCalled();
+    expect(manager.sendAdvertMock).not.toHaveBeenCalled();
+    expect(manager.loginToNodeMock).not.toHaveBeenCalled();
+    expect(manager.tracePathRawMock).not.toHaveBeenCalled();
+    expect(manager.requestRemoteTelemetryRawMock).not.toHaveBeenCalled();
+    expect(manager.requestNodeStatusMock).not.toHaveBeenCalled();
+    expect(manager.getNeighboursMock).not.toHaveBeenCalled();
+    expect(manager.sendCliCommandMock).not.toHaveBeenCalled();
+  });
+
+  // ── Flag-flip test (§3.6): the guard reads live state, it is not latched ──
+
+  it('reads live receive-only state: flips OFF mid-session and the same command then reaches the manager (Phase 2 latch hazard, VN shape)', async () => {
+    manager = new FakeManager(); // starts false
+    server = new MeshCoreVirtualNodeServer({ port: 0, manager, databaseService: CHANNELS_DB });
+    await server.start();
+    client = new TestClient();
+    await client.connect(server.getListeningPort()!);
+
+    manager.receiveOnlyMock.mockReturnValue(true);
+    const refused = await client.request(advertFrame);
+    expect(refused[0]).toBe(ResponseCodes.Err);
+    expect(refused[1]).toBe(ErrorCodes.BadState);
+    expect(manager.sendAdvertMock).not.toHaveBeenCalled();
+
+    manager.receiveOnlyMock.mockReturnValue(false);
+    const allowed = await client.request(advertFrame);
+    expect(allowed[0]).toBe(ResponseCodes.Ok);
+    expect(manager.sendAdvertMock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Fail-closed test (§3.7) ──
+
+  it('fails closed: a manager whose isReceiveOnly() throws still refuses, without calling sendAdvert', async () => {
+    manager = new FakeManager();
+    manager.receiveOnlyMock.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    server = new MeshCoreVirtualNodeServer({ port: 0, manager, databaseService: CHANNELS_DB });
+    await server.start();
+    client = new TestClient();
+    await client.connect(server.getListeningPort()!);
+
+    const payload = await client.request(advertFrame);
+    expect(payload[0]).toBe(ResponseCodes.Err);
+    expect(payload[1]).toBe(ErrorCodes.BadState);
+    expect(manager.sendAdvertMock).not.toHaveBeenCalled();
+  });
+
+  // ── Receive-only OFF regression: the guard did not alter existing generic
+  // failure paths. SendChannelTxtMsg, SendTxtMsg (Plain DM) and SendSelfAdvert
+  // already replied Err(BadState) on an ordinary node-side failure before this
+  // change (the other 6 guarded handlers reply Sent unconditionally and only
+  // fail silently); this proves those three are byte-identical with the guard
+  // in place but not tripped. ──
+
+  it('receive-only OFF: SendChannelTxtMsg, SendTxtMsg (Plain DM) and SendSelfAdvert still reply Err(BadState) on ordinary node failure, unchanged by the new guard', async () => {
+    manager = new FakeManager(); // isReceiveOnly() defaults to false
+    server = new MeshCoreVirtualNodeServer({ port: 0, manager, databaseService: CHANNELS_DB });
+    await server.start();
+    client = new TestClient();
+    await client.connect(server.getListeningPort()!);
+
+    manager.sendMessageMock.mockResolvedValueOnce(false);
+    const channelRes = await client.request(channelFrame('nope'));
+    expect(channelRes[0]).toBe(ResponseCodes.Err);
+    expect(channelRes[1]).toBe(ErrorCodes.BadState);
+
+    manager.sendMessageWithResultMock.mockResolvedValueOnce({ ok: false });
+    const dmRes = await client.request(dmFrame(REMOTE_PREFIX, 'nope'));
+    expect(dmRes[0]).toBe(ResponseCodes.Err);
+    expect(dmRes[1]).toBe(ErrorCodes.BadState);
+
+    manager.sendAdvertMock.mockResolvedValueOnce(false);
+    const advertRes = await client.request(advertFrame);
+    expect(advertRes[0]).toBe(ResponseCodes.Err);
+    expect(advertRes[1]).toBe(ErrorCodes.BadState);
   });
 });

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -70,6 +70,12 @@ export interface MeshCoreVirtualNodeManager {
   isConnected(): boolean;
   getLocalNode(): MeshCoreNode | null;
   getContacts(): MeshCoreContact[];
+  /**
+   * True when this source is configured strictly receive-only (#4547). Sync and
+   * cached on the manager — no DB read on the command path. The server refuses
+   * the 9 TX-causing companion commands while this is true.
+   */
+  isReceiveOnly(): boolean;
   /** Send a text message to the real node: channel (by index) or DM (full key). */
   sendMessage(text: string, toPublicKey?: string, channelIdx?: number): Promise<boolean>;
   /**
@@ -270,6 +276,12 @@ interface ConnectedClient {
  * Reads are synthesized from the manager's local-node state; nothing is
  * forwarded to the real node yet (that arrives in Phase 2). Structure mirrors
  * src/server/virtualNodeServer.ts (the proven Meshtastic equivalent).
+ *
+ * Receive-only mode (#4547 Phase 3): when `manager.isReceiveOnly()` is true,
+ * the 9 TX-causing companion commands (self-advert, login, trace-path,
+ * telemetry/status/neighbour requests, channel/DM sends incl. the CLI relay)
+ * are refused with `Err(BadState)` via `refuseIfReceiveOnly()`, before any
+ * frame is written. Every read path and the live push feed keep working.
  */
 export class MeshCoreVirtualNodeServer extends EventEmitter {
   private readonly options: MeshCoreVirtualNodeServerOptions;
@@ -706,6 +718,48 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
   }
 
   /**
+   * Receive-only refusal for the 9 TX-causing companion commands (#4547 Phase 3).
+   * Returns true when it has ALREADY replied and the caller must return —
+   * same contract as `rejectIfReceiveOnly()` in routes/meshcoreRouteShared.ts.
+   *
+   * MUST be called before the handler writes anything, in particular before
+   * the `Sent(6)` that six of these handlers emit up front: meshcore.js drops
+   * its `Err` listener the instant `Sent` arrives (connection.js:1641, :2373),
+   * so an error written afterwards is silently discarded and the client waits
+   * out its estimated timeout instead.
+   *
+   * Replies Err(BadState) — the only refusal every meshcore.js command wrapper
+   * terminates on. Disabled(15) is listened for by exportPrivateKey() alone
+   * (connection.js:1576) and would hang the untimed send/advert promises
+   * forever.
+   *
+   * Fails CLOSED: a manager that cannot answer is treated as receive-only, in
+   * line with `isRfBridgeCommand()`'s fail-closed default (constants/meshcoreTx.ts).
+   *
+   * Logged at debug, matching the sibling `allowAdminCommands` refusal — a
+   * companion app retries sends on its own schedule, so an info-level line
+   * here would be a log flood. The operator-facing signal is the single
+   * state-change info line from `MeshCoreManager.setReceiveOnly()`.
+   */
+  private refuseIfReceiveOnly(clientId: string, commandName: string): boolean {
+    let receiveOnly: boolean;
+    try {
+      receiveOnly = this.options.manager.isReceiveOnly() !== false;
+    } catch (err) {
+      logger.warn(
+        `[MeshCore VN ${this.sourceId}] receive-only check threw, refusing ${commandName}: ${(err as Error).message}`,
+      );
+      receiveOnly = true;
+    }
+    if (!receiveOnly) return false;
+    logger.debug(
+      `[MeshCore VN ${this.sourceId}] ${commandName} refused from ${clientId} (receive-only mode)`,
+    );
+    this.send(clientId, encodeErr(ErrorCodes.BadState));
+    return true;
+  }
+
+  /**
    * Shared path for config-mutating commands (issue #3904). Gates on
    * `allowAdminCommands`, runs `apply()` (which parses the payload and calls the
    * matching MeshCoreManager method against the real node), and translates the
@@ -766,6 +820,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
    * Err(BadState) if the manager reported failure or threw (issue #3904).
    */
   private async handleSendSelfAdvert(clientId: string): Promise<void> {
+    if (this.refuseIfReceiveOnly(clientId, 'SendSelfAdvert')) return;
     try {
       const ok = await this.options.manager.sendAdvert();
       if (!ok) {
@@ -801,6 +856,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
    * Not gated on allowAdminCommands — logging in is a normal unlock step.
    */
   private async handleSendLogin(clientId: string, command: ParsedCommand): Promise<void> {
+    if (this.refuseIfReceiveOnly(clientId, 'SendLogin')) return;
     let parsed;
     try {
       parsed = parseSendLogin(command.payload);
@@ -844,6 +900,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
    * alongside the measured SNRs. On failure we emit nothing (app times out).
    */
   private async handleSendTracePath(clientId: string, command: ParsedCommand): Promise<void> {
+    if (this.refuseIfReceiveOnly(clientId, 'SendTracePath')) return;
     let parsed;
     try {
       parsed = parseSendTracePath(command.payload);
@@ -880,6 +937,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
    * from the real node, then push them verbatim. On failure we emit nothing.
    */
   private async handleSendTelemetryReq(clientId: string, command: ParsedCommand): Promise<void> {
+    if (this.refuseIfReceiveOnly(clientId, 'SendTelemetryReq')) return;
     let parsed;
     try {
       parsed = parseSendTelemetryReq(command.payload);
@@ -925,6 +983,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
    * exactly what the app renders.
    */
   private async handleSendStatusReq(clientId: string, command: ParsedCommand): Promise<void> {
+    if (this.refuseIfReceiveOnly(clientId, 'SendStatusReq')) return;
     let parsed;
     try {
       parsed = parseSendStatusReq(command.payload);
@@ -961,6 +1020,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
    * Sent, mirroring the sibling req handlers.
    */
   private async handleSendBinaryReq(clientId: string, command: ParsedCommand): Promise<void> {
+    if (this.refuseIfReceiveOnly(clientId, 'SendBinaryReq')) return;
     let parsed: SendBinaryReqCmd;
     try {
       parsed = parseSendBinaryReq(command.payload);
@@ -1141,6 +1201,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
 
   /** SendChannelTxtMsg → forward to the real node on the given channel, reply Sent. */
   private async handleSendChannelTxtMsg(clientId: string, cmd: ParsedCommand): Promise<void> {
+    if (this.refuseIfReceiveOnly(clientId, 'SendChannelTxtMsg')) return;
     const text = cmd.text ?? '';
     const channelIdx = cmd.channelIdx ?? 0;
     try {
@@ -1170,6 +1231,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
    * remote's CLI handler and the app would just time out waiting for a reply.
    */
   private async handleSendTxtMsg(clientId: string, cmd: ParsedCommand): Promise<void> {
+    if (this.refuseIfReceiveOnly(clientId, 'SendTxtMsg')) return;
     const text = cmd.text ?? '';
     const prefixHex = (cmd.pubKeyPrefix ?? Buffer.alloc(0)).toString('hex');
     const fullKey = this.resolveContactKey(prefixHex);
@@ -1260,6 +1322,11 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
    * thread. On failure/timeout we emit nothing further, mirroring
    * SendStatusReq/SendTelemetryReq: a real node that never got a CLI reply
    * doesn't push anything either, so the app's own timeout takes over.
+   *
+   * Receive-only (#4547 Phase 3): NOT separately guarded here. This method is
+   * `private` with exactly one caller, `handleSendTxtMsg`, which already calls
+   * `refuseIfReceiveOnly()` before dispatching to CliData vs. plain-DM — a
+   * second guard here would be unreachable.
    */
   private async handleSendCliTxtMsg(clientId: string, targetPublicKey: string, command: string): Promise<void> {
     if (!this.allowAdminCommands) {


### PR DESCRIPTION
## Phase 3 of 3 — Virtual Node gating + documentation. **Closes #4547.**

Follows #4550 (backend enforcement) and #4552 (frontend gating). Epic plan:
`docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_EPIC.md`.

Closes the last transmit path and ships the user documentation.

### Why the Virtual Node mattered

The VN server is a TCP/companion-protocol port that **bypasses the entire HTTP API**. Phases 1 and
2 gated routes, manager primitives, schedulers, automations and the UI — but a third-party MeshCore
client connected to the VN port could still reach the radio through nine command handlers.

Per the epic's interview decision, the VN **stays up and serves reads** (AppStart, contacts,
channels, message sync, device time, battery, config setters, PKI export, and the live push feed).
Only the nine transmit commands are refused.

### The refusal shape — the obvious choice would have hung real clients

Refusing with `Disabled(15)` looks natural, and is wrong. In `@liamcottle/meshcore.js` v1.13.0 only
`exportPrivateKey()` listens for `Disabled` (`connection.js:1576`), and `sendTextMessage`,
`sendChannelTextMessage` and `sendAdvert` have **no timeout at all** — so a `Disabled` reply to
those emits an event with no listener and the client's promise never settles.

We use `Err(1)` + `ErrorCodes.BadState(4)`: the only refusal every command wrapper terminates on.
`BadState` rather than `UnsupportedCmd` because the latter is a *capability* claim a client may
cache, whereas receive-only is runtime state.

### The guard must precede the `Sent` frame

Six of the nine handlers wrote `Sent(6)` before reaching the manager, and the client wrappers for
`login` and `tracePath` do `onSent → this.off(Err, onErr)` (`connection.js:1641`, `:2373`) — they
tear down the error listener the moment `Sent` arrives. Any refusal emitted after that is silently
discarded.

That makes relying on Phase 1's downstream `TxDisabledError` throw **structurally incapable** of
refusing those six. Before this PR they did not transmit (Phase 1 blocked them) but never refused
either — the client just hung 12–30 s to its own timeout. Every guard now runs before any frame is
written and before payload parsing.

Three handlers already replied `Err(BadState)`, so for those the behaviour is byte-identical — and
there's a test pinning that their ordinary (non-receive-only) failure path is unchanged.

### Fail-closed by construction

`isReceiveOnly()` is a **required** interface member, not optional — an optional one would default
to "allowed", the wrong direction for a safety gate. Making it required meant the existing
`FakeManager` stopped compiling and 41 tests failed until the harness was updated; that noisy
failure is intended and was not silenced with a cast. The helper also treats a throw as blocked.

### Documentation

New user page `docs/features/meshcore-receive-only.md`, plus cross-links from the MeshCore, Virtual
Node and Analyzer Observer pages, and `409 TX_DISABLED` / `400 INVALID_BOOLEAN_SETTING` documented
in `REST_API.md` and `API_REFERENCE.md`.

**The firmware limitation is stated prominently, above the fold**, because someone deploying this
for a regulatory or site-policy reason needs it: MeshCore firmware exposes no radio-level transmit
kill switch, so MeshMonitor enforces receive-only **in software**. It cannot stop transmissions the
firmware makes on its own — link-layer acknowledgements, or an advert schedule configured on the
device outside MeshMonitor. The guarantee is "MeshMonitor will not initiate a transmission", not
"this radio is electrically silent".

Also fixed a now-false claim in `docs/features/receive-only-mode.md` that MeshCore had "no
equivalent flag", and a wrong route path recorded in the epic doc (`POST /nodes/:publicKey/telemetry/poll`).

### Testing

- Full Vitest suite: **14,168 tests, 0 failures** (`success: true` via JSON reporter).
- VN suite 104/104: a refusal test per command asserting `Err(BadState)` **as the first frame** and
  the manager TX method never called; a read-path regression; a flag-flip test; a fail-closed test;
  a decode test using the **real `meshcore.js` client** proving a genuine client parses the refusal
  rather than desyncing; and an **inventory test** firing every `CommandCodes` value with
  receive-only ON, asserting no TX mock is reached — so a future unguarded handler fails on day one.
- `npm run typecheck` clean; `npm run lint:ci` clean of in-repo failures; `npm run docs:build`
  succeeds with no dead links.

### Epic complete

Every MeshMonitor-controlled transmit path for a MeshCore source is now gated: HTTP routes (409),
manager primitives (throw), schedulers and automations (silent skip, settings preserved), the
discovery auto-responder, and the Virtual Node port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf
