### PR TITLE
perf(analysis): bound the hop-counts scan; fix(ui): surface telemetry request failures

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -941,6 +941,7 @@
   "toast.neighbor_info_rate_limited": "Neighbor Info was already requested for this node recently. Try again in a few minutes.",
   "toast.neighbor_info_rate_limited_seconds": "Neighbor Info was already requested for this node recently. Try again in {{seconds}}s.",
   "toast.neighbor_info_failed": "Neighbor Info request failed: {{error}}",
+  "toast.telemetry_request_failed": "Telemetry request failed: {{error}}",
   "toast.failed_purge_traceroutes": "Failed to purge traceroutes: {{error}}",
   "toast.failed_purge_telemetry": "Failed to purge telemetry: {{error}}",
   "toast.failed_purge_position_history": "Failed to purge position history: {{error}}",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2193,8 +2193,21 @@ function App() {
         setTelemetryRequestLoading(null);
       }, 30000);
     } catch (error) {
+      // The throw above and a genuine network failure both land here, and this
+      // used to only log — so a rejected telemetry request cleared its spinner
+      // and told the user nothing: the same silent-failure shape fixed for
+      // neighbor info in #4568. Unlike that endpoint there is no 403/429 to
+      // explain specially — the server answers 400 (validation), 503 (not
+      // connected) or 500 — so its own message is the most specific thing
+      // available and gets surfaced directly.
       logger.error('Failed to send telemetry request:', error);
       setTelemetryRequestLoading(null);
+      showToast(
+        t('toast.telemetry_request_failed', {
+          error: error instanceof Error ? error.message : t('errors.network'),
+        }),
+        'error',
+      );
     }
   };
 

--- a/src/db/repositories/analysis.hopCounts.multiBackend.test.ts
+++ b/src/db/repositories/analysis.hopCounts.multiBackend.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Cross-dialect coverage for `AnalysisRepository.getHopCounts`.
+ *
+ * `analysis.test.ts` constructs the repository with `'sqlite'` in all 15 of
+ * its cases, so nothing exercised this query against PostgreSQL or MySQL.
+ * That was tolerable while it was a flat `SELECT ... WHERE ... ORDER BY`, but
+ * the query now narrows to the newest ANSWERED row per node with a
+ * `GROUP BY` + `INNER JOIN` against a subquery — and dialect compatibility is
+ * the entire risk of that change. So it is executed here on every backend.
+ *
+ * The DDL below is hand-written per dialect, matching the convention in
+ * `newsCache.test.ts` / `channels.test.ts`: only the SQLite suite builds its
+ * schema from the migration registry. Note the PostgreSQL identifiers are
+ * quoted (camelCase columns) while MySQL's are bare.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { AnalysisRepository } from './analysis.js';
+import {
+  createSqliteBackend,
+  createPostgresBackend,
+  createMysqlBackend,
+  clearTable,
+  postgresAvailable,
+  mysqlAvailable,
+  type TestBackend,
+} from './test-utils.js';
+
+const SQLITE_CREATE = `
+  CREATE TABLE traceroutes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    fromNodeNum INTEGER NOT NULL,
+    toNodeNum INTEGER NOT NULL,
+    fromNodeId TEXT NOT NULL,
+    toNodeId TEXT NOT NULL,
+    route TEXT,
+    routeBack TEXT,
+    snrTowards TEXT,
+    snrBack TEXT,
+    routePositions TEXT,
+    channel INTEGER,
+    packetId INTEGER,
+    timestamp INTEGER NOT NULL,
+    createdAt INTEGER NOT NULL,
+    sourceId TEXT
+  )
+`;
+
+const POSTGRES_CREATE = `
+  DROP TABLE IF EXISTS traceroutes CASCADE;
+  CREATE TABLE traceroutes (
+    id SERIAL PRIMARY KEY,
+    "fromNodeNum" BIGINT NOT NULL,
+    "toNodeNum" BIGINT NOT NULL,
+    "fromNodeId" TEXT NOT NULL,
+    "toNodeId" TEXT NOT NULL,
+    route TEXT,
+    "routeBack" TEXT,
+    "snrTowards" TEXT,
+    "snrBack" TEXT,
+    "routePositions" TEXT,
+    channel INTEGER,
+    "packetId" BIGINT,
+    timestamp BIGINT NOT NULL,
+    "createdAt" BIGINT NOT NULL,
+    "sourceId" TEXT
+  )
+`;
+
+const MYSQL_CREATE = `
+  DROP TABLE IF EXISTS traceroutes;
+  CREATE TABLE traceroutes (
+    id SERIAL PRIMARY KEY,
+    fromNodeNum BIGINT NOT NULL,
+    toNodeNum BIGINT NOT NULL,
+    fromNodeId VARCHAR(32) NOT NULL,
+    toNodeId VARCHAR(32) NOT NULL,
+    route TEXT,
+    routeBack TEXT,
+    snrTowards TEXT,
+    snrBack TEXT,
+    routePositions TEXT,
+    channel INT,
+    packetId BIGINT,
+    timestamp BIGINT NOT NULL,
+    createdAt BIGINT NOT NULL,
+    sourceId VARCHAR(64)
+  )
+`;
+
+/** Dialect-correct INSERT — PostgreSQL needs quoted camelCase identifiers. */
+function insertSql(dbType: string): string {
+  const cols = ['fromNodeNum', 'toNodeNum', 'fromNodeId', 'toNodeId', 'sourceId', 'route', 'timestamp', 'createdAt'];
+  const quoted = dbType === 'postgres' ? cols.map((c) => `"${c}"`) : cols;
+  const placeholders = dbType === 'postgres'
+    ? cols.map((_, i) => `$${i + 1}`).join(',')
+    : cols.map(() => '?').join(',');
+  return `INSERT INTO traceroutes (${quoted.join(',')}) VALUES (${placeholders})`;
+}
+
+type Row = [number, number, string, string, string, string | null, number, number];
+
+async function insertRows(backend: TestBackend, rows: Row[]): Promise<void> {
+  const sql = insertSql(backend.dbType);
+  for (const row of rows) {
+    // Values are inlined rather than parameterised because `TestBackend.exec`
+    // takes a bare SQL string. Every value here is test-authored, so there is
+    // no injection surface; NULL is spelled literally so the pending case is
+    // genuinely NULL rather than the string 'null'.
+    const literal = sql.replace(/\$\d+|\?/g, () => {
+      const v = row.shift() as string | number | null;
+      if (v === null) return 'NULL';
+      return typeof v === 'number' ? String(v) : `'${v}'`;
+    });
+    await backend.exec(literal);
+  }
+}
+
+/**
+ * The behaviours that must hold identically on every dialect. Deliberately the
+ * same scenarios as the SQLite suite in `analysis.test.ts` — the point is to
+ * prove the SQL, not to invent new semantics.
+ */
+function runHopCountsTests(getBackend: () => TestBackend) {
+  const NOW = 1_760_000_000_000;
+
+  it('reports the newest answered traceroute per node', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await insertRows(backend, [
+      [1, 99, '!00000001', '!00000063', 'src-a', '[10,20,30]', NOW - 1000, NOW - 1000],
+      [1, 99, '!00000001', '!00000063', 'src-a', '[10,20]', NOW, NOW],
+    ]);
+
+    const repo = new AnalysisRepository(backend.drizzleDb, backend.dbType);
+    const r = await repo.getHopCounts({ sourceIds: ['src-a'] });
+
+    expect(r.entries.find((e) => Number(e.nodeNum) === 99)?.hops).toBe(2);
+  });
+
+  it('excludes a pending (NULL route) row and falls back to the answered one', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await insertRows(backend, [
+      [1, 99, '!00000001', '!00000063', 'src-a', '[10,20,30]', NOW - 5000, NOW - 5000],
+      [1, 99, '!00000001', '!00000063', 'src-a', null, NOW, NOW],
+    ]);
+
+    const repo = new AnalysisRepository(backend.drizzleDb, backend.dbType);
+    const r = await repo.getHopCounts({ sourceIds: ['src-a'] });
+
+    expect(r.entries.find((e) => Number(e.nodeNum) === 99)?.hops).toBe(3);
+  });
+
+  it('omits a node whose only traceroute is pending', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await insertRows(backend, [
+      [1, 99, '!00000001', '!00000063', 'src-a', null, NOW, NOW],
+    ]);
+
+    const repo = new AnalysisRepository(backend.drizzleDb, backend.dbType);
+    const r = await repo.getHopCounts({ sourceIds: ['src-a'] });
+
+    expect(r.entries.find((e) => Number(e.nodeNum) === 99)).toBeUndefined();
+  });
+
+  it('still reports a direct neighbour (empty route) as 0 hops', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await insertRows(backend, [
+      [1, 77, '!00000001', '!0000004d', 'src-a', '[]', NOW, NOW],
+    ]);
+
+    const repo = new AnalysisRepository(backend.drizzleDb, backend.dbType);
+    const r = await repo.getHopCounts({ sourceIds: ['src-a'] });
+
+    expect(r.entries.find((e) => Number(e.nodeNum) === 77)?.hops).toBe(0);
+  });
+
+  it('groups per (sourceId, nodeNum) rather than collapsing across sources', async () => {
+    // The GROUP BY must key on both columns; getting it wrong would let one
+    // source's traceroute answer for another's node.
+    const backend = getBackend();
+    if (!backend.available) return;
+    await insertRows(backend, [
+      [1, 99, '!00000001', '!00000063', 'src-a', '[10]', NOW, NOW],
+      [1, 99, '!00000001', '!00000063', 'src-b', '[10,20,30,40]', NOW, NOW],
+    ]);
+
+    const repo = new AnalysisRepository(backend.drizzleDb, backend.dbType);
+    const r = await repo.getHopCounts({ sourceIds: ['src-a', 'src-b'] });
+
+    expect(r.entries.find((e) => Number(e.nodeNum) === 99 && e.sourceId === 'src-a')?.hops).toBe(1);
+    expect(r.entries.find((e) => Number(e.nodeNum) === 99 && e.sourceId === 'src-b')?.hops).toBe(4);
+  });
+
+  it('returns one entry per node even when two rows tie on the max timestamp', async () => {
+    // The join emits both tied rows; the `seen` guard must collapse them.
+    const backend = getBackend();
+    if (!backend.available) return;
+    await insertRows(backend, [
+      [1, 55, '!00000001', '!00000037', 'src-a', '[10]', NOW, NOW],
+      [1, 55, '!00000001', '!00000037', 'src-a', '[10,20]', NOW, NOW],
+    ]);
+
+    const repo = new AnalysisRepository(backend.drizzleDb, backend.dbType);
+    const r = await repo.getHopCounts({ sourceIds: ['src-a'] });
+
+    expect(r.entries.filter((e) => Number(e.nodeNum) === 55)).toHaveLength(1);
+  });
+
+  it('restricts to the requested sources', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await insertRows(backend, [
+      [1, 99, '!00000001', '!00000063', 'src-a', '[10]', NOW, NOW],
+      [1, 42, '!00000001', '!0000002a', 'src-b', '[10,20]', NOW, NOW],
+    ]);
+
+    const repo = new AnalysisRepository(backend.drizzleDb, backend.dbType);
+    const r = await repo.getHopCounts({ sourceIds: ['src-a'] });
+
+    expect(r.entries.find((e) => Number(e.nodeNum) === 99)).toBeDefined();
+    expect(r.entries.find((e) => Number(e.nodeNum) === 42)).toBeUndefined();
+  });
+}
+
+describe('AnalysisRepository.getHopCounts - SQLite Backend', () => {
+  let backend: TestBackend;
+  beforeAll(() => {
+    backend = createSqliteBackend(SQLITE_CREATE);
+  });
+  afterAll(async () => {
+    if (backend) await backend.close();
+  });
+  beforeEach(async () => {
+    await clearTable(backend, 'traceroutes');
+  });
+  runHopCountsTests(() => backend);
+});
+
+describe.skipIf(!postgresAvailable)('AnalysisRepository.getHopCounts - PostgreSQL Backend', () => {
+  let backend: TestBackend;
+  beforeAll(async () => {
+    backend = await createPostgresBackend(POSTGRES_CREATE);
+  });
+  afterAll(async () => {
+    if (backend) await backend.close();
+  });
+  beforeEach(async () => {
+    if (!backend.available) return;
+    await clearTable(backend, 'traceroutes');
+  });
+  runHopCountsTests(() => backend);
+});
+
+describe.skipIf(!mysqlAvailable)('AnalysisRepository.getHopCounts - MySQL Backend', () => {
+  let backend: TestBackend;
+  beforeAll(async () => {
+    backend = await createMysqlBackend(MYSQL_CREATE);
+  });
+  afterAll(async () => {
+    if (backend) await backend.close();
+  });
+  beforeEach(async () => {
+    if (!backend.available) return;
+    await clearTable(backend, 'traceroutes');
+  });
+  runHopCountsTests(() => backend);
+});

--- a/src/db/repositories/analysis.test.ts
+++ b/src/db/repositories/analysis.test.ts
@@ -388,6 +388,25 @@ describe('AnalysisRepository.getHopCounts — pending traceroutes (#4570)', () =
     close();
   });
 
+  it('does not fall back to an older row when the newest answered route is corrupt', async () => {
+    // Documents a deliberate consequence of selecting "newest answered row"
+    // in SQL: the database cannot judge whether `route` is valid JSON, so a
+    // corrupt newest row yields grey rather than reaching past it to an older
+    // one. Both writers store JSON.stringify(route), so reaching this needs
+    // manual DB editing — and grey is the honest answer for unreadable data.
+    const { sqlite, db, close } = createTestDb();
+    const now = Date.now();
+    const ins = sqlite.prepare(INSERT);
+    ins.run(1, 98, '!00000001', '!00000062', 'src-a', '[10,20]', now - 5000, now - 5000);
+    ins.run(1, 98, '!00000001', '!00000062', 'src-a', 'not-json', now, now);
+
+    const repo = new AnalysisRepository(db, 'sqlite');
+    const r = await repo.getHopCounts({ sourceIds: ['src-a'] });
+
+    expect(r.entries.find((e: { nodeNum: number }) => e.nodeNum === 98)).toBeUndefined();
+    close();
+  });
+
   it('keeps sources independent when one has a pending row and the other does not', async () => {
     const { sqlite, db, close } = createTestDb();
     const now = Date.now();

--- a/src/db/repositories/analysis.ts
+++ b/src/db/repositories/analysis.ts
@@ -20,7 +20,7 @@
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import type { MySql2Database } from 'drizzle-orm/mysql2';
-import { and, desc, gte, inArray, lt, or, eq } from 'drizzle-orm';
+import { and, desc, gte, inArray, isNotNull, lt, max, or, eq } from 'drizzle-orm';
 import { isBogusPosition } from '../../utils/nullIsland.js';
 import {
   telemetrySqlite,
@@ -618,11 +618,18 @@ export class AnalysisRepository {
    * reported symptom was dozens of remote nodes across several hundred km all
    * shading green/local on Map Analysis.
    *
-   * Skipping rather than substituting a sentinel matters: `continue` leaves
-   * the key unseen, so an older ANSWERED traceroute for the same node still
-   * supplies its hop count. Only a node with no answered traceroute at all
+   * Excluding rather than substituting a sentinel matters: a node's newest
+   * ANSWERED traceroute still supplies its hop count even while a fresh
+   * request is outstanding. Only a node with no answered traceroute at all
    * drops out and renders grey. A legitimately direct neighbour stores
    * `'[]'` — a real empty route, not NULL — and still correctly reports 0.
+   *
+   * Note on corrupt data: the selection of "newest answered row" happens in
+   * SQL, which cannot judge whether `route` is valid JSON. So if that newest
+   * row's JSON is unparseable or not an array, the node is omitted (grey)
+   * rather than falling back to an older row. Both writers store
+   * `JSON.stringify(route)`, so this is unreachable short of manual database
+   * edits — and grey is the honest answer for data we cannot read.
    */
   async getHopCounts(args: GetHopCountsArgs): Promise<HopCountsResult> {
     if (args.sourceIds.length === 0) {
@@ -632,16 +639,49 @@ export class AnalysisRepository {
     const traceroutes = pickTraceroutesTable(this.dbType);
 
     /* eslint-disable @typescript-eslint/no-explicit-any -- Drizzle cross-dialect union */
-    const rows: any[] = await (this.db as any)
+    const db = this.db as any;
+
+    // Narrow to the newest ANSWERED row per (sourceId, toNodeNum) in SQL
+    // rather than fetching the whole table and reducing in JS.
+    //
+    // Traceroute history is capped per node-pair by TRACEROUTE_HISTORY_LIMIT
+    // (default 50, env-tunable up to much higher), so the old "select
+    // everything, keep the first row per node" scan read ~50x the rows it
+    // needed — a 500-node mesh pulled ~25,000 rows to produce ~500 entries,
+    // on every Map Analysis load. Both halves also filter `route IS NOT NULL`,
+    // which drops PENDING rows (see the doc comment above) at the database
+    // instead of skipping them one by one in the loop.
+    //
+    // Plain GROUP BY + INNER JOIN rather than a window function: identical
+    // standard SQL on SQLite, PostgreSQL and MySQL, so there is no dialect
+    // branch to get wrong. Verified against all three.
+    const newest = db
+      .select({
+        sourceId: traceroutes.sourceId,
+        toNodeNum: traceroutes.toNodeNum,
+        maxTs: max(traceroutes.timestamp).as('maxTs'),
+      })
+      .from(traceroutes)
+      .where(and(inArray(traceroutes.sourceId, args.sourceIds), isNotNull(traceroutes.route)))
+      .groupBy(traceroutes.sourceId, traceroutes.toNodeNum)
+      .as('newest');
+
+    const rows: any[] = await db
       .select({
         sourceId: traceroutes.sourceId,
         toNodeNum: traceroutes.toNodeNum,
         route: traceroutes.route,
-        timestamp: traceroutes.timestamp,
       })
       .from(traceroutes)
-      .where(inArray(traceroutes.sourceId, args.sourceIds))
-      .orderBy(desc(traceroutes.timestamp));
+      .innerJoin(
+        newest,
+        and(
+          eq(traceroutes.sourceId, newest.sourceId),
+          eq(traceroutes.toNodeNum, newest.toNodeNum),
+          eq(traceroutes.timestamp, newest.maxTs),
+        ),
+      )
+      .where(and(inArray(traceroutes.sourceId, args.sourceIds), isNotNull(traceroutes.route)));
     /* eslint-enable @typescript-eslint/no-explicit-any */
 
     const seen = new Map<string, HopEntry>();
@@ -650,11 +690,11 @@ export class AnalysisRepository {
       if (!sourceId) continue;
       const nodeNum = Number(r.toNodeNum);
       const key = `${sourceId}:${nodeNum}`;
+      // Two rows can share the max timestamp for one node; either is "newest",
+      // so take the first and ignore the rest.
       if (seen.has(key)) continue;
 
-      // Pending traceroute (no response yet) — carries no hop information.
-      // Skip WITHOUT marking the key seen, so an older answered row can still
-      // supply this node's hop count.
+      // Belt-and-braces: the query already excludes NULL routes.
       if (r.route == null) continue;
 
       let hops: number;


### PR DESCRIPTION
## Summary

The two follow-ups the #4570 and #4568 reviews flagged. Independent changes, one per commit — reviewable separately.

---

### 1. `perf(analysis)` — bound the hop-counts scan (`27d018a6`)

`getHopCounts` fetched **every** traceroute row for the requested sources and reduced to one row per node in JS.

Traceroute history is capped per node-pair by `TRACEROUTE_HISTORY_LIMIT` (default 50, env-tunable higher), so the scan read roughly **50× the rows it needed** — a 500-node mesh pulls ~25,000 rows to produce ~500 entries, on every Map Analysis load. Pending rows, generated continuously by auto-traceroute, were fetched only to be discarded.

Now narrowed with `route IS NOT NULL` on both halves and the newest row per `(sourceId, toNodeNum)` picked via `GROUP BY` + `INNER JOIN`. Plain standard SQL rather than a window function, so there's no dialect branch to get wrong.

**The coverage gap this exposed:** `AnalysisRepository` was constructed with `'sqlite'` in **all 15** existing cases — this query had zero PostgreSQL or MySQL coverage. That's not acceptable for a change whose entire risk is dialect compatibility, so this adds `analysis.hopCounts.multiBackend.test.ts`: the same seven behaviours on all three backends, following the `newsCache.test.ts` pattern. **21 assertions, 0 skipped** with the containers up — verified all three actually ran rather than skipping vacuously.

**Behavior change worth a reviewer's eye:** picking the newest answered row now happens in SQL, which can't judge whether `route` is valid JSON. A corrupt newest row therefore yields grey instead of falling back to an older row. Both writers store `JSON.stringify(route)`, so reaching this needs manual DB editing — and grey is the honest answer for data we can't read. Pinned by a test.

---

### 2. `fix(ui)` — surface telemetry request failures (`b19d77fc`)

`handleRequestTelemetry` throws on any non-TX-disabled HTTP error, and that throw — plus any genuine network failure — landed in a `catch` that only called `logger.error`. Spinner cleared, user told nothing: the identical silent-failure shape #4568 just fixed for neighbor info.

Unlike that endpoint there's no 403/429 needing special explanation — the server answers 400 (validation), 503 (not connected) or 500 — and the thrown `Error` already carries `detail.error` when the server sent one. So it surfaces that directly rather than adding a second status-mapping helper.

---

## Test plan

- [x] `npx tsc --noEmit` and `npx tsc -p tsconfig.server.json --noEmit` — clean
- [x] `npm run lint:ci` — clean, no baseline growth
- [x] **Full suite with PostgreSQL and MySQL containers up: 14,154 passed, 0 failed** (109 skipped)
- [x] New `analysis.hopCounts.multiBackend.test.ts` — 7 behaviours × 3 backends
- [x] Existing SQLite `analysis.test.ts` suite still green, including every #4570 assertion

### Not covered

No browser validation. The hop-shading outcome is asserted at the repository layer, and the telemetry toast is not exercised by a rendering test (`App.tsx` isn't renderable in this suite — the same limitation that let the silent failure survive). The telemetry toast in particular is a one-line behaviour I could not unit-test without extracting it, and unlike #4568's status mapping there was no logic worth extracting.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf