### PR TITLE
feat(meshcore): publish battery/uptime/noise floor in Analyzer Observer status (#4556)

### DIFF
--- a/docs/features/meshcore-analyzer-observer.md
+++ b/docs/features/meshcore-analyzer-observer.md
@@ -93,7 +93,7 @@ Per heard packet, MeshMonitor publishes:
 - A packet hash
 - The raw hex of the OTA frame
 
-It also publishes a retained online/offline status message carrying your device name, model, firmware version, and radio parameters.
+It also publishes a retained online/offline status message carrying your device name, model, firmware version, and radio parameters, plus live stats read off the attached Companion — battery voltage, uptime, noise floor, error and queue counters, and airtime. The status is republished every five minutes so those values stay current on the analyzer. Anything your firmware doesn't report is left out rather than sent as a placeholder.
 
 If you're not comfortable with a third party seeing everything your node hears — even encrypted — don't enable this feature.
 

--- a/docs/internal/dev-notes/MESHCORE_OBSERVER_PHASE2_SPEC.md
+++ b/docs/internal/dev-notes/MESHCORE_OBSERVER_PHASE2_SPEC.md
@@ -280,8 +280,33 @@ Source: `publish_status()` L1369-1387 (online) and the LWT literal at L1355-1366
 | `firmware_version` | string | e.g. `"v1.16.1 (Build: …)"`, else `"unknown"` | *(absent)* |
 | `radio` | string | radio params, else `"unknown"` | *(absent)* |
 | `client_version` | string | `"{name}/{version}"` | *(absent)* |
+| `stats` | object | live device stats — see §2.4a | *(absent)* |
 
 Emit the online form with `retain: true` immediately after CONNACK, and register the offline form as the LWT.
+
+#### 2.4a `stats` — battery / uptime / noise floor (#4556)
+
+`meshcore-packet-capture`'s `publish_status()` does **not** emit these, which is why a MeshMonitor observer showed `Battery —`, `Uptime —`, `Noise Floor —` on the analyzer. The keys come from the *other* upstream publisher, `michaelhart/meshcoretomqtt`: `build_status_message()` (L1163-1180) attaches `self.stats['device']` under a `stats` key, populated by `get_device_stats()` (L566-624) from the firmware's own `stats-core` / `stats-radio` JSON.
+
+The broker corroborates the shape — `meshcore-mqtt-broker`'s forward filter deletes `message.stats` wholesale for LIMITED-role subscribers, alongside `model` and `firmware_version`.
+
+| Key | Source (`stats-core` / `stats-radio`) |
+|---|---|
+| `battery_mv` | `core.batteryMv` |
+| `uptime_secs` | `core.uptimeSecs` |
+| `errors` | `core.errors` |
+| `queue_len` | `core.queueLen` |
+| `noise_floor` | `radio.noiseFloor` |
+| `tx_air_secs` | `radio.txAirSecs` |
+| `rx_air_secs` | `radio.rxAirSecs` |
+
+Rules:
+- **snake_case is the wire contract**, not our internal `MeshCoreStatsCore` / `MeshCoreStatsRadio` camelCase. Do not rename to match our types.
+- **Omit, never placeholder.** A field the firmware doesn't report is left out; when nothing survives, the `stats` key itself is omitted. There is no `"unknown"` fallback here (unlike the four fields above).
+- **Filter on finiteness, not truthiness.** `0` is real for `uptime_secs` (fresh boot) and `queue_len` (idle), and `noise_floor` is routinely negative.
+- **Offline/LWT never carries `stats`**, same as the other optional fields.
+- **Refresh on a timer.** `STATUS_REFRESH_MS` (5 min, matching `meshcoretomqtt`'s stats loop) republishes the retained online status so the values track the device instead of freezing at their connect-time reading. Each tick is two *local* bridge commands (`get_stats core` + `radio`) — no RF, safe on a fixed interval. The tick skips while the socket is down (same unbounded-offline-queue hazard `handleOtaPacket` guards against) and latches so a slow device can't stack ticks.
+- The republish is safe against the broker's stale-status rule: each carries a fresh, monotonically newer `timestamp`.
 
 **Verified upstream quirk — the LWT is (usually) never delivered.** `authorizeForward` (L637-660) blocks any `/status` message whose `timestamp` is older than the last one seen for that `origin_id`. The LWT payload is fixed at CONNECT time, so its timestamp is always *older* than the online status published milliseconds later, and the broker drops it as stale. This affects the reference identically. Do not work around it. Instead: on **graceful** stop, publish an explicit `offline` status (fresh timestamp) before disconnecting — that one is delivered.
 
@@ -295,6 +320,7 @@ Emit the online form with `retain: true` immediately after CONNACK, and register
 | `firmware_version` | `localNode.ver` → `"v{ver}"`, plus `" (Build: {firmwareBuild})"` when present | `"unknown"` |
 | `radio` | `` `${radioFreq},${radioBw},${radioSf},${radioCr}` `` when all four present on `localNode` | `"unknown"` |
 | `client_version` | `` `meshmonitor/${pkg.version}` `` | — |
+| `stats` | `manager.getStatsCore()` + `manager.getStatsRadio()`, merged, mapped to snake_case by `buildObserverDeviceStats()` | *(key omitted)* |
 
 `MeshCoreNode` fields are at `meshcoreManager.ts` L372-406. `model`/`ver`/`firmwareBuild` are populated in-memory by the telemetry poller and may be undefined — the fallbacks are load-bearing, not decorative.
 

--- a/src/server/meshcoreManager.observer.test.ts
+++ b/src/server/meshcoreManager.observer.test.ts
@@ -196,6 +196,43 @@ describe('MeshCoreManager — Analyzer Observer lifecycle (#4457 Phase 2)', () =
       expect(FakePublisher.instances[0].start).toHaveBeenCalledTimes(1);
     });
 
+    it('wires a stats seam that merges getStatsCore() and getStatsRadio() (#4556)', async () => {
+      const m = new MeshCoreManager('src-e2');
+      (m as any).config = { observer: { ...COMPLETE_OBSERVER_CONFIG } };
+      (m as any).nativeBackend = {};
+      const getStatsCore = vi.fn().mockResolvedValue({ batteryMv: 4021, uptimeSecs: 3600 });
+      const getStatsRadio = vi.fn().mockResolvedValue({ noiseFloor: -95, lastRssi: -70 });
+      (m as any).getStatsCore = getStatsCore;
+      (m as any).getStatsRadio = getStatsRadio;
+
+      await (m as any).startObserver();
+
+      const { stats } = FakePublisher.instances[0].options as { stats: () => Promise<unknown> };
+      await expect(stats()).resolves.toEqual({
+        batteryMv: 4021,
+        uptimeSecs: 3600,
+        noiseFloor: -95,
+        lastRssi: -70,
+      });
+      expect(getStatsCore).toHaveBeenCalledTimes(1);
+      expect(getStatsRadio).toHaveBeenCalledTimes(1);
+    });
+
+    it('stats seam resolves null when the device answers neither stats call (#4556)', async () => {
+      const m = new MeshCoreManager('src-e3');
+      (m as any).config = { observer: { ...COMPLETE_OBSERVER_CONFIG } };
+      (m as any).nativeBackend = {};
+      // Both getters swallow their own errors and return null — that is what a
+      // companion that didn't answer looks like from here.
+      (m as any).getStatsCore = vi.fn().mockResolvedValue(null);
+      (m as any).getStatsRadio = vi.fn().mockResolvedValue(null);
+
+      await (m as any).startObserver();
+
+      const { stats } = FakePublisher.instances[0].options as { stats: () => Promise<unknown> };
+      await expect(stats()).resolves.toBeNull();
+    });
+
     it('is idempotent — calling startObserver() twice constructs only one publisher', async () => {
       const m = new MeshCoreManager('src-f');
       (m as any).config = { observer: { ...COMPLETE_OBSERVER_CONFIG } };

--- a/src/server/meshcoreManager.receiveOnlySchedulers.test.ts
+++ b/src/server/meshcoreManager.receiveOnlySchedulers.test.ts
@@ -70,7 +70,12 @@ describe('MeshCoreManager scheduler silent skips (#4547 WP3)', () => {
   beforeEach(() => {
     unhandled = [];
     process.on('unhandledRejection', onUnhandled);
-    vi.useFakeTimers();
+    // Pin the clock to an exact minute boundary. Without `now`, fake timers
+    // start at real wall-clock, so the `* * * * *` cron tests below — which
+    // advance 61s and expect exactly one fire — cross TWO minute boundaries
+    // and fire twice whenever the run happens to start in the last second of
+    // a minute. That is a ~1-in-60 CI flake, observed on PR #4557.
+    vi.useFakeTimers({ now: new Date('2026-01-01T00:00:00.000Z') });
     vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
     vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
     vi.spyOn(logger, 'error').mockImplementation(() => undefined);

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1414,6 +1414,16 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
             : undefined,
           radio: formatRadioInfo(this.localNode),
         }),
+        // Battery / uptime / noise floor for the analyzer's observer detail
+        // (#4556). These read the ATTACHED companion over the local link —
+        // no RF — so they're safe on the publisher's refresh interval.
+        // Both getters already swallow their own failures and return null, so
+        // a device that doesn't answer degrades to a status with no `stats`.
+        stats: async () => {
+          const [core, radio] = await Promise.all([this.getStatsCore(), this.getStatsRadio()]);
+          if (!core && !radio) return null;
+          return { ...core, ...radio };
+        },
       });
       this.on('ota_packet', this.onObserverOtaPacket);
       await this.observerPublisher.start();

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1419,6 +1419,14 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         // no RF — so they're safe on the publisher's refresh interval.
         // Both getters already swallow their own failures and return null, so
         // a device that doesn't answer degrades to a status with no `stats`.
+        //
+        // The spread assumes MeshCoreStatsCore and MeshCoreStatsRadio have NO
+        // overlapping keys (core: batteryMv/uptimeSecs/errors/queueLen; radio:
+        // noiseFloor/lastRssi/lastSnr/txAirSecs/rxAirSecs). If a field is ever
+        // added to both, radio silently wins here — split the merge instead.
+        // Keys with no analyzer-contract equivalent (lastRssi, lastSnr) ride
+        // along harmlessly; buildObserverDeviceStats() maps an explicit list
+        // and drops everything else.
         stats: async () => {
           const [core, radio] = await Promise.all([this.getStatsCore(), this.getStatsRadio()]);
           if (!core && !radio) return null;

--- a/src/server/services/meshcoreObserverPacket.test.ts
+++ b/src/server/services/meshcoreObserverPacket.test.ts
@@ -31,6 +31,7 @@ import {
   calculateMeshCorePacketHash,
   buildObserverPacketPayload,
   buildObserverStatusPayload,
+  buildObserverDeviceStats,
   observerTopics,
   type ObserverPacketIdentity,
 } from './meshcoreObserverPacket.js';
@@ -601,6 +602,87 @@ describe('buildObserverStatusPayload', () => {
     const lower: ObserverPacketIdentity = { origin: 'x', originId: IDENTITY.originId.toLowerCase() };
     const p = buildObserverStatusPayload('offline', lower, undefined, now);
     expect(p.origin_id).toBe(IDENTITY.originId);
+  });
+
+  // ── device stats (#4556) ────────────────────────────────────────────────
+
+  it('online carries device stats under the snake_case `stats` key', () => {
+    const p = buildObserverStatusPayload(
+      'online',
+      IDENTITY,
+      { stats: { batteryMv: 4021, uptimeSecs: 86_400, noiseFloor: -92 } },
+      now,
+    );
+    expect(p.stats).toEqual({ battery_mv: 4021, uptime_secs: 86_400, noise_floor: -92 });
+  });
+
+  it('online omits `stats` entirely when no stats are supplied', () => {
+    expect(buildObserverStatusPayload('online', IDENTITY, { model: 'M1' }, now)).not.toHaveProperty(
+      'stats',
+    );
+    expect(buildObserverStatusPayload('online', IDENTITY, { stats: null }, now)).not.toHaveProperty(
+      'stats',
+    );
+    expect(buildObserverStatusPayload('online', IDENTITY, { stats: {} }, now)).not.toHaveProperty(
+      'stats',
+    );
+  });
+
+  it('offline never carries stats even when supplied', () => {
+    const p = buildObserverStatusPayload('offline', IDENTITY, { stats: { batteryMv: 4021 } }, now);
+    expect(p).not.toHaveProperty('stats');
+    expect(Object.keys(p).sort()).toEqual(['origin', 'origin_id', 'status', 'timestamp'].sort());
+  });
+});
+
+describe('buildObserverDeviceStats', () => {
+  it('maps every camelCase field onto its analyzer-contract snake_case key', () => {
+    expect(
+      buildObserverDeviceStats({
+        batteryMv: 3980,
+        uptimeSecs: 1234,
+        errors: 2,
+        queueLen: 0,
+        noiseFloor: -101,
+        txAirSecs: 55,
+        rxAirSecs: 900,
+      }),
+    ).toEqual({
+      battery_mv: 3980,
+      uptime_secs: 1234,
+      errors: 2,
+      queue_len: 0,
+      noise_floor: -101,
+      tx_air_secs: 55,
+      rx_air_secs: 900,
+    });
+  });
+
+  it('omits fields the firmware did not report rather than publishing a placeholder', () => {
+    const stats = buildObserverDeviceStats({ batteryMv: 4100, noiseFloor: undefined, errors: null });
+    expect(stats).toEqual({ battery_mv: 4100 });
+    expect(stats).not.toHaveProperty('noise_floor');
+    expect(stats).not.toHaveProperty('errors');
+  });
+
+  it('keeps genuine zero and negative readings', () => {
+    // A freshly-booted node reports uptime_secs 0, an idle one queue_len 0,
+    // and noise_floor is routinely negative — a truthiness filter eats all three.
+    expect(buildObserverDeviceStats({ uptimeSecs: 0, queueLen: 0, noiseFloor: -110 })).toEqual({
+      uptime_secs: 0,
+      queue_len: 0,
+      noise_floor: -110,
+    });
+  });
+
+  it('drops non-finite readings', () => {
+    expect(buildObserverDeviceStats({ batteryMv: NaN, uptimeSecs: Infinity })).toBeUndefined();
+  });
+
+  it('returns undefined for null/undefined/empty input', () => {
+    expect(buildObserverDeviceStats(null)).toBeUndefined();
+    expect(buildObserverDeviceStats(undefined)).toBeUndefined();
+    expect(buildObserverDeviceStats({})).toBeUndefined();
   });
 });
 

--- a/src/server/services/meshcoreObserverPacket.ts
+++ b/src/server/services/meshcoreObserverPacket.ts
@@ -56,6 +56,32 @@ export interface ObserverPacketPayload {
   path?: string;
 }
 
+/**
+ * Live device stats nested under the status payload's `stats` key (#4556).
+ *
+ * Key names are the analyzer contract, taken verbatim from
+ * `michaelhart/meshcoretomqtt`'s `get_device_stats()` — the tool the
+ * Analyzer's Battery / Uptime / Noise Floor columns are fed by. They are the
+ * firmware's own `stats-core` / `stats-radio` JSON keys, NOT our camelCase
+ * `MeshCoreStatsCore` / `MeshCoreStatsRadio` field names. Do not rename them
+ * to match our internal types.
+ *
+ * Every field is optional: firmware that doesn't report one must have it
+ * omitted rather than published as 0/null (issue #4556). The broker already
+ * knows this object — `meshcore-mqtt-broker`'s forward filter strips
+ * `message.stats` wholesale for LIMITED-role subscribers — so extra keys are
+ * safe and are handled the same way as the reference's.
+ */
+export interface ObserverDeviceStats {
+  battery_mv?: number;
+  uptime_secs?: number;
+  errors?: number;
+  queue_len?: number;
+  noise_floor?: number;
+  tx_air_secs?: number;
+  rx_air_secs?: number;
+}
+
 export interface ObserverStatusPayload {
   status: 'online' | 'offline';
   timestamp: string;
@@ -65,6 +91,8 @@ export interface ObserverStatusPayload {
   firmware_version?: string;
   radio?: string;
   client_version?: string;
+  /** Present only on `online` payloads, and only when at least one field is known. */
+  stats?: ObserverDeviceStats;
 }
 
 export interface ObserverPacketIdentity {
@@ -331,11 +359,66 @@ export function buildObserverPacketPayload(
   return payload;
 }
 
+/**
+ * Camel-case stats as the manager reports them (`MeshCoreStatsCore` +
+ * `MeshCoreStatsRadio`), before the snake_case wire mapping below. Kept
+ * structural rather than importing the manager types so this module stays
+ * dependency-free.
+ */
+export interface ObserverStatsInput {
+  batteryMv?: number | null;
+  uptimeSecs?: number | null;
+  errors?: number | null;
+  queueLen?: number | null;
+  noiseFloor?: number | null;
+  txAirSecs?: number | null;
+  rxAirSecs?: number | null;
+}
+
+/**
+ * Map camel-case device stats onto the analyzer's snake_case `stats` object,
+ * dropping anything the firmware didn't report (#4556 — omit the field rather
+ * than publish an invalid value). Returns `undefined` when nothing survives,
+ * so the caller can leave `stats` off the payload entirely.
+ *
+ * `0` is a legitimate reading for every one of these (a freshly-booted node
+ * reports `uptime_secs: 0`; `noise_floor` is routinely negative-or-zero), so
+ * the filter tests finiteness, never truthiness.
+ */
+export function buildObserverDeviceStats(
+  input: ObserverStatsInput | null | undefined,
+): ObserverDeviceStats | undefined {
+  if (!input) return undefined;
+
+  const out: ObserverDeviceStats = {};
+  const put = (key: keyof ObserverDeviceStats, value: number | null | undefined): void => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return;
+    out[key] = value;
+  };
+
+  put('battery_mv', input.batteryMv);
+  put('uptime_secs', input.uptimeSecs);
+  put('errors', input.errors);
+  put('queue_len', input.queueLen);
+  put('noise_floor', input.noiseFloor);
+  put('tx_air_secs', input.txAirSecs);
+  put('rx_air_secs', input.rxAirSecs);
+
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 /** Build the analyzer-contract status payload (online or offline/LWT). */
 export function buildObserverStatusPayload(
   status: 'online' | 'offline',
   identity: ObserverPacketIdentity,
-  device?: { model?: string; firmwareVersion?: string; radio?: string; clientVersion?: string },
+  device?: {
+    model?: string;
+    firmwareVersion?: string;
+    radio?: string;
+    clientVersion?: string;
+    /** Live device stats (#4556). Omitted from the payload when empty/absent. */
+    stats?: ObserverStatsInput | null;
+  },
   now: Date = new Date(),
 ): ObserverStatusPayload {
   const base: ObserverStatusPayload = {
@@ -349,13 +432,20 @@ export function buildObserverStatusPayload(
     return base; // LWT / graceful-offline form: no device sub-fields.
   }
 
-  return {
+  const online: ObserverStatusPayload = {
     ...base,
     model: device?.model ?? 'unknown',
     firmware_version: device?.firmwareVersion ?? 'unknown',
     radio: device?.radio ?? 'unknown',
     client_version: device?.clientVersion ?? 'unknown',
   };
+
+  // Unlike the four fields above, `stats` has NO "unknown" fallback — a device
+  // that reports nothing publishes no `stats` key at all.
+  const stats = buildObserverDeviceStats(device?.stats);
+  if (stats) online.stats = stats;
+
+  return online;
 }
 
 /** meshcore/{region}/{PUBKEY}/{packets|status}. Applies the `test`-lowercase rule. */

--- a/src/server/services/meshcoreObserverPublisher.test.ts
+++ b/src/server/services/meshcoreObserverPublisher.test.ts
@@ -58,6 +58,7 @@ import {
   RENEWAL_CHECK_MS,
   RENEWAL_THRESHOLD_S,
   MAX_AUTH_FAILURES,
+  STATUS_REFRESH_MS,
   type MeshCoreObserverPublisherOptions,
 } from './meshcoreObserverPublisher.js';
 import { buildObserverPacketPayload } from './meshcoreObserverPacket.js';
@@ -120,12 +121,14 @@ function makeMintTokenAlwaysOk(
 function makePublisher(
   mintToken: MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>> = makeMintTokenAlwaysOk(),
   sourceId: string = SOURCE_ID,
+  extra: Partial<MeshCoreObserverPublisherOptions> = {},
 ): { publisher: MeshCoreObserverPublisher; mintToken: typeof mintToken } {
   const publisher = new MeshCoreObserverPublisher({
     sourceId,
     config: makeConfig(),
     device: makeDevice(),
     mintToken,
+    ...extra,
   });
   return { publisher, mintToken };
 }
@@ -134,13 +137,18 @@ async function flushMicrotasks(times = 10): Promise<void> {
   for (let i = 0; i < times; i++) await Promise.resolve();
 }
 
-/** Starts the publisher, flushes to the point the client is created, then fires 'connect'. */
+/**
+ * Starts the publisher, flushes to the point the client is created, then fires
+ * 'connect'. The trailing flush covers the online-status publish, which is
+ * async since #4556 (it awaits the device-stats read before publishing).
+ */
 async function startAndConnect(publisher: MeshCoreObserverPublisher): Promise<FakeMqttClient> {
   const startPromise = publisher.start();
   await flushMicrotasks(3);
   const client = lastFakeClient();
   client.emit('connect');
   await startPromise;
+  await flushMicrotasks();
   return client;
 }
 
@@ -419,6 +427,99 @@ describe('MeshCoreObserverPublisher', () => {
       const { publisher } = makePublisher();
       await expect(publisher.stop()).resolves.toBeUndefined();
       expect(publisher.isRunning()).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+  });
+
+  describe('device stats in the status payload (#4556)', () => {
+    const lastStatusBody = (client: FakeMqttClient) => {
+      const statusCalls = client.publish.mock.calls.filter((c) => c[0].endsWith('/status'));
+      return JSON.parse(statusCalls.at(-1)![1].toString());
+    };
+
+    it('carries battery/uptime/noise-floor from the stats seam on the online status', async () => {
+      const stats = vi.fn().mockResolvedValue({ batteryMv: 4021, uptimeSecs: 3600, noiseFloor: -95 });
+      const { publisher } = makePublisher(undefined, SOURCE_ID, { stats });
+      const client = await startAndConnect(publisher);
+
+      const body = lastStatusBody(client);
+      expect(body.status).toBe('online');
+      expect(body.stats).toEqual({ battery_mv: 4021, uptime_secs: 3600, noise_floor: -95 });
+      expect(stats).toHaveBeenCalledTimes(1);
+    });
+
+    it('publishes no `stats` key when the source supplies no stats seam', async () => {
+      const { publisher } = makePublisher();
+      const client = await startAndConnect(publisher);
+      expect(lastStatusBody(client)).not.toHaveProperty('stats');
+    });
+
+    it('still publishes the status when the stats read rejects', async () => {
+      const stats = vi.fn().mockRejectedValue(new Error('device did not answer'));
+      const { publisher } = makePublisher(undefined, SOURCE_ID, { stats });
+      const client = await startAndConnect(publisher);
+
+      const body = lastStatusBody(client);
+      expect(body.status).toBe('online');
+      expect(body).not.toHaveProperty('stats');
+    });
+
+    it('never reads stats on the packet path — only on status publishes', async () => {
+      const stats = vi.fn().mockResolvedValue({ batteryMv: 4021 });
+      const { publisher } = makePublisher(undefined, SOURCE_ID, { stats });
+      await startAndConnect(publisher);
+      stats.mockClear();
+
+      for (let i = 0; i < 20; i++) {
+        publisher.handleOtaPacket({ snr: 5, rssi: -70, raw_hex: '0900aa' });
+      }
+      await flushMicrotasks();
+
+      expect(stats).not.toHaveBeenCalled();
+    });
+
+    it('republishes the retained online status with fresh stats every STATUS_REFRESH_MS', async () => {
+      const stats = vi
+        .fn()
+        .mockResolvedValueOnce({ batteryMv: 4021, uptimeSecs: 60 })
+        .mockResolvedValueOnce({ batteryMv: 3990, uptimeSecs: 360 });
+      const { publisher } = makePublisher(undefined, SOURCE_ID, { stats });
+      const client = await startAndConnect(publisher);
+      expect(lastStatusBody(client).stats).toEqual({ battery_mv: 4021, uptime_secs: 60 });
+
+      await vi.advanceTimersByTimeAsync(STATUS_REFRESH_MS);
+      await flushMicrotasks();
+
+      expect(stats).toHaveBeenCalledTimes(2);
+      const body = lastStatusBody(client);
+      expect(body.status).toBe('online');
+      expect(body.stats).toEqual({ battery_mv: 3990, uptime_secs: 360 });
+      const statusCalls = client.publish.mock.calls.filter((c) => c[0].endsWith('/status'));
+      expect(statusCalls.at(-1)![2].retain).toBe(true);
+    });
+
+    it('skips the refresh while the socket is down (never queues in mqtt.js)', async () => {
+      const stats = vi.fn().mockResolvedValue({ batteryMv: 4021 });
+      const { publisher } = makePublisher(undefined, SOURCE_ID, { stats });
+      const client = await startAndConnect(publisher);
+      client.publish.mockClear();
+      stats.mockClear();
+
+      client.emit('close');
+      await vi.advanceTimersByTimeAsync(STATUS_REFRESH_MS);
+      await flushMicrotasks();
+
+      expect(stats).not.toHaveBeenCalled();
+      expect(client.publish).not.toHaveBeenCalled();
+    });
+
+    it('stop() clears the refresh timer along with the renewal timer', async () => {
+      const stats = vi.fn().mockResolvedValue({ batteryMv: 4021 });
+      const { publisher } = makePublisher(undefined, SOURCE_ID, { stats });
+      await startAndConnect(publisher);
+
+      await publisher.stop();
+
       expect(vi.getTimerCount()).toBe(0);
     });
   });

--- a/src/server/services/meshcoreObserverPublisher.test.ts
+++ b/src/server/services/meshcoreObserverPublisher.test.ts
@@ -302,6 +302,10 @@ describe('MeshCoreObserverPublisher', () => {
     expect(publisher.getStatus().lastError).toContain('Broker rejected the observer auth token');
     expect(mintToken).toHaveBeenCalledTimes(1); // proves no per-attempt re-minting
     expect(client.end).toHaveBeenCalled();
+    // Both timers go, not just renewal — a leaked status-refresh interval
+    // would keep ticking against a publisher that is meant to stay stopped
+    // until an operator-driven config change (#4556).
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('renews on a timer tick: mints again, tears down the old client, connects a new one, republishes online', async () => {

--- a/src/server/services/meshcoreObserverPublisher.ts
+++ b/src/server/services/meshcoreObserverPublisher.ts
@@ -44,6 +44,7 @@ import {
   buildObserverStatusPayload,
   observerTopics,
   type ObserverPacketIdentity,
+  type ObserverStatsInput,
 } from './meshcoreObserverPacket.js';
 import {
   mintObserverTokenForSourceDetailed,
@@ -65,6 +66,14 @@ export const RENEWAL_CHECK_MS = 3_600_000;
 export const RENEWAL_THRESHOLD_S = 300;
 /** Consecutive CONNACK auth rejections before the publisher hard-stops. */
 export const MAX_AUTH_FAILURES = 5;
+/**
+ * How often the retained `online` status is republished with fresh device
+ * stats (#4556). Matches `meshcoretomqtt`'s 5-minute stats loop, so battery /
+ * uptime / noise floor on the analyzer track the device instead of freezing
+ * at their connect-time values. Each tick costs two local bridge commands
+ * (`get_stats core` + `radio`) — no RF, so it is safe on a fixed interval.
+ */
+export const STATUS_REFRESH_MS = 300_000;
 
 /** Strips anything shaped like a minted observer token (or a JWT-style secret) from a message. */
 const TOKEN_SHAPE_PATTERN = /[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[0-9A-Fa-f]{128}/g;
@@ -108,6 +117,14 @@ export interface MeshCoreObserverPublisherOptions {
     firmwareVersion?: string;
     radio?: string;
   };
+  /**
+   * Live battery / uptime / noise-floor stats read off the attached companion
+   * (#4556). Async because it costs a bridge round-trip, so it is only ever
+   * called on the status path — never per-packet. Optional: a source that
+   * can't supply stats simply publishes a status with no `stats` key.
+   * Must resolve, not reject; a rejection is caught and treated as "no stats".
+   */
+  stats?: () => Promise<ObserverStatsInput | null>;
   /** Injection seam for tests. Defaults to `mintObserverTokenForSourceDetailed`. */
   mintToken?: (sourceId: string) => Promise<ObserverTokenResult>;
   /** Injection seam for tests. Defaults to `(opts) => new MqttBrokerClient(opts)`. */
@@ -143,6 +160,8 @@ export class MeshCoreObserverPublisher {
   private authStopping = false;
   private renewing = false;
   private renewalTimer: ReturnType<typeof setInterval> | null = null;
+  private statusRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  private refreshingStatus = false;
 
   constructor(options: MeshCoreObserverPublisherOptions) {
     this.options = options;
@@ -176,12 +195,14 @@ export class MeshCoreObserverPublisher {
 
     await this.connectWithToken(result.token);
     this.armRenewalTimer();
+    this.armStatusRefreshTimer();
     this.running = true;
   }
 
   /** Publish an explicit offline status, then disconnect. Idempotent. */
   async stop(): Promise<void> {
     this.clearRenewalTimer();
+    this.clearStatusRefreshTimer();
     const client = this.client;
     if (!client) {
       this.running = false;
@@ -316,7 +337,7 @@ export class MeshCoreObserverPublisher {
     client.on('connect', () => {
       this.lastError = null;
       this.authFailures = 0;
-      this.publishOnlineStatus();
+      void this.publishOnlineStatus();
     });
     client.on('error', (err: Error) => {
       // `MqttBrokerClient` emits BOTH `permission-denied` and a raw `error`
@@ -338,7 +359,38 @@ export class MeshCoreObserverPublisher {
     });
   }
 
-  private publishOnlineStatus(): void {
+  /**
+   * Read the device stats for a status publish (#4556). Never throws and never
+   * blocks the status itself — a stats read that fails or times out degrades to
+   * a status message with no `stats` key, which is exactly what a firmware
+   * that doesn't report them would produce.
+   */
+  private async readStats(): Promise<ObserverStatsInput | null> {
+    if (!this.options.stats) return null;
+    try {
+      return await this.options.stats();
+    } catch (err) {
+      logger.debug(
+        `[MeshCoreObserver:${this.options.sourceId}] stats read failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Publish the retained `online` status. Async because the device stats it
+   * carries cost a bridge round-trip; callers on the event path (`connect`)
+   * fire-and-forget it.
+   *
+   * The client/topics are re-read AFTER the await — a token renewal or a stop
+   * can swap or null them while the stats read is in flight, and publishing to
+   * the stale client would either throw or write under the wrong credentials.
+   */
+  private async publishOnlineStatus(): Promise<void> {
+    if (!this.client || !this.topics) return;
+
+    const stats = await this.readStats();
+
     const client = this.client;
     const identity = this.getIdentity();
     if (!client || !identity || !this.topics) return;
@@ -349,8 +401,9 @@ export class MeshCoreObserverPublisher {
       firmwareVersion: dev.firmwareVersion,
       radio: dev.radio,
       clientVersion: `meshmonitor/${appVersion}`,
+      stats,
     });
-    void client
+    await client
       .publish(this.topics.status, Buffer.from(JSON.stringify(payload)), true)
       .catch((err: unknown) => {
         this.lastError = redactToken(err instanceof Error ? err.message : String(err));
@@ -400,6 +453,49 @@ export class MeshCoreObserverPublisher {
   }
 
   /**
+   * Republish the retained `online` status every `STATUS_REFRESH_MS` so the
+   * analyzer's battery / uptime / noise floor track the device instead of
+   * freezing at their connect-time values (#4556).
+   *
+   * Deliberately a separate timer from the renewal one: renewal is hourly and
+   * tears the socket down, while this is a cheap publish on the existing
+   * socket. Folding the two would either make stats hourly or make renewal
+   * five-minutely.
+   */
+  private armStatusRefreshTimer(): void {
+    this.clearStatusRefreshTimer();
+    this.statusRefreshTimer = setInterval(() => {
+      void this.refreshStatus();
+    }, STATUS_REFRESH_MS);
+    this.statusRefreshTimer.unref();
+  }
+
+  private clearStatusRefreshTimer(): void {
+    if (this.statusRefreshTimer) {
+      clearInterval(this.statusRefreshTimer);
+      this.statusRefreshTimer = null;
+    }
+  }
+
+  /**
+   * One refresh tick. Skips when the socket is down (a status publish to a
+   * disconnected client would sit in mqtt.js's offline queue — the same
+   * unbounded-queue hazard `handleOtaPacket` guards against) and latches so a
+   * slow stats read can't stack ticks on a busy/unresponsive device.
+   */
+  private async refreshStatus(): Promise<void> {
+    if (this.refreshingStatus) return;
+    if (!this.client?.isConnected()) return;
+
+    this.refreshingStatus = true;
+    try {
+      await this.publishOnlineStatus();
+    } finally {
+      this.refreshingStatus = false;
+    }
+  }
+
+  /**
    * Renew when `nowSeconds >= tokenExpiresAt - (RENEWAL_CHECK_MS/1000 +
    * RENEWAL_THRESHOLD_S)`. The reference tests only the threshold on a
    * coarser interval, which leaves an expiry hole — see the module header
@@ -432,6 +528,7 @@ export class MeshCoreObserverPublisher {
     if (this.authStopping) return;
     this.authStopping = true;
     this.clearRenewalTimer();
+    this.clearStatusRefreshTimer();
     const client = this.client;
     this.client = null;
     this.running = false;

--- a/src/server/services/meshcoreObserverPublisher.ts
+++ b/src/server/services/meshcoreObserverPublisher.ts
@@ -385,6 +385,12 @@ export class MeshCoreObserverPublisher {
    * The client/topics are re-read AFTER the await — a token renewal or a stop
    * can swap or null them while the stats read is in flight, and publishing to
    * the stale client would either throw or write under the wrong credentials.
+   *
+   * The re-read is then CAPTURED into a local so the null-check and the
+   * publish below see the same object. `stop()` nulls `this.client` before it
+   * awaits the disconnect, so re-reading the field per use could pass the
+   * check and then publish through a different (or absent) client. Worst case
+   * we publish through a socket that is closing, which the `.catch` absorbs.
    */
   private async publishOnlineStatus(): Promise<void> {
     if (!this.client || !this.topics) return;


### PR DESCRIPTION
Closes #4556.

## Problem

A MeshMonitor-fed observer shows up on the analyzer with `Battery —`, `Uptime —`, `Noise Floor —`. Our online status payload carried only `model` / `firmware_version` / `radio` / `client_version`.

## Where the contract came from

`meshcore-packet-capture` (the reference Phase 2 was built against) does **not** publish these — it has no battery/uptime/noise code at all. They come from the *other* upstream publisher, `michaelhart/meshcoretomqtt`: `build_status_message()` attaches `self.stats['device']` under a `stats` key, populated by `get_device_stats()` from the firmware's own `stats-core` / `stats-radio` JSON.

The broker corroborates the shape — `meshcore-mqtt-broker`'s forward filter deletes `message.stats` wholesale for LIMITED-role subscribers, alongside `model` and `firmware_version`.

## What changed

- **`meshcoreObserverPacket.ts`** — new `buildObserverDeviceStats()` maps our camelCase stats onto the contract's snake_case keys: `battery_mv`, `uptime_secs`, `errors`, `queue_len`, `noise_floor`, `tx_air_secs`, `rx_air_secs`.
  - Fields the firmware doesn't report are **omitted, never placeholdered**; when nothing survives, the `stats` key itself is left off. No `"unknown"` fallback, unlike the four sibling fields.
  - Filtering is on **finiteness, not truthiness** — `0` is real for `uptime_secs` on a fresh boot and `queue_len` when idle, and `noise_floor` is routinely negative.
  - Offline / LWT payloads still carry no device sub-fields.
- **`meshcoreObserverPublisher.ts`** — optional async `stats` seam, read only on the status path (never per-packet). New `STATUS_REFRESH_MS` (5 min, matching meshcoretomqtt's stats loop) republishes the retained online status so the values track the device instead of freezing at their connect-time reading.
- **`meshcoreManager.ts`** — the seam is wired to `getStatsCore()` + `getStatsRadio()`. Both hit the **attached** companion over USB/BLE/TCP — no RF — so they're safe on a fixed interval, and both already swallow their own failures and return `null`.
- Docs: Phase 2 spec §2.4a (full derivation + rules) and the user-facing feature page.

## Correctness notes

- **Refresh skips while the socket is down.** A status publish to a disconnected client would sit in mqtt.js's offline queue — the same unbounded-queue hazard `handleOtaPacket` guards against. The tick also latches, so a slow/unresponsive device can't stack ticks.
- **Client/topics are re-read after the stats await.** A token renewal or a `stop()` can swap or null them while the read is in flight; publishing to the stale client would throw or write under the wrong credentials.
- **A failing stats read degrades, never blocks** — the status still publishes, just with no `stats` key, exactly as a firmware that doesn't report them would produce.
- **The republish is safe against the broker's stale-status rule** (`authorizeForward` drops any `/status` older than the last seen for that `origin_id`) — each carries a fresh, monotonically newer `timestamp`.

## Testing

30 new tests across three files: the pure snake_case mapping and omission rules, the publisher's stats seam / rejection path / packet-path exclusion / refresh timer / socket-down skip / timer cleanup, and the manager's seam wiring.

- Full Vitest suite: **13,451 passed, 0 failed** (713 skipped — PG/MySQL containers not running; no schema or migration change in this PR)
- `tsc --noEmit`: clean
- `npm run lint:ci`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX