### PR TITLE
Gate MeshCore map positions on nodes:viewOnMap, not just nodes:read

### DIFF
--- a/src/components/UsersTab.test.tsx
+++ b/src/components/UsersTab.test.tsx
@@ -283,6 +283,28 @@ describe('UsersTab — PR-C grid additions', () => {
     expect(nodesRow!.textContent).toContain('users.view_on_map');
   });
 
+  it('includes viewOnMap in the PUT payload for the nodes resource on a MeshCore source (#4559)', async () => {
+    setupApi({
+      sources: [{ id: 'mc-1', name: 'MeshCore', type: 'meshcore' }],
+      channels: [],
+    });
+    render(<UsersTab />);
+    fireEvent.click(await screen.findByText(/Alice/));
+    const select = (await screen.findByLabelText(/permission_scope/i)) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'mc-1' } });
+
+    await waitFor(() => expect(screen.getByText('Node Map & List')).toBeInTheDocument());
+    const nodesRow = screen.getByText('Node Map & List').closest('.permission-item')!;
+    const [viewOnMapCheckbox] = Array.from(nodesRow.querySelectorAll('input[type="checkbox"]'));
+    fireEvent.click(viewOnMapCheckbox);
+
+    fireEvent.click(screen.getByText('users.save_permissions'));
+
+    await waitFor(() => expect(apiPutMock).toHaveBeenCalled());
+    const [, body] = apiPutMock.mock.calls[0];
+    expect(body.permissions.nodes).toMatchObject({ viewOnMap: true });
+  });
+
   it('channel-database section renders a canWrite checkbox column', async () => {
     setupApi({
       channelDbEntries: [

--- a/src/components/UsersTab.test.tsx
+++ b/src/components/UsersTab.test.tsx
@@ -249,6 +249,40 @@ describe('UsersTab — PR-C grid additions', () => {
     expect(channelNRows).toHaveLength(1);
   });
 
+  it('shows a "View on Map" checkbox for the nodes resource only when a MeshCore source is scoped (#4559)', async () => {
+    // MeshCore has no per-channel device slots, so map visibility for its
+    // contacts is controlled by nodes:viewOnMap directly. The checkbox must
+    // appear when a MeshCore source is selected, and stay absent for a
+    // Meshtastic source (where nodes:viewOnMap is not checked anywhere, and
+    // showing it would just be a dead control).
+    setupApi({
+      sources: [
+        { id: 'tcp-1', name: 'TCP Source', type: 'meshtastic_tcp' },
+        { id: 'mc-1', name: 'MeshCore', type: 'meshcore' },
+      ],
+      channels: [{ id: 0, name: '' }],
+    });
+    render(<UsersTab />);
+    fireEvent.click(await screen.findByText(/Alice/));
+    const select = (await screen.findByLabelText(/permission_scope/i)) as HTMLSelectElement;
+
+    // Meshtastic source: nodes row has just read/write, no View on Map checkbox
+    // (channel_0's own "View on Map" checkbox is a separate row and separate
+    // concern — asserted here by checkbox count scoped to the nodes row only).
+    fireEvent.change(select, { target: { value: 'tcp-1' } });
+    await waitFor(() => expect(screen.getByText('Node Map & List')).toBeInTheDocument());
+    let nodesRow = screen.getByText('Node Map & List').closest('.permission-item');
+    expect(nodesRow!.querySelectorAll('input[type="checkbox"]')).toHaveLength(2);
+    expect(nodesRow!.textContent).not.toContain('users.view_on_map');
+
+    // MeshCore source: nodes row gains the View on Map checkbox.
+    fireEvent.change(select, { target: { value: 'mc-1' } });
+    await waitFor(() => expect(screen.getByText('Node Map & List')).toBeInTheDocument());
+    nodesRow = screen.getByText('Node Map & List').closest('.permission-item');
+    expect(nodesRow!.querySelectorAll('input[type="checkbox"]')).toHaveLength(3);
+    expect(nodesRow!.textContent).toContain('users.view_on_map');
+  });
+
   it('channel-database section renders a canWrite checkbox column', async () => {
     setupApi({
       channelDbEntries: [

--- a/src/components/UsersTab.tsx
+++ b/src/components/UsersTab.tsx
@@ -269,7 +269,10 @@ const UsersTab: React.FC = () => {
       const allKeys: ResourceType[] = [...PERMISSION_KEYS, ...GLOBAL_PERMISSION_RESOURCES];
       allKeys.forEach(resource => {
         if (!permissions[resource]) return;
-        if (resource.startsWith('channel_')) {
+        // `nodes` carries viewOnMap alongside channel_* resources (#4559):
+        // read makes the node/contact list available, viewOnMap additionally
+        // publishes positions on the map — the same split channels already have.
+        if (resource.startsWith('channel_') || resource === 'nodes') {
           validPermissions[resource] = {
             viewOnMap: permissions[resource]?.viewOnMap || false,
             read: permissions[resource]?.read || false,
@@ -980,7 +983,17 @@ const UsersTab: React.FC = () => {
 
                 const tooltip = resource.startsWith('channel_')
                   ? 'View on Map: show nodes heard on this channel. Read: view messages. Write: send messages.'
+                  : resource === 'nodes'
+                  ? 'View on Map: publish node/contact positions on the map. Read: view the node list.'
                   : tooltipMap[resource] || '';
+
+                // MeshCore has no per-channel device slots, so map visibility
+                // for its contacts is gated on `nodes:viewOnMap` directly
+                // rather than per-channel like Meshtastic (#4559). Only show
+                // the extra checkbox when it does something — on a Meshtastic
+                // source, `nodes:viewOnMap` isn't checked anywhere.
+                const scopedSourceForNodes = sources.find(s => s.id === permissionScope);
+                const showNodesViewOnMap = resource === 'nodes' && scopedSourceForNodes?.type === 'meshcore';
 
                 return (
                   <div key={resource} className="permission-item">
@@ -1067,6 +1080,35 @@ const UsersTab: React.FC = () => {
                               onChange={() => toggleChannelWrite(resource)}
                             />
                             {t('users.send_messages')}
+                          </label>
+                        </>
+                      ) : showNodesViewOnMap ? (
+                        // MeshCore: nodes:viewOnMap independently gates positions
+                        // on the map, same split as channel_* (#4559).
+                        <>
+                          <label>
+                            <input
+                              type="checkbox"
+                              checked={permissions[resource]?.viewOnMap || false}
+                              onChange={() => toggleChannelViewOnMap(resource)}
+                            />
+                            {t('users.view_on_map')}
+                          </label>
+                          <label>
+                            <input
+                              type="checkbox"
+                              checked={permissions[resource]?.read || false}
+                              onChange={() => togglePermission(resource, 'read')}
+                            />
+                            {t('users.read')}
+                          </label>
+                          <label>
+                            <input
+                              type="checkbox"
+                              checked={permissions[resource]?.write || false}
+                              onChange={() => togglePermission(resource, 'write')}
+                            />
+                            {t('users.write')}
                           </label>
                         </>
                       ) : (

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -149,6 +149,7 @@ import { migration as seedPerSourceNodeDisplayMigration, runMigration131Postgres
 import { migration as fanOutSettingsPermissionsMigration, runMigration132Postgres, runMigration132Mysql } from '../server/migrations/132_fan_out_settings_permissions.js';
 import { migration as addMeshCoreObserverKeysMigration, runMigration133Postgres, runMigration133Mysql } from '../server/migrations/133_add_meshcore_observer_keys.js';
 import { migration as clearNullIslandEstimatesMigration, runMigration134Postgres, runMigration134Mysql } from '../server/migrations/134_clear_null_island_estimates.js';
+import { migration as backfillMeshcoreNodesViewOnMapMigration, runMigration135Postgres, runMigration135Mysql } from '../server/migrations/135_backfill_meshcore_nodes_viewonmap.js';
 
 // ============================================================================
 // Registry
@@ -2136,4 +2137,13 @@ registry.register({
   sqlite: (db) => clearNullIslandEstimatesMigration.up(db),
   postgres: (client) => runMigration134Postgres(client),
   mysql: (pool) => runMigration134Mysql(pool),
+});
+
+registry.register({
+  number: 135,
+  name: 'backfill_meshcore_nodes_viewonmap',
+  settingsKey: 'migration_135_backfill_meshcore_nodes_viewonmap',
+  sqlite: (db) => backfillMeshcoreNodesViewOnMapMigration.up(db),
+  postgres: (client) => runMigration135Postgres(client),
+  mysql: (pool) => runMigration135Mysql(pool),
 });

--- a/src/server/migrations/135_backfill_meshcore_nodes_viewonmap.test.ts
+++ b/src/server/migrations/135_backfill_meshcore_nodes_viewonmap.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import DatabaseConstructor from 'better-sqlite3';
+import type { Database } from 'better-sqlite3';
+import { migration } from './135_backfill_meshcore_nodes_viewonmap.js';
+
+/**
+ * Migration 135 (issue #4559): buildSourceNodes() is being fixed to require
+ * nodes:viewOnMap (not just nodes:read) before publishing MeshCore contact
+ * positions on the map. Without this backfill, every existing `nodes` grant
+ * has canViewOnMap=false (the admin UI never exposed a control to set it for
+ * `nodes`), so the fix would silently blank every MeshCore map that works
+ * today. This migration sets canViewOnMap=true on existing `nodes` grants for
+ * meshcore-typed sources that already have canRead=true.
+ */
+describe('migration 135: backfill canViewOnMap on meshcore nodes grants', () => {
+  let db: Database;
+
+  const insertSource = (id: string, type: string) =>
+    db.prepare(`INSERT INTO sources (id, type) VALUES (?, ?)`).run(id, type);
+
+  const insertPermission = (
+    userId: number,
+    resource: string,
+    sourceId: string | null,
+    canRead: 0 | 1,
+    canViewOnMap: 0 | 1,
+  ) =>
+    db
+      .prepare(
+        `INSERT INTO permissions (user_id, resource, can_view_on_map, can_read, can_write, granted_at, sourceId)
+         VALUES (?, ?, ?, ?, 0, ?, ?)`,
+      )
+      .run(userId, resource, canViewOnMap, canRead, Date.now(), sourceId);
+
+  const viewOnMapFor = (userId: number, sourceId: string) =>
+    (db
+      .prepare(`SELECT can_view_on_map FROM permissions WHERE user_id = ? AND resource = 'nodes' AND sourceId = ?`)
+      .get(userId, sourceId) as { can_view_on_map: number } | undefined)?.can_view_on_map;
+
+  beforeEach(() => {
+    db = new DatabaseConstructor(':memory:');
+    db.exec(`
+      CREATE TABLE sources (
+        id TEXT PRIMARY KEY,
+        type TEXT NOT NULL
+      );
+      CREATE TABLE permissions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        resource TEXT NOT NULL,
+        can_view_on_map INTEGER NOT NULL DEFAULT 0,
+        can_read INTEGER NOT NULL DEFAULT 0,
+        can_write INTEGER NOT NULL DEFAULT 0,
+        granted_at INTEGER NOT NULL,
+        granted_by INTEGER,
+        sourceId TEXT
+      );
+    `);
+  });
+
+  it('sets canViewOnMap=true on a meshcore nodes:read grant', () => {
+    insertSource('mc-1', 'meshcore');
+    insertPermission(10, 'nodes', 'mc-1', 1, 0);
+
+    migration.up(db);
+
+    expect(viewOnMapFor(10, 'mc-1')).toBe(1);
+  });
+
+  it('leaves a meshtastic nodes:read grant untouched', () => {
+    insertSource('mt-1', 'meshtastic_tcp');
+    insertPermission(10, 'nodes', 'mt-1', 1, 0);
+
+    migration.up(db);
+
+    expect(viewOnMapFor(10, 'mt-1')).toBe(0);
+  });
+
+  it('does not grant viewOnMap when canRead is false', () => {
+    insertSource('mc-1', 'meshcore');
+    insertPermission(10, 'nodes', 'mc-1', 0, 0);
+
+    migration.up(db);
+
+    expect(viewOnMapFor(10, 'mc-1')).toBe(0);
+  });
+
+  it('leaves other resources (e.g. messages) untouched', () => {
+    insertSource('mc-1', 'meshcore');
+    insertPermission(10, 'messages', 'mc-1', 1, 0);
+
+    migration.up(db);
+
+    expect(
+      (db.prepare(`SELECT can_view_on_map FROM permissions WHERE resource = 'messages'`).get() as any)
+        .can_view_on_map,
+    ).toBe(0);
+  });
+
+  it('is idempotent — a second run does not throw and leaves state unchanged', () => {
+    insertSource('mc-1', 'meshcore');
+    insertPermission(10, 'nodes', 'mc-1', 1, 0);
+
+    migration.up(db);
+    expect(() => migration.up(db)).not.toThrow();
+
+    expect(viewOnMapFor(10, 'mc-1')).toBe(1);
+  });
+
+  it('does not touch a grant that already has viewOnMap set (no-op, not an error)', () => {
+    insertSource('mc-1', 'meshcore');
+    insertPermission(10, 'nodes', 'mc-1', 1, 1);
+
+    expect(() => migration.up(db)).not.toThrow();
+    expect(viewOnMapFor(10, 'mc-1')).toBe(1);
+  });
+});

--- a/src/server/migrations/135_backfill_meshcore_nodes_viewonmap.ts
+++ b/src/server/migrations/135_backfill_meshcore_nodes_viewonmap.ts
@@ -1,0 +1,102 @@
+/**
+ * Migration 135: Backfill `canViewOnMap` on existing `nodes` permission grants
+ * for MeshCore-typed sources.
+ *
+ * Context (issue #4559):
+ *   Until now, MeshCore contact positions reaching the Dashboard/Unified/Map
+ *   Analysis maps were gated only by the coarse `nodes:read` permission —
+ *   unlike Meshtastic, which additionally requires `viewOnMap` (per channel)
+ *   before a node's position is included. `buildSourceNodes()` is being fixed
+ *   to apply the same `nodes:viewOnMap` gate to MeshCore sources.
+ *
+ *   Without a backfill, that fix would silently blank every MeshCore map that
+ *   works today: `canViewOnMap` defaults to false and the admin UI never had
+ *   a control to set it for the `nodes` resource, so no existing grant has it
+ *   set to true. This migration preserves current behavior across the
+ *   upgrade by setting `canViewOnMap = true` on existing `nodes` grants for
+ *   meshcore-typed sources that already have `canRead = true` — admins can
+ *   tighten individual grants afterward now that the UI exposes the control.
+ *
+ *   Mirrors migration 058's pattern of joining against `sources WHERE type =
+ *   'meshcore'`.
+ *
+ * Idempotency:
+ *   A plain UPDATE ... WHERE canViewOnMap = false AND canRead = true; once a
+ *   row is updated it no longer matches the WHERE clause, so a second run is
+ *   a no-op. Safe to re-run on a partially-applied database.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 135';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): backfilling canViewOnMap on meshcore nodes grants...`);
+    try {
+      const result = db
+        .prepare(
+          `UPDATE permissions
+             SET can_view_on_map = 1
+           WHERE resource = 'nodes'
+             AND can_read = 1
+             AND can_view_on_map = 0
+             AND sourceId IN (SELECT id FROM sources WHERE type = 'meshcore')`,
+        )
+        .run();
+      if (result.changes > 0) {
+        logger.info(`${LABEL} (SQLite): backfilled canViewOnMap on ${result.changes} grant(s)`);
+      }
+    } catch (e) {
+      logger.warn(`${LABEL} (SQLite): could not backfill canViewOnMap:`, e instanceof Error ? e.message : String(e));
+    }
+    logger.info(`${LABEL} complete (SQLite)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration135Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): backfilling canViewOnMap on meshcore nodes grants...`);
+  try {
+    const result = await client.query(
+      `UPDATE permissions
+          SET "canViewOnMap" = true
+        WHERE resource = 'nodes'
+          AND "canRead" = true
+          AND "canViewOnMap" = false
+          AND "sourceId" IN (SELECT id FROM sources WHERE type = 'meshcore')`,
+    );
+    if (result.rowCount && result.rowCount > 0) {
+      logger.info(`${LABEL} (PostgreSQL): backfilled canViewOnMap on ${result.rowCount} grant(s)`);
+    }
+  } catch (e) {
+    logger.warn(`${LABEL} (PostgreSQL): could not backfill canViewOnMap:`, e instanceof Error ? e.message : String(e));
+  }
+  logger.info(`${LABEL} complete (PostgreSQL)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration135Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): backfilling canViewOnMap on meshcore nodes grants...`);
+  try {
+    const [result] = await pool.query<import('mysql2').ResultSetHeader>(
+      `UPDATE permissions
+          SET canViewOnMap = true
+        WHERE resource = 'nodes'
+          AND canRead = true
+          AND canViewOnMap = false
+          AND sourceId IN (SELECT id FROM sources WHERE type = 'meshcore')`,
+    );
+    const affected = result?.affectedRows ?? 0;
+    if (affected > 0) {
+      logger.info(`${LABEL} (MySQL): backfilled canViewOnMap on ${affected} grant(s)`);
+    }
+  } catch (e) {
+    logger.warn(`${LABEL} (MySQL): could not backfill canViewOnMap:`, e instanceof Error ? e.message : String(e));
+  }
+  logger.info(`${LABEL} complete (MySQL)`);
+}

--- a/src/server/routes/meshcoreContactsRoutes.ts
+++ b/src/server/routes/meshcoreContactsRoutes.ts
@@ -153,10 +153,15 @@ router.post('/contacts/refresh', meshcoreDeviceLimiter, requireAuth(), requirePe
       allContacts.unshift(buildLocalContactRow(localNode));
     }
 
+    // nodes:write (required above) does not imply nodes:viewOnMap — mask the
+    // same as GET /contacts so refreshing doesn't become a side-channel
+    // around the read-path's position gate (#4559 review follow-up).
+    const masked = await maskContactPositionsForViewOnMap(allContacts, req.user ?? null, req.params.id);
+
     res.json({
       success: true,
-      data: allContacts,
-      count: allContacts.length,
+      data: masked,
+      count: masked.length,
     });
   } catch (error) {
     logger.error('[API] Error refreshing contacts:', error);

--- a/src/server/routes/meshcoreContactsRoutes.ts
+++ b/src/server/routes/meshcoreContactsRoutes.ts
@@ -21,7 +21,7 @@ import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddle
 import { meshcoreDeviceLimiter } from '../middleware/rateLimiters.js';
 import meshcorePositionHistoryService from '../services/meshcorePositionHistoryService.js';
 import { isBogusPosition } from '../../utils/nullIsland.js';
-import { managerFor, isValidPublicKey, auditMeshcoreEvent, parseHexPathChain, requireMeshcoreTx, failIfTxDisabled } from './meshcoreRouteShared.js';
+import { managerFor, isValidPublicKey, auditMeshcoreEvent, parseHexPathChain, requireMeshcoreTx, failIfTxDisabled, maskContactPositionsForViewOnMap } from './meshcoreRouteShared.js';
 import { ok, fail } from '../utils/apiResponse.js';
 import { buildLocalContactRow, withoutLocalFlag, type MeshCoreContactResponse } from './meshcoreLocalContactRow.js';
 
@@ -33,7 +33,11 @@ const router = Router({ mergeParams: true });
  */
 router.get('/nodes', optionalAuth(), requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }), async (req: Request, res: Response) => {
   try {
-    const nodes = await managerFor(req, res).getAllNodes();
+    const nodes = await maskContactPositionsForViewOnMap(
+      await managerFor(req, res).getAllNodes(),
+      req.user ?? null,
+      req.params.id,
+    );
     res.json({
       success: true,
       data: nodes,
@@ -107,10 +111,16 @@ router.get('/contacts', optionalAuth(), requirePermission('nodes', 'read', { sou
       allContacts.unshift(buildLocalContactRow(localNode));
     }
 
+    const masked = await maskContactPositionsForViewOnMap(
+      allContacts,
+      req.user ?? null,
+      req.params.id,
+    );
+
     res.json({
       success: true,
-      data: allContacts,
-      count: allContacts.length,
+      data: masked,
+      count: masked.length,
     });
   } catch (error) {
     logger.error('[API] Error getting contacts:', error);

--- a/src/server/routes/meshcoreDeviceRoutes.ts
+++ b/src/server/routes/meshcoreDeviceRoutes.ts
@@ -10,9 +10,9 @@ import { Router, Request, Response } from 'express';
 import { ConnectionType, MeshCoreDeviceType } from '../meshcoreManager.js';
 import { getMeshCoreTelemetryPoller, nodeNumFromPubkey } from '../services/meshcoreTelemetryPoller.js';
 import { logger } from '../../utils/logger.js';
-import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
+import { requireAuth, optionalAuth, requirePermission, hasPermission } from '../auth/authMiddleware.js';
 import { meshcoreDeviceLimiter } from '../middleware/rateLimiters.js';
-import { managerFor, isValidConnectionParams, requireMeshcoreTx, failIfTxDisabled, maskContactPositionsForViewOnMap } from './meshcoreRouteShared.js';
+import { managerFor, isValidConnectionParams, requireMeshcoreTx, failIfTxDisabled, stripPositions } from './meshcoreRouteShared.js';
 import databaseService from '../../services/database.js';
 import { buildLocalContactRow, withoutLocalFlag, type MeshCoreContactResponse } from './meshcoreLocalContactRow.js';
 
@@ -185,8 +185,12 @@ router.get('/snapshot', optionalAuth(), requirePermission('connection', 'read', 
     // map — that additionally requires `nodes:viewOnMap`, mirroring the
     // messages gate above (issue #4559). Strip lat/lon rather than dropping
     // the rows so the contact list this snapshot also feeds keeps working.
-    const maskedContacts = await maskContactPositionsForViewOnMap(allContacts, user ?? null, sourceId);
-    const maskedNodes = await maskContactPositionsForViewOnMap(nodes, user ?? null, sourceId);
+    // Resolved once (not via maskContactPositionsForViewOnMap per array) —
+    // it's the same user/source for both, so a second permission check would
+    // just be a redundant DB round-trip on every snapshot request.
+    const canViewOnMap = user ? await hasPermission(user, 'nodes', 'viewOnMap', sourceId) : false;
+    const maskedContacts = canViewOnMap ? allContacts : stripPositions(allContacts);
+    const maskedNodes = canViewOnMap ? nodes : stripPositions(nodes);
 
     res.json({
       success: true,

--- a/src/server/routes/meshcoreDeviceRoutes.ts
+++ b/src/server/routes/meshcoreDeviceRoutes.ts
@@ -12,7 +12,7 @@ import { getMeshCoreTelemetryPoller, nodeNumFromPubkey } from '../services/meshc
 import { logger } from '../../utils/logger.js';
 import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
 import { meshcoreDeviceLimiter } from '../middleware/rateLimiters.js';
-import { managerFor, isValidConnectionParams, requireMeshcoreTx, failIfTxDisabled } from './meshcoreRouteShared.js';
+import { managerFor, isValidConnectionParams, requireMeshcoreTx, failIfTxDisabled, maskContactPositionsForViewOnMap } from './meshcoreRouteShared.js';
 import databaseService from '../../services/database.js';
 import { buildLocalContactRow, withoutLocalFlag, type MeshCoreContactResponse } from './meshcoreLocalContactRow.js';
 
@@ -181,6 +181,13 @@ router.get('/snapshot', optionalAuth(), requirePermission('connection', 'read', 
       allContacts.unshift(buildLocalContactRow(localNode));
     }
 
+    // `connection:read` alone does not entitle a caller to positions on the
+    // map — that additionally requires `nodes:viewOnMap`, mirroring the
+    // messages gate above (issue #4559). Strip lat/lon rather than dropping
+    // the rows so the contact list this snapshot also feeds keeps working.
+    const maskedContacts = await maskContactPositionsForViewOnMap(allContacts, user ?? null, sourceId);
+    const maskedNodes = await maskContactPositionsForViewOnMap(nodes, user ?? null, sourceId);
+
     res.json({
       success: true,
       data: {
@@ -189,8 +196,8 @@ router.get('/snapshot', optionalAuth(), requirePermission('connection', 'read', 
           localNode,
           deviceTypeName: MeshCoreDeviceType[status.deviceType],
         },
-        contacts: allContacts,
-        nodes,
+        contacts: maskedContacts,
+        nodes: maskedNodes,
         messages,
         seqCursor,
       },

--- a/src/server/routes/meshcoreRouteShared.ts
+++ b/src/server/routes/meshcoreRouteShared.ts
@@ -200,6 +200,23 @@ export async function resolveCliTimeoutMs(timeoutMs?: number): Promise<number | 
  * Validation helper functions
  */
 /**
+ * Strip `latitude`/`longitude` from a set of contact/node rows. Pure —
+ * callers resolve the `viewOnMap` permission themselves (see
+ * `maskContactPositionsForViewOnMap` for the single-array case, or resolve
+ * once and call this directly when masking more than one array for the same
+ * user/source, e.g. GET /snapshot's contacts + nodes).
+ */
+export function stripPositions<T extends { latitude?: number; longitude?: number }>(items: T[]): T[] {
+  return items.map((item) => {
+    if (item.latitude === undefined && item.longitude === undefined) return item;
+    const masked = { ...item };
+    delete masked.latitude;
+    delete masked.longitude;
+    return masked;
+  });
+}
+
+/**
  * Strip `latitude`/`longitude` from contact/node rows when the caller lacks
  * `nodes:viewOnMap` on this source (#4559). `nodes:read` makes the contact
  * list available; publishing positions additionally requires `viewOnMap` —
@@ -213,14 +230,7 @@ export async function maskContactPositionsForViewOnMap<T extends { latitude?: nu
   sourceId: string,
 ): Promise<T[]> {
   const canViewOnMap = user ? await hasPermission(user, 'nodes', 'viewOnMap', sourceId) : false;
-  if (canViewOnMap) return items;
-  return items.map((item) => {
-    if (item.latitude === undefined && item.longitude === undefined) return item;
-    const masked = { ...item };
-    delete masked.latitude;
-    delete masked.longitude;
-    return masked;
-  });
+  return canViewOnMap ? items : stripPositions(items);
 }
 
 export function isValidPublicKey(key: string | undefined): boolean {

--- a/src/server/routes/meshcoreRouteShared.ts
+++ b/src/server/routes/meshcoreRouteShared.ts
@@ -21,6 +21,8 @@ import { logger } from '../../utils/logger.js';
 import { fail } from '../utils/apiResponse.js';
 import { TX_DISABLED_CODE, isTxDisabledError } from '../errors/txDisabledError.js';
 import { MESHCORE_RECEIVE_ONLY_MESSAGE } from '../constants/meshcoreTx.js';
+import { hasPermission } from '../auth/authMiddleware.js';
+import type { User } from '../../types/auth.js';
 
 /**
  * Resolve the manager for a request. Mounted only under
@@ -197,6 +199,30 @@ export async function resolveCliTimeoutMs(timeoutMs?: number): Promise<number | 
 /**
  * Validation helper functions
  */
+/**
+ * Strip `latitude`/`longitude` from contact/node rows when the caller lacks
+ * `nodes:viewOnMap` on this source (#4559). `nodes:read` makes the contact
+ * list available; publishing positions additionally requires `viewOnMap` —
+ * mirrors the gate `buildSourceNodes()` applies to the same data for the
+ * Dashboard/Unified/Map Analysis maps. Admins and any caller with the grant
+ * pass through unchanged.
+ */
+export async function maskContactPositionsForViewOnMap<T extends { latitude?: number; longitude?: number }>(
+  items: T[],
+  user: User | null | undefined,
+  sourceId: string,
+): Promise<T[]> {
+  const canViewOnMap = user ? await hasPermission(user, 'nodes', 'viewOnMap', sourceId) : false;
+  if (canViewOnMap) return items;
+  return items.map((item) => {
+    if (item.latitude === undefined && item.longitude === undefined) return item;
+    const masked = { ...item };
+    delete masked.latitude;
+    delete masked.longitude;
+    return masked;
+  });
+}
+
 export function isValidPublicKey(key: string | undefined): boolean {
   if (!key || typeof key !== 'string') return false;
   return /^[0-9a-fA-F]{64}$/.test(key);

--- a/src/server/routes/meshcoreViewOnMap.permissions.test.ts
+++ b/src/server/routes/meshcoreViewOnMap.permissions.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Route test — MeshCore contact/node routes require nodes:viewOnMap before
+ * publishing positions, not just nodes:read / connection:read (issue #4559).
+ *
+ * Before this fix, GET /nodes, GET /contacts, and GET /snapshot all returned
+ * full latitude/longitude for anyone who cleared their (coarser) read gate —
+ * there was no way for an admin to grant the MeshCore contact list to a user
+ * (or the built-in `anonymous` user) without also unconditionally publishing
+ * every contact's position on the map. The fix masks lat/lon on these three
+ * routes when the caller lacks nodes:viewOnMap, mirroring the equivalent
+ * per-channel viewOnMap gate Meshtastic already has via
+ * filterNodesByChannelPermission/maskNodeLocationByChannel.
+ *
+ * Uses the real-middleware harness (createRouteTestApp) per CLAUDE.md.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import meshcoreRoutes from './meshcoreRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+const STUB_CONTACT = {
+  publicKey: 'a'.repeat(64),
+  advName: 'Repeater One',
+  name: 'Repeater One',
+  latitude: 40.0,
+  longitude: -105.0,
+  advType: 1,
+  lastSeen: 1000,
+};
+
+const STUB_NODE = {
+  publicKey: 'a'.repeat(64),
+  name: 'Repeater One',
+  advType: 1,
+  latitude: 40.0,
+  longitude: -105.0,
+};
+
+vi.mock('../sourceManagerRegistry.js', () => {
+  const stubFor = (sourceId: string) => ({
+    sourceId,
+    sourceType: 'meshcore' as const,
+    getConnectionStatus: () => ({ connected: true, deviceType: 1, config: null }),
+    getLocalNode: () => null,
+    getContacts: () => [STUB_CONTACT],
+    getAllNodes: async () => [STUB_NODE],
+    getRecentMessages: (_limit?: number) => [],
+  });
+  const managers = new Map([['rt-source-a', stubFor('rt-source-a')]]);
+  return {
+    sourceManagerRegistry: {
+      getManager: (sourceId: string) => managers.get(sourceId),
+      getAllManagers: () => Array.from(managers.values()),
+    },
+  };
+});
+
+describe('MeshCore routes — nodes:viewOnMap gates position data (#4559)', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/sources/:id/meshcore', meshcoreRoutes),
+    });
+  });
+
+  afterEach(async () => {
+    // harness.cleanup() only revokes `limited`/`admin` grants; the built-in
+    // `anonymous` user is shared across tests in this file, so its grants
+    // must be cleared too or a later test's grant hits the (user, resource,
+    // sourceId) unique constraint.
+    await harness.db.auth.deletePermissionsForUser(harness.anonymous.id).catch(() => {});
+    await harness.cleanup();
+  });
+
+  const grantViewOnMap = async (userId: number) => {
+    await harness.db.auth.createPermission({
+      userId,
+      resource: 'nodes',
+      canRead: true,
+      canViewOnMap: true,
+      canWrite: false,
+      sourceId: harness.sourceA,
+      grantedAt: Date.now(),
+      grantedBy: null,
+    });
+  };
+
+  describe('GET /nodes', () => {
+    it('masks lat/lon with nodes:read but not nodes:viewOnMap', async () => {
+      await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceA);
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.get(`/sources/${harness.sourceA}/meshcore/nodes`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].latitude).toBeUndefined();
+      expect(res.body.data[0].longitude).toBeUndefined();
+      expect(res.body.data[0].publicKey).toBe(STUB_NODE.publicKey);
+    });
+
+    it('includes lat/lon once nodes:viewOnMap is also granted', async () => {
+      await grantViewOnMap(harness.limited.id);
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.get(`/sources/${harness.sourceA}/meshcore/nodes`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data[0].latitude).toBe(40.0);
+      expect(res.body.data[0].longitude).toBe(-105.0);
+    });
+
+    it('admin always sees positions', async () => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.get(`/sources/${harness.sourceA}/meshcore/nodes`);
+      expect(res.body.data[0].latitude).toBe(40.0);
+    });
+  });
+
+  describe('GET /contacts', () => {
+    it('masks lat/lon with nodes:read but not nodes:viewOnMap', async () => {
+      await harness.grant(harness.anonymous.id, 'nodes', 'read', harness.sourceA);
+      const agent = await harness.loginAs(null);
+
+      const res = await agent.get(`/sources/${harness.sourceA}/meshcore/contacts`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].latitude).toBeUndefined();
+      expect(res.body.data[0].longitude).toBeUndefined();
+      expect(res.body.data[0].name).toBe(STUB_CONTACT.name);
+    });
+
+    it('includes lat/lon for anonymous once nodes:viewOnMap is granted', async () => {
+      await grantViewOnMap(harness.anonymous.id);
+      const agent = await harness.loginAs(null);
+
+      const res = await agent.get(`/sources/${harness.sourceA}/meshcore/contacts`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data[0].latitude).toBe(40.0);
+      expect(res.body.data[0].longitude).toBe(-105.0);
+    });
+  });
+
+  describe('GET /snapshot', () => {
+    it('masks contacts/nodes lat/lon with connection:read but not nodes:viewOnMap', async () => {
+      await harness.grant(harness.limited.id, 'connection', 'read', harness.sourceA);
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.get(`/sources/${harness.sourceA}/meshcore/snapshot`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.contacts[0].latitude).toBeUndefined();
+      expect(res.body.data.nodes[0].latitude).toBeUndefined();
+    });
+
+    it('includes positions once nodes:viewOnMap is also granted', async () => {
+      await harness.grant(harness.limited.id, 'connection', 'read', harness.sourceA);
+      await grantViewOnMap(harness.limited.id);
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.get(`/sources/${harness.sourceA}/meshcore/snapshot`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.contacts[0].latitude).toBe(40.0);
+      expect(res.body.data.nodes[0].latitude).toBe(40.0);
+    });
+  });
+});

--- a/src/server/routes/meshcoreViewOnMap.permissions.test.ts
+++ b/src/server/routes/meshcoreViewOnMap.permissions.test.ts
@@ -45,6 +45,7 @@ vi.mock('../sourceManagerRegistry.js', () => {
     getContacts: () => [STUB_CONTACT],
     getAllNodes: async () => [STUB_NODE],
     getRecentMessages: (_limit?: number) => [],
+    refreshContacts: async () => new Map([[STUB_CONTACT.publicKey, STUB_CONTACT]]),
   });
   const managers = new Map([['rt-source-a', stubFor('rt-source-a')]]);
   return {
@@ -141,6 +142,42 @@ describe('MeshCore routes — nodes:viewOnMap gates position data (#4559)', () =
       expect(res.status).toBe(200);
       expect(res.body.data[0].latitude).toBe(40.0);
       expect(res.body.data[0].longitude).toBe(-105.0);
+    });
+  });
+
+  describe('POST /contacts/refresh', () => {
+    it('masks lat/lon with nodes:write but not nodes:viewOnMap', async () => {
+      // nodes:write is a stronger grant than nodes:read but does not itself
+      // imply viewOnMap — refresh must not be a side-channel around the
+      // read-path's position gate (#4559 review follow-up).
+      await harness.grant(harness.limited.id, 'nodes', 'write', harness.sourceA);
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.post(`/sources/${harness.sourceA}/meshcore/contacts/refresh`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].latitude).toBeUndefined();
+      expect(res.body.data[0].longitude).toBeUndefined();
+    });
+
+    it('includes lat/lon once nodes:viewOnMap is also granted', async () => {
+      await harness.db.auth.createPermission({
+        userId: harness.limited.id,
+        resource: 'nodes',
+        canRead: true,
+        canWrite: true,
+        canViewOnMap: true,
+        sourceId: harness.sourceA,
+        grantedAt: Date.now(),
+        grantedBy: null,
+      });
+      const agent = await harness.loginAs(harness.limited);
+
+      const res = await agent.post(`/sources/${harness.sourceA}/meshcore/contacts/refresh`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data[0].latitude).toBe(40.0);
     });
   });
 

--- a/src/server/services/sourceDashboardData.meshcoreViewOnMap.test.ts
+++ b/src/server/services/sourceDashboardData.meshcoreViewOnMap.test.ts
@@ -1,0 +1,87 @@
+/**
+ * buildSourceNodes — MeshCore contacts require nodes:viewOnMap, not just
+ * nodes:read, before positions reach the Dashboard/Unified/Map Analysis maps
+ * (issue #4559).
+ *
+ * Before this fix, the MeshCore branch of buildSourceNodes() returned every
+ * positioned contact once the caller had nodes:read — mirroring Meshtastic's
+ * nodes:read gate but skipping the additional per-channel viewOnMap gate
+ * Meshtastic applies via filterNodesByChannelPermission/maskNodeLocationByChannel.
+ * MeshCore has no per-channel granularity here, so this uses a single
+ * per-source nodes:viewOnMap check instead.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildSourceNodes } from './sourceDashboardData.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import type { User } from '../../types/auth.js';
+
+const STUB_CONTACT = {
+  publicKey: 'a'.repeat(64),
+  name: 'Repeater One',
+  latitude: 40.0,
+  longitude: -105.0,
+  advType: 1,
+  lastHeard: Math.floor(Date.now() / 1000),
+};
+
+vi.mock('../sourceManagerRegistry.js', () => {
+  const stub = {
+    sourceId: 'rt-source-a',
+    sourceType: 'meshcore' as const,
+    getAllNodes: async () => [STUB_CONTACT],
+  };
+  return {
+    sourceManagerRegistry: {
+      getManager: (sourceId: string) => (sourceId === 'rt-source-a' ? stub : undefined),
+      getAllManagers: () => [stub],
+    },
+  };
+});
+
+describe('buildSourceNodes — MeshCore nodes:viewOnMap gate (#4559)', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({ mount: () => {} });
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  const sourceRow = { id: 'rt-source-a', name: 'MeshCore Source', type: 'meshcore' };
+
+  it('returns no contacts for a user with nodes:read but not nodes:viewOnMap', async () => {
+    await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceA);
+    const result = await buildSourceNodes(sourceRow, harness.limited as unknown as User);
+    expect(result).toEqual([]);
+  });
+
+  it('returns positioned contacts once nodes:viewOnMap is also granted', async () => {
+    await harness.db.auth.createPermission({
+      userId: harness.limited.id,
+      resource: 'nodes',
+      canRead: true,
+      canViewOnMap: true,
+      canWrite: false,
+      sourceId: 'rt-source-a',
+      grantedAt: Date.now(),
+      grantedBy: null,
+    });
+
+    const result = await buildSourceNodes(sourceRow, harness.limited as unknown as User);
+    expect(result).toHaveLength(1);
+    expect((result[0] as any).latitude).toBe(40.0);
+    expect((result[0] as any).longitude).toBe(-105.0);
+  });
+
+  it('anonymous caller with no grant at all sees nothing', async () => {
+    const result = await buildSourceNodes(sourceRow, harness.anonymous as unknown as User);
+    expect(result).toEqual([]);
+  });
+
+  it('admin bypasses the gate with no explicit grant', async () => {
+    const result = await buildSourceNodes(sourceRow, harness.admin as unknown as User);
+    expect(result).toHaveLength(1);
+  });
+});

--- a/src/server/services/sourceDashboardData.ts
+++ b/src/server/services/sourceDashboardData.ts
@@ -47,6 +47,16 @@ export async function buildSourceNodes(source: SourceRow, user: ReqUser): Promis
   // reach the position-override logic below: MeshCore contacts have no
   // override columns (that's a Meshtastic-node feature, #3551).
   if (source.type === 'meshcore') {
+    // Mirror the Meshtastic path below: canRead("nodes") makes the contact
+    // list available, but publishing positions on the map additionally
+    // requires viewOnMap("nodes") — MeshCore has no per-channel granularity
+    // here, so this is a single per-source check rather than per-node
+    // (#4559). Admins bypass, as everywhere else in this file.
+    const canViewOnMap = user ? await hasPermission(user, 'nodes', 'viewOnMap', source.id) : false;
+    if (!canViewOnMap) {
+      return [];
+    }
+
     const _raw = sourceManagerRegistry.getManager(source.id);
     const mcManager = _raw && isMeshCoreManager(_raw) ? _raw : null;
     const mcNodes: any[] = [];


### PR DESCRIPTION
## Summary

Fixes #4559.

MeshCore contact/node positions reached the Dashboard, Unified, and Map Analysis maps — plus the MeshCore page's own `/nodes`, `/contacts`, and `/snapshot` routes — as soon as a caller had read access, with no independent way for an admin to withhold positions on the map. Meshtastic already splits this: per-channel `viewOnMap` gates whether a node's position is published, separate from `read`. MeshCore has no per-channel granularity in this data path, so it now uses a per-source `nodes:viewOnMap` check that mirrors the same pattern.

- `buildSourceNodes()` requires `nodes:viewOnMap` before returning MeshCore contact positions (backs `/api/sources/:id/nodes`, the per-source dashboard, and `/api/unified/dashboard`).
- `GET .../meshcore/nodes`, `/contacts`, and `/snapshot` **mask** lat/lon (rather than dropping the row) for callers lacking `viewOnMap`, so the contact list keeps working even when the map is withheld.
- `UsersTab` renders a "View on Map" checkbox for the `nodes` resource when a MeshCore source is scoped (and only then — it's a no-op for Meshtastic sources, which use per-channel `viewOnMap` instead), and includes `viewOnMap` in the permissions PUT payload for that resource.
- Migration 135 backfills `canViewOnMap = true` on existing `nodes` grants for MeshCore-typed sources that already have `canRead = true`, so upgrading doesn't silently blank out maps that work today. Admins can tighten individual grants afterward now that the UI exposes the control.

## Test plan

- [x] `npx tsc -p tsconfig.server.json --noEmit` and `npx tsc --noEmit` — clean
- [x] `npm run lint:ci` — clean (no baseline growth)
- [x] New tests added and passing:
  - `src/server/services/sourceDashboardData.meshcoreViewOnMap.test.ts` (buildSourceNodes gate)
  - `src/server/routes/meshcoreViewOnMap.permissions.test.ts` (`/nodes`, `/contacts`, `/snapshot` masking)
  - `src/server/migrations/135_backfill_meshcore_nodes_viewonmap.test.ts` (backfill + idempotency)
  - `src/components/UsersTab.test.tsx` (checkbox render, scoped to MeshCore sources only)
- [x] Full `npx vitest run` suite: 13289 passed, 9 failed. All 9 failures are in `src/server/mqttBrokerManager.test.ts` (protobuf `encode failed` errors, unrelated MQTT zero-hop-injection tests), confirmed pre-existing/environmental — that file has zero diff against `origin/main` and fails identically on `main` in this sandbox.
- [ ] PostgreSQL/MySQL backends not exercised locally (no service containers running in this session) — migration 135 SQL was written and reviewed against the same three-backend pattern as migration 058; CI's service containers will cover it.

---
_Generated by [Claude Code](https://claude.ai/code/session_011igLWjR69bbxRaqPYcKA1o)_