### PR TITLE
chore(release): 4.14.1-rc1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.14.0",
+  "version": "4.14.1-rc1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.14.0",
+  "version": "4.14.1-rc1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/features/per-source-permissions.md
+++ b/docs/features/per-source-permissions.md
@@ -23,6 +23,10 @@ Each row in the `permissions` table grants a user a set of action flags on a **r
 
 Resources cover per-source items like messages, nodes, channels, schedulers, and admin-command surfaces, plus global items like users, settings, audit log, and system backup. When a resource is source-scoped, the row also carries a `sourceId` so the same user can have different rights on different sources.
 
+::: tip MeshCore map positions honour `canViewOnMap` (4.14.1)
+MeshCore contact positions used to be returned to anyone with `nodes` read access. They now require `canViewOnMap` on that source, matching how Meshtastic nodes have always behaved — so a user granted read-only access can see the contact list without learning where those nodes are. Existing users are backfilled on upgrade: anyone who already had `nodes` read on a MeshCore source keeps map visibility, so nothing disappears for current accounts. New grants must set the flag explicitly.
+:::
+
 ## Users page
 
 **Settings → Users** (admin only) is the central management page. Admins can:

--- a/docs/features/per-source-permissions.md
+++ b/docs/features/per-source-permissions.md
@@ -23,7 +23,7 @@ Each row in the `permissions` table grants a user a set of action flags on a **r
 
 Resources cover per-source items like messages, nodes, channels, schedulers, and admin-command surfaces, plus global items like users, settings, audit log, and system backup. When a resource is source-scoped, the row also carries a `sourceId` so the same user can have different rights on different sources.
 
-::: tip MeshCore map positions honour `canViewOnMap` (4.14.1)
+::: tip MeshCore map positions honor `canViewOnMap` (4.14.1)
 MeshCore contact positions used to be returned to anyone with `nodes` read access. They now require `canViewOnMap` on that source, matching how Meshtastic nodes have always behaved — so a user granted read-only access can see the contact list without learning where those nodes are. Existing users are backfilled on upgrade: anyone who already had `nodes` read on a MeshCore source keeps map visibility, so nothing disappears for current accounts. New grants must set the flag explicitly.
 :::
 

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -398,7 +398,7 @@ separate from channel sharing, which uses Meshtastic's `/e/#` URL format.
 
 **Default**: 13 (range 0–18)
 
-**Effect**: Below this zoom, a click on a marker that has another marker within ~20 screen pixels re-centres and zooms in rather than opening a popup. An **isolated** marker opens its popup right away at any zoom — crowding is measured per click, so a lone node on the edge of the map is never withheld. Set the value to `0` to turn the gate off entirely and always open popups on the first click.
+**Effect**: Below this zoom, a click on a marker that has another marker within ~20 screen pixels re-centers and zooms in rather than opening a popup. An **isolated** marker opens its popup right away at any zoom — crowding is measured per click, so a lone node on the edge of the map is never withheld. Set the value to `0` to turn the gate off entirely and always open popups on the first click.
 
 Raise the threshold if your nodes sit close together and you keep opening the wrong popup; lower it (or zero it) if you mostly view a sparse mesh and want one-click popups when zoomed out.
 

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -389,6 +389,21 @@ separate from channel sharing, which uses Meshtastic's `/e/#` URL format.
 
 ## Map Settings
 
+### Map Click Zoom Gate
+
+::: tip New in 4.14.1
+:::
+
+**Description**: The zoom level below which clicking a **crowded** marker zooms the map in first instead of opening that marker's popup, so you can pick the node you actually meant.
+
+**Default**: 13 (range 0–18)
+
+**Effect**: Below this zoom, a click on a marker that has another marker within ~20 screen pixels re-centres and zooms in rather than opening a popup. An **isolated** marker opens its popup right away at any zoom — crowding is measured per click, so a lone node on the edge of the map is never withheld. Set the value to `0` to turn the gate off entirely and always open popups on the first click.
+
+Raise the threshold if your nodes sit close together and you keep opening the wrong popup; lower it (or zero it) if you mostly view a sparse mesh and want one-click popups when zoomed out.
+
+**Location**: Settings → Map Settings
+
 ### Discard Invalid Positions
 
 ::: tip New in 4.13

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.14.0
-appVersion: "4.14.0"
+version: 4.14.1-rc1
+appVersion: "4.14.1-rc1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.0",
+  "version": "4.14.1-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.14.0",
+      "version": "4.14.1-rc1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.0",
+  "version": "4.14.1-rc1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,

--- a/tests/README-v1-api-tests.md
+++ b/tests/README-v1-api-tests.md
@@ -20,7 +20,6 @@ Comprehensive unit tests for all V1 API endpoints using Vitest and Supertest.
 
 - Nodes API (`GET /api/v1/sources/default/nodes`)
   - Returns list of nodes with standard response format
-  - Includes known test node ("Yeraze Station G2")
   - Returns specific node by ID
   - Returns 404 for non-existent nodes
 
@@ -65,8 +64,7 @@ Integration test that runs against a live Quick Start container.
 **Test Coverage:**
 - API Root endpoint returns version info
 - Nodes list endpoint returns data
-- Node count validation (>= 10 nodes)
-- Known node validation ("Yeraze Station G2" exists)
+- Node count validation (>= 1 node)
 - Specific node retrieval by ID
 - Messages endpoint with pagination
 - Telemetry endpoint
@@ -120,8 +118,7 @@ This will run all system tests including:
 ## Test Data Requirements
 
 The V1 API tests expect:
-- At least 10 nodes in the mesh network
-- A node with short name containing "YERG2" or "YerG2" or long name "Yeraze Station G2"
+- At least 1 node in the mesh network
 - Some telemetry data
 - Some message data
 - Some packet log data
@@ -130,7 +127,7 @@ The V1 API tests expect:
 
 - Unit tests create mock data and may not catch all integration issues
 - System tests require access to a real Meshtastic node
-- Some tests check for minimum data counts (e.g., >= 10 nodes) which may fail on smaller networks
+- Some tests check for minimum data counts (e.g., >= 1 node) which may fail on an empty mesh
 - Tests assume the default admin credentials (admin/admin) for Quick Start deployment
 
 ## Future Enhancements

--- a/tests/README-v1-api-tests.md
+++ b/tests/README-v1-api-tests.md
@@ -18,23 +18,23 @@ Comprehensive unit tests for all V1 API endpoints using Vitest and Supertest.
   - Returns API version info
   - Lists all available endpoints
 
-- Nodes API (`GET /api/v1/nodes`)
+- Nodes API (`GET /api/v1/sources/default/nodes`)
   - Returns list of nodes with standard response format
   - Includes known test node ("Yeraze Station G2")
   - Returns specific node by ID
   - Returns 404 for non-existent nodes
 
-- Messages API (`GET /api/v1/messages`)
+- Messages API (`GET /api/v1/sources/default/messages`)
   - Returns messages with pagination
   - Respects offset and limit parameters
 
-- Telemetry API (`GET /api/v1/telemetry`)
+- Telemetry API (`GET /api/v1/sources/default/telemetry`)
   - Returns telemetry data array
 
-- Traceroutes API (`GET /api/v1/traceroutes`)
+- Traceroutes API (`GET /api/v1/sources/default/traceroutes`)
   - Returns traceroute data array
 
-- Packets API (`GET /api/v1/packets`)
+- Packets API (`GET /api/v1/sources/default/packets`)
   - Returns packet log data with pagination
   - Supports filtering by portnum
   - Returns specific packet by ID

--- a/tests/api-exercise-test.sh
+++ b/tests/api-exercise-test.sh
@@ -610,7 +610,7 @@ echo ""
 echo -e "${BLUE}=== V1 API (no token, expect 401) ===${NC}"
 
 check "GET /api/v1 (no token)" "$(api GET /api/v1)" 401
-check "GET /api/v1/nodes (no token)" "$(api GET /api/v1/nodes)" 401
+check "GET /api/v1/sources/default/nodes (no token)" "$(api GET /api/v1/sources/default/nodes)" 401
 
 echo ""
 echo -e "${BLUE}=== V1 API (with token) ===${NC}"
@@ -674,27 +674,34 @@ except Exception as e:
     fi
   }
 
+  # The legacy root shape (/api/v1/nodes etc.) was removed in 4.14 (#4117,
+  # commit 6399407d); those paths now 404. Per-source resources live under
+  # /api/v1/sources/{sourceId}/..., and `default` is the alias attachSource
+  # resolves to the oldest source. Only the version index, channel-database,
+  # solar and docs remain at the root.
+  V1S="/api/v1/sources/default"
+
   check_v1 "GET /api/v1" "/api/v1" "'version' in data or 'success' in data"
-  check_v1 "GET /api/v1/nodes" "/api/v1/nodes" "'success' in data and 'data' in data"
-  check_v1 "GET /api/v1/channels" "/api/v1/channels" "'success' in data and 'data' in data"
-  check_v1 "GET /api/v1/messages" "/api/v1/messages" "'success' in data and 'data' in data"
-  check_v1 "GET /api/v1/telemetry" "/api/v1/telemetry" "'success' in data or isinstance(data, dict)"
-  check_v1 "GET /api/v1/traceroutes" "/api/v1/traceroutes" "'success' in data and 'data' in data"
-  check_v1 "GET /api/v1/network" "/api/v1/network" "'success' in data and 'data' in data"
-  check_v1 "GET /api/v1/network/topology" "/api/v1/network/topology" "'success' in data and 'data' in data"
-  check_v1 "GET /api/v1/network/direct-neighbors" "/api/v1/network/direct-neighbors" "'success' in data or isinstance(data, dict)"
-  check_v1 "GET /api/v1/packets" "/api/v1/packets" "'success' in data and 'data' in data"
+  check_v1 "GET $V1S/nodes" "$V1S/nodes" "'success' in data and 'data' in data"
+  check_v1 "GET $V1S/channels" "$V1S/channels" "'success' in data and 'data' in data"
+  check_v1 "GET $V1S/messages" "$V1S/messages" "'success' in data and 'data' in data"
+  check_v1 "GET $V1S/telemetry" "$V1S/telemetry" "'success' in data or isinstance(data, dict)"
+  check_v1 "GET $V1S/traceroutes" "$V1S/traceroutes" "'success' in data and 'data' in data"
+  check_v1 "GET $V1S/network" "$V1S/network" "'success' in data and 'data' in data"
+  check_v1 "GET $V1S/network/topology" "$V1S/network/topology" "'success' in data and 'data' in data"
+  check_v1 "GET $V1S/network/direct-neighbors" "$V1S/network/direct-neighbors" "'success' in data or isinstance(data, dict)"
+  check_v1 "GET $V1S/packets" "$V1S/packets" "'success' in data and 'data' in data"
   check_v1 "GET /api/v1/channel-database" "/api/v1/channel-database" "'success' in data and 'data' in data"
   check "GET /api/v1/solar" "$(v1 GET /api/v1/solar)" 200
   check "GET /api/v1/solar/range" "$(v1 GET '/api/v1/solar/range?start=0&end=9999999999999')" 200
-  check "GET /api/v1/messages/search?q=test" "$(v1 GET '/api/v1/messages/search?q=test')" 200
+  check "GET $V1S/messages/search?q=test" "$(v1 GET "$V1S/messages/search?q=test")" 200
   check "GET /api/v1/docs/openapi.json" "$(v1 GET /api/v1/docs/openapi.json)" 200
   check "GET /api/v1/docs/openapi.yaml" "$(v1 GET /api/v1/docs/openapi.yaml)" 200
 
   if [ -n "$FIRST_NODE_ID" ]; then
-    check "GET /api/v1/nodes/:nodeId" "$(v1 GET /api/v1/nodes/$FIRST_NODE_ID)" 200
-    check "GET /api/v1/telemetry/:nodeId" "$(v1 GET /api/v1/telemetry/$FIRST_NODE_ID)" 200
-    check "GET /api/v1/nodes/:nodeId/position-history" "$(v1 GET /api/v1/nodes/$FIRST_NODE_ID/position-history)" 200
+    check "GET $V1S/nodes/:nodeId" "$(v1 GET $V1S/nodes/$FIRST_NODE_ID)" 200
+    check "GET $V1S/telemetry/:nodeId" "$(v1 GET $V1S/telemetry/$FIRST_NODE_ID)" 200
+    check "GET $V1S/nodes/:nodeId/position-history" "$(v1 GET $V1S/nodes/$FIRST_NODE_ID/position-history)" 200
   fi
 
   # Cleanup token

--- a/tests/api-exercise-test.sh
+++ b/tests/api-exercise-test.sh
@@ -585,14 +585,16 @@ check "GET /api/firmware/releases" "$(api GET /api/firmware/releases)" 200
 check "GET /api/firmware/backups" "$(api GET /api/firmware/backups)" 200
 
 # ─── Upgrade ───────────────────────────────────────────────
-# Auto-upgrade was retired in 4.13 (#4108): endpoints return 410 FEATURE_RETIRED
-# until their removal in 4.14.
+# Auto-upgrade was retired in 4.13 (#4108), where the endpoints returned 410
+# FEATURE_RETIRED for one release. The router was deleted in 4.14 (#4117,
+# commit 6399407d) — the same removal that took the v1 root paths — so these
+# are now plain 404s. Asserting the shape keeps a future re-add honest.
 
 echo ""
-echo -e "${BLUE}=== Upgrade (retired) ===${NC}"
+echo -e "${BLUE}=== Upgrade (removed) ===${NC}"
 
-check "GET /api/upgrade/history" "$(api GET /api/upgrade/history)" 410
-check "GET /api/upgrade/status" "$(api GET /api/upgrade/status)" 410
+check "GET /api/upgrade/history" "$(api GET /api/upgrade/history)" 404
+check "GET /api/upgrade/status" "$(api GET /api/upgrade/status)" 404
 
 # ─── MeshCore ──────────────────────────────────────────────
 

--- a/tests/api-status-ws-token-test.mjs
+++ b/tests/api-status-ws-token-test.mjs
@@ -1,5 +1,5 @@
 /**
- * Test: GET /api/v1/status + WebSocket Bearer token auth
+ * Test: GET /api/v1/sources/default/status + WebSocket Bearer token auth
  *
  * Usage:
  *   node tests/api-status-ws-token-test.mjs [BASE_URL] [API_TOKEN]
@@ -47,8 +47,8 @@ const SOCKET_PATH = `${baseUrlObj.pathname.replace(/\/$/, '')}/socket.io`;
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 async function testStatus() {
-  console.log('\n--- GET /api/v1/status ---');
-  const { status, data } = await fetchJSON('/api/v1/status');
+  console.log('\n--- GET /api/v1/sources/default/status ---');
+  const { status, data } = await fetchJSON('/api/v1/sources/default/status');
   assert(status === 200, 'Status 200');
   assert(data.success === true, 'success: true');
   assert('localNodeNum' in data.data, 'Has localNodeNum');
@@ -60,8 +60,8 @@ async function testStatus() {
 }
 
 async function testStatusNoAuth() {
-  console.log('\n--- GET /api/v1/status without auth ---');
-  const res = await fetch(`${BASE_URL}/api/v1/status`);
+  console.log('\n--- GET /api/v1/sources/default/status without auth ---');
+  const res = await fetch(`${BASE_URL}/api/v1/sources/default/status`);
   assert(res.status === 401, 'Returns 401');
 }
 

--- a/tests/test-v1-api.sh
+++ b/tests/test-v1-api.sh
@@ -262,6 +262,16 @@ fi
 
 echo -e "${GREEN}✓ API Token generated: ${API_TOKEN:0:15}...${NC}"
 
+# Per-source route prefix. The legacy root shape (`/api/v1/nodes?sourceId=…`)
+# had a one-release deprecation window in 4.13 and was REMOVED in 4.14
+# (#4117 / commit 6399407d) — those paths now 404, and a 404 body is not JSON,
+# which is why every root-path assertion below used to die inside jq with
+# "parse error: Invalid numeric literal" rather than a readable failure.
+# `default` is the alias `attachSource` resolves to the oldest source, so this
+# stays correct without hardcoding a source id. Scoping lives in the PATH now,
+# so no endpoint below needs a `?sourceId=` query param.
+V1_SRC="${BASE_URL}/api/v1/sources/default"
+
 # Resolve the gauntlet channel slot dynamically. Project rule: use the
 # "gauntlet" channel for testing, never primary. Hardcoding a slot index
 # (e.g. `channel: 3`) drifts every time channels get reordered on the test
@@ -269,7 +279,7 @@ echo -e "${GREEN}✓ API Token generated: ${API_TOKEN:0:15}...${NC}"
 # entirely if the test device's slot N happens to share a PSK (notably the
 # default `AQ==`) with another slot.
 GAUNTLET_SLOT=$(curl -sS -H "Authorization: Bearer $API_TOKEN" \
-    "${BASE_URL}/api/v1/channels" \
+    "${V1_SRC}/channels" \
     | jq -r '.data[]? | select((.name // "") | ascii_downcase == "gauntlet") | .id' \
     | head -n1)
 
@@ -293,77 +303,77 @@ run_test "GET /api/v1/ - API version info" \
     | jq -e '.version == \"v1\" and .endpoints.nodes != null'"
 
 # Test 2: Nodes List
-run_test "GET /api/v1/nodes - List all nodes" \
+run_test "GET /api/v1/sources/default/nodes - List all nodes" \
     "curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-    '${BASE_URL}/api/v1/nodes' \
+    '${V1_SRC}/nodes' \
     | jq -e '.success == true and .count > 0 and (.data | type) == \"array\"'"
 
 # Test 3: Verify node count is reasonable (at least 1 node, the test node)
 run_test "Verify node count >= 1" \
     "curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-    '${BASE_URL}/api/v1/nodes' \
+    '${V1_SRC}/nodes' \
     | jq -e '.count >= 1'"
 
 # Test 4: Get specific node by ID (get first node's ID)
 NODE_ID=$(curl -sS -H "Authorization: Bearer $API_TOKEN" \
-    "${BASE_URL}/api/v1/nodes" \
+    "${V1_SRC}/nodes" \
     | jq -r '.data[0].node_id')
 
 if [ -n "$NODE_ID" ] && [ "$NODE_ID" != "null" ]; then
-    run_test "GET /api/v1/nodes/:id - Get specific node" \
+    run_test "GET /api/v1/sources/default/nodes/:id - Get specific node" \
         "curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-        '${BASE_URL}/api/v1/nodes/${NODE_ID}' \
+        '${V1_SRC}/nodes/${NODE_ID}' \
         | jq -e '.success == true and .data.node_id == $NODE_ID'"
 fi
 
 # Test 5: Messages endpoint
-run_test "GET /api/v1/messages - List messages" \
+run_test "GET /api/v1/sources/default/messages - List messages" \
     "curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-    '${BASE_URL}/api/v1/messages?limit=10' \
+    '${V1_SRC}/messages?limit=10' \
     | jq -e '.success == true and (.data | type) == \"array\"'"
 
 # Test 7: Telemetry endpoint
-run_test "GET /api/v1/telemetry - List telemetry data" \
+run_test "GET /api/v1/sources/default/telemetry - List telemetry data" \
     "curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-    '${BASE_URL}/api/v1/telemetry' \
+    '${V1_SRC}/telemetry' \
     | jq -e '.success == true and (.data | type) == \"array\"'"
 
 # Test 8: Traceroutes endpoint
-run_test "GET /api/v1/traceroutes - List traceroutes" \
+run_test "GET /api/v1/sources/default/traceroutes - List traceroutes" \
     "curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-    '${BASE_URL}/api/v1/traceroutes' \
+    '${V1_SRC}/traceroutes' \
     | jq -e '.success == true and (.data | type) == \"array\"'"
 
 # Test 6: Network stats endpoint
-run_test "GET /api/v1/network - Get network stats" \
+run_test "GET /api/v1/sources/default/network - Get network stats" \
     "curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-    '${BASE_URL}/api/v1/network' \
+    '${V1_SRC}/network' \
     | jq -e '.success == true and .data.totalNodes != null'"
 
 # Test 10: Packets endpoint
-run_test "GET /api/v1/packets - List packet logs" \
+run_test "GET /api/v1/sources/default/packets - List packet logs" \
     "curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-    '${BASE_URL}/api/v1/packets?limit=50' \
+    '${V1_SRC}/packets?limit=50' \
     | jq -e '.success == true and .limit == 50 and (.data | type) == \"array\"'"
 
 # Test 11: Packets with filtering
-run_test "GET /api/v1/packets with filter - Filter by encrypted" \
+run_test "GET /api/v1/sources/default/packets with filter - Filter by encrypted" \
     "curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-    '${BASE_URL}/api/v1/packets?encrypted=true&limit=10' \
+    '${V1_SRC}/packets?encrypted=true&limit=10' \
     | jq -e '.success == true and (.data | type) == \"array\"'"
 
-# Test 12: Get specific packet (if any exist). GET /api/v1/packets/:id now
-# requires a sourceId (packet IDs are a global PK), so grab the packet's own
-# sourceId from the list and scope the by-id read to it.
+# Test 12: Get specific packet (if any exist). Packet IDs are a global PK, so
+# the by-id read has to be scoped to a source or a caller on source A could
+# read source B's packet by guessing its id. The per-source path carries that
+# scope now, so no `?sourceId=` query param is needed.
 FIRST_PACKET=$(curl -sS -H "Authorization: Bearer $API_TOKEN" \
-    "${BASE_URL}/api/v1/packets?limit=1")
+    "${V1_SRC}/packets?limit=1")
 PACKET_ID=$(echo "$FIRST_PACKET" | jq -r '.data[0].id // empty')
-PACKET_SRC=$(echo "$FIRST_PACKET" | jq -r '.data[0].sourceId // empty')
 
 if [ -n "$PACKET_ID" ] && [ "$PACKET_ID" != "null" ]; then
-    run_test "GET /api/v1/packets/:id - Get specific packet" \
+    run_test "GET /api/v1/sources/default/packets/:id - Get specific packet" \
         "curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-        '${BASE_URL}/api/v1/packets/${PACKET_ID}?sourceId=${PACKET_SRC}' \
+        '${V1_SRC}/packets/${PACKET_ID}' \
         | jq -e '.success == true and .data.id == $PACKET_ID'"
 fi
 
@@ -375,13 +385,13 @@ echo ""
 
 # Test 13: Reject request without token
 run_test "Reject request without Authorization header" \
-    "[ \$(curl -sS -w '%{http_code}' -o /dev/null '${BASE_URL}/api/v1/nodes') = '401' ]"
+    "[ \$(curl -sS -w '%{http_code}' -o /dev/null '${V1_SRC}/nodes') = '401' ]"
 
 # Test 14: Reject request with invalid token
 run_test "Reject request with invalid token" \
     "[ \$(curl -sS -w '%{http_code}' -o /dev/null \
     -H 'Authorization: Bearer mm_v1_invalid_token_123' \
-    '${BASE_URL}/api/v1/nodes') = '401' ]"
+    '${V1_SRC}/nodes') = '401' ]"
 
 echo ""
 echo "=========================================="
@@ -395,11 +405,11 @@ echo ""
 # Test: POST to messages endpoint without CSRF token (should work with Bearer)
 # Uses the gauntlet channel for testing per project rules. Slot is resolved
 # dynamically above so this stays correct even when channels get reordered.
-run_test "POST /api/v1/messages without CSRF token succeeds with Bearer auth" \
+run_test "POST /api/v1/sources/default/messages without CSRF token succeeds with Bearer auth" \
     "RESPONSE=\$(curl -sS -w '\\n%{http_code}' \
         -H 'Authorization: Bearer $API_TOKEN' \
         -H 'Content-Type: application/json' \
-        -X POST '${BASE_URL}/api/v1/messages' \
+        -X POST '${V1_SRC}/messages' \
         -d '{\"text\": \"API v1 test message\", \"channel\": ${GAUNTLET_SLOT}}')
     HTTP_CODE=\$(echo \"\$RESPONSE\" | tail -n1)
     BODY=\$(echo \"\$RESPONSE\" | head -n -1)
@@ -431,7 +441,7 @@ echo ""
 run_test "All list endpoints return success: true" \
     "for endpoint in nodes messages telemetry traceroutes packets; do
         curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-            \"${BASE_URL}/api/v1/\$endpoint\" \
+            \"${V1_SRC}/\$endpoint\" \
             | jq -e '.success == true' > /dev/null || exit 1
     done"
 
@@ -439,7 +449,7 @@ run_test "All list endpoints return success: true" \
 run_test "All list endpoints return data array" \
     "for endpoint in nodes messages telemetry traceroutes packets; do
         curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-            \"${BASE_URL}/api/v1/\$endpoint\" \
+            \"${V1_SRC}/\$endpoint\" \
             | jq -e '(.data | type) == \"array\"' > /dev/null || exit 1
     done"
 
@@ -447,7 +457,7 @@ run_test "All list endpoints return data array" \
 run_test "All list endpoints return count field" \
     "for endpoint in nodes messages telemetry traceroutes packets; do
         curl -sS -H 'Authorization: Bearer $API_TOKEN' \
-            \"${BASE_URL}/api/v1/\$endpoint\" \
+            \"${V1_SRC}/\$endpoint\" \
             | jq -e '.count != null' > /dev/null || exit 1
     done"
 


### PR DESCRIPTION
Opens the 4.14.1 release candidate.

## Version bump

All five version files → `4.14.1-rc1`: `package.json`, `package-lock.json` (regenerated), `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`), `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`.

## Documentation review

Reviewed all 14 commits since `v4.14.0`. Most already shipped their own docs (MeshCore receive-only has a dedicated guide, the Analyzer Observer page was updated, translations and site-gallery are self-documenting). Two shipped user-visible behaviour with no public documentation — both are fixed here:

**1. Map Click Zoom Gate (#4551)** → `docs/features/settings.md`

`mapZoomGateThreshold` is a new setting in Settings → Map Settings with no entry in the settings reference. Documents the default (13), the `0`-disables escape hatch, and the crowded-vs-isolated distinction that makes it behave differently from the old blanket zoom gate.

**2. MeshCore map positions now honour `canViewOnMap` (#4559/#4560)** → `docs/features/per-source-permissions.md`

The permissions table already described the `canViewOnMap` flag generically, but not that MeshCore positions moved behind it, nor that migration 135 backfills the flag for anyone who already had `nodes` read on a MeshCore source. That backfill is the reason nothing disappears for existing users on upgrade, which is exactly what an upgrader needs to know.

## Verification

- Full Vitest suite: `success: true`, **13,499 passed, 0 failed, 0 failed suites** (713 pending — the PostgreSQL/MySQL suites, which skip without their containers; this PR touches no schema or migration).
- `npx tsc --noEmit` — clean.
- `npm run lint:ci` — no in-repo failures.

## Known gap, not addressed here

`CHANGELOG.md` is stale: its `## [Unreleased]` section still holds items already shipped in 4.13.3 and 4.14.0, and the newest released heading is `[4.13.2] - 2026-07-27`. Reconciling two releases of history is out of scope for an RC bump — flagged for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX