### PR TITLE
refactor(themes): migrate non-module component CSS to semantic tokens — batch 2 (#4579)

### DIFF
--- a/src/components/AdvancedNodeFilterPopup/AdvancedNodeFilterPopup.css
+++ b/src/components/AdvancedNodeFilterPopup/AdvancedNodeFilterPopup.css
@@ -15,8 +15,8 @@
 }
 
 .filter-popup {
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface0);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface);
   border-radius: var(--radius-xl);
   width: 90%;
   max-width: 500px;
@@ -31,12 +31,12 @@
   justify-content: space-between;
   align-items: center;
   padding: 1rem 1.25rem;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 .filter-popup-header h4 {
   margin: 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.1rem;
   font-weight: 600;
 }
@@ -45,7 +45,7 @@
   background: none;
   border: none;
   font-size: 1.25rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   cursor: pointer;
   padding: 0;
   width: 32px;
@@ -58,8 +58,8 @@
 }
 
 .filter-popup-close:hover {
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
+  background: var(--color-surface);
+  color: var(--color-text);
 }
 
 .filter-popup-content {
@@ -82,7 +82,7 @@
   gap: 0.5rem;
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   margin-bottom: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -107,9 +107,9 @@
 .filter-toggle-btn {
   flex: 1;
   padding: 0.5rem 1rem;
-  border: 1px solid var(--ctp-surface1);
-  background: var(--ctp-surface0);
-  color: var(--ctp-subtext0);
+  border: 1px solid var(--color-surface-hover);
+  background: var(--color-surface);
+  color: var(--color-text-subtle);
   border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 0.875rem;
@@ -117,19 +117,19 @@
 }
 
 .filter-toggle-btn:hover {
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  color: var(--color-text);
 }
 
 .filter-toggle-btn.active {
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
-  border-color: var(--ctp-blue);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
+  border-color: var(--color-accent);
 }
 
 .filter-mode-description {
   font-size: 0.75rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-style: italic;
 }
 
@@ -146,11 +146,11 @@
   gap: 0.5rem;
   cursor: pointer;
   font-size: 0.875rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .filter-radio input[type="radio"] {
-  accent-color: var(--ctp-blue);
+  accent-color: var(--color-accent);
 }
 
 /* Checkbox group */
@@ -160,7 +160,7 @@
   gap: 0.5rem;
   cursor: pointer;
   font-size: 0.875rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin-bottom: 0.5rem;
 }
 
@@ -169,7 +169,7 @@
 }
 
 .filter-checkbox input[type="checkbox"] {
-  accent-color: var(--ctp-blue);
+  accent-color: var(--color-accent);
 }
 
 .filter-label-with-icon {
@@ -192,22 +192,22 @@
 
 .filter-range-input label {
   font-size: 0.875rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .filter-range-input input[type="number"] {
   width: 60px;
   padding: 0.375rem 0.5rem;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
+  background: var(--color-surface);
+  color: var(--color-text);
   font-size: 0.875rem;
 }
 
 .filter-range-input input[type="number"]:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 /* Role/channel group */
@@ -222,15 +222,15 @@
   display: flex;
   gap: 0.75rem;
   padding: 1rem 1.25rem;
-  border-top: 1px solid var(--ctp-surface0);
+  border-top: 1px solid var(--color-surface);
 }
 
 .filter-reset-btn {
   flex: 1;
   padding: 0.625rem 1rem;
-  border: 1px solid var(--ctp-surface1);
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
+  border: 1px solid var(--color-surface-hover);
+  background: var(--color-surface);
+  color: var(--color-text);
   border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 0.875rem;
@@ -238,15 +238,15 @@
 }
 
 .filter-reset-btn:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .filter-apply-btn {
   flex: 1;
   padding: 0.625rem 1rem;
   border: none;
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
   border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 0.875rem;
@@ -255,7 +255,7 @@
 }
 
 .filter-apply-btn:hover {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
 }
 
 /* Responsive adjustments */

--- a/src/components/AppBanners/AppBanners.css
+++ b/src/components/AppBanners/AppBanners.css
@@ -15,15 +15,15 @@
 
 .warning-banner {
   top: var(--header-height);
-  background-color: var(--ctp-red);
-  color: var(--ctp-crust);
-  border-bottom: 2px solid var(--ctp-maroon);
+  background-color: var(--color-error);
+  color: var(--color-bg-sunken);
+  border-bottom: 2px solid var(--color-danger);
 }
 
 .update-banner {
-  background-color: var(--ctp-blue);
-  color: var(--ctp-crust);
-  border-bottom: 2px solid var(--ctp-sapphire);
+  background-color: var(--color-accent);
+  color: var(--color-bg-sunken);
+  border-bottom: 2px solid var(--color-accent-hover);
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -78,8 +78,8 @@
 }
 
 .update-banner-command {
-  background: var(--ctp-crust);
-  color: var(--ctp-text);
+  background: var(--color-bg-sunken);
+  color: var(--color-text);
   padding: 0.2rem 0.6rem;
   border-radius: 4px;
   font-family: monospace;

--- a/src/components/AppHeader/AppHeader.css
+++ b/src/components/AppHeader/AppHeader.css
@@ -1,7 +1,7 @@
 /* App Header container */
 .app-header {
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface);
   padding: 1.5rem 2rem;
   padding-top: max(1.5rem, env(safe-area-inset-top)); /* Account for iPhone notch/status bar */
   position: fixed;
@@ -43,17 +43,17 @@
 
 .app-header h1 {
   margin: 0;
-  color: var(--ctp-lavender);
+  color: var(--color-accent-muted);
   font-size: 2rem;
   font-weight: 700;
 }
 
 /* Back to sources button */
 .back-to-sources-btn {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border: 1px solid var(--ctp-overlay0);
   border-radius: var(--radius-sm);
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   cursor: pointer;
   font-size: 0.85rem;
   padding: 0.25rem 0.75rem;
@@ -62,17 +62,17 @@
 }
 
 .back-to-sources-btn:hover {
-  background: var(--ctp-surface1);
-  border-color: var(--ctp-overlay1);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border-color: var(--color-text-disabled);
+  color: var(--color-text);
 }
 
 /* Source name badge shown beside the title */
 .header-source-name {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   border: 1px solid var(--ctp-overlay0);
   border-radius: var(--radius-sm);
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   font-size: 0.8rem;
   font-weight: 500;
   padding: 0.2rem 0.6rem;
@@ -84,26 +84,26 @@
   gap: 0.5rem;
   align-items: center;
   font-size: 0.9rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .node-address {
   font-family: var(--font-mono);
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   padding: 0.25rem 0.5rem;
   border-radius: var(--radius-sm);
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   transition: all 0.2s ease;
 }
 
 .node-address.clickable:hover {
-  background: var(--ctp-surface1);
-  color: var(--ctp-sapphire);
+  background: var(--color-surface-hover);
+  color: var(--color-accent-hover);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .device-name {
-  color: var(--ctp-green);
+  color: var(--color-success);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -121,7 +121,7 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-weight: 500;
   cursor: pointer;
 }
@@ -130,35 +130,35 @@
   width: 12px;
   height: 12px;
   border-radius: var(--radius-full);
-  background: var(--ctp-overlay1);
+  background: var(--color-text-disabled);
 }
 
 .status-indicator.connected {
-  background: var(--ctp-green);
+  background: var(--color-success);
   animation: pulse 2s infinite;
 }
 
 .status-indicator.connecting {
-  background: var(--ctp-yellow);
+  background: var(--color-warning);
   animation: pulse 1s infinite;
 }
 
 .status-indicator.configuring {
-  background: var(--ctp-blue);
+  background: var(--color-accent);
   animation: pulse 1.5s infinite;
 }
 
 .status-indicator.disconnected {
-  background: var(--ctp-red);
+  background: var(--color-error);
 }
 
 .status-indicator.rebooting {
-  background: var(--ctp-peach);
+  background: var(--color-caution);
   animation: pulse 1s infinite;
 }
 
 .status-indicator.node-offline {
-  background: var(--ctp-yellow);
+  background: var(--color-warning);
   animation: pulse 1.5s infinite;
 }
 
@@ -182,11 +182,11 @@
 }
 
 .update-method-indicator.websocket {
-  color: var(--ctp-green);
+  color: var(--color-success);
 }
 
 .update-method-indicator.polling {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 /* Connection control buttons */
@@ -195,8 +195,8 @@
   padding: 4px 12px;
   font-size: 12px;
   border: 1px solid var(--ctp-overlay0);
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
+  background: var(--color-surface);
+  color: var(--color-text);
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.2s;
@@ -204,19 +204,19 @@
 }
 
 .connection-control-btn:hover {
-  background: var(--ctp-surface1);
-  border-color: var(--ctp-overlay1);
+  background: var(--color-surface-hover);
+  border-color: var(--color-text-disabled);
 }
 
 .connection-control-btn.reconnect {
-  background: var(--ctp-blue);
-  border-color: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-accent-text);
 }
 
 .connection-control-btn.reconnect:hover {
-  background: var(--ctp-sapphire);
-  border-color: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
 }
 
 /* Login button */
@@ -225,10 +225,10 @@
   align-items: center;
   gap: 8px;
   padding: 8px 16px;
-  background: var(--ctp-blue);
+  background: var(--color-accent);
   border: none;
   border-radius: var(--radius-lg);
-  color: var(--ctp-accent-text);
+  color: var(--color-accent-text);
   cursor: pointer;
   font-size: 0.95em;
   font-weight: 600;
@@ -237,7 +237,7 @@
 }
 
 .login-button:hover {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(137, 180, 250, 0.3);
 }

--- a/src/components/CustomThemeManagement.css
+++ b/src/components/CustomThemeManagement.css
@@ -10,32 +10,32 @@
   align-items: flex-start;
   gap: 1rem;
   padding-bottom: 1rem;
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .theme-management-header h3 {
   margin: 0 0 0.5rem 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.25rem;
 }
 
 .theme-management-header p {
   margin: 0;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.9rem;
 }
 
 .no-themes-message {
   text-align: center;
   padding: 3rem 1rem;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
-  border: 2px dashed var(--ctp-surface2);
+  border: 2px dashed var(--color-surface-active);
 }
 
 .no-themes-message p {
   margin: 0.5rem 0;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .theme-list {
@@ -45,26 +45,26 @@
 }
 
 .theme-card {
-  background: var(--ctp-surface0);
-  border: 2px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 2px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   overflow: hidden;
   transition: all 0.2s;
 }
 
 .theme-card:hover {
-  border-color: var(--ctp-surface2);
+  border-color: var(--color-surface-active);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 .theme-card.active {
-  border-color: var(--ctp-blue);
-  box-shadow: 0 0 0 1px var(--ctp-blue);
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 1px var(--color-accent);
 }
 
 .theme-card-preview {
-  background: var(--ctp-base);
+  background: var(--color-bg);
   padding: 0.75rem;
 }
 
@@ -97,22 +97,22 @@
 
 .theme-card-info h4 {
   margin: 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1rem;
   font-weight: 600;
 }
 
 .theme-slug {
   font-size: 0.8rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-family: var(--font-mono);
 }
 
 .builtin-badge {
   display: inline-block;
   padding: 0.125rem 0.5rem;
-  background: var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-active);
+  color: var(--color-text);
   font-size: 0.75rem;
   font-weight: 600;
   border-radius: var(--radius-sm);
@@ -129,8 +129,8 @@
 .assignment-badge {
   display: inline-block;
   padding: 0.125rem 0.5rem;
-  background: var(--ctp-blue);
-  color: var(--ctp-crust);
+  background: var(--color-accent);
+  color: var(--color-bg-sunken);
   font-size: 0.75rem;
   font-weight: 600;
   border-radius: var(--radius-sm);
@@ -147,8 +147,8 @@
 .btn-apply {
   flex: 1 1 120px;
   padding: 0.5rem 1rem;
-  background: var(--ctp-blue);
-  color: var(--ctp-crust);
+  background: var(--color-accent);
+  color: var(--color-bg-sunken);
   border: none;
   border-radius: var(--radius-md);
   font-weight: 600;
@@ -157,12 +157,12 @@
 }
 
 .btn-apply:hover:not(:disabled) {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
   transform: translateY(-1px);
 }
 
 .btn-apply.active {
-  background: var(--ctp-green);
+  background: var(--color-success);
   cursor: default;
 }
 
@@ -175,7 +175,7 @@
   width: 36px;
   height: 36px;
   padding: 0;
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   border: none;
   border-radius: var(--radius-md);
   font-size: 1.1rem;
@@ -187,12 +187,12 @@
 }
 
 .btn-icon:hover {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   transform: scale(1.1);
 }
 
 .btn-icon.btn-danger:hover {
-  background: var(--ctp-red);
+  background: var(--color-error);
 }
 
 @media (max-width: 768px) {

--- a/src/components/CustomTilesetManager.css
+++ b/src/components/CustomTilesetManager.css
@@ -1,7 +1,11 @@
+/* Some colors below deliberately stay on raw `--ctp-*` palette names (#4579):
+ * the `--ctp-*-rgb` variants are a separate mechanism (numeric triplets fed to
+ * rgba()), and teal/pink/overlay0/overlay2 have no semantic role yet. Roles get
+ * added when a real one appears, not to reach 100%. */
 .custom-tileset-manager {
   margin-top: 1rem;
   padding: 1rem;
-  background-color: var(--ctp-surface0);
+  background-color: var(--color-surface);
   border-radius: var(--radius-lg);
   border: 1px solid var(--ctp-overlay0);
 }
@@ -12,19 +16,19 @@
 
 .manager-header h3 {
   margin: 0 0 0.25rem 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.1rem;
 }
 
 .manager-description {
   font-size: 0.9rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .no-custom-tilesets {
   text-align: center;
   padding: 2rem 1rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .no-custom-tilesets p {
@@ -33,7 +37,7 @@
 
 .no-custom-tilesets .hint {
   font-size: 0.85rem;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
 }
 
 .tileset-list {
@@ -48,14 +52,14 @@
   justify-content: space-between;
   align-items: flex-start;
   padding: 1rem;
-  background-color: var(--ctp-crust);
+  background-color: var(--color-bg-sunken);
   border: 1px solid var(--ctp-overlay0);
   border-radius: var(--radius-md);
   transition: border-color 0.2s;
 }
 
 .tileset-item:hover {
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .tileset-info {
@@ -72,7 +76,7 @@
 
 .tileset-name {
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1rem;
 }
 
@@ -88,8 +92,8 @@
 
 .tileset-badge.vector {
   background-color: rgba(var(--ctp-mauve-rgb, 203, 166, 247), 0.2);
-  color: var(--ctp-mauve);
-  border: 1px solid var(--ctp-mauve);
+  color: var(--color-accent-alt);
+  border: 1px solid var(--color-accent-alt);
 }
 
 .tileset-badge.raster {
@@ -101,20 +105,20 @@
 .tileset-url {
   font-family: var(--font-mono);
   font-size: 0.85rem;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   word-break: break-all;
   margin-bottom: 0.25rem;
 }
 
 .tileset-description {
   font-size: 0.9rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin-bottom: 0.25rem;
 }
 
 .tileset-meta {
   font-size: 0.8rem;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -136,8 +140,8 @@
   padding: 0.4rem 0.8rem;
   border: 1px solid var(--ctp-overlay0);
   border-radius: var(--radius-sm);
-  background-color: var(--ctp-surface0);
-  color: var(--ctp-text);
+  background-color: var(--color-surface);
+  color: var(--color-text);
   cursor: pointer;
   font-size: 0.85rem;
   transition: all 0.2s;
@@ -148,15 +152,15 @@
 }
 
 .btn-edit:hover:not(:disabled) {
-  background-color: var(--ctp-blue);
-  color: var(--ctp-accent-text);
-  border-color: var(--ctp-blue);
+  background-color: var(--color-accent);
+  color: var(--color-accent-text);
+  border-color: var(--color-accent);
 }
 
 .btn-delete:hover:not(:disabled) {
-  background-color: var(--ctp-red);
-  color: var(--ctp-accent-text);
-  border-color: var(--ctp-red);
+  background-color: var(--color-error);
+  color: var(--color-accent-text);
+  border-color: var(--color-error);
 }
 
 .tileset-actions button:disabled {
@@ -165,16 +169,16 @@
 }
 
 .tileset-form {
-  background-color: var(--ctp-crust);
+  background-color: var(--color-bg-sunken);
   padding: 1.5rem;
   border-radius: var(--radius-md);
-  border: 1px solid var(--ctp-blue);
+  border: 1px solid var(--color-accent);
   margin-bottom: 1rem;
 }
 
 .form-header h4 {
   margin: 0 0 1rem 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1rem;
 }
 
@@ -185,22 +189,22 @@
 .form-field label {
   display: block;
   margin-bottom: 0.4rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-weight: 500;
   font-size: 0.9rem;
 }
 
 .form-field .required {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .form-field input {
   width: 100%;
   padding: 0.6rem;
-  background-color: var(--ctp-surface0);
+  background-color: var(--color-surface);
   border: 1px solid var(--ctp-overlay0);
   border-radius: var(--radius-sm);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
   font-family: inherit;
   transition: border-color 0.2s;
@@ -208,11 +212,11 @@
 
 .form-field input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .form-field input.error {
-  border-color: var(--ctp-red);
+  border-color: var(--color-error);
 }
 
 .form-field input:disabled {
@@ -224,7 +228,7 @@
   display: block;
   margin-top: 0.3rem;
   font-size: 0.8rem;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
 }
 
 .form-field small.example {
@@ -241,14 +245,14 @@
 
 .validation-message.error {
   background-color: rgba(var(--ctp-red-rgb, 243, 139, 168), 0.15);
-  color: var(--ctp-red);
-  border-left: 3px solid var(--ctp-red);
+  color: var(--color-error);
+  border-left: 3px solid var(--color-error);
 }
 
 .validation-message.warning {
   background-color: rgba(var(--ctp-yellow-rgb, 249, 226, 175), 0.15);
-  color: var(--ctp-yellow);
-  border-left: 3px solid var(--ctp-yellow);
+  color: var(--color-warning);
+  border-left: 3px solid var(--color-warning);
 }
 
 .form-actions {
@@ -270,12 +274,12 @@
 }
 
 .btn-save {
-  background-color: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background-color: var(--color-accent);
+  color: var(--color-accent-text);
 }
 
 .btn-save:hover:not(:disabled) {
-  background-color: var(--ctp-sapphire);
+  background-color: var(--color-accent-hover);
 }
 
 .btn-save:disabled {
@@ -284,8 +288,8 @@
 }
 
 .btn-cancel {
-  background-color: var(--ctp-surface0);
-  color: var(--ctp-text);
+  background-color: var(--color-surface);
+  color: var(--color-text);
   border: 1px solid var(--ctp-overlay0);
 }
 
@@ -301,10 +305,10 @@
 .btn-add-tileset {
   width: 100%;
   padding: 0.75rem;
-  background-color: var(--ctp-surface0);
+  background-color: var(--color-surface);
   border: 2px dashed var(--ctp-overlay0);
   border-radius: var(--radius-md);
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   font-size: 0.9rem;
   font-weight: 500;
   cursor: pointer;
@@ -312,7 +316,7 @@
 }
 
 .btn-add-tileset:hover:not(:disabled) {
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
   background-color: rgba(var(--ctp-blue-rgb, 137, 180, 250), 0.1);
 }
 
@@ -334,10 +338,10 @@
 
 .btn-test {
   padding: 0.6rem 1rem;
-  background-color: var(--ctp-surface1);
+  background-color: var(--color-surface-hover);
   border: 1px solid var(--ctp-overlay0);
   border-radius: var(--radius-sm);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
   font-weight: 500;
   cursor: pointer;
@@ -347,9 +351,9 @@
 }
 
 .btn-test:hover:not(:disabled) {
-  background-color: var(--ctp-blue);
-  color: var(--ctp-accent-text);
-  border-color: var(--ctp-blue);
+  background-color: var(--color-accent);
+  color: var(--color-accent-text);
+  border-color: var(--color-accent);
 }
 
 .btn-test:disabled {
@@ -367,17 +371,17 @@
 
 .test-result-success {
   background-color: rgba(var(--ctp-green-rgb, 166, 227, 161), 0.15);
-  border: 1px solid var(--ctp-green);
+  border: 1px solid var(--color-success);
 }
 
 .test-result-warning {
   background-color: rgba(var(--ctp-yellow-rgb, 249, 226, 175), 0.15);
-  border: 1px solid var(--ctp-yellow);
+  border: 1px solid var(--color-warning);
 }
 
 .test-result-error {
   background-color: rgba(var(--ctp-red-rgb, 243, 139, 168), 0.15);
-  border: 1px solid var(--ctp-red);
+  border: 1px solid var(--color-error);
 }
 
 .test-result-header {
@@ -392,11 +396,11 @@
 }
 
 .test-result-message {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .test-result-time {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.85rem;
   font-weight: normal;
 }
@@ -405,7 +409,7 @@
   margin-top: 0.5rem;
   padding-top: 0.5rem;
   border-top: 1px solid var(--ctp-overlay0);
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.85rem;
 }
 
@@ -415,12 +419,12 @@
 }
 
 .test-result-layers .layers-matched {
-  color: var(--ctp-green);
+  color: var(--color-success);
   margin-bottom: 0.25rem;
 }
 
 .test-result-layers .layers-missing {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .test-result .test-result-warning {
@@ -428,7 +432,7 @@
   padding: 0.4rem 0.6rem;
   background-color: rgba(var(--ctp-yellow-rgb, 249, 226, 175), 0.1);
   border-radius: var(--radius-sm);
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
   font-size: 0.85rem;
   border: none;
 }
@@ -438,7 +442,7 @@
   padding: 0.4rem 0.6rem;
   background-color: rgba(var(--ctp-red-rgb, 243, 139, 168), 0.1);
   border-radius: var(--radius-sm);
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-size: 0.85rem;
   border: none;
 }
@@ -447,7 +451,7 @@
 .autodetect-section {
   margin-top: 1rem;
   padding: 1rem;
-  background-color: var(--ctp-surface0);
+  background-color: var(--color-surface);
   border-radius: var(--radius-md);
   border: 1px solid var(--ctp-overlay0);
 }
@@ -458,7 +462,7 @@
   gap: 0.5rem;
   margin-bottom: 0.75rem;
   font-weight: 500;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .autodetect-icon {
@@ -474,24 +478,24 @@
 .autodetect-input-row input {
   flex: 1;
   padding: 0.6rem;
-  background-color: var(--ctp-crust);
+  background-color: var(--color-bg-sunken);
   border: 1px solid var(--ctp-overlay0);
   border-radius: var(--radius-sm);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
 }
 
 .autodetect-input-row input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .btn-autodetect {
   padding: 0.6rem 1rem;
-  background-color: var(--ctp-mauve);
+  background-color: var(--color-accent-alt);
   border: none;
   border-radius: var(--radius-sm);
-  color: var(--ctp-accent-text);
+  color: var(--color-accent-text);
   font-size: 0.9rem;
   font-weight: 500;
   cursor: pointer;
@@ -513,7 +517,7 @@
   display: block;
   margin-top: 0.4rem;
   font-size: 0.8rem;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
 }
 
 /* Autodetect progress */
@@ -530,14 +534,14 @@
 
 .progress-fill {
   height: 100%;
-  background-color: var(--ctp-mauve);
+  background-color: var(--color-accent-alt);
   transition: width 0.2s ease-out;
 }
 
 .progress-text {
   margin-top: 0.4rem;
   font-size: 0.8rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   text-align: center;
 }
 
@@ -550,17 +554,17 @@
 
 .autodetect-result.success {
   background-color: rgba(var(--ctp-green-rgb, 166, 227, 161), 0.15);
-  border: 1px solid var(--ctp-green);
+  border: 1px solid var(--color-success);
 }
 
 .autodetect-result.error {
   background-color: rgba(var(--ctp-red-rgb, 243, 139, 168), 0.15);
-  border: 1px solid var(--ctp-red);
+  border: 1px solid var(--color-error);
 }
 
 .autodetect-result-header {
   font-weight: 500;
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin-bottom: 0.75rem;
 }
 
@@ -576,7 +580,7 @@
   justify-content: space-between;
   gap: 0.75rem;
   padding: 0.5rem 0.75rem;
-  background-color: var(--ctp-crust);
+  background-color: var(--color-bg-sunken);
   border-radius: var(--radius-sm);
   border: 1px solid var(--ctp-overlay0);
 }
@@ -592,16 +596,16 @@
 .autodetect-url-text {
   font-family: var(--font-mono);
   font-size: 0.85rem;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   word-break: break-all;
 }
 
 .btn-use-url {
   padding: 0.4rem 0.8rem;
-  background-color: var(--ctp-green);
+  background-color: var(--color-success);
   border: none;
   border-radius: var(--radius-sm);
-  color: var(--ctp-accent-text);
+  color: var(--color-accent-text);
   font-size: 0.85rem;
   font-weight: 500;
   cursor: pointer;
@@ -619,7 +623,7 @@
   padding: 0.4rem 0.6rem;
   background-color: rgba(var(--ctp-red-rgb, 243, 139, 168), 0.1);
   border-radius: var(--radius-sm);
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-size: 0.85rem;
 }
 
@@ -628,7 +632,7 @@
   margin-bottom: 1rem;
   padding: 0.75rem 1rem;
   background-color: rgba(var(--ctp-yellow-rgb, 249, 226, 175), 0.15);
-  border: 1px solid var(--ctp-yellow);
+  border: 1px solid var(--color-warning);
   border-radius: var(--radius-md);
 }
 
@@ -646,17 +650,17 @@
 
 .reload-notice-text {
   flex: 1;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
   min-width: 200px;
 }
 
 .btn-reload {
   padding: 0.4rem 0.8rem;
-  background-color: var(--ctp-yellow);
+  background-color: var(--color-warning);
   border: none;
   border-radius: var(--radius-sm);
-  color: var(--ctp-accent-text);
+  color: var(--color-accent-text);
   font-size: 0.85rem;
   font-weight: 500;
   cursor: pointer;
@@ -665,14 +669,14 @@
 }
 
 .btn-reload:hover {
-  background-color: var(--ctp-peach);
+  background-color: var(--color-caution);
 }
 
 .btn-dismiss {
   padding: 0.3rem 0.5rem;
   background: none;
   border: none;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 1rem;
   cursor: pointer;
   transition: color 0.2s;
@@ -680,5 +684,5 @@
 }
 
 .btn-dismiss:hover {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -16,10 +16,10 @@
 
 .dashboard-add-widget-btn {
   padding: 10px 16px;
-  background-color: var(--ctp-blue);
+  background-color: var(--color-accent);
   border: none;
   border-radius: var(--radius-md);
-  color: var(--ctp-accent-text);
+  color: var(--color-accent-text);
   font-size: 0.9rem;
   font-weight: 500;
   cursor: pointer;
@@ -27,7 +27,7 @@
 }
 
 .dashboard-add-widget-btn:hover {
-  background-color: var(--ctp-sapphire);
+  background-color: var(--color-accent-hover);
 }
 
 .dashboard-add-widget-btn:active {
@@ -35,14 +35,14 @@
 }
 
 .dashboard-title {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0 0 5px 0;
   font-size: 1.5rem;
   font-weight: 600;
 }
 
 .dashboard-subtitle {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin: 0;
   font-size: 0.9rem;
 }
@@ -54,9 +54,9 @@
   align-items: flex-end;
   margin-bottom: 15px;
   padding: 15px;
-  background-color: var(--ctp-mantle);
+  background-color: var(--color-bg-raised);
   border-radius: var(--radius-lg);
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
 }
 
 .dashboard-filters {
@@ -71,17 +71,17 @@
   flex: 1;
   min-width: 200px;
   padding: 8px 12px;
-  background-color: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
   outline: none;
   transition: border-color 0.2s ease;
 }
 
 .dashboard-search:focus {
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .dashboard-search::placeholder {
@@ -90,10 +90,10 @@
 
 .dashboard-filter-select {
   padding: 8px 12px;
-  background-color: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
   outline: none;
   cursor: pointer;
@@ -102,11 +102,11 @@
 }
 
 .dashboard-filter-select:hover {
-  border-color: var(--ctp-surface2);
+  border-color: var(--color-surface-active);
 }
 
 .dashboard-filter-select:focus {
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .dashboard-role-filter-dropdown {
@@ -119,10 +119,10 @@
   justify-content: space-between;
   align-items: center;
   padding: 8px 12px;
-  background-color: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
   cursor: pointer;
   transition: border-color 0.2s ease;
@@ -130,12 +130,12 @@
 }
 
 .dashboard-role-filter-button:hover {
-  border-color: var(--ctp-surface2);
+  border-color: var(--color-surface-active);
 }
 
 .dashboard-dropdown-arrow {
   margin-left: 8px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.7rem;
 }
 
@@ -145,8 +145,8 @@
   left: 0;
   right: 0;
   margin-top: 4px;
-  background-color: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
   padding: 8px;
   z-index: 1000;
@@ -160,7 +160,7 @@
   align-items: center;
   gap: 8px;
   cursor: pointer;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.85rem;
   padding: 6px 4px;
   transition: background-color 0.2s ease;
@@ -168,20 +168,20 @@
 }
 
 .dashboard-role-checkbox-label:hover {
-  background-color: var(--ctp-surface0);
+  background-color: var(--color-surface);
 }
 
 .dashboard-role-checkbox-label input[type='checkbox'] {
   cursor: pointer;
   width: 16px;
   height: 16px;
-  accent-color: var(--ctp-blue);
+  accent-color: var(--color-accent);
   flex-shrink: 0;
 }
 
 .dashboard-role-divider {
   height: 1px;
-  background-color: var(--ctp-surface1);
+  background-color: var(--color-surface-hover);
   margin: 4px 0;
 }
 
@@ -200,17 +200,17 @@
 }
 
 .dashboard-sort label {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.9rem;
   white-space: nowrap;
 }
 
 .dashboard-sort-select {
   padding: 8px 12px;
-  background-color: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
   outline: none;
   cursor: pointer;
@@ -219,15 +219,15 @@
 }
 
 .dashboard-sort-select:hover {
-  border-color: var(--ctp-surface2);
+  border-color: var(--color-surface-active);
 }
 
 .dashboard-sort-select:focus {
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .dashboard-results-info {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.85rem;
   margin-bottom: 15px;
   text-align: right;
@@ -236,25 +236,25 @@
 .dashboard-loading,
 .dashboard-error,
 .dashboard-empty {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   text-align: center;
   padding: 40px 20px;
-  background-color: var(--ctp-mantle);
+  background-color: var(--color-bg-raised);
   border-radius: var(--radius-lg);
   margin: 20px;
 }
 
 .dashboard-empty h2 {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin-bottom: 10px;
 }
 
 .dashboard-empty p {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .dashboard-error {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .dashboard-grid {
@@ -265,8 +265,8 @@
 }
 
 .dashboard-chart-container {
-  background-color: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   padding: 15px;
   min-width: 0;
@@ -280,7 +280,7 @@
 }
 
 .dashboard-drag-handle {
-  color: var(--ctp-surface2);
+  color: var(--color-surface-active);
   font-size: 1.2rem;
   cursor: grab;
   padding: 0 4px;
@@ -292,16 +292,16 @@
 }
 
 .dashboard-drag-handle:hover {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
 }
 
 .dashboard-drag-handle:active {
   cursor: grabbing;
-  color: var(--ctp-sky);
+  color: var(--color-info);
 }
 
 .dashboard-chart-title {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0;
   font-size: 0.95rem;
   font-weight: 500;
@@ -322,7 +322,7 @@
 .dashboard-remove-btn {
   background: none;
   border: none;
-  color: var(--ctp-surface2);
+  color: var(--color-surface-active);
   font-size: 1.2rem;
   cursor: pointer;
   padding: 0;
@@ -337,14 +337,14 @@
 }
 
 .dashboard-remove-btn:hover {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 /* Solar toggle button */
 .solar-toggle-btn {
   background: none;
   border: none;
-  color: var(--ctp-surface2);
+  color: var(--color-surface-active);
   font-size: 1rem;
   cursor: pointer;
   padding: 0;
@@ -358,15 +358,15 @@
 }
 
 .solar-toggle-btn:hover {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .solar-toggle-btn.active {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .dashboard-no-data {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   text-align: center;
   padding: 40px 20px;
   font-style: italic;
@@ -472,8 +472,8 @@
 }
 
 .add-widget-modal {
-  background-color: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-xl);
   width: 90%;
   max-width: 500px;
@@ -487,19 +487,19 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 20px;
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
 }
 
 .add-widget-modal-header h2 {
   margin: 0;
   font-size: 1.2rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .add-widget-modal-close {
   background: none;
   border: none;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 1.5rem;
   cursor: pointer;
   padding: 0;
@@ -508,7 +508,7 @@
 }
 
 .add-widget-modal-close:hover {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .add-widget-modal-content {
@@ -523,16 +523,16 @@
   align-items: flex-start;
   gap: 16px;
   padding: 16px;
-  background-color: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   cursor: pointer;
   transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
 .add-widget-option:hover {
-  background-color: var(--ctp-surface1);
-  border-color: var(--ctp-blue);
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-accent);
 }
 
 .add-widget-option-icon {
@@ -543,13 +543,13 @@
 .add-widget-option-info h3 {
   margin: 0 0 4px 0;
   font-size: 1rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .add-widget-option-info p {
   margin: 0;
   font-size: 0.85rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   line-height: 1.4;
 }
 
@@ -559,7 +559,7 @@
 
 .add-widget-help-intro {
   margin: 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.95rem;
   line-height: 1.5;
 }
@@ -567,7 +567,7 @@
 .add-widget-help-steps {
   margin: 0;
   padding-left: 1.25rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
   line-height: 1.6;
   display: flex;
@@ -577,9 +577,9 @@
 
 .add-widget-help-back {
   align-self: flex-start;
-  background-color: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
-  color: var(--ctp-text);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
+  color: var(--color-text);
   padding: 8px 14px;
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -588,8 +588,8 @@
 }
 
 .add-widget-help-back:hover {
-  background-color: var(--ctp-surface1);
-  border-color: var(--ctp-blue);
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-accent);
 }
 
 /* Node Status Widget */
@@ -614,10 +614,10 @@
 .node-status-search {
   width: 100%;
   padding: 8px 12px;
-  background-color: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-raised);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.85rem;
   outline: none;
   transition: border-color 0.2s ease;
@@ -625,7 +625,7 @@
 }
 
 .node-status-search:focus {
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .node-status-search::placeholder {
@@ -638,8 +638,8 @@
   left: 0;
   right: 0;
   margin-top: 4px;
-  background-color: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
   max-height: 200px;
   overflow-y: auto;
@@ -653,17 +653,17 @@
   align-items: center;
   padding: 8px 12px;
   cursor: pointer;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.85rem;
   transition: background-color 0.2s ease;
 }
 
 .node-status-search-item:hover {
-  background-color: var(--ctp-surface0);
+  background-color: var(--color-surface);
 }
 
 .node-status-search-id {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.75rem;
   font-family: var(--font-mono);
 }
@@ -677,15 +677,15 @@
 .node-status-table th {
   text-align: left;
   padding: 8px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: 500;
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
 }
 
 .node-status-table td {
   padding: 8px;
-  color: var(--ctp-text);
-  border-bottom: 1px solid var(--ctp-surface0);
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 .node-status-table tr:last-child td {
@@ -701,7 +701,7 @@
   border: none;
   padding: 0;
   margin: 0;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   text-decoration: underline;
   cursor: pointer;
   font: inherit;
@@ -709,16 +709,16 @@
 }
 
 .node-status-name-link:hover {
-  color: var(--ctp-sapphire);
+  color: var(--color-accent-hover);
 }
 
 .node-status-time {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .node-status-hops {
   text-align: center;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .node-status-hops-header {
@@ -733,7 +733,7 @@
 .node-status-remove-node {
   background: none;
   border: none;
-  color: var(--ctp-surface2);
+  color: var(--color-surface-active);
   font-size: 1rem;
   cursor: pointer;
   padding: 2px 6px;
@@ -741,11 +741,11 @@
 }
 
 .node-status-remove-node:hover {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .node-status-empty {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.85rem;
   text-align: center;
   padding: 20px;
@@ -775,7 +775,7 @@
   flex-direction: column;
   align-items: center;
   padding: 8px 16px;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
   min-width: 80px;
 }
@@ -783,13 +783,13 @@
 .hop-stat-value {
   font-size: 1.5rem;
   font-weight: 700;
-  color: var(--ctp-text);
+  color: var(--color-text);
   line-height: 1.2;
 }
 
 .hop-stat-label {
   font-size: 0.7rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   text-transform: uppercase;
   letter-spacing: 0.03em;
   text-align: center;
@@ -809,7 +809,7 @@
 
 .hop-bar-label {
   font-size: 0.8rem;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   min-width: 70px;
   text-align: right;
   white-space: nowrap;
@@ -818,7 +818,7 @@
 .hop-bar-track {
   flex: 1;
   height: 20px;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-sm);
   overflow: hidden;
 }
@@ -833,7 +833,7 @@
 .hop-bar-count {
   font-size: 0.85rem;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
   min-width: 28px;
   text-align: right;
 }
@@ -845,8 +845,8 @@
 
 .distance-unit-badge {
   font-size: 0.7rem;
-  color: var(--ctp-subtext0);
-  background: var(--ctp-surface0);
+  color: var(--color-text-subtle);
+  background: var(--color-surface);
   padding: 2px 6px;
   border-radius: var(--radius-sm);
   margin-left: 8px;
@@ -865,7 +865,7 @@
   background: none;
   border: none;
   font-size: 1rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   cursor: pointer;
   padding: 2px 6px;
   border-radius: var(--radius-sm);
@@ -873,13 +873,13 @@
 }
 
 .distance-settings-btn:hover {
-  color: var(--ctp-text);
-  background: var(--ctp-surface0);
+  color: var(--color-text);
+  background: var(--color-surface);
 }
 
 .distance-settings-panel {
   padding: 8px 12px;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-md);
   margin-bottom: 8px;
   display: flex;
@@ -889,16 +889,16 @@
 
 .distance-settings-label {
   font-size: 0.8rem;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
 .distance-bucket-select {
-  background: var(--ctp-base);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
   padding: 4px 8px;
   font-size: 0.8rem;
@@ -907,7 +907,7 @@
 
 .distance-bucket-select:focus {
   outline: none;
-  border-color: var(--ctp-lavender);
+  border-color: var(--color-accent-muted);
 }
 
 /* Hop-Distance Heatmap Widget */
@@ -939,7 +939,7 @@
   height: 40px;
   padding: 4px 8px;
   font-weight: 400;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.65rem;
   text-transform: uppercase;
   letter-spacing: 0.03em;
@@ -966,8 +966,8 @@
   background: linear-gradient(
     to top right,
     transparent calc(50% - 0.5px),
-    var(--ctp-surface1) calc(50% - 0.5px),
-    var(--ctp-surface1) calc(50% + 0.5px),
+    var(--color-surface-hover) calc(50% - 0.5px),
+    var(--color-surface-hover) calc(50% + 0.5px),
     transparent calc(50% + 0.5px)
   );
   pointer-events: none;
@@ -976,21 +976,21 @@
 .heatmap-col-header {
   padding: 6px 4px;
   text-align: center;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: 500;
   font-size: 0.7rem;
   white-space: nowrap;
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
 }
 
 .heatmap-row-header {
   padding: 6px 8px;
   text-align: right;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: 500;
   font-size: 0.75rem;
   white-space: nowrap;
-  border-right: 1px solid var(--ctp-surface1);
+  border-right: 1px solid var(--color-surface-hover);
 }
 
 .heatmap-cell {
@@ -999,19 +999,19 @@
   min-width: 36px;
   font-size: 0.8rem;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
   border-radius: var(--radius-xs);
   transition: opacity 0.2s;
   cursor: default;
 }
 
 .heatmap-cell:hover {
-  outline: 1px solid var(--ctp-overlay1);
+  outline: 1px solid var(--color-text-disabled);
 }
 
 .heatmap-skipped {
   font-size: 0.75rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   text-align: center;
   font-style: italic;
 }
@@ -1022,7 +1022,7 @@
   justify-content: center;
   gap: 8px;
   font-size: 0.7rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .heatmap-legend-bar {
@@ -1063,10 +1063,10 @@
 .traceroute-search {
   width: 100%;
   padding: 8px 12px;
-  background-color: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-raised);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.85rem;
   outline: none;
   transition: border-color 0.2s ease;
@@ -1074,7 +1074,7 @@
 }
 
 .traceroute-search:focus {
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .traceroute-search::placeholder {
@@ -1087,8 +1087,8 @@
   left: 0;
   right: 0;
   margin-top: 4px;
-  background-color: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
   max-height: 200px;
   overflow-y: auto;
@@ -1102,17 +1102,17 @@
   align-items: center;
   padding: 8px 12px;
   cursor: pointer;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.85rem;
   transition: background-color 0.2s ease;
 }
 
 .traceroute-search-item:hover {
-  background-color: var(--ctp-surface0);
+  background-color: var(--color-surface);
 }
 
 .traceroute-search-id {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.75rem;
   font-family: var(--font-mono);
 }
@@ -1128,11 +1128,11 @@
   justify-content: space-between;
   align-items: center;
   padding-bottom: 8px;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 .traceroute-timestamp {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.8rem;
 }
 
@@ -1141,17 +1141,17 @@
   align-items: center;
   gap: 4px;
   padding: 4px 10px;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-sm);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.75rem;
   cursor: pointer;
   transition: background-color 0.2s ease;
 }
 
 .traceroute-map-toggle-inline:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .traceroute-path-section {
@@ -1161,7 +1161,7 @@
 }
 
 .traceroute-path-label {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.8rem;
   font-weight: 500;
 }
@@ -1178,15 +1178,15 @@
   display: inline-flex;
   flex-direction: column;
   align-items: center;
-  background-color: var(--ctp-surface0);
+  background-color: var(--color-surface);
   padding: 6px 10px;
   border-radius: var(--radius-md);
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .traceroute-snr {
   font-size: 0.7rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin-top: 2px;
 }
 
@@ -1198,7 +1198,7 @@
 .traceroute-empty,
 .traceroute-loading,
 .traceroute-no-data {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.85rem;
   text-align: center;
   padding: 20px;
@@ -1210,11 +1210,11 @@
   margin: 8px 0;
   border-radius: var(--radius-lg);
   overflow: hidden;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
 }
 
 .traceroute-map-container .leaflet-container {
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
 }
 
 .traceroute-map-legend {
@@ -1222,9 +1222,9 @@
   gap: 16px;
   justify-content: center;
   padding: 8px;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   font-size: 0.75rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .traceroute-map-legend .legend-item {
@@ -1238,11 +1238,11 @@
 }
 
 .traceroute-map-legend .legend-item:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .traceroute-map-legend .legend-item.highlighted {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   font-weight: 600;
 }
 

--- a/src/components/DraggableOverlay.css
+++ b/src/components/DraggableOverlay.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   backdrop-filter: blur(10px);
   border-radius: var(--radius-lg);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
@@ -22,21 +22,21 @@
   justify-content: center;
   width: 16px;
   min-height: 100%;
-  background: linear-gradient(to right, var(--ctp-surface1), var(--ctp-surface0));
+  background: linear-gradient(to right, var(--color-surface-hover), var(--color-surface));
   cursor: grab;
   flex-shrink: 0;
-  border-right: 1px solid var(--ctp-surface1);
+  border-right: 1px solid var(--color-surface-hover);
   transition: background 0.2s ease;
 }
 
 .drag-handle:hover {
-  background: linear-gradient(to right, var(--ctp-surface2), var(--ctp-surface1));
+  background: linear-gradient(to right, var(--color-surface-active), var(--color-surface-hover));
 }
 
 .drag-handle:active,
 .draggable-overlay.dragging .drag-handle {
   cursor: grabbing;
-  background: linear-gradient(to right, var(--ctp-overlay0), var(--ctp-surface2));
+  background: linear-gradient(to right, var(--ctp-overlay0), var(--color-surface-active));
 }
 
 .drag-handle-icon {
@@ -55,7 +55,7 @@
 }
 
 .draggable-overlay.dragging .drag-handle-icon span {
-  background-color: var(--ctp-subtext0);
+  background-color: var(--color-text-subtle);
 }
 
 .draggable-content {

--- a/src/components/EmojiPickerModal/EmojiPickerModal.css
+++ b/src/components/EmojiPickerModal/EmojiPickerModal.css
@@ -1,7 +1,7 @@
 /* Emoji Picker Modal */
 .emoji-picker-modal {
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface0);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface);
   border-radius: var(--radius-xl);
   padding: 0;
   max-width: 400px;
@@ -14,12 +14,12 @@
   justify-content: space-between;
   align-items: center;
   padding: 1rem 1.25rem;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 .emoji-picker-header h3 {
   margin: 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.1rem;
   font-weight: 600;
 }
@@ -28,7 +28,7 @@
   background: none;
   border: none;
   font-size: 1.5rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   cursor: pointer;
   padding: 0;
   line-height: 1;
@@ -42,8 +42,8 @@
 }
 
 .emoji-picker-close:hover {
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
+  background: var(--color-surface);
+  color: var(--color-text);
 }
 
 @media (hover: none) and (pointer: coarse) {
@@ -77,7 +77,7 @@
 }
 
 .emoji-picker-item:hover {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   transform: scale(1.1);
 }
 
@@ -87,12 +87,12 @@
 
 /* Custom emoji button styling */
 .emoji-picker-custom-btn {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   font-size: 1rem !important;
 }
 
 .emoji-picker-custom-btn:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 /* Custom emoji input section */
@@ -100,34 +100,34 @@
   display: flex;
   gap: 0.5rem;
   padding: 0.75rem 1rem 1rem;
-  border-top: 1px solid var(--ctp-surface0);
+  border-top: 1px solid var(--color-surface);
 }
 
 .emoji-picker-custom-input input {
   flex: 1;
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
+  background: var(--color-surface);
+  color: var(--color-text);
   font-size: 1rem;
 }
 
 .emoji-picker-custom-input input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .emoji-picker-custom-input input::placeholder {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .emoji-picker-custom-input button {
   padding: 0.5rem 1rem;
   border: none;
   border-radius: var(--radius-md);
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
   font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
@@ -135,7 +135,7 @@
 }
 
 .emoji-picker-custom-input button:hover:not(:disabled) {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
 }
 
 .emoji-picker-custom-input button:disabled {

--- a/src/components/LoginPage.css
+++ b/src/components/LoginPage.css
@@ -11,7 +11,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, var(--ctp-blue) 0%, var(--ctp-mauve) 100%);
+  background: linear-gradient(135deg, var(--color-accent) 0%, var(--color-accent-alt) 100%);
   padding: 20px;
   /* iOS keyboard overlay (issue #2994): the form centers in the viewport;
      padding-bottom equal to the keyboard height shifts it upward so the
@@ -21,7 +21,7 @@
 }
 
 .login-container {
-  background: var(--ctp-base);
+  background: var(--color-bg);
   border-radius: 12px;
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
   padding: 40px;
@@ -36,7 +36,7 @@
 }
 
 .login-logo svg {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   margin-bottom: 10px;
 }
 
@@ -50,7 +50,7 @@
 .login-logo h1 {
   font-size: 32px;
   font-weight: 700;
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0;
 }
 
@@ -74,14 +74,14 @@
   display: block;
   margin-bottom: 6px;
   font-weight: 500;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 14px;
 }
 
 .login-form .form-group input {
   width: 100%;
   padding: 12px;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   border-radius: 6px;
   font-size: 14px;
   transition: border-color 0.2s;
@@ -90,19 +90,19 @@
 
 .login-form .form-group input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ctp-blue) 10%, transparent);
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 10%, transparent);
 }
 
 .login-form .form-group input:disabled {
-  background-color: var(--ctp-surface0);
+  background-color: var(--color-surface);
   cursor: not-allowed;
 }
 
 /* Error Message */
 .error-message {
-  background-color: color-mix(in srgb, var(--ctp-red) 20%, var(--ctp-base));
-  color: var(--ctp-red);
+  background-color: color-mix(in srgb, var(--color-error) 20%, var(--color-bg));
+  color: var(--color-error);
   padding: 12px;
   border-radius: 6px;
   font-size: 14px;
@@ -123,21 +123,21 @@
 }
 
 .login-button.button-primary {
-  background-color: var(--ctp-blue);
-  color: var(--ctp-base);
+  background-color: var(--color-accent);
+  color: var(--color-bg);
 }
 
 .login-button.button-primary:hover:not(:disabled) {
-  background-color: var(--ctp-sapphire);
+  background-color: var(--color-accent-hover);
 }
 
 .login-button.button-secondary {
-  background-color: var(--ctp-surface0);
-  color: var(--ctp-text);
+  background-color: var(--color-surface);
+  color: var(--color-text);
 }
 
 .login-button.button-secondary:hover:not(:disabled) {
-  background-color: var(--ctp-surface2);
+  background-color: var(--color-surface-active);
 }
 
 .login-button:disabled {
@@ -159,12 +159,12 @@
   top: 50%;
   width: 100%;
   height: 1px;
-  background-color: var(--ctp-surface2);
+  background-color: var(--color-surface-active);
 }
 
 .login-divider span {
   position: relative;
-  background-color: var(--ctp-base);
+  background-color: var(--color-bg);
   padding: 0 15px;
   color: var(--ctp-overlay0);
   font-size: 14px;
@@ -173,7 +173,7 @@
 
 /* Footer */
 .login-footer {
-  border-top: 1px solid var(--ctp-surface2);
+  border-top: 1px solid var(--color-surface-active);
   padding-top: 20px;
   display: flex;
   justify-content: space-between;
@@ -182,18 +182,18 @@
 }
 
 .login-footer .version {
-  color: var(--ctp-overlay1);
+  color: var(--color-text-disabled);
 }
 
 .login-footer .github-link {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   text-decoration: none;
   font-weight: 500;
   transition: color 0.2s;
 }
 
 .login-footer .github-link:hover {
-  color: var(--ctp-sapphire);
+  color: var(--color-accent-hover);
   text-decoration: underline;
 }
 
@@ -204,7 +204,7 @@
 }
 
 .mfa-prompt p {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 14px;
   margin: 0;
 }
@@ -220,7 +220,7 @@
 .button-link {
   background: none;
   border: none;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   cursor: pointer;
   font-size: 13px;
   text-decoration: underline;
@@ -228,7 +228,7 @@
 }
 
 .button-link:hover {
-  color: var(--ctp-sapphire);
+  color: var(--color-accent-hover);
 }
 
 /* Mobile Responsive */

--- a/src/components/MQTT/MqttPacketMonitor.css
+++ b/src/components/MQTT/MqttPacketMonitor.css
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: var(--ctp-base);
+  background: var(--color-bg);
   overflow: hidden;
 }
 
@@ -14,8 +14,8 @@
   align-items: center;
   gap: 12px;
   padding: 12px 16px;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface2);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface-active);
   flex-shrink: 0;
 }
 
@@ -23,14 +23,14 @@
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .mqpm-count {
   font-size: 12px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   padding: 4px 8px;
-  background: var(--ctp-crust);
+  background: var(--color-bg-sunken);
   border-radius: var(--radius-sm);
   font-family: var(--font-mono);
 }
@@ -47,18 +47,18 @@
   align-items: center;
   gap: 6px;
   background: transparent;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
   padding: 6px 10px;
   cursor: pointer;
   font-size: 13px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   transition: all 0.2s;
 }
 
 .mqpm-btn:hover:not(:disabled) {
-  background: var(--ctp-crust);
-  border-color: var(--ctp-blue);
+  background: var(--color-bg-sunken);
+  border-color: var(--color-accent);
 }
 
 .mqpm-btn:disabled {
@@ -67,13 +67,13 @@
 }
 
 .mqpm-btn.active {
-  border-color: var(--ctp-blue);
-  color: var(--ctp-blue);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 .mqpm-btn-danger:hover:not(:disabled) {
-  border-color: var(--ctp-red);
-  color: var(--ctp-red);
+  border-color: var(--color-error);
+  color: var(--color-error);
 }
 
 .mqpm-disabled-banner {
@@ -81,9 +81,9 @@
   align-items: center;
   gap: 12px;
   padding: 10px 16px;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface2);
-  color: var(--ctp-subtext0);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface-active);
+  color: var(--color-text-subtle);
   font-size: 13px;
 }
 
@@ -96,8 +96,8 @@
   flex-wrap: wrap;
   gap: 12px;
   padding: 12px 16px;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface2);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface-active);
   position: relative;
 }
 
@@ -106,16 +106,16 @@
   flex-direction: column;
   gap: 4px;
   font-size: 12px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mqpm-filters select,
 .mqpm-filters input[type='number'] {
   padding: 6px 10px;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  background: var(--color-bg);
+  color: var(--color-text);
   font-size: 13px;
 }
 
@@ -129,15 +129,15 @@
 .mqpm-filter-note {
   flex-basis: 100%;
   font-size: 11px;
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .mqpm-error {
   padding: 8px 16px;
-  background: var(--ctp-crust);
-  color: var(--ctp-red);
+  background: var(--color-bg-sunken);
+  color: var(--color-error);
   font-size: 13px;
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .mqpm-table-container {
@@ -153,7 +153,7 @@
   height: 100%;
   padding: 32px;
   text-align: center;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mqpm-table {
@@ -168,25 +168,25 @@
   z-index: 1;
   text-align: left;
   padding: 8px 12px;
-  background: var(--ctp-mantle);
-  color: var(--ctp-subtext0);
+  background: var(--color-bg-raised);
+  color: var(--color-text-subtle);
   font-weight: 600;
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
   white-space: nowrap;
 }
 
 .mqpm-row {
   cursor: pointer;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 .mqpm-row:hover {
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
 }
 
 .mqpm-row td {
   padding: 6px 12px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   white-space: nowrap;
 }
 
@@ -204,36 +204,36 @@
   display: inline-block;
   padding: 2px 8px;
   border-radius: var(--radius-sm);
-  background: var(--ctp-crust);
-  color: var(--ctp-blue);
+  background: var(--color-bg-sunken);
+  color: var(--color-accent);
   font-family: var(--font-mono);
   font-size: 12px;
 }
 
 /* Outcome badge color variants (mirrors .mcpm-decode-note's color-mix approach). */
 .mqpm-badge-encrypted {
-  color: var(--ctp-yellow);
-  background: color-mix(in srgb, var(--ctp-yellow) 15%, transparent);
+  color: var(--color-warning);
+  background: color-mix(in srgb, var(--color-warning) 15%, transparent);
 }
 
 .mqpm-badge-ignored {
-  color: var(--ctp-peach);
-  background: color-mix(in srgb, var(--ctp-peach) 15%, transparent);
+  color: var(--color-caution);
+  background: color-mix(in srgb, var(--color-caution) 15%, transparent);
 }
 
 .mqpm-badge-geo-ignored {
-  color: var(--ctp-peach);
-  background: color-mix(in srgb, var(--ctp-peach) 15%, transparent);
+  color: var(--color-caution);
+  background: color-mix(in srgb, var(--color-caution) 15%, transparent);
 }
 
 .mqpm-badge-distance {
-  color: var(--ctp-maroon);
-  background: color-mix(in srgb, var(--ctp-maroon) 15%, transparent);
+  color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 15%, transparent);
 }
 
 .mqpm-badge-error {
-  color: var(--ctp-red);
-  background: color-mix(in srgb, var(--ctp-red) 15%, transparent);
+  color: var(--color-error);
+  background: color-mix(in srgb, var(--color-error) 15%, transparent);
 }
 
 /* ok_to_mqtt violation (#4114). Sixth member of the badge family above. Shares
@@ -243,9 +243,9 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  color: var(--ctp-red);
-  background: color-mix(in srgb, var(--ctp-red) 18%, transparent);
-  border: 1px solid color-mix(in srgb, var(--ctp-red) 45%, transparent);
+  color: var(--color-error);
+  background: color-mix(in srgb, var(--color-error) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-error) 45%, transparent);
 }
 
 /* Non-violating ok_to_mqtt states: quiet mono text, deliberately NOT badges, so
@@ -257,11 +257,11 @@
 }
 
 .mqpm-oktomqtt-ok {
-  color: var(--ctp-green);
+  color: var(--color-success);
 }
 
 .mqpm-oktomqtt-optedout {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mqpm-oktomqtt-unknown {
@@ -276,14 +276,14 @@
 }
 
 .mqpm-route {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 12px;
 }
 
 .mqpm-detail-row td {
   padding: 8px 16px;
-  background: var(--ctp-crust);
-  border-bottom: 1px solid var(--ctp-surface2);
+  background: var(--color-bg-sunken);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .mqpm-detail {
@@ -291,11 +291,11 @@
   flex-direction: column;
   gap: 4px;
   font-size: 12px;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
 }
 
 .mqpm-detail strong {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .mqpm-raw {
@@ -317,8 +317,8 @@
   min-width: 220px;
   max-height: 260px;
   overflow-y: auto;
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
   padding: 6px;
@@ -328,14 +328,14 @@
   display: flex;
   gap: 8px;
   padding: 4px 6px 8px;
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
   margin-bottom: 4px;
 }
 
 .mqpm-gateway-dropdown-actions button {
   background: none;
   border: none;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   font-size: 11px;
   cursor: pointer;
   padding: 0;
@@ -347,18 +347,18 @@
   gap: 8px;
   padding: 4px 6px;
   font-size: 12px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   cursor: pointer;
   border-radius: var(--radius-sm);
 }
 
 .mqpm-gateway-option:hover {
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
 }
 
 .mqpm-gateway-option-count {
   margin-left: auto;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-family: var(--font-mono);
   font-size: 11px;
 }
@@ -376,8 +376,8 @@
 }
 
 .mqpm-modal-content {
-  background: var(--ctp-base);
-  border: 2px solid var(--ctp-blue);
+  background: var(--color-bg);
+  border: 2px solid var(--color-accent);
   border-radius: 8px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
   width: 100%;
@@ -393,26 +393,26 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.75rem 1rem;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface2);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .mqpm-modal-header h4 {
   margin: 0;
   font-size: 1rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .mqpm-modal-close {
   background: none;
   border: none;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 1.5rem;
   line-height: 1;
   cursor: pointer;
   padding: 0 0.25rem;
 }
-.mqpm-modal-close:hover { color: var(--ctp-text); }
+.mqpm-modal-close:hover { color: var(--color-text); }
 
 .mqpm-modal-body {
   padding: 0.75rem 1rem 1rem;
@@ -428,8 +428,8 @@
   font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--ctp-blue);
-  border-bottom: 1px solid var(--ctp-surface1);
+  color: var(--color-accent);
+  border-bottom: 1px solid var(--color-surface-hover);
   padding-bottom: 0.2rem;
 }
 
@@ -443,11 +443,11 @@
 }
 
 .mqpm-dl-label {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mqpm-dl-value {
-  color: var(--ctp-text);
+  color: var(--color-text);
   min-width: 0;
 }
 
@@ -477,24 +477,24 @@
 .mqpm-recv-table th {
   text-align: left;
   padding: 4px 8px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: 600;
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
   white-space: nowrap;
 }
 
 .mqpm-recv-table td {
   padding: 4px 8px;
-  color: var(--ctp-text);
-  border-bottom: 1px solid var(--ctp-surface0);
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-surface);
   white-space: nowrap;
 }
 
 .mqpm-decode-note {
   font-size: 0.78rem;
-  color: var(--ctp-yellow);
-  background: color-mix(in srgb, var(--ctp-yellow) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--ctp-yellow) 30%, transparent);
+  color: var(--color-warning);
+  background: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-warning) 30%, transparent);
   border-radius: 4px;
   padding: 0.4rem 0.6rem;
 }
@@ -503,11 +503,11 @@
    independent of the packet-log opt-in, so "no badge" must not read as
    "no violations". */
 .mqpm-banner-note {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mqpm-empty-note {
   margin-top: 8px;
   font-size: 12px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }

--- a/src/components/MapLegend.css
+++ b/src/components/MapLegend.css
@@ -23,10 +23,10 @@
 }
 
 .legend-collapse-btn {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   border: none;
   border-radius: var(--radius-sm);
-  color: var(--ctp-text);
+  color: var(--color-text);
   cursor: pointer;
   width: 24px;
   height: 24px;
@@ -41,7 +41,7 @@
 }
 
 .legend-collapse-btn:hover {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   transform: scale(1.1);
 }
 
@@ -52,7 +52,7 @@
 .legend-title {
   font-size: 0.8rem;
   font-weight: 600;
-  color: var(--ctp-mauve);
+  color: var(--color-accent-alt);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 2px;
@@ -75,7 +75,7 @@
 }
 
 .legend-label {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-weight: 500;
   white-space: nowrap;
 }
@@ -83,7 +83,7 @@
 .legend-divider {
   width: 100%;
   height: 1px;
-  background: var(--ctp-surface1, rgba(255,255,255,0.15));
+  background: var(--color-surface-hover, rgba(255,255,255,0.15));
   margin: 6px 0;
 }
 
@@ -105,7 +105,7 @@
   height: 12px;
   border-radius: var(--radius-sm);
   /* Gradient set via inline style from overlayColors for theme-awareness */
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
 }
 
 .legend-gradient-labels {
@@ -116,16 +116,16 @@
 
 .legend-gradient-label {
   font-size: 10px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: 500;
 }
 
 .legend-gradient-label.oldest {
-  color: var(--ctp-sky);
+  color: var(--color-info);
 }
 
 .legend-gradient-label.newest {
-  color: var(--ctp-peach);
+  color: var(--color-caution);
 }
 
 .legend-time-labels {
@@ -133,7 +133,7 @@
   justify-content: space-between;
   width: 100%;
   padding-top: 2px;
-  border-top: 1px solid var(--ctp-surface1);
+  border-top: 1px solid var(--color-surface-hover);
 }
 
 .legend-time-label {
@@ -173,8 +173,8 @@
     z-index: 1150;
     /* Never wider than the screen — the page must not scroll sideways. */
     max-width: min(320px, calc(100vw - 24px));
-    background: var(--ctp-surface0);
-    border: 1px solid var(--ctp-surface1);
+    background: var(--color-surface);
+    border: 1px solid var(--color-surface-hover);
     border-radius: var(--radius-lg);
     box-shadow: 0 2px 12px rgb(0 0 0 / 35%);
     overflow: hidden;

--- a/src/components/MeshCore/MeshCoreAclManager.css
+++ b/src/components/MeshCore/MeshCoreAclManager.css
@@ -1,7 +1,7 @@
 .meshcore-acl-manager {
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md, 6px);
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   padding: 0.6rem 0.75rem;
   display: flex;
   flex-direction: column;
@@ -12,13 +12,13 @@
   margin: 0;
   font-size: 0.95rem;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .acl-hint {
   margin: 0;
   font-size: 0.8rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   line-height: 1.4;
 }
 
@@ -45,14 +45,14 @@
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .acl-input {
   padding: 0.4rem 0.6rem;
-  border: 1px solid var(--ctp-surface2);
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  border: 1px solid var(--color-surface-active);
+  background: var(--color-bg);
+  color: var(--color-text);
   border-radius: var(--radius-md, 4px);
   font: inherit;
   font-size: 0.85rem;
@@ -60,7 +60,7 @@
 
 .acl-input:focus {
   outline: none;
-  border-color: var(--ctp-mauve);
+  border-color: var(--color-accent-alt);
 }
 
 .acl-pubkey-input {
@@ -68,10 +68,10 @@
 }
 
 .acl-input-invalid {
-  border-color: var(--ctp-red);
+  border-color: var(--color-error);
 }
 
 .acl-error-hint {
   font-size: 0.75rem;
-  color: var(--ctp-red);
+  color: var(--color-error);
 }

--- a/src/components/MeshCore/MeshCoreAutomation.css
+++ b/src/components/MeshCore/MeshCoreAutomation.css
@@ -14,9 +14,9 @@
 /* Apply setting-input visual treatment to selects too. */
 .meshcore-automations-view select.setting-input,
 .meshcore-automations-view select.meshcore-select {
-  background: var(--ctp-surface1);
-  border: 2px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 2px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.5rem 0.75rem;
   border-radius: var(--radius-lg, 8px);
   font-size: 0.95rem;
@@ -30,7 +30,7 @@
 .meshcore-automations-view select.setting-input:focus,
 .meshcore-automations-view select.meshcore-select:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 .meshcore-automations-view select:disabled {
   opacity: 0.6;
@@ -51,9 +51,9 @@
 /* Inline text/number/textarea controls inside the trigger cards. */
 .meshcore-automations-view input.meshcore-input,
 .meshcore-automations-view textarea.meshcore-input {
-  background: var(--ctp-surface1);
-  border: 2px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 2px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.4rem 0.6rem;
   border-radius: var(--radius-md, 6px);
   font-size: 0.95rem;
@@ -67,8 +67,8 @@
 .meshcore-automations-view input.meshcore-input:focus,
 .meshcore-automations-view textarea.meshcore-input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
-  background: var(--ctp-base);
+  border-color: var(--color-accent);
+  background: var(--color-bg);
 }
 .meshcore-automations-view input.meshcore-input:disabled,
 .meshcore-automations-view textarea.meshcore-input:disabled {
@@ -97,28 +97,28 @@
 }
 
 .meshcore-automations-view .meshcore-btn-primary {
-  background: var(--ctp-blue);
-  color: var(--ctp-base);
+  background: var(--color-accent);
+  color: var(--color-bg);
 }
 .meshcore-automations-view .meshcore-btn-primary:hover:not(:disabled) {
-  background: var(--ctp-sapphire, var(--ctp-blue));
+  background: var(--color-accent-hover, var(--color-accent));
 }
 
 .meshcore-automations-view .meshcore-btn-danger {
-  background: var(--ctp-red);
-  color: var(--ctp-base);
+  background: var(--color-error);
+  color: var(--color-bg);
 }
 .meshcore-automations-view .meshcore-btn-danger:hover:not(:disabled) {
-  background: var(--ctp-maroon, var(--ctp-red));
+  background: var(--color-danger, var(--color-error));
 }
 
 .meshcore-automations-view .meshcore-btn-secondary {
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-active);
 }
 .meshcore-automations-view .meshcore-btn-secondary:hover:not(:disabled) {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
 }
 
 /* --- Trigger cards ------------------------------------------------- */
@@ -126,8 +126,8 @@
 .meshcore-automations-view .meshcore-trigger-card {
   padding: 1rem 1.25rem;
   margin-bottom: 1rem;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: 8px;
 }
 
@@ -154,18 +154,18 @@
 
 .meshcore-automations-view .meshcore-trigger-card label {
   font-size: 0.85rem;
-  color: var(--ctp-subtext1, var(--ctp-text));
+  color: var(--color-text-muted, var(--color-text));
   display: block;
 }
 
 .meshcore-automations-view .meshcore-trigger-card legend {
   font-size: 0.8rem;
   padding: 0 0.5rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .meshcore-automations-view .meshcore-trigger-card fieldset {
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   border-radius: 6px;
   padding: 0.5rem 0.75rem;
   margin-top: 0.5rem;
@@ -175,24 +175,24 @@
 .meshcore-automations-view .meshcore-add-card {
   padding: 1rem 1.25rem;
   margin-bottom: 1rem;
-  background: var(--ctp-surface0);
-  border: 1px dashed var(--ctp-surface2);
+  background: var(--color-surface);
+  border: 1px dashed var(--color-surface-active);
   border-radius: 8px;
 }
 .meshcore-automations-view .meshcore-add-card h3 {
   margin: 0 0 0.75rem 0;
   font-size: 1rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 /* The "Last run …" banner under each trigger. */
 .meshcore-automations-view .meshcore-trigger-lastrun {
   margin-top: 0.5rem;
   font-size: 0.8rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
-.meshcore-automations-view .meshcore-trigger-lastrun .ok { color: var(--ctp-green); }
-.meshcore-automations-view .meshcore-trigger-lastrun .err { color: var(--ctp-red); }
+.meshcore-automations-view .meshcore-trigger-lastrun .ok { color: var(--color-success); }
+.meshcore-automations-view .meshcore-trigger-lastrun .err { color: var(--color-error); }
 
 /* --- Section header send-now button ------------------------------- */
 
@@ -212,7 +212,7 @@
 
 .meshcore-automations-view .meshcore-token-list-label {
   font-size: 0.8rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin-right: 0.25rem;
 }
 
@@ -223,14 +223,14 @@
   font-size: 0.78rem;
   padding: 0.15rem 0.5rem;
   border-radius: var(--radius-md, 6px);
-  background: var(--ctp-surface1);
-  color: var(--ctp-blue);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-surface-hover);
+  color: var(--color-accent);
+  border: 1px solid var(--color-surface-active);
   cursor: pointer;
   transition: background-color 0.15s, border-color 0.15s;
 }
 .meshcore-automations-view .meshcore-token-chip:hover:not(:disabled) {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   border-color: var(--ctp-overlay0);
 }
 .meshcore-automations-view .meshcore-token-chip:disabled {

--- a/src/components/MeshCore/MeshCorePacketMonitor.css
+++ b/src/components/MeshCore/MeshCorePacketMonitor.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: var(--ctp-base);
+  background: var(--color-bg);
   overflow: hidden;
 }
 
@@ -12,8 +12,8 @@
   align-items: center;
   gap: 12px;
   padding: 12px 16px;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface2);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface-active);
   flex-shrink: 0;
 }
 
@@ -21,14 +21,14 @@
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .mcpm-count {
   font-size: 12px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   padding: 4px 8px;
-  background: var(--ctp-crust);
+  background: var(--color-bg-sunken);
   border-radius: var(--radius-sm);
   font-family: var(--font-mono);
 }
@@ -45,18 +45,18 @@
   align-items: center;
   gap: 6px;
   background: transparent;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
   padding: 6px 10px;
   cursor: pointer;
   font-size: 13px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   transition: all 0.2s;
 }
 
 .mcpm-btn:hover:not(:disabled) {
-  background: var(--ctp-crust);
-  border-color: var(--ctp-blue);
+  background: var(--color-bg-sunken);
+  border-color: var(--color-accent);
 }
 
 .mcpm-btn:disabled {
@@ -65,13 +65,13 @@
 }
 
 .mcpm-btn.active {
-  border-color: var(--ctp-blue);
-  color: var(--ctp-blue);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 .mcpm-btn-danger:hover:not(:disabled) {
-  border-color: var(--ctp-red);
-  color: var(--ctp-red);
+  border-color: var(--color-error);
+  color: var(--color-error);
 }
 
 .mcpm-disabled-banner {
@@ -79,9 +79,9 @@
   align-items: center;
   gap: 12px;
   padding: 10px 16px;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface2);
-  color: var(--ctp-subtext0);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface-active);
+  color: var(--color-text-subtle);
   font-size: 13px;
 }
 
@@ -94,8 +94,8 @@
   flex-wrap: wrap;
   gap: 12px;
   padding: 12px 16px;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface2);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .mcpm-filters label {
@@ -103,16 +103,16 @@
   flex-direction: column;
   gap: 4px;
   font-size: 12px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mcpm-filters select,
 .mcpm-filters input[type='number'] {
   padding: 6px 10px;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  background: var(--color-bg);
+  color: var(--color-text);
   font-size: 13px;
 }
 
@@ -125,10 +125,10 @@
 
 .mcpm-error {
   padding: 8px 16px;
-  background: var(--ctp-crust);
-  color: var(--ctp-red);
+  background: var(--color-bg-sunken);
+  color: var(--color-error);
   font-size: 13px;
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .mcpm-table-container {
@@ -144,7 +144,7 @@
   height: 100%;
   padding: 32px;
   text-align: center;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mcpm-table {
@@ -159,25 +159,25 @@
   z-index: 1;
   text-align: left;
   padding: 8px 12px;
-  background: var(--ctp-mantle);
-  color: var(--ctp-subtext0);
+  background: var(--color-bg-raised);
+  color: var(--color-text-subtle);
   font-weight: 600;
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
   white-space: nowrap;
 }
 
 .mcpm-row {
   cursor: pointer;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 .mcpm-row:hover {
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
 }
 
 .mcpm-row td {
   padding: 6px 12px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   white-space: nowrap;
 }
 
@@ -195,21 +195,21 @@
   display: inline-block;
   padding: 2px 8px;
   border-radius: var(--radius-sm);
-  background: var(--ctp-crust);
-  color: var(--ctp-blue);
+  background: var(--color-bg-sunken);
+  color: var(--color-accent);
   font-family: var(--font-mono);
   font-size: 12px;
 }
 
 .mcpm-route {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 12px;
 }
 
 .mcpm-detail-row td {
   padding: 8px 16px;
-  background: var(--ctp-crust);
-  border-bottom: 1px solid var(--ctp-surface2);
+  background: var(--color-bg-sunken);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .mcpm-detail {
@@ -217,11 +217,11 @@
   flex-direction: column;
   gap: 4px;
   font-size: 12px;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
 }
 
 .mcpm-detail strong {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .mcpm-raw {
@@ -243,8 +243,8 @@
 }
 
 .mcpm-modal-content {
-  background: var(--ctp-base);
-  border: 2px solid var(--ctp-blue);
+  background: var(--color-bg);
+  border: 2px solid var(--color-accent);
   border-radius: 8px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
   width: 100%;
@@ -260,26 +260,26 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.75rem 1rem;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface2);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .mcpm-modal-header h4 {
   margin: 0;
   font-size: 1rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .mcpm-modal-close {
   background: none;
   border: none;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 1.5rem;
   line-height: 1;
   cursor: pointer;
   padding: 0 0.25rem;
 }
-.mcpm-modal-close:hover { color: var(--ctp-text); }
+.mcpm-modal-close:hover { color: var(--color-text); }
 
 .mcpm-modal-body {
   padding: 0.75rem 1rem 1rem;
@@ -295,8 +295,8 @@
   font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--ctp-blue);
-  border-bottom: 1px solid var(--ctp-surface1);
+  color: var(--color-accent);
+  border-bottom: 1px solid var(--color-surface-hover);
   padding-bottom: 0.2rem;
 }
 
@@ -310,11 +310,11 @@
 }
 
 .mcpm-dl-label {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mcpm-dl-value {
-  color: var(--ctp-text);
+  color: var(--color-text);
   min-width: 0;
 }
 
@@ -327,9 +327,9 @@
   margin: 0;
   font-family: var(--font-mono);
   font-size: 0.75rem;
-  color: var(--ctp-subtext1);
-  background: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  color: var(--color-text-muted);
+  background: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: 4px;
   padding: 0.5rem;
   word-break: break-all;
@@ -338,9 +338,9 @@
 
 .mcpm-decode-note {
   font-size: 0.78rem;
-  color: var(--ctp-yellow);
-  background: color-mix(in srgb, var(--ctp-yellow) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--ctp-yellow) 30%, transparent);
+  color: var(--color-warning);
+  background: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-warning) 30%, transparent);
   border-radius: 4px;
   padding: 0.4rem 0.6rem;
 }
@@ -350,7 +350,7 @@
   height: 240px;
   border-radius: 6px;
   overflow: hidden;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
 }
 .mc-route-flow-label {
   font-size: 0.7rem;

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -13,7 +13,7 @@
   flex: 1;
   min-height: 0;
   overflow: hidden;
-  background: var(--ctp-base);
+  background: var(--color-bg);
 }
 
 /* Status strip under the AppHeader */
@@ -23,8 +23,8 @@
   justify-content: space-between;
   gap: 1rem;
   padding: 0.5rem 1rem;
-  background: var(--ctp-surface0);
-  border-bottom: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-surface-hover);
   flex-shrink: 0;
 }
 
@@ -52,18 +52,18 @@
 }
 
 .meshcore-status-bar .status-dot.connected {
-  background: var(--ctp-green);
-  box-shadow: 0 0 8px var(--ctp-green);
+  background: var(--color-success);
+  box-shadow: 0 0 8px var(--color-success);
 }
 
 .meshcore-status-bar .status-text {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-weight: 500;
   font-size: 0.95rem;
 }
 
 .meshcore-status-bar .status-meta {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.8rem;
   white-space: nowrap;
   overflow: hidden;
@@ -71,8 +71,8 @@
 }
 
 .meshcore-status-bar button {
-  background: var(--ctp-mauve);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent-alt);
+  color: var(--color-accent-text);
   border: none;
   padding: 0.4rem 0.85rem;
   border-radius: var(--radius-md);
@@ -83,12 +83,12 @@
 
 .meshcore-status-bar button:hover { background: var(--ctp-pink); }
 .meshcore-status-bar button:disabled {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   color: var(--ctp-overlay0);
   cursor: not-allowed;
 }
-.meshcore-status-bar button.disconnect { background: var(--ctp-red); }
-.meshcore-status-bar button.disconnect:hover { background: var(--ctp-maroon); }
+.meshcore-status-bar button.disconnect { background: var(--color-error); }
+.meshcore-status-bar button.disconnect:hover { background: var(--color-danger); }
 
 /* Error banner */
 .meshcore-error-bar {
@@ -97,14 +97,14 @@
   justify-content: space-between;
   gap: 1rem;
   padding: 0.5rem 1rem;
-  background: var(--ctp-red);
-  color: var(--ctp-accent-text);
+  background: var(--color-error);
+  color: var(--color-accent-text);
 }
 
 .meshcore-error-bar button {
   background: transparent;
-  border: 1px solid var(--ctp-accent-text);
-  color: var(--ctp-accent-text);
+  border: 1px solid var(--color-accent-text);
+  color: var(--color-accent-text);
   padding: 0.2rem 0.6rem;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -128,7 +128,7 @@
   display: inline-block;
   width: 8px;
   height: 8px;
-  background: var(--ctp-red);
+  background: var(--color-error);
   border-radius: var(--radius-full);
   flex-shrink: 0;
   margin-right: 2px;
@@ -154,8 +154,8 @@
 .meshcore-list-pane {
   width: 320px;
   flex-shrink: 0;
-  background: var(--ctp-surface0);
-  border-right: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-surface-hover);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -166,15 +166,15 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.6rem 0.9rem;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface1);
-  color: var(--ctp-text);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface-hover);
+  color: var(--color-text);
   font-weight: 500;
   font-size: 0.95rem;
 }
 
 .meshcore-list-pane-header .pane-count {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: normal;
   font-size: 0.8rem;
 }
@@ -218,9 +218,9 @@
 }
 
 .meshcore-collapse-btn {
-  background: var(--ctp-surface1);
-  border: 2px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 2px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0;
   border-radius: var(--radius-sm);
   font-size: 0.6rem;
@@ -236,9 +236,9 @@
 }
 
 .meshcore-collapse-btn:hover {
-  background: var(--ctp-blue);
-  border-color: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-accent-text);
 }
 
 .meshcore-main-pane {
@@ -266,8 +266,8 @@
 .meshcore-dm-no-messaging {
   padding: 12px 16px;
   font-style: italic;
-  color: var(--ctp-subtext0);
-  border-bottom: 1px solid var(--ctp-surface0);
+  color: var(--color-text-subtle);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 /* Map area */
@@ -280,7 +280,7 @@
 .meshcore-map-pane .leaflet-container {
   height: 100%;
   width: 100%;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
 }
 
 /* Nodes list items — flat row style matching Meshtastic .node-item */
@@ -290,7 +290,7 @@
   gap: 0.2rem;
   padding: 0.5rem 0.75rem;
   cursor: pointer;
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
   background: transparent;
   border-radius: 0;
   margin-bottom: 0;
@@ -299,16 +299,16 @@
   transition: background 0.2s ease;
 }
 
-.mc-node-row:hover { background: var(--ctp-surface1); }
+.mc-node-row:hover { background: var(--color-surface-hover); }
 .mc-node-row.selected {
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
 }
 
 .mc-node-row.selected .mc-node-row-name,
 .mc-node-row.selected .mc-node-row-meta,
 .mc-node-row.selected .mc-node-row-key {
-  color: var(--ctp-accent-text);
+  color: var(--color-accent-text);
 }
 
 /* Nodes-view variant: wrapper div with the row content as one button and a
@@ -343,8 +343,8 @@
   padding: 0 0.7rem;
   background: transparent;
   border: none;
-  border-left: 1px solid var(--ctp-surface1);
-  color: var(--ctp-subtext0);
+  border-left: 1px solid var(--color-surface-hover);
+  color: var(--color-text-subtle);
   font-size: 1.3rem;
   line-height: 1;
   cursor: pointer;
@@ -352,13 +352,13 @@
 }
 
 .mc-node-row-details-btn:hover {
-  color: var(--ctp-blue);
-  background: var(--ctp-surface2);
+  color: var(--color-accent);
+  background: var(--color-surface-active);
 }
 
 .mc-node-row.selected .mc-node-row-details-btn {
-  color: var(--ctp-accent-text);
-  border-left-color: color-mix(in srgb, var(--ctp-accent-text) 30%, transparent);
+  color: var(--color-accent-text);
+  border-left-color: color-mix(in srgb, var(--color-accent-text) 30%, transparent);
 }
 
 /* Favorite (pin-to-top) toggle in each node row (#3588) */
@@ -369,8 +369,8 @@
   padding: 0 0.6rem;
   background: transparent;
   border: none;
-  border-left: 1px solid var(--ctp-surface1);
-  color: var(--ctp-subtext0);
+  border-left: 1px solid var(--color-surface-hover);
+  color: var(--color-text-subtle);
   font-size: 1.2rem;
   line-height: 1;
   cursor: pointer;
@@ -378,12 +378,12 @@
 }
 
 .mc-node-row-favorite-btn:hover {
-  color: var(--ctp-yellow);
-  background: var(--ctp-surface2);
+  color: var(--color-warning);
+  background: var(--color-surface-active);
 }
 
 .mc-node-row-favorite-btn.is-favorite {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .mc-node-row-favorite-btn:disabled {
@@ -395,7 +395,7 @@
 .mc-dm-row-favorite {
   flex: 0 0 auto;
   margin-right: 0.35rem;
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
   line-height: 1;
 }
 
@@ -419,8 +419,8 @@
   display: flex;
   flex-direction: column;
   min-width: 12rem;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-md);
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
   overflow: hidden;
@@ -432,13 +432,13 @@
   padding: 0.5rem 0.85rem;
   text-align: left;
   font-size: 0.85rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   cursor: pointer;
 }
 
 .mc-discover-menu button:hover {
-  background: var(--ctp-surface1);
-  color: var(--ctp-blue);
+  background: var(--color-surface-hover);
+  color: var(--color-accent);
 }
 
 /* Channel list items — card button style matching Meshtastic .channel-button */
@@ -449,8 +449,8 @@
   gap: 0.35rem;
   padding: 1rem 1.25rem;
   margin: 0 0.4rem 0.5rem;
-  background: var(--ctp-surface0);
-  border: 2px solid var(--ctp-surface2);
+  background: var(--color-surface);
+  border: 2px solid var(--color-surface-active);
   border-radius: var(--radius-xl);
   cursor: pointer;
   width: calc(100% - 0.8rem);
@@ -459,16 +459,16 @@
 }
 
 .mc-channel-row:hover {
-  background: var(--ctp-surface1);
-  border-color: var(--ctp-blue);
+  background: var(--color-surface-hover);
+  border-color: var(--color-accent);
   transform: translateY(-2px);
   box-shadow: 0 8px 25px -5px rgba(137, 180, 250, 0.3);
 }
 
 .mc-channel-row.selected {
-  background: var(--ctp-blue);
-  border-color: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-accent-text);
   box-shadow: 0 8px 25px -5px rgba(137, 180, 250, 0.5);
 }
 
@@ -480,12 +480,12 @@
 
 .mc-channel-row-meta {
   font-size: 0.85rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   opacity: 0.7;
 }
 
 .mc-channel-row.selected .mc-channel-row-meta {
-  color: var(--ctp-accent-text);
+  color: var(--color-accent-text);
   opacity: 0.9;
 }
 
@@ -501,13 +501,13 @@
   width: 0.7rem;
   height: 0.7rem;
   border-radius: 50%;
-  background: var(--ctp-blue);
-  box-shadow: 0 0 0 2px var(--ctp-surface0);
+  background: var(--color-accent);
+  box-shadow: 0 0 0 2px var(--color-surface);
 }
 
 .mc-channel-row.selected .mc-channel-unread-dot {
-  background: var(--ctp-accent-text);
-  box-shadow: 0 0 0 2px var(--ctp-blue);
+  background: var(--color-accent-text);
+  box-shadow: 0 0 0 2px var(--color-accent);
 }
 
 .meshcore-list-pane-header-actions {
@@ -524,8 +524,8 @@
   align-items: center;
   justify-content: center;
   border-radius: 999px;
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
   font-size: 0.72rem;
   font-weight: 700;
 }
@@ -537,19 +537,19 @@
   font-size: 1rem;
   line-height: 1;
   padding: 0.1rem 0.2rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mc-channel-sort-toggle.active {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .mc-channel-sort-toggle:hover {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .mc-node-row-name {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-weight: 500;
   font-size: 0.9rem;
   display: flex;
@@ -568,7 +568,7 @@
 .mc-node-row-meta {
   display: flex;
   gap: 0.6rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.75rem;
   flex-wrap: wrap;
 }
@@ -585,7 +585,7 @@
   flex-direction: column;
   flex: 1;
   min-height: 0;
-  background: var(--ctp-base);
+  background: var(--color-bg);
 }
 
 /* DM-variant stream: bounded height so the inner message list scrolls
@@ -619,20 +619,20 @@
 .mc-date-separator::after {
   content: '';
   flex: 1;
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .mc-date-separator-text {
   padding: 0 1rem;
   font-size: 0.75rem;
   font-weight: 600;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .mc-message-row {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
   padding: 0.5rem 0.75rem;
   max-width: 75%;
@@ -641,7 +641,7 @@
 
 .mc-message-row.outgoing {
   align-self: flex-end;
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .mc-message-header {
@@ -653,13 +653,13 @@
 }
 
 .mc-message-from {
-  color: var(--ctp-mauve);
+  color: var(--color-accent-alt);
   font-weight: 500;
 }
 
 /* Message metadata uses subtext0 — sufficient contrast on bright screens (iPad)
    in both Catppuccin light and dark themes (#3769, #3811). */
-.mc-message-time { color: var(--ctp-subtext0); }
+.mc-message-time { color: var(--color-text-subtle); }
 /* Right-side metadata group (timestamp + reply). Keeps the Reply button a
    sibling of the time span — not nested inside it — for cleaner semantics. */
 .mc-message-meta { display: inline-flex; align-items: center; gap: 0.25rem; }
@@ -668,7 +668,7 @@
 .mc-message-reply {
   background: none;
   border: none;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   cursor: pointer;
   padding: 0 0.15rem;
   font-size: 0.8rem;
@@ -676,14 +676,14 @@
   transition: opacity 0.15s, color 0.15s;
 }
 .mc-message-row:hover .mc-message-reply { opacity: 1; }
-.mc-message-reply:hover { color: var(--ctp-mauve); opacity: 1; }
+.mc-message-reply:hover { color: var(--color-accent-alt); opacity: 1; }
 @media (hover: none) { .mc-message-reply { opacity: 1; } }
 /* Per-message delete affordance (#3981). Same subtle-until-hover treatment as
    the reply button; turns red on hover to signal it's destructive. */
 .mc-message-delete {
   background: none;
   border: none;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   cursor: pointer;
   padding: 0 0.15rem;
   font-size: 0.8rem;
@@ -691,7 +691,7 @@
   transition: opacity 0.15s, color 0.15s;
 }
 .mc-message-row:hover .mc-message-delete { opacity: 1; }
-.mc-message-delete:hover { color: var(--ctp-red); opacity: 1; }
+.mc-message-delete:hover { color: var(--color-error); opacity: 1; }
 @media (hover: none) { .mc-message-delete { opacity: 1; } }
 /* Conversation / channel "clear" toolbar above the message stream (#3981). */
 .meshcore-conversation-toolbar {
@@ -701,8 +701,8 @@
 }
 .meshcore-clear-conversation-btn {
   background: none;
-  border: 1px solid var(--ctp-surface1);
-  color: var(--ctp-subtext0);
+  border: 1px solid var(--color-surface-hover);
+  color: var(--color-text-subtle);
   cursor: pointer;
   border-radius: 6px;
   padding: 0.2rem 0.5rem;
@@ -710,13 +710,13 @@
   transition: color 0.15s, border-color 0.15s, background 0.15s;
 }
 .meshcore-clear-conversation-btn:hover {
-  color: var(--ctp-red);
-  border-color: var(--ctp-red);
+  color: var(--color-error);
+  border-color: var(--color-error);
 }
 /* Prominent destructive action: purge every message for the source (#3981). */
 .meshcore-purge-all-btn {
-  background: var(--ctp-red);
-  color: var(--ctp-base);
+  background: var(--color-error);
+  color: var(--color-bg);
   border: none;
   border-radius: 6px;
   padding: 0.4rem 0.75rem;
@@ -726,13 +726,13 @@
 }
 .meshcore-purge-all-btn:hover:not(:disabled) { filter: brightness(1.1); }
 .meshcore-purge-all-btn:disabled { opacity: 0.6; cursor: default; }
-.mc-message-text { color: var(--ctp-text); font-size: 0.9rem; word-wrap: break-word; }
+.mc-message-text { color: var(--color-text); font-size: 0.9rem; word-wrap: break-word; }
 /* Hop count + relay route for received messages (#3742). */
-.mc-message-route { color: var(--ctp-subtext0); font-size: 0.75rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
+.mc-message-route { color: var(--color-text-subtle); font-size: 0.75rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
 /* Signal quality on a directly-received message (#4504). Same muted treatment
    as the rest of the route row — it is provenance, not content. */
-.mc-message-signal { color: var(--ctp-subtext0); white-space: nowrap; }
-.mc-message-scope { color: var(--ctp-subtext0); font-size: 0.75rem; margin-top: 0.1rem; font-family: var(--font-mono, monospace); }
+.mc-message-signal { color: var(--color-text-subtle); white-space: nowrap; }
+.mc-message-scope { color: var(--color-text-subtle); font-size: 0.75rem; margin-top: 0.1rem; font-family: var(--font-mono, monospace); }
 /* Clickable relay-hash chain — opens the route-detail modal (repeater names). */
 .mc-route-chain-link {
   background: none;
@@ -745,16 +745,16 @@
   text-decoration: underline dotted;
   text-underline-offset: 2px;
 }
-.mc-route-chain-link:hover { color: var(--ctp-blue); }
-.mc-route-best-guess { color: var(--ctp-subtext0); font-style: italic; }
+.mc-route-chain-link:hover { color: var(--color-accent); }
+.mc-route-best-guess { color: var(--color-text-subtle); font-style: italic; }
 
 .mc-mention {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   font-weight: 600;
   cursor: default;
   border-radius: var(--radius-sm);
   padding: 0 0.15rem;
-  background: color-mix(in srgb, var(--ctp-blue) 12%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
 }
 
 .mc-delivery-status {
@@ -763,8 +763,8 @@
 }
 
 .mc-delivery-sent { color: var(--ctp-overlay0); }
-.mc-delivery-delivered { color: var(--ctp-green); }
-.mc-delivery-failed { color: var(--ctp-red); }
+.mc-delivery-delivered { color: var(--color-success); }
+.mc-delivery-failed { color: var(--color-error); }
 .mc-delivery-sending { color: var(--ctp-overlay0); }
 
 /* Channel "heard repeaters" badge + expandable list (#3700) */
@@ -774,11 +774,11 @@
   padding: 0;
   border: none;
   background: none;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   cursor: pointer;
 }
 .mc-heard-by-badge:hover {
-  color: var(--ctp-sapphire);
+  color: var(--color-accent-hover);
   text-decoration: underline;
 }
 .mc-heard-by-list {
@@ -786,14 +786,14 @@
   margin: 0.15rem 0 0;
   padding: 0.15rem 0 0 0.5rem;
   font-size: 0.75rem;
-  color: var(--ctp-subtext0);
-  border-left: 2px solid var(--ctp-surface1);
+  color: var(--color-text-subtle);
+  border-left: 2px solid var(--color-surface-hover);
 }
 .mc-heard-by-item {
   line-height: 1.3;
 }
 .mc-heard-by-name {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
 }
 .mc-heard-by-snr {
   color: var(--ctp-overlay0);
@@ -803,27 +803,27 @@
   display: flex;
   gap: 0.5rem;
   padding: 0.6rem 0.75rem;
-  background: var(--ctp-surface0);
-  border-top: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-surface-hover);
 }
 
 .meshcore-send-bar input {
   flex: 1;
-  background: var(--ctp-surface1);
-  border: 1px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.5rem 0.75rem;
   border-radius: var(--radius-md);
 }
 
 .meshcore-send-bar input:focus {
   outline: none;
-  border-color: var(--ctp-mauve);
+  border-color: var(--color-accent-alt);
 }
 
 .meshcore-send-bar button {
-  background: var(--ctp-mauve);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent-alt);
+  color: var(--color-accent-text);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: var(--radius-md);
@@ -833,7 +833,7 @@
 
 .meshcore-send-bar button:hover { background: var(--ctp-pink); }
 .meshcore-send-bar button:disabled {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   color: var(--ctp-overlay0);
   cursor: not-allowed;
 }
@@ -857,8 +857,8 @@
    composer. Scroll the right pane to reach it. */
 .meshcore-detail-pane {
   flex-shrink: 0;
-  background: var(--ctp-base);
-  border-top: 1px solid var(--ctp-surface1);
+  background: var(--color-bg);
+  border-top: 1px solid var(--color-surface-hover);
   padding: 0.75rem;
 }
 
@@ -888,7 +888,7 @@
 }
 
 .meshcore-detail-pane::-webkit-scrollbar-thumb {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   border-radius: var(--radius-xs);
 }
 
@@ -916,27 +916,27 @@
 
 .meshcore-form-view .form-section {
   max-width: 640px;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   padding: 1.5rem;
   margin-bottom: 1.5rem;
 }
 
 .meshcore-form-view .form-section h3 {
-  color: var(--ctp-lavender);
+  color: var(--color-accent-muted);
   font-size: 1.25rem;
   margin-bottom: 1rem;
 }
 
 .meshcore-form-view .form-section p.hint {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.85rem;
   margin-bottom: 0.75rem;
 }
 
 .meshcore-form-view label {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.85rem;
   display: block;
   margin-bottom: 0.25rem;
@@ -944,9 +944,9 @@
 
 .meshcore-form-view input,
 .meshcore-form-view select {
-  background: var(--ctp-surface1);
-  border: 1px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.5rem 0.75rem;
   border-radius: var(--radius-md);
   font-size: 0.9rem;
@@ -957,7 +957,7 @@
 .meshcore-form-view input:focus,
 .meshcore-form-view select:focus {
   outline: none;
-  border-color: var(--ctp-mauve);
+  border-color: var(--color-accent-alt);
 }
 
 .meshcore-form-view .form-row {
@@ -973,8 +973,8 @@
 }
 
 .meshcore-form-view button {
-  background: var(--ctp-mauve);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent-alt);
+  color: var(--color-accent-text);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: var(--radius-md);
@@ -985,7 +985,7 @@
 
 .meshcore-form-view button:hover { background: var(--ctp-pink); }
 .meshcore-form-view button:disabled {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   color: var(--ctp-overlay0);
   cursor: not-allowed;
 }
@@ -1009,7 +1009,7 @@
 }
 
 .meshcore-disconnected-hero-inner {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
   padding: 2rem;
   max-width: 480px;
@@ -1017,12 +1017,12 @@
 }
 
 .meshcore-disconnected-hero-inner h3 {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin-bottom: 0.5rem;
 }
 
 .meshcore-disconnected-hero-inner p {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin-bottom: 1rem;
   font-size: 0.9rem;
 }
@@ -1037,7 +1037,7 @@
 .meshcore-list-pane-body::-webkit-scrollbar-thumb,
 .meshcore-message-list::-webkit-scrollbar-thumb,
 .meshcore-form-view::-webkit-scrollbar-thumb {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   border-radius: var(--radius-xs);
 }
 
@@ -1059,11 +1059,11 @@
 .meshcore-info-empty {
   padding: 2rem;
   text-align: center;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .meshcore-info-error {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .meshcore-info-grid {
@@ -1074,8 +1074,8 @@
 
 /* Info cards — match Meshtastic .info-section vocabulary */
 .meshcore-info-card {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-xl);
   padding: 1.5rem;
 }
@@ -1083,7 +1083,7 @@
 .meshcore-info-card h3 {
   margin: 0 0 1rem 0;
   font-size: 1.25rem;
-  color: var(--ctp-lavender);
+  color: var(--color-accent-muted);
 }
 
 .meshcore-info-card dl {
@@ -1095,19 +1095,19 @@
 }
 
 .meshcore-info-card dt {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   font-weight: 600;
 }
 
 .meshcore-info-card dd {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0;
   font-variant-numeric: tabular-nums;
   word-break: break-word;
 }
 
 .meshcore-info-note {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.85rem;
   font-style: italic;
   margin: 0;
@@ -1115,8 +1115,8 @@
 
 /* Graphs section — wrap as a card to match the info-section card row above */
 .meshcore-info-graphs {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-xl);
   padding: 1.5rem;
 }
@@ -1130,7 +1130,7 @@
 
 .meshcore-info-graphs-header h3 {
   margin: 0;
-  color: var(--ctp-lavender);
+  color: var(--color-accent-muted);
   font-size: 1.25rem;
 }
 
@@ -1141,8 +1141,8 @@
 
 /* Time-range pills — match the inline timeRangeButtonStyle in InfoTab.tsx */
 .meshcore-info-range .mc-range-btn {
-  background: var(--ctp-surface1);
-  color: var(--ctp-subtext0);
+  background: var(--color-surface-hover);
+  color: var(--color-text-subtle);
   border: none;
   padding: 0.25rem 0.75rem;
   border-radius: 4px;
@@ -1153,12 +1153,12 @@
 }
 
 .meshcore-info-range .mc-range-btn:hover {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
 }
 
 .meshcore-info-range .mc-range-btn.active {
-  background: var(--ctp-blue);
-  color: var(--ctp-crust);
+  background: var(--color-accent);
+  color: var(--color-bg-sunken);
   font-weight: 600;
 }
 
@@ -1170,8 +1170,8 @@
 }
 
 .meshcore-info-graph {
-  background: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   padding: 1rem;
 }
@@ -1179,7 +1179,7 @@
 .meshcore-info-graph-title {
   font-size: 1rem;
   font-weight: 500;
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin-bottom: 0.75rem;
 }
 
@@ -1190,10 +1190,10 @@
   vertical-align: middle;
 }
 .mc-room-row-status.logged-in {
-  color: var(--ctp-green);
+  color: var(--color-success);
 }
 .mc-room-row-status.has-saved {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 .mc-room-row-status.not-logged-in {
   color: var(--ctp-overlay0);
@@ -1212,8 +1212,8 @@
   flex-direction: column;
   gap: 0.75rem;
   padding: 1.5rem 2rem;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: 8px;
   max-width: 320px;
   width: 100%;
@@ -1223,11 +1223,11 @@
 .meshcore-room-login-card h3 {
   margin: 0;
   font-size: 1.1rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .meshcore-room-login-name {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.9rem;
   margin: 0;
   word-break: break-all;
@@ -1236,27 +1236,27 @@
 .meshcore-room-login-input {
   padding: 0.5rem 0.75rem;
   border-radius: 4px;
-  border: 1px solid var(--ctp-surface2);
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  border: 1px solid var(--color-surface-active);
+  background: var(--color-bg);
+  color: var(--color-text);
   font-size: 0.9rem;
 }
 .meshcore-room-login-input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .meshcore-room-login-btn {
   padding: 0.5rem 1rem;
   border-radius: 4px;
   border: none;
-  background: var(--ctp-blue);
-  color: var(--ctp-base);
+  background: var(--color-accent);
+  color: var(--color-bg);
   font-size: 0.9rem;
   cursor: pointer;
 }
 .meshcore-room-login-btn:hover:not(:disabled) {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
 }
 .meshcore-room-login-btn:disabled {
   opacity: 0.6;
@@ -1264,7 +1264,7 @@
 }
 
 .meshcore-room-login-error {
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-size: 0.85rem;
 }
 
@@ -1273,7 +1273,7 @@
   align-items: center;
   gap: 0.4rem;
   font-size: 0.85rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   cursor: pointer;
 }
 .meshcore-room-login-remember input {
@@ -1285,24 +1285,24 @@
   align-items: center;
   gap: 1rem;
   padding: 0.5rem 0.75rem;
-  background: var(--ctp-surface0);
-  border-bottom: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-surface-hover);
   font-size: 0.85rem;
   flex-shrink: 0;
 }
 .meshcore-room-stats-name {
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 .meshcore-room-stats-info {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 .meshcore-room-sync-config {
   margin-left: auto;
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 .meshcore-room-sync-config label {
   display: flex;
@@ -1313,17 +1313,17 @@
 .meshcore-room-sync-config select {
   padding: 0.15rem 0.3rem;
   border-radius: 3px;
-  border: 1px solid var(--ctp-surface2);
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  border: 1px solid var(--color-surface-active);
+  background: var(--color-bg);
+  color: var(--color-text);
   font-size: 0.8rem;
 }
 .meshcore-room-sync-save {
   padding: 0.15rem 0.5rem;
   border-radius: 3px;
   border: none;
-  background: var(--ctp-blue);
-  color: var(--ctp-base);
+  background: var(--color-accent);
+  color: var(--color-bg);
   font-size: 0.8rem;
   cursor: pointer;
 }
@@ -1333,7 +1333,7 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.95rem;
 }
 
@@ -1346,17 +1346,17 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.4rem 0.6rem;
-  background: var(--ctp-surface0);
-  border-bottom: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-surface-hover);
   flex-shrink: 0;
   position: relative;
 }
 
 .meshcore-search-input {
   flex: 1;
-  background: var(--ctp-surface1);
-  border: 1px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.35rem 0.6rem;
   border-radius: var(--radius-md);
   font-size: 0.85rem;
@@ -1364,7 +1364,7 @@
 
 .meshcore-search-input:focus {
   outline: none;
-  border-color: var(--ctp-mauve);
+  border-color: var(--color-accent-alt);
 }
 
 .meshcore-search-input::placeholder {
@@ -1384,7 +1384,7 @@
 }
 
 .meshcore-search-clear:hover {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 /* ============================================================
@@ -1416,7 +1416,7 @@
   top: 10px;
   right: 10px;
   z-index: 1000;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   user-select: none;
@@ -1429,7 +1429,7 @@
 .meshcore-map-pane .map-controls-title {
   font-size: 0.8rem;
   font-weight: 600;
-  color: var(--ctp-mauve);
+  color: var(--color-accent-alt);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 0.4rem;
@@ -1447,11 +1447,11 @@
   cursor: pointer;
   width: 16px;
   height: 16px;
-  accent-color: var(--ctp-mauve);
+  accent-color: var(--color-accent-alt);
 }
 
 .meshcore-map-pane .map-control-item span {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.85rem;
   font-weight: 500;
 }
@@ -1465,15 +1465,15 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface1);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface-hover);
   flex-shrink: 0;
 }
 
 .meshcore-mobile-back-btn {
   background: transparent;
-  border: 1px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  border: 1px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.3rem 0.6rem;
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -1484,12 +1484,12 @@
 }
 
 .meshcore-mobile-back-btn:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .meshcore-mobile-back-title {
   font-weight: 500;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1515,7 +1515,7 @@
 
 .meshcore-collapsible-chevron {
   font-size: 0.75rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   transition: transform 0.2s ease;
   flex-shrink: 0;
   margin-left: 0.5rem;
@@ -1587,7 +1587,7 @@
   .meshcore-list-pane {
     width: 100%;
     border-right: none;
-    border-bottom: 1px solid var(--ctp-surface1);
+    border-bottom: 1px solid var(--color-surface-hover);
   }
 
   .meshcore-main-pane {
@@ -1708,7 +1708,7 @@
 .mc-scope-override-toggle {
   background: none;
   border: none;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.75rem;
   padding: 0.15rem 0.25rem;
   cursor: pointer;
@@ -1716,8 +1716,8 @@
 }
 
 .mc-scope-override-toggle:hover {
-  color: var(--ctp-text);
-  background: var(--ctp-surface0);
+  color: var(--color-text);
+  background: var(--color-surface);
 }
 
 .mc-scope-override-row {
@@ -1728,7 +1728,7 @@
 
 .mc-scope-override-label {
   font-size: 0.75rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   white-space: nowrap;
 }
 
@@ -1737,17 +1737,17 @@
   min-width: 0;
   font-size: 0.8rem;
   padding: 0.25rem 0.4rem;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-sm, 4px);
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .mc-scope-override-unscoped {
   flex: 0 0 auto;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
-  color: var(--ctp-subtext0);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
+  color: var(--color-text-subtle);
   cursor: pointer;
   font-size: 0.75rem;
   padding: 0.2rem 0.5rem;
@@ -1756,21 +1756,21 @@
 }
 
 .mc-scope-override-unscoped:hover {
-  color: var(--ctp-text);
+  color: var(--color-text);
   border-color: var(--ctp-overlay0);
 }
 
 /* Active = this send will go out explicitly unscoped (overrideScope === ''). */
 .mc-scope-override-unscoped.active {
-  background: var(--ctp-blue);
-  border-color: var(--ctp-blue);
-  color: var(--ctp-base);
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-bg);
 }
 
 .mc-scope-override-clear {
   background: none;
   border: none;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   cursor: pointer;
   font-size: 0.8rem;
   padding: 0.15rem 0.3rem;
@@ -1778,6 +1778,6 @@
 }
 
 .mc-scope-override-clear:hover {
-  color: var(--ctp-red);
-  background: var(--ctp-surface0);
+  color: var(--color-error);
+  background: var(--color-surface);
 }

--- a/src/components/MeshCore/MeshCoreRemoteConsole.css
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.css
@@ -12,10 +12,10 @@
   gap: 0.75rem;
   padding: 0.75rem;
   margin-top: 0.75rem;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md, 6px);
-  background: var(--ctp-mantle);
-  color: var(--ctp-text);
+  background: var(--color-bg-raised);
+  color: var(--color-text);
 }
 
 .mrc-header {
@@ -29,7 +29,7 @@
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .mrc-status-chip {
@@ -40,20 +40,20 @@
 }
 
 .mrc-status-ok {
-  background: var(--ctp-green);
-  color: var(--ctp-crust);
+  background: var(--color-success);
+  color: var(--color-bg-sunken);
 }
 
 .mrc-status-idle {
-  background: var(--ctp-surface2);
-  color: var(--ctp-subtext0);
+  background: var(--color-surface-active);
+  color: var(--color-text-subtle);
 }
 
 /* Saved-password-available (not yet logged in): teal, distinct from the
    green "session active" so it doesn't read as an active session. */
 .mrc-status-saved {
   background: var(--ctp-teal);
-  color: var(--ctp-crust);
+  color: var(--color-bg-sunken);
 }
 
 .mrc-banner {
@@ -73,23 +73,23 @@
 }
 
 .mrc-banner-warn {
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-yellow);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-warning);
 }
 
 .mrc-banner-warn strong {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .mrc-banner-info {
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-blue);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-accent);
 }
 
 .mrc-muted {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mrc-actions {
@@ -100,7 +100,7 @@
 .mrc-link-btn {
   background: none;
   border: none;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   text-decoration: underline;
   cursor: pointer;
   padding: 0;
@@ -108,14 +108,14 @@
 }
 
 .mrc-link-btn:hover {
-  color: var(--ctp-lavender);
+  color: var(--color-accent-muted);
 }
 
 .mrc-btn-primary {
   padding: 0.4rem 0.9rem;
   border: none;
-  background: var(--ctp-mauve);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent-alt);
+  color: var(--color-accent-text);
   border-radius: var(--radius-md, 4px);
   cursor: pointer;
   font-size: 0.9rem;
@@ -128,16 +128,16 @@
 }
 
 .mrc-btn-primary:disabled {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   color: var(--ctp-overlay0);
   cursor: not-allowed;
 }
 
 .mrc-btn-secondary {
   padding: 0.4rem 0.9rem;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   background: transparent;
-  color: var(--ctp-text);
+  color: var(--color-text);
   border-radius: var(--radius-md, 4px);
   cursor: pointer;
   font-size: 0.9rem;
@@ -145,7 +145,7 @@
 }
 
 .mrc-btn-secondary:hover:not(:disabled) {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .mrc-btn-secondary:disabled {
@@ -156,9 +156,9 @@
 .mrc-transcript {
   max-height: 280px;
   overflow-y: auto;
-  background: var(--ctp-crust);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-sunken);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface);
   border-radius: var(--radius-md, 4px);
   padding: 0.6rem 0.8rem;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -168,7 +168,7 @@
 .mrc-transcript-empty {
   margin: 0;
   font-style: italic;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mrc-line {
@@ -191,27 +191,27 @@
 }
 
 .mrc-line-sent .mrc-line-text {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
 }
 
 .mrc-line-sent .mrc-line-prefix {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
 }
 
 .mrc-line-reply .mrc-line-text {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .mrc-line-error .mrc-line-text {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .mrc-line-error .mrc-line-prefix {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .mrc-line-info .mrc-line-text {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-style: italic;
 }
 
@@ -223,9 +223,9 @@
 .mrc-input {
   flex: 1;
   padding: 0.45rem 0.7rem;
-  border: 1px solid var(--ctp-surface2);
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  border: 1px solid var(--color-surface-active);
+  background: var(--color-bg);
+  color: var(--color-text);
   border-radius: var(--radius-md, 4px);
   font: inherit;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -234,7 +234,7 @@
 
 .mrc-input:focus {
   outline: none;
-  border-color: var(--ctp-mauve);
+  border-color: var(--color-accent-alt);
 }
 
 .mrc-input::placeholder {
@@ -252,9 +252,9 @@
 }
 
 .mrc-modal {
-  background: var(--ctp-mantle);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg-raised);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg, 6px);
   padding: 1rem 1.25rem;
   min-width: 340px;
@@ -267,7 +267,7 @@
 
 .mrc-modal h4 {
   margin: 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .mrc-modal-label {
@@ -275,13 +275,13 @@
   flex-direction: column;
   gap: 0.25rem;
   font-size: 0.9rem;
-  color: var(--ctp-subtext1, var(--ctp-text));
+  color: var(--color-text-muted, var(--color-text));
 }
 
 .mrc-modal-hint {
   margin: 0;
   font-size: 0.8rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mrc-modal-checkbox {
@@ -289,17 +289,17 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.9rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   cursor: pointer;
 }
 
 .mrc-modal-checkbox.mrc-disabled {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   cursor: not-allowed;
 }
 
 .mrc-modal-error {
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-size: 0.85rem;
 }
 
@@ -313,15 +313,15 @@
   margin: 0;
   font-size: 0.9rem;
   line-height: 1.4;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .mrc-modal-danger {
-  border-color: var(--ctp-red);
+  border-color: var(--color-error);
 }
 
 .mrc-modal-danger h4 {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 /* Quick-action buttons row (Phase 4a) */
@@ -334,9 +334,9 @@
 
 .mrc-btn-quick {
   padding: 0.3rem 0.7rem;
-  border: 1px solid var(--ctp-surface2);
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
+  border: 1px solid var(--color-surface-active);
+  background: var(--color-surface);
+  color: var(--color-text);
   border-radius: var(--radius-sm, 4px);
   cursor: pointer;
   font-size: 0.82rem;
@@ -345,8 +345,8 @@
 }
 
 .mrc-btn-quick:hover:not(:disabled) {
-  background: var(--ctp-surface1);
-  border-color: var(--ctp-mauve);
+  background: var(--color-surface-hover);
+  border-color: var(--color-accent-alt);
 }
 
 .mrc-btn-quick:disabled {
@@ -357,8 +357,8 @@
 .mrc-btn-danger {
   padding: 0.4rem 0.9rem;
   border: none;
-  background: var(--ctp-red);
-  color: var(--ctp-accent-text);
+  background: var(--color-error);
+  color: var(--color-accent-text);
   border-radius: var(--radius-md, 4px);
   cursor: pointer;
   font-size: 0.85rem;
@@ -367,11 +367,11 @@
 }
 
 .mrc-btn-danger:hover:not(:disabled) {
-  background: var(--ctp-maroon);
+  background: var(--color-danger);
 }
 
 .mrc-btn-danger:disabled {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   color: var(--ctp-overlay0);
   cursor: not-allowed;
 }

--- a/src/components/MeshCore/MeshCoreRemoteStatsPanel.css
+++ b/src/components/MeshCore/MeshCoreRemoteStatsPanel.css
@@ -3,10 +3,10 @@
  */
 
 .meshcore-remote-stats {
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md, 6px);
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
+  background: var(--color-surface);
+  color: var(--color-text);
 }
 
 .mrs-header {
@@ -21,11 +21,11 @@
 }
 
 .mrs-header:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .mrs-chevron {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.7em;
 }
 
@@ -33,20 +33,20 @@
   margin: 0;
   font-size: 0.95rem;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
   flex: 1;
 }
 
 .mrs-updated {
   font-size: 0.75rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mrs-refresh-btn {
   padding: 0.2rem 0.7rem;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   background: transparent;
-  color: var(--ctp-text);
+  color: var(--color-text);
   border-radius: var(--radius-sm, 3px);
   cursor: pointer;
   font-size: 0.78rem;
@@ -54,8 +54,8 @@
 }
 
 .mrs-refresh-btn:hover:not(:disabled) {
-  background: var(--ctp-surface1);
-  border-color: var(--ctp-mauve);
+  background: var(--color-surface-hover);
+  border-color: var(--color-accent-alt);
 }
 
 .mrs-refresh-btn:disabled {
@@ -65,14 +65,14 @@
 
 .mrs-body {
   padding: 0.5rem 0.75rem 0.75rem;
-  border-top: 1px solid var(--ctp-surface1);
+  border-top: 1px solid var(--color-surface-hover);
 }
 
 .mrs-error,
 .mrs-loading {
   margin: 0;
   font-size: 0.85rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-style: italic;
 }
 
@@ -88,15 +88,15 @@
 .mrs-empty-hint {
   margin: 0;
   font-size: 0.8rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-style: italic;
 }
 
 .mrs-fetch-btn {
   padding: 0.35rem 1rem;
-  border: 1px solid var(--ctp-mauve);
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
+  border: 1px solid var(--color-accent-alt);
+  background: var(--color-surface);
+  color: var(--color-text);
   border-radius: var(--radius-sm, 3px);
   cursor: pointer;
   font-size: 0.82rem;
@@ -105,7 +105,7 @@
 }
 
 .mrs-fetch-btn:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .mrs-grid {
@@ -124,13 +124,13 @@
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .mrs-field-value {
   font-size: 0.95rem;
   font-weight: 500;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-variant-numeric: tabular-nums;
 }
 
@@ -144,7 +144,7 @@
 
 .mrs-section {
   grid-column: 1 / -1;
-  border-top: 1px solid var(--ctp-surface1);
+  border-top: 1px solid var(--color-surface-hover);
   padding-top: 0.5rem;
 }
 
@@ -153,7 +153,7 @@
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--ctp-mauve);
+  color: var(--color-accent-alt);
   font-weight: 600;
 }
 

--- a/src/components/MeshCore/MeshCoreTab.css
+++ b/src/components/MeshCore/MeshCoreTab.css
@@ -10,13 +10,13 @@
 }
 
 .meshcore-tab h2 {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin-bottom: 1.5rem;
   font-size: 1.5rem;
 }
 
 .meshcore-tab h3 {
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   margin-bottom: 1rem;
   font-size: 1.1rem;
   display: flex;
@@ -26,8 +26,8 @@
 
 /* Error banner */
 .meshcore-error {
-  background: var(--ctp-red);
-  color: var(--ctp-accent-text);
+  background: var(--color-error);
+  color: var(--color-accent-text);
   padding: 0.75rem 1rem;
   border-radius: var(--radius-lg);
   margin-bottom: 1rem;
@@ -38,8 +38,8 @@
 
 .meshcore-error button {
   background: transparent;
-  border: 1px solid var(--ctp-base);
-  color: var(--ctp-accent-text);
+  border: 1px solid var(--color-bg);
+  color: var(--color-accent-text);
   padding: 0.25rem 0.5rem;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -47,7 +47,7 @@
 
 /* Sections */
 .meshcore-section {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
   padding: 1.25rem;
   margin-bottom: 1.5rem;
@@ -67,15 +67,15 @@
 }
 
 .form-group label {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.875rem;
 }
 
 .form-group input,
 .form-group select {
-  background: var(--ctp-surface1);
-  border: 1px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.5rem 0.75rem;
   border-radius: var(--radius-md);
   font-size: 0.9rem;
@@ -84,13 +84,13 @@
 .form-group input:focus,
 .form-group select:focus {
   outline: none;
-  border-color: var(--ctp-mauve);
+  border-color: var(--color-accent-alt);
 }
 
 /* Buttons */
 .meshcore-tab button {
-  background: var(--ctp-mauve);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent-alt);
+  color: var(--color-accent-text);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: var(--radius-md);
@@ -104,17 +104,17 @@
 }
 
 .meshcore-tab button:disabled {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   color: var(--ctp-overlay0);
   cursor: not-allowed;
 }
 
 .meshcore-tab button.disconnect {
-  background: var(--ctp-red);
+  background: var(--color-error);
 }
 
 .meshcore-tab button.disconnect:hover {
-  background: var(--ctp-maroon);
+  background: var(--color-danger);
 }
 
 .refresh-btn {
@@ -135,7 +135,7 @@
   align-items: center;
   gap: 0.5rem;
   font-weight: 500;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .status-dot {
@@ -146,15 +146,15 @@
 }
 
 .status-dot.connected {
-  background: var(--ctp-green);
-  box-shadow: 0 0 8px var(--ctp-green);
+  background: var(--color-success);
+  box-shadow: 0 0 8px var(--color-success);
 }
 
 .status-details {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.875rem;
 }
 
@@ -176,7 +176,7 @@
 
 .meshcore-node-item,
 .meshcore-contact-item {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   border-radius: var(--radius-lg);
   padding: 0.75rem 1rem;
   display: flex;
@@ -192,7 +192,7 @@
 
 .node-name,
 .contact-name {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-weight: 500;
   display: flex;
   align-items: center;
@@ -200,8 +200,8 @@
 }
 
 .node-type {
-  background: var(--ctp-surface2);
-  color: var(--ctp-subtext0);
+  background: var(--color-surface-active);
+  color: var(--color-text-subtle);
   padding: 0.125rem 0.5rem;
   border-radius: var(--radius-sm);
   font-size: 0.75rem;
@@ -213,7 +213,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.8rem;
 }
 
@@ -233,7 +233,7 @@
 }
 
 .meshcore-message {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   border-radius: var(--radius-lg);
   padding: 0.75rem;
 }
@@ -245,7 +245,7 @@
 }
 
 .message-from {
-  color: var(--ctp-mauve);
+  color: var(--color-accent-alt);
   font-weight: 500;
   font-size: 0.8rem;
 }
@@ -256,7 +256,7 @@
 }
 
 .message-text {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 /* Send Form */
@@ -266,9 +266,9 @@
 }
 
 .meshcore-send-form select {
-  background: var(--ctp-surface1);
-  border: 1px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.5rem;
   border-radius: var(--radius-md);
   min-width: 150px;
@@ -276,16 +276,16 @@
 
 .meshcore-send-form input {
   flex: 1;
-  background: var(--ctp-surface1);
-  border: 1px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.5rem 0.75rem;
   border-radius: var(--radius-md);
 }
 
 .meshcore-send-form input:focus {
   outline: none;
-  border-color: var(--ctp-mauve);
+  border-color: var(--color-accent-alt);
 }
 
 /* Admin Section */
@@ -297,13 +297,13 @@
 }
 
 .meshcore-admin-status {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   border-radius: var(--radius-lg);
   padding: 1rem;
 }
 
 .meshcore-admin-status h4 {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin-bottom: 0.75rem;
   font-size: 0.9rem;
 }
@@ -312,7 +312,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: 0.5rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.875rem;
 }
 
@@ -334,14 +334,14 @@
 .meshcore-node-list::-webkit-scrollbar-track,
 .meshcore-contact-list::-webkit-scrollbar-track,
 .meshcore-messages::-webkit-scrollbar-track {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xs);
 }
 
 .meshcore-node-list::-webkit-scrollbar-thumb,
 .meshcore-contact-list::-webkit-scrollbar-thumb,
 .meshcore-messages::-webkit-scrollbar-thumb {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   border-radius: var(--radius-xs);
 }
 

--- a/src/components/MessageEmojiButton/MessageEmojiButton.css
+++ b/src/components/MessageEmojiButton/MessageEmojiButton.css
@@ -1,7 +1,7 @@
 .emoji-insert-button {
   background: transparent;
-  border: 1px solid var(--ctp-surface1, #45475a);
-  color: var(--ctp-text, #cdd6f4);
+  border: 1px solid var(--color-surface-hover, #45475a);
+  color: var(--color-text, #cdd6f4);
   cursor: pointer;
   font-size: 1.1rem;
   height: 2.5rem;
@@ -14,11 +14,11 @@
 }
 
 .emoji-insert-button:hover {
-  background: var(--ctp-surface0, #313244);
+  background: var(--color-surface, #313244);
 }
 
 .emoji-insert-button:focus-visible {
-  outline: 2px solid var(--ctp-blue, #89b4fa);
+  outline: 2px solid var(--color-accent, #89b4fa);
   outline-offset: 2px;
 }
 

--- a/src/components/NewsPopup/NewsPopup.css
+++ b/src/components/NewsPopup/NewsPopup.css
@@ -22,7 +22,7 @@
 
 /* Modal content container */
 .news-modal-content {
-  background: var(--ctp-base);
+  background: var(--color-bg);
   border-radius: var(--radius-xl);
   padding: 0;
   max-width: 600px;
@@ -30,7 +30,7 @@
   max-height: 85vh;
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--ctp-surface0);
+  border: 1px solid var(--color-surface);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
 
@@ -40,7 +40,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 1rem 1.5rem;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
   flex-shrink: 0;
 }
 
@@ -52,14 +52,14 @@
 
 .news-modal-header h2 {
   margin: 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.25rem;
 }
 
 .news-pagination {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.875rem;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   padding: 0.25rem 0.75rem;
   border-radius: var(--radius-xl);
 }
@@ -74,7 +74,7 @@
 .news-loading,
 .news-empty {
   text-align: center;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   padding: 2rem;
 }
 
@@ -103,23 +103,23 @@
 }
 
 .news-category-release {
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
 }
 
 .news-category-security {
-  background: var(--ctp-red);
-  color: var(--ctp-accent-text);
+  background: var(--color-error);
+  color: var(--color-accent-text);
 }
 
 .news-category-feature {
-  background: var(--ctp-green);
-  color: var(--ctp-accent-text);
+  background: var(--color-success);
+  color: var(--color-accent-text);
 }
 
 .news-category-maintenance {
-  background: var(--ctp-yellow);
-  color: var(--ctp-accent-text);
+  background: var(--color-warning);
+  color: var(--color-accent-text);
 }
 
 /* Priority badge */
@@ -129,14 +129,14 @@
   text-transform: uppercase;
   padding: 0.25rem 0.5rem;
   border-radius: var(--radius-sm);
-  background: var(--ctp-maroon);
-  color: var(--ctp-accent-text);
+  background: var(--color-danger);
+  color: var(--color-accent-text);
   letter-spacing: 0.05em;
 }
 
 /* Date */
 .news-date {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.875rem;
   margin-left: auto;
 }
@@ -144,7 +144,7 @@
 /* Title */
 .news-item-title {
   margin: 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.5rem;
   font-weight: 600;
   line-height: 1.3;
@@ -152,7 +152,7 @@
 
 /* Content with markdown */
 .news-item-content {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1rem;
   line-height: 1.6;
 }
@@ -166,7 +166,7 @@
 }
 
 .news-item-content a {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   text-decoration: none;
 }
 
@@ -175,7 +175,7 @@
 }
 
 .news-item-content code {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   padding: 0.125rem 0.375rem;
   border-radius: var(--radius-sm);
   font-family: var(--font-mono);
@@ -183,7 +183,7 @@
 }
 
 .news-item-content pre {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   padding: 1rem;
   border-radius: var(--radius-lg);
   overflow-x: auto;
@@ -208,8 +208,8 @@
 .news-item-content blockquote {
   margin: 1rem 0;
   padding-left: 1rem;
-  border-left: 3px solid var(--ctp-surface1);
-  color: var(--ctp-subtext0);
+  border-left: 3px solid var(--color-surface-hover);
+  color: var(--color-text-subtle);
 }
 
 .news-item-content h1,
@@ -217,7 +217,7 @@
 .news-item-content h3,
 .news-item-content h4 {
   margin: 1.5rem 0 0.5rem 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .news-item-content h1:first-child,
@@ -233,7 +233,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 1rem 1.5rem;
-  border-top: 1px solid var(--ctp-surface0);
+  border-top: 1px solid var(--color-surface);
   flex-shrink: 0;
   gap: 1rem;
 }
@@ -252,7 +252,7 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.875rem;
   cursor: pointer;
   user-select: none;
@@ -261,7 +261,7 @@
 .news-dont-show-checkbox input[type='checkbox'] {
   width: 16px;
   height: 16px;
-  accent-color: var(--ctp-blue);
+  accent-color: var(--color-accent);
   cursor: pointer;
 }
 
@@ -277,21 +277,21 @@
 }
 
 .news-button-primary {
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
 }
 
 .news-button-primary:hover {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
 }
 
 .news-button-secondary {
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
+  background: var(--color-surface);
+  color: var(--color-text);
 }
 
 .news-button-secondary:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 /* Responsive adjustments */

--- a/src/components/NodeDetailsBlock.css
+++ b/src/components/NodeDetailsBlock.css
@@ -3,7 +3,7 @@
   width: 100%;
   margin-bottom: 20px;
   padding: 20px;
-  background-color: var(--ctp-mantle);
+  background-color: var(--color-bg-raised);
   border-radius: var(--radius-lg);
 }
 
@@ -15,7 +15,7 @@
 }
 
 .node-details-title {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0;
   font-size: 1.2rem;
   font-weight: 600;
@@ -24,7 +24,7 @@
 .node-details-toggle {
   background: none;
   border: none;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1rem;
   cursor: pointer;
   padding: 5px 10px;
@@ -33,12 +33,12 @@
 }
 
 .node-details-toggle:hover {
-  background-color: var(--ctp-surface0);
-  color: var(--ctp-blue);
+  background-color: var(--color-surface);
+  color: var(--color-accent);
 }
 
 .node-details-toggle:focus {
-  outline: 2px solid var(--ctp-blue);
+  outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 
@@ -49,19 +49,19 @@
 }
 
 .node-detail-card {
-  background-color: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   padding: 12px 15px;
   transition: border-color 0.2s ease;
 }
 
 .node-detail-card:hover {
-  border-color: var(--ctp-surface2);
+  border-color: var(--color-surface-active);
 }
 
 .node-detail-label {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.85rem;
   font-weight: 500;
   margin-bottom: 6px;
@@ -70,14 +70,14 @@
 }
 
 .node-detail-value {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.1rem;
   font-weight: 600;
   transition: color 0.2s ease;
 }
 
 .node-detail-secondary {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.9rem;
   font-weight: 400;
 }
@@ -110,49 +110,49 @@
 
 /* A device-reported fix: the trustworthy case, styled quietly. */
 .position-source-pill-gps {
-  background-color: color-mix(in srgb, var(--ctp-green) 18%, transparent);
-  border-color: color-mix(in srgb, var(--ctp-green) 45%, transparent);
-  color: var(--ctp-green);
+  background-color: color-mix(in srgb, var(--color-success) 18%, transparent);
+  border-color: color-mix(in srgb, var(--color-success) 45%, transparent);
+  color: var(--color-success);
 }
 
 /* A trilaterated guess — the case this pill exists to disclose. */
 .position-source-pill-estimated {
-  background-color: color-mix(in srgb, var(--ctp-peach) 18%, transparent);
-  border-color: color-mix(in srgb, var(--ctp-peach) 45%, transparent);
-  color: var(--ctp-peach);
+  background-color: color-mix(in srgb, var(--color-caution) 18%, transparent);
+  border-color: color-mix(in srgb, var(--color-caution) 45%, transparent);
+  color: var(--color-caution);
 }
 
 /* Operator-placed, so accurate by definition but not from the device. */
 .position-source-pill-override {
-  background-color: color-mix(in srgb, var(--ctp-blue) 18%, transparent);
-  border-color: color-mix(in srgb, var(--ctp-blue) 45%, transparent);
-  color: var(--ctp-blue);
+  background-color: color-mix(in srgb, var(--color-accent) 18%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent) 45%, transparent);
+  color: var(--color-accent);
 }
 
 /* Battery Level Color Indicators */
 .battery-good {
-  color: var(--ctp-green);
+  color: var(--color-success);
 }
 
 .battery-medium {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .battery-low {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 /* Signal Quality Color Indicators */
 .signal-good {
-  color: var(--ctp-green);
+  color: var(--color-success);
 }
 
 .signal-medium {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .signal-low {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 /* Signal Trend Badge (#4110) */
@@ -167,28 +167,28 @@
 }
 
 .signal-trend-improving {
-  color: var(--ctp-green);
+  color: var(--color-success);
 }
 
 .signal-trend-stable {
-  color: var(--ctp-subtext0, var(--ctp-text));
+  color: var(--color-text-subtle, var(--color-text));
 }
 
 .signal-trend-degrading {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 /* Utilization Color Indicators */
 .utilization-good {
-  color: var(--ctp-green);
+  color: var(--color-success);
 }
 
 .utilization-medium {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .utilization-high {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 /* Wide card styling - spans full width */
@@ -207,9 +207,9 @@
   box-sizing: border-box;
   margin-top: 4px;
   padding: 8px 10px;
-  background-color: var(--ctp-base);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-sm);
   font-family: inherit;
   font-size: 0.95rem;
@@ -219,7 +219,7 @@
 
 .node-detail-notes-input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .node-detail-notes-input:disabled {
@@ -235,7 +235,7 @@
 
 .node-detail-notes-error {
   display: block;
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-size: 0.85rem;
   margin-top: 4px;
 }
@@ -247,8 +247,8 @@
 }
 
 .node-detail-notes-save {
-  background-color: var(--ctp-blue);
-  color: var(--ctp-base);
+  background-color: var(--color-accent);
+  color: var(--color-bg);
   border: none;
   border-radius: var(--radius-sm);
   padding: 6px 14px;
@@ -291,13 +291,13 @@
   /* SVG inversion for dark theme - makes dark SVGs visible */
   filter: invert(1) hue-rotate(180deg);
   border-radius: var(--radius-sm);
-  background-color: var(--ctp-crust);
+  background-color: var(--color-bg-sunken);
   padding: 8px;
 }
 
 .hardware-name {
   flex: 1;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 /* Responsive Design */

--- a/src/components/NodeInfoModal/NodeInfoModal.css
+++ b/src/components/NodeInfoModal/NodeInfoModal.css
@@ -5,7 +5,7 @@
 .node-info-section {
   margin-bottom: 1.5rem;
   padding-bottom: 1rem;
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
 }
 
 .node-info-section:last-of-type {
@@ -15,7 +15,7 @@
 .node-info-section-title {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin-bottom: 0.75rem;
 }
 
@@ -28,11 +28,11 @@
 
 .node-info-label {
   font-weight: 500;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .node-info-value {
-  color: var(--ctp-text);
+  color: var(--color-text);
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -43,7 +43,7 @@
 }
 
 .node-info-value.muted {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.9rem;
 }
 
@@ -55,23 +55,23 @@
 }
 
 .override-badge {
-  background-color: var(--ctp-peach);
-  color: var(--ctp-accent-text);
+  background-color: var(--color-caution);
+  color: var(--color-accent-text);
 }
 
 /* Admin Section */
 .admin-section {
-  background-color: var(--ctp-surface0);
+  background-color: var(--color-surface);
   padding: 1rem;
   border-radius: var(--radius-lg);
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   margin-top: 0.5rem;
 }
 
 /* Warning Banner */
 .node-info-warning {
   background-color: rgba(250, 179, 135, 0.15);
-  border: 1px solid var(--ctp-peach);
+  border: 1px solid var(--color-caution);
   border-radius: var(--radius-md);
   padding: 0.75rem 1rem;
   margin-bottom: 1rem;
@@ -79,7 +79,7 @@
 
 .node-info-warning-title {
   font-weight: 600;
-  color: var(--ctp-peach);
+  color: var(--color-caution);
   margin-bottom: 0.5rem;
 }
 
@@ -87,7 +87,7 @@
   margin: 0;
   padding-left: 1.25rem;
   font-size: 0.9rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .node-info-warning-list li {
@@ -101,8 +101,8 @@
 /* Success Message */
 .node-info-success {
   background-color: rgba(166, 227, 161, 0.15);
-  border: 1px solid var(--ctp-green);
-  color: var(--ctp-green);
+  border: 1px solid var(--color-success);
+  color: var(--color-success);
   padding: 0.75rem;
   border-radius: var(--radius-sm);
   margin-bottom: 1rem;
@@ -111,9 +111,9 @@
 
 /* Change IP Button */
 .change-ip-btn {
-  background-color: var(--ctp-surface1);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface2);
+  background-color: var(--color-surface-hover);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-active);
   padding: 0.5rem 1rem;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -122,8 +122,8 @@
 }
 
 .change-ip-btn:hover:not(:disabled) {
-  background-color: var(--ctp-surface2);
-  border-color: var(--ctp-blue);
+  background-color: var(--color-surface-active);
+  border-color: var(--color-accent);
 }
 
 .change-ip-btn:disabled {
@@ -145,28 +145,28 @@
 
 .node-info-field label {
   font-weight: 500;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
 }
 
 .node-info-field input {
   padding: 0.75rem;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
-  background-color: var(--ctp-crust);
-  color: var(--ctp-text);
+  background-color: var(--color-bg-sunken);
+  color: var(--color-text);
   font-size: 1rem;
   font-family: var(--font-mono);
 }
 
 .node-info-field input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
   box-shadow: 0 0 0 2px rgba(137, 180, 250, 0.2);
 }
 
 .node-info-field input.input-error {
-  border-color: var(--ctp-red);
+  border-color: var(--color-error);
 }
 
 .node-info-field input.input-error:focus {
@@ -174,7 +174,7 @@
 }
 
 .node-info-field .error-message {
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-size: 0.85rem;
   margin-top: 0.25rem;
 }
@@ -187,8 +187,8 @@
 }
 
 .node-info-form-actions .cancel-btn {
-  background-color: var(--ctp-surface1);
-  color: var(--ctp-text);
+  background-color: var(--color-surface-hover);
+  color: var(--color-text);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: var(--radius-sm);
@@ -197,12 +197,12 @@
 }
 
 .node-info-form-actions .cancel-btn:hover:not(:disabled) {
-  background-color: var(--ctp-surface2);
+  background-color: var(--color-surface-active);
 }
 
 .node-info-form-actions .save-btn {
-  background-color: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background-color: var(--color-accent);
+  color: var(--color-accent-text);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: var(--radius-sm);
@@ -211,7 +211,7 @@
 }
 
 .node-info-form-actions .save-btn:hover:not(:disabled) {
-  background-color: var(--ctp-sapphire);
+  background-color: var(--color-accent-hover);
 }
 
 .node-info-form-actions .save-btn:disabled,
@@ -228,8 +228,8 @@
 }
 
 .node-info-actions .close-btn {
-  background-color: var(--ctp-surface1);
-  color: var(--ctp-text);
+  background-color: var(--color-surface-hover);
+  color: var(--color-text);
   border: none;
   padding: 0.75rem 1.5rem;
   border-radius: var(--radius-sm);
@@ -239,7 +239,7 @@
 }
 
 .node-info-actions .close-btn:hover:not(:disabled) {
-  background-color: var(--ctp-surface2);
+  background-color: var(--color-surface-active);
 }
 
 .node-info-actions .close-btn:disabled {

--- a/src/components/PacketMonitorPanel.css
+++ b/src/components/PacketMonitorPanel.css
@@ -3,8 +3,8 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: var(--ctp-base);
-  border-left: 1px solid var(--ctp-surface2);
+  background: var(--color-bg);
+  border-left: 1px solid var(--color-surface-active);
   overflow: hidden;
 }
 
@@ -27,8 +27,8 @@
   align-items: center;
   gap: 12px;
   padding: 12px 16px;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface2);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface-active);
   flex-shrink: 0;
 }
 
@@ -36,14 +36,14 @@
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .packet-count {
   font-size: 12px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   padding: 4px 8px;
-  background: var(--ctp-crust);
+  background: var(--color-bg-sunken);
   border-radius: var(--radius-sm);
   font-family: var(--font-mono);
 }
@@ -57,18 +57,18 @@
 
 .control-btn {
   background: transparent;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
   padding: 6px 10px;
   cursor: pointer;
   font-size: 14px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   transition: all 0.2s;
 }
 
 .control-btn:hover:not(:disabled) {
-  background: var(--ctp-crust);
-  border-color: var(--ctp-blue);
+  background: var(--color-bg-sunken);
+  border-color: var(--color-accent);
 }
 
 .control-btn:disabled {
@@ -81,13 +81,13 @@
   border: none;
   font-size: 24px;
   cursor: pointer;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   padding: 0 8px;
   transition: color 0.2s;
 }
 
 .close-btn:hover {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .packet-monitor-no-permission {
@@ -97,19 +97,19 @@
   height: 100%;
   padding: 32px;
   text-align: center;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .packet-monitor-no-permission strong {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
 }
 
 .packet-filters {
   display: flex;
   gap: 8px;
   padding: 12px 16px;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface2);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface-active);
   flex-wrap: wrap;
 }
 
@@ -117,38 +117,38 @@
   flex: 1;
   min-width: 150px;
   padding: 6px 10px;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  background: var(--color-bg);
+  color: var(--color-text);
   font-size: 13px;
 }
 
 .packet-filters select option {
-  background: var(--ctp-surface0, #313244);
-  color: var(--ctp-text, #cdd6f4);
+  background: var(--color-surface, #313244);
+  color: var(--color-text, #cdd6f4);
   padding: 6px;
 }
 
 .packet-filters select option:hover {
-  background: var(--ctp-surface1, #45475a);
+  background: var(--color-surface-hover, #45475a);
 }
 
 .clear-filters-btn {
   padding: 6px 12px;
-  background: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 13px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   transition: all 0.2s;
 }
 
 .clear-filters-btn:hover {
-  background: var(--ctp-blue);
+  background: var(--color-accent);
   color: white;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .packet-table-container {
@@ -163,7 +163,7 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 14px;
 }
 
@@ -180,7 +180,7 @@
 .packet-table thead {
   position: sticky;
   top: 0;
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   z-index: 10;
 }
 
@@ -188,19 +188,19 @@
   padding: 10px 8px;
   text-align: left;
   font-weight: 600;
-  color: var(--ctp-subtext0);
-  border-bottom: 2px solid var(--ctp-surface2);
+  color: var(--color-text-subtle);
+  border-bottom: 2px solid var(--color-surface-active);
   white-space: nowrap;
 }
 
 .packet-table tbody tr {
   cursor: pointer;
   transition: background 0.2s;
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .packet-table tbody tr:hover {
-  background: var(--ctp-crust);
+  background: var(--color-bg-sunken);
 }
 
 .packet-table tbody tr.selected {
@@ -209,7 +209,7 @@
 
 .packet-table td {
   padding: 8px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -217,7 +217,7 @@
 
 .packet-table .packet-number {
   font-size: 11px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-family: var(--font-mono);
   font-weight: 600;
   padding-right: 12px;
@@ -225,7 +225,7 @@
 
 .packet-table .timestamp {
   font-size: 12px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .packet-table .from-node,
@@ -234,7 +234,7 @@
 }
 
 .node-id-link {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   cursor: pointer;
   text-decoration: underline;
   text-decoration-style: dotted;
@@ -242,12 +242,12 @@
 }
 
 .node-id-link:hover {
-  color: var(--ctp-sapphire);
+  color: var(--color-accent-hover);
   text-decoration-style: solid;
 }
 
 .hops-link {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   cursor: pointer;
   text-decoration: underline;
   text-decoration-style: dotted;
@@ -255,7 +255,7 @@
 }
 
 .hops-link:hover {
-  color: var(--ctp-sapphire);
+  color: var(--color-accent-hover);
   text-decoration-style: solid;
 }
 
@@ -284,7 +284,7 @@
 }
 
 .relay-link {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   cursor: pointer;
   text-decoration: underline;
   text-decoration-style: dotted;
@@ -292,7 +292,7 @@
 }
 
 .relay-link:hover {
-  color: var(--ctp-sapphire);
+  color: var(--color-accent-hover);
   text-decoration-style: solid;
 }
 
@@ -322,21 +322,21 @@
 }
 
 .packet-table .direction-rx {
-  color: var(--ctp-green, #a6e3a1);
+  color: var(--color-success, #a6e3a1);
 }
 
 .packet-table .direction-tx {
-  color: var(--ctp-peach, #fab387);
+  color: var(--color-caution, #fab387);
 }
 
 /* Impersonation/spoof-suspected packet (#2584): claims our local node id but
    arrived over RF. */
 .packet-table .direction.spoofed {
-  color: var(--ctp-red, #f38ba8);
+  color: var(--color-error, #f38ba8);
 }
 
 .packet-table tr.spoofed-row td {
-  background: color-mix(in srgb, var(--ctp-red, #f38ba8) 12%, transparent);
+  background: color-mix(in srgb, var(--color-error, #f38ba8) 12%, transparent);
 }
 
 /* Transport mechanism column colors */
@@ -346,22 +346,22 @@
 }
 
 .packet-table .transport-0 { /* INTERNAL */
-  color: var(--ctp-subtext1, #a6adc8);
+  color: var(--color-text-muted, #a6adc8);
 }
 
 .packet-table .transport-1,
 .packet-table .transport-2,
 .packet-table .transport-3,
 .packet-table .transport-4 { /* LORA variants */
-  color: var(--ctp-green, #a6e3a1);
+  color: var(--color-success, #a6e3a1);
 }
 
 .packet-table .transport-5 { /* MQTT */
-  color: var(--ctp-mauve, #cba6f7);
+  color: var(--color-accent-alt, #cba6f7);
 }
 
 .packet-table .transport-6 { /* UDP */
-  color: var(--ctp-blue, #89b4fa);
+  color: var(--color-accent, #89b4fa);
 }
 
 .packet-table .transport-7 { /* API */
@@ -369,7 +369,7 @@
 }
 
 .packet-table .transport-unknown {
-  color: var(--ctp-subtext0, #6c7086);
+  color: var(--color-text-subtle, #6c7086);
 }
 
 .encrypted-indicator {
@@ -397,8 +397,8 @@
 }
 
 .packet-detail-content {
-  background: var(--ctp-surface0, #313244);
-  border: 3px solid var(--ctp-blue, #4a9eff);
+  background: var(--color-surface, #313244);
+  border: 3px solid var(--color-accent, #4a9eff);
   border-radius: var(--radius-xl);
   max-width: 600px;
   width: 100%;
@@ -409,7 +409,7 @@
               0 0 20px rgba(74, 158, 255, 0.2);
   position: relative;
   z-index: 10000;
-  color: var(--ctp-text, #cdd6f4);
+  color: var(--color-text, #cdd6f4);
 }
 
 .packet-detail-header {
@@ -417,8 +417,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface2);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface-active);
   border-radius: 8px 8px 0 0;
 }
 
@@ -426,7 +426,7 @@
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .packet-detail-body {
@@ -443,12 +443,12 @@
 
 .detail-label {
   font-weight: 600;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 13px;
 }
 
 .detail-value {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 13px;
   word-break: break-word;
 }
@@ -468,10 +468,10 @@
 }
 
 .detail-value-json {
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   padding: 8px 12px;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.4;
@@ -480,16 +480,16 @@
   margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .payload-content,
 .metadata-json,
 .packet-json {
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   padding: 12px;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.4;
@@ -520,7 +520,7 @@
 .payload-content::-webkit-scrollbar-track,
 .metadata-json::-webkit-scrollbar-track,
 .packet-json::-webkit-scrollbar-track {
-  background: var(--ctp-crust);
+  background: var(--color-bg-sunken);
 }
 
 .packet-table-container::-webkit-scrollbar-thumb,
@@ -528,7 +528,7 @@
 .payload-content::-webkit-scrollbar-thumb,
 .metadata-json::-webkit-scrollbar-thumb,
 .packet-json::-webkit-scrollbar-thumb {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   border-radius: var(--radius-sm);
 }
 
@@ -537,5 +537,5 @@
 .payload-content::-webkit-scrollbar-thumb:hover,
 .metadata-json::-webkit-scrollbar-thumb:hover,
 .packet-json::-webkit-scrollbar-thumb:hover {
-  background: var(--ctp-subtext0);
+  background: var(--color-text-subtle);
 }

--- a/src/components/PositionOverrideModal/PositionOverrideModal.css
+++ b/src/components/PositionOverrideModal/PositionOverrideModal.css
@@ -5,12 +5,12 @@
 .position-override-loading {
   text-align: center;
   padding: 2rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .position-override-description {
   margin-bottom: 1.5rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.95rem;
   line-height: 1.5;
 }
@@ -29,14 +29,14 @@
 .private-checkbox {
   margin-left: 1.5rem;
   padding: 0.75rem;
-  background-color: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
   transition: all 0.2s ease;
 }
 
 .private-checkbox:hover {
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .private-checkbox label {
@@ -84,34 +84,34 @@
 
 .position-override-field label {
   font-weight: 500;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .position-override-field .field-description {
   display: block;
   font-size: 0.85rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: normal;
   margin-top: 2px;
 }
 
 .position-override-field input {
   padding: 0.75rem;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-sm);
-  background-color: var(--ctp-surface0);
-  color: var(--ctp-text);
+  background-color: var(--color-surface);
+  color: var(--color-text);
   font-size: 1rem;
 }
 
 .position-override-field input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
   box-shadow: 0 0 0 2px rgba(137, 180, 250, 0.2);
 }
 
 .position-override-field input.input-error {
-  border-color: var(--ctp-red);
+  border-color: var(--color-error);
 }
 
 .position-override-field input.input-error:focus {
@@ -119,7 +119,7 @@
 }
 
 .position-override-field .error-message {
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-size: 0.85rem;
   margin-top: 0.25rem;
 }
@@ -129,7 +129,7 @@
 }
 
 .position-override-link a {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   text-decoration: none;
   font-size: 0.9rem;
 }
@@ -140,8 +140,8 @@
 
 .position-override-error {
   background-color: rgba(243, 139, 168, 0.1);
-  border: 1px solid var(--ctp-red);
-  color: var(--ctp-red);
+  border: 1px solid var(--color-error);
+  color: var(--color-error);
   padding: 0.75rem;
   border-radius: var(--radius-sm);
   margin-bottom: 1rem;
@@ -156,8 +156,8 @@
 }
 
 .position-override-actions .cancel-btn {
-  background-color: var(--ctp-surface1);
-  color: var(--ctp-text);
+  background-color: var(--color-surface-hover);
+  color: var(--color-text);
   border: none;
   padding: 0.75rem 1.5rem;
   border-radius: var(--radius-sm);
@@ -167,12 +167,12 @@
 }
 
 .position-override-actions .cancel-btn:hover:not(:disabled) {
-  background-color: var(--ctp-surface2);
+  background-color: var(--color-surface-active);
 }
 
 .position-override-actions .save-btn {
-  background-color: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background-color: var(--color-accent);
+  color: var(--color-accent-text);
   border: none;
   padding: 0.75rem 1.5rem;
   border-radius: var(--radius-sm);
@@ -182,7 +182,7 @@
 }
 
 .position-override-actions .save-btn:hover:not(:disabled) {
-  background-color: var(--ctp-sapphire);
+  background-color: var(--color-accent-hover);
 }
 
 .position-override-actions .save-btn:disabled,

--- a/src/components/RelayNodeModal.css
+++ b/src/components/RelayNodeModal.css
@@ -4,7 +4,7 @@
 }
 
 .relay-info-section {
-  background-color: var(--ctp-mantle);
+  background-color: var(--color-bg-raised);
   border-radius: var(--radius-md);
   padding: 16px;
   margin-bottom: 24px;
@@ -18,34 +18,34 @@
 }
 
 .relay-info-row:not(:last-child) {
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .unknown-relay-notice {
   margin: 12px 0 0 0;
   padding: 12px;
-  background-color: var(--ctp-surface0);
-  border-left: 4px solid var(--ctp-blue);
+  background-color: var(--color-surface);
+  border-left: 4px solid var(--color-accent);
   border-radius: var(--radius-sm);
   font-size: 0.9em;
-  color: var(--ctp-text);
+  color: var(--color-text);
   line-height: 1.5;
 }
 
 .relay-info-label {
   font-weight: 600;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .relay-info-value {
   font-family: var(--font-mono);
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .potential-relays-section h3 {
   margin-top: 0;
   margin-bottom: 16px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.1em;
 }
 
@@ -60,27 +60,27 @@
   flex-direction: column;
   gap: 8px;
   padding: 12px 16px;
-  background-color: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface2);
+  background-color: var(--color-bg-raised);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
 .relay-node-item:hover {
-  background-color: var(--ctp-surface0);
-  border-color: var(--ctp-blue);
+  background-color: var(--color-surface);
+  border-color: var(--color-accent);
   transform: translateX(4px);
 }
 
 .relay-node-item:focus {
-  outline: 2px solid var(--ctp-blue);
+  outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 
 .relay-node-item.never-heard {
   opacity: 0.6;
-  background-color: var(--ctp-crust);
+  background-color: var(--color-bg-sunken);
 }
 
 .relay-node-item.never-heard:hover {
@@ -103,7 +103,7 @@
 
 .node-name {
   font-weight: 500;
-  color: var(--ctp-text);
+  color: var(--color-text);
   flex: 1;
   display: flex;
   align-items: center;
@@ -111,7 +111,7 @@
 }
 
 .direct-indicator {
-  color: var(--ctp-green);
+  color: var(--color-success);
   font-weight: bold;
   margin-right: 4px;
 }
@@ -124,8 +124,8 @@
 .node-rssi {
   font-family: var(--font-mono);
   font-size: 0.85em;
-  color: var(--ctp-blue);
-  background-color: var(--ctp-surface0);
+  color: var(--color-accent);
+  background-color: var(--color-surface);
   padding: 2px 8px;
   border-radius: 10px;
   flex-shrink: 0;
@@ -133,8 +133,8 @@
 
 .node-hops {
   font-size: 0.85em;
-  color: var(--ctp-green);
-  background-color: var(--ctp-surface0);
+  color: var(--color-success);
+  background-color: var(--color-surface);
   padding: 2px 8px;
   border-radius: 10px;
   flex-shrink: 0;
@@ -142,15 +142,15 @@
 
 .node-id {
   font-family: var(--font-mono);
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.9em;
 }
 
 .no-matches {
   padding: 20px;
   text-align: center;
-  color: var(--ctp-subtext0);
-  background-color: var(--ctp-mantle);
+  color: var(--color-text-subtle);
+  background-color: var(--color-bg-raised);
   border-radius: var(--radius-md);
   font-style: italic;
 }
@@ -158,11 +158,11 @@
 .multiple-matches-note {
   margin-top: 16px;
   padding: 12px;
-  background-color: var(--ctp-surface0);
-  border-left: 4px solid var(--ctp-yellow);
+  background-color: var(--color-surface);
+  border-left: 4px solid var(--color-warning);
   border-radius: var(--radius-sm);
   font-size: 0.9em;
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 /* Dark mode adjustments */

--- a/src/components/SaveBar/SaveBar.css
+++ b/src/components/SaveBar/SaveBar.css
@@ -4,8 +4,8 @@
   right: 0;
   bottom: 0;
   z-index: 10000;
-  background: var(--ctp-surface0);
-  border-top: 2px solid var(--ctp-green);
+  background: var(--color-surface);
+  border-top: 2px solid var(--color-success);
   animation: saveBarSlideIn 0.3s ease-out;
   box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.15);
   padding-bottom: env(safe-area-inset-bottom);
@@ -61,23 +61,23 @@
 
 .save-bar-tab {
   padding: 0.375rem 0.75rem;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  color: var(--color-text);
   font-size: 0.85rem;
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
 .save-bar-tab:hover:not(:disabled) {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
 }
 
 .save-bar-tab.active {
-  background: var(--ctp-green);
-  color: var(--ctp-accent-text);
-  border-color: var(--ctp-green);
+  background: var(--color-success);
+  color: var(--color-accent-text);
+  border-color: var(--color-success);
 }
 
 .save-bar-tab:disabled {
@@ -86,7 +86,7 @@
 }
 
 .save-bar-message {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.95rem;
   font-weight: 500;
 }
@@ -98,18 +98,18 @@
 
 .save-bar-dismiss {
   padding: 0.5rem 1rem;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.9rem;
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
 .save-bar-dismiss:hover:not(:disabled) {
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  color: var(--color-text);
 }
 
 .save-bar-dismiss:disabled {
@@ -121,8 +121,8 @@
   padding: 0.5rem 1.5rem;
   border: none;
   border-radius: var(--radius-sm);
-  background: var(--ctp-green);
-  color: var(--ctp-accent-text);
+  background: var(--color-success);
+  color: var(--color-accent-text);
   font-size: 0.9rem;
   font-weight: 600;
   cursor: pointer;
@@ -146,8 +146,8 @@
   height: 20px;
   padding: 0 6px;
   border-radius: 10px;
-  background: var(--ctp-red);
-  color: var(--ctp-accent-text);
+  background: var(--color-error);
+  color: var(--color-accent-text);
   font-size: 0.75rem;
   font-weight: 600;
   display: flex;

--- a/src/components/SearchModal/SearchModal.css
+++ b/src/components/SearchModal/SearchModal.css
@@ -15,14 +15,14 @@
 }
 
 .search-modal {
-  background: var(--ctp-base);
+  background: var(--color-bg);
   border-radius: var(--radius-xl);
   max-width: 700px;
   width: 90%;
   max-height: calc(75vh - var(--keyboard-inset, 0px));
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--ctp-surface0);
+  border: 1px solid var(--color-surface);
   overflow: hidden;
 }
 
@@ -31,12 +31,12 @@
   justify-content: space-between;
   align-items: center;
   padding: 1rem 1.5rem;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 .search-modal-header h2 {
   margin: 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.25rem;
 }
 
@@ -44,14 +44,14 @@
   background: none;
   border: none;
   font-size: 1.5rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   cursor: pointer;
   padding: 0;
   line-height: 1;
 }
 
 .search-modal-close:hover {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .search-modal-body {
@@ -70,26 +70,26 @@
 .search-input-row input[type="text"] {
   flex: 1;
   padding: 0.6rem 0.75rem;
-  background-color: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-raised);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.95rem;
 }
 
 .search-input-row input[type="text"]::placeholder {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .search-input-row input[type="text"]:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
   box-shadow: 0 0 0 2px rgba(137, 180, 250, 0.2);
 }
 
 .search-submit-btn {
-  background-color: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background-color: var(--color-accent);
+  color: var(--color-accent-text);
   border: none;
   padding: 0.6rem 1.25rem;
   border-radius: var(--radius-md);
@@ -101,7 +101,7 @@
 }
 
 .search-submit-btn:hover:not(:disabled) {
-  background-color: var(--ctp-sapphire);
+  background-color: var(--color-accent-hover);
 }
 
 .search-submit-btn:disabled {
@@ -115,7 +115,7 @@
   gap: 0.75rem;
   padding-bottom: 0.75rem;
   margin-bottom: 0.75rem;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
   align-items: flex-end;
 }
 
@@ -127,24 +127,24 @@
 
 .search-filter-group label {
   font-size: 0.8rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: 500;
 }
 
 .search-filter-group select,
 .search-filter-group input[type="date"] {
   padding: 0.4rem 0.5rem;
-  background-color: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-raised);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.85rem;
 }
 
 .search-filter-group select:focus,
 .search-filter-group input[type="date"]:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
   box-shadow: 0 0 0 2px rgba(137, 180, 250, 0.2);
 }
 
@@ -153,18 +153,18 @@
   align-items: center;
   gap: 0.4rem;
   font-size: 0.85rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   cursor: pointer;
   padding-bottom: 0.15rem;
 }
 
 .search-case-toggle input[type="checkbox"] {
-  accent-color: var(--ctp-blue);
+  accent-color: var(--color-accent);
 }
 
 .search-results-header {
   font-size: 0.85rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin-bottom: 0.5rem;
 }
 
@@ -176,14 +176,14 @@
 
 .search-result-item {
   padding: 0.75rem;
-  border: 1px solid var(--ctp-surface0);
+  border: 1px solid var(--color-surface);
   border-radius: var(--radius-lg);
   cursor: pointer;
   transition: background-color 0.15s ease;
 }
 
 .search-result-item:hover {
-  background-color: var(--ctp-surface0);
+  background-color: var(--color-surface);
 }
 
 .search-result-meta {
@@ -196,30 +196,30 @@
 
 .search-result-context {
   font-size: 0.8rem;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   font-weight: 500;
 }
 
 .search-result-sender {
   font-size: 0.8rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .search-result-time {
   font-size: 0.75rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .search-result-text {
   font-size: 0.9rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   line-height: 1.4;
   word-break: break-word;
 }
 
 .search-result-text mark {
-  background-color: var(--ctp-yellow);
-  color: var(--ctp-accent-text);
+  background-color: var(--color-warning);
+  color: var(--color-accent-text);
   border-radius: var(--radius-xs);
   padding: 0 2px;
 }
@@ -231,8 +231,8 @@
 }
 
 .search-load-more-btn {
-  background-color: var(--ctp-surface1);
-  color: var(--ctp-text);
+  background-color: var(--color-surface-hover);
+  color: var(--color-text);
   border: none;
   padding: 0.5rem 1.5rem;
   border-radius: var(--radius-md);
@@ -243,7 +243,7 @@
 }
 
 .search-load-more-btn:hover:not(:disabled) {
-  background-color: var(--ctp-surface2);
+  background-color: var(--color-surface-active);
 }
 
 .search-load-more-btn:disabled {
@@ -254,28 +254,28 @@
 .search-loading {
   text-align: center;
   padding: 1.5rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.9rem;
 }
 
 .search-error {
   text-align: center;
   padding: 1rem;
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-size: 0.9rem;
 }
 
 .search-no-results {
   text-align: center;
   padding: 1.5rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.9rem;
 }
 
 .search-min-length {
   text-align: center;
   padding: 1rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.85rem;
 }
 

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -12,8 +12,8 @@
 .sidebar {
   --source-nav-collapsed-width: calc(60px + env(safe-area-inset-left, 0px));
   --source-nav-expanded-width: calc(240px + env(safe-area-inset-left, 0px));
-  --source-nav-bg: var(--ctp-base);
-  --source-nav-border: 1px solid var(--ctp-surface1);
+  --source-nav-bg: var(--color-bg);
+  --source-nav-border: 1px solid var(--color-surface-hover);
 
   position: fixed;
   left: 0;
@@ -34,7 +34,7 @@
    carries its own CSS module. .github-link survives — LoginPage uses it. */
 
 .github-link {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -43,13 +43,13 @@
 }
 
 .github-link:hover {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .sidebar-toggle {
-  background: var(--ctp-blue, #2a2a2a);
-  border: 1px solid var(--ctp-sapphire, #333);
-  color: var(--ctp-base, #e0e0e0);
+  background: var(--color-accent, #2a2a2a);
+  border: 1px solid var(--color-accent-hover, #333);
+  color: var(--color-bg, #e0e0e0);
   width: 36px;
   height: 36px;
   border-radius: var(--radius-md);
@@ -64,7 +64,7 @@
 }
 
 .sidebar-toggle:hover {
-  background: var(--ctp-sapphire, #74c7ec);
+  background: var(--color-accent-hover, #74c7ec);
   transform: scale(1.05);
 }
 
@@ -87,9 +87,9 @@
 }
 
 .sidebar-pin {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
-  color: var(--ctp-subtext0);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
+  color: var(--color-text-subtle);
   width: 36px;
   height: 36px;
   border-radius: var(--radius-md);
@@ -103,30 +103,30 @@
 }
 
 .sidebar-pin:hover {
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  color: var(--color-text);
   transform: scale(1.05);
 }
 
 .sidebar-pin.pinned {
-  background: var(--ctp-green);
-  border-color: var(--ctp-green);
-  color: var(--ctp-crust);
+  background: var(--color-success);
+  border-color: var(--color-success);
+  color: var(--color-bg-sunken);
 }
 
 .sidebar-pin.pinned:hover {
   background: var(--ctp-teal);
   border-color: var(--ctp-teal);
-  color: var(--ctp-crust);
+  color: var(--color-bg-sunken);
 }
 
 .sidebar-header {
   padding: 12px;
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
   display: flex;
   align-items: center;
   gap: 12px;
-  background: var(--ctp-base);
+  background: var(--color-bg);
   flex-shrink: 0;
 }
 
@@ -154,7 +154,7 @@
 .sidebar-app-name {
   font-size: 16px;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -162,7 +162,7 @@
 
 .sidebar-node-name {
   font-size: 11px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/SystemStatusModal/SystemStatusModal.css
+++ b/src/components/SystemStatusModal/SystemStatusModal.css
@@ -12,12 +12,12 @@
 }
 
 .status-item strong {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.875rem;
 }
 
 .status-item span {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1rem;
 }
 

--- a/src/components/TelemetryGraphs.css
+++ b/src/components/TelemetryGraphs.css
@@ -2,7 +2,7 @@
   width: 100%;
   margin-bottom: 20px;
   padding: 20px;
-  background-color: var(--ctp-mantle);
+  background-color: var(--color-bg-raised);
   border-radius: var(--radius-lg);
 }
 
@@ -30,7 +30,7 @@
 }
 
 .telemetry-title {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0;
   font-size: 1.2rem;
   font-weight: 600;
@@ -45,10 +45,10 @@
 }
 
 .telemetry-range-btn {
-  background-color: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-sm);
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   cursor: pointer;
   font-size: 0.8rem;
   font-weight: 500;
@@ -57,19 +57,19 @@
 }
 
 .telemetry-range-btn:hover {
-  color: var(--ctp-text);
-  border-color: var(--ctp-surface2);
+  color: var(--color-text);
+  border-color: var(--color-surface-active);
 }
 
 .telemetry-range-btn.active {
-  background-color: var(--ctp-blue);
-  border-color: var(--ctp-blue);
-  color: var(--ctp-crust);
+  background-color: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-bg-sunken);
 }
 
 .telemetry-loading,
 .telemetry-empty {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   text-align: center;
   padding: 20px;
   font-style: italic;
@@ -82,8 +82,8 @@
 }
 
 .graph-container {
-  background-color: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   padding: 15px;
 }
@@ -96,7 +96,7 @@
 }
 
 .graph-title {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0;
   font-size: 1rem;
   font-weight: 500;
@@ -126,19 +126,19 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--ctp-surface2);
+  color: var(--color-surface-active);
   transition: color 0.2s ease;
 }
 
 .favorite-btn:hover,
 .graph-menu-btn:hover,
 .solar-toggle-btn:hover {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .favorite-btn.favorited,
 .solar-toggle-btn.active {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .graph-menu-btn {
@@ -148,8 +148,8 @@
 }
 
 .telemetry-context-menu {
-  background-color: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   z-index: 1000;
@@ -163,7 +163,7 @@
   padding: 8px 16px;
   background: none;
   border: none;
-  color: var(--ctp-text);
+  color: var(--color-text);
   text-align: left;
   cursor: pointer;
   font-size: 0.9rem;
@@ -171,8 +171,8 @@
 }
 
 .context-menu-item:hover {
-  background-color: var(--ctp-surface0);
-  color: var(--ctp-red);
+  background-color: var(--color-surface);
+  color: var(--color-error);
 }
 
 /* Mode toggle button group */
@@ -193,17 +193,17 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--ctp-surface2);
+  color: var(--color-surface-active);
   transition: color 0.2s ease;
   border-radius: var(--radius-sm);
 }
 
 .mode-toggle-btn:hover {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .mode-toggle-btn.active {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 /* Gauge display */
@@ -227,19 +227,19 @@
   width: 56px;
   padding: 2px 4px;
   font-size: 0.8rem;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-sm);
-  color: var(--ctp-text);
+  color: var(--color-text);
   text-align: center;
 }
 
 .gauge-range-input:focus {
-  outline: 1px solid var(--ctp-blue);
+  outline: 1px solid var(--color-accent);
 }
 
 .gauge-range-dash {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.8rem;
   letter-spacing: -2px;
 }
@@ -262,13 +262,13 @@
 
 .telemetry-numeric-unit {
   font-size: 1rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .telemetry-numeric-time {
   font-size: 0.8rem;
   font-style: italic;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 @media (max-width: 768px) {

--- a/src/components/TelemetryRequestModal.css
+++ b/src/components/TelemetryRequestModal.css
@@ -4,7 +4,7 @@
 }
 
 .telemetry-modal-subtitle {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin-bottom: 20px;
   font-size: 0.95em;
 }
@@ -20,8 +20,8 @@
   align-items: center;
   gap: 12px;
   padding: 16px;
-  background-color: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   cursor: pointer;
   transition: all 0.2s ease;
@@ -30,13 +30,13 @@
 }
 
 .telemetry-type-button:hover:not(:disabled) {
-  background-color: var(--ctp-surface1);
-  border-color: var(--ctp-blue);
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-accent);
   transform: translateX(4px);
 }
 
 .telemetry-type-button:focus {
-  outline: 2px solid var(--ctp-blue);
+  outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 
@@ -61,13 +61,13 @@
 
 .telemetry-type-name {
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1em;
 }
 
 .telemetry-type-description {
   font-size: 0.85em;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   line-height: 1.4;
 }
 

--- a/src/components/ThemeDocumentation.css
+++ b/src/components/ThemeDocumentation.css
@@ -9,14 +9,14 @@
 }
 
 .theme-doc-header h2 {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0 0 10px 0;
   font-size: 2rem;
   font-weight: 600;
 }
 
 .theme-doc-header p {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 1.1rem;
   margin: 0;
 }
@@ -30,9 +30,9 @@
 
 .category-btn {
   padding: 10px 20px;
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
-  border: 2px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 2px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   cursor: pointer;
   font-size: 0.95rem;
@@ -41,14 +41,14 @@
 }
 
 .category-btn:hover {
-  background: var(--ctp-surface1);
-  border-color: var(--ctp-blue);
+  background: var(--color-surface-hover);
+  border-color: var(--color-accent);
 }
 
 .category-btn.active {
-  background: var(--ctp-blue);
-  color: var(--ctp-crust);
-  border-color: var(--ctp-blue);
+  background: var(--color-accent);
+  color: var(--color-bg-sunken);
+  border-color: var(--color-accent);
 }
 
 .themes-grid {
@@ -59,8 +59,8 @@
 }
 
 .theme-card {
-  background: var(--ctp-mantle);
-  border: 2px solid var(--ctp-surface1);
+  background: var(--color-bg-raised);
+  border: 2px solid var(--color-surface-hover);
   border-radius: var(--radius-xl);
   padding: 20px;
   cursor: pointer;
@@ -68,15 +68,15 @@
 }
 
 .theme-card:hover {
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
 .theme-card.active {
-  border-color: var(--ctp-green);
-  background: var(--ctp-base);
-  box-shadow: 0 0 0 2px var(--ctp-green);
+  border-color: var(--color-success);
+  background: var(--color-bg);
+  box-shadow: 0 0 0 2px var(--color-success);
 }
 
 .theme-card-header {
@@ -87,15 +87,15 @@
 }
 
 .theme-card-header h3 {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0;
   font-size: 1.3rem;
   font-weight: 600;
 }
 
 .current-badge {
-  background: var(--ctp-green);
-  color: var(--ctp-crust);
+  background: var(--color-success);
+  color: var(--color-bg-sunken);
   padding: 4px 12px;
   border-radius: var(--radius-xl);
   font-size: 0.8rem;
@@ -103,15 +103,15 @@
 }
 
 .theme-description {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.95rem;
   margin: 0 0 15px 0;
   line-height: 1.5;
 }
 
 .accessibility-badge {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-blue);
+  background: var(--color-surface);
+  border: 1px solid var(--color-accent);
   border-radius: var(--radius-lg);
   padding: 10px;
   margin-bottom: 15px;
@@ -126,7 +126,7 @@
 }
 
 .badge-text {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.85rem;
   line-height: 1.4;
 }
@@ -149,7 +149,7 @@
   width: 100%;
   aspect-ratio: 1;
   border-radius: var(--radius-lg);
-  border: 2px solid var(--ctp-surface2);
+  border: 2px solid var(--color-surface-active);
   transition: transform 0.2s ease;
 }
 
@@ -159,15 +159,15 @@
 
 .swatch-label {
   font-size: 0.75rem;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   font-weight: 500;
 }
 
 .preview-btn {
   width: 100%;
   padding: 12px;
-  background: var(--ctp-blue);
-  color: var(--ctp-crust);
+  background: var(--color-accent);
+  color: var(--color-bg-sunken);
   border: none;
   border-radius: var(--radius-lg);
   font-size: 1rem;
@@ -177,7 +177,7 @@
 }
 
 .preview-btn:hover {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
   transform: scale(1.02);
 }
 
@@ -194,33 +194,33 @@
 
 /* Only the button for the slot this theme is assigned to turns green. */
 .preview-btn.active {
-  background: var(--ctp-green);
+  background: var(--color-success);
   cursor: default;
 }
 
 .preview-btn.active:hover {
-  background: var(--ctp-green);
+  background: var(--color-success);
   transform: none;
 }
 
 /* Keep the unassigned slot's button blue even when the card is highlighted. */
 .theme-card.active .theme-card-actions .preview-btn:not(.active) {
-  background: var(--ctp-blue);
+  background: var(--color-accent);
 }
 
 .theme-card.active .theme-card-actions .preview-btn:not(.active):hover {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
 }
 
 .theme-doc-footer {
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   border-radius: var(--radius-xl);
   padding: 30px;
   margin-top: 40px;
 }
 
 .theme-doc-footer h3 {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0 0 20px 0;
   font-size: 1.5rem;
   font-weight: 600;
@@ -233,21 +233,21 @@
 }
 
 .info-section {
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   padding: 20px;
 }
 
 .info-section h4 {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   margin: 0 0 10px 0;
   font-size: 1.1rem;
   font-weight: 600;
 }
 
 .info-section p {
-  color: var(--ctp-text);
+  color: var(--color-text);
   line-height: 1.6;
   margin: 0 0 10px 0;
 }
@@ -255,7 +255,7 @@
 .info-section ul {
   margin: 10px 0 0 0;
   padding-left: 20px;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .info-section li {
@@ -264,7 +264,7 @@
 }
 
 .info-section strong {
-  color: var(--ctp-mauve);
+  color: var(--color-accent-alt);
 }
 
 @media (max-width: 768px) {

--- a/src/components/ThemeEditor.css
+++ b/src/components/ThemeEditor.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: 1.5rem;
   padding: 1.5rem;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
   max-width: 1200px;
   margin: 0 auto;
@@ -13,13 +13,13 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
   padding-bottom: 1rem;
 }
 
 .theme-editor-header h2 {
   margin: 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.5rem;
 }
 
@@ -41,27 +41,27 @@
 }
 
 .form-group label {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-weight: 600;
   font-size: 0.9rem;
 }
 
 .form-control {
   padding: 0.5rem;
-  background: var(--ctp-base);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
   font-size: 1rem;
 }
 
 .form-control:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .form-text {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.85rem;
   margin: 0;
 }
@@ -69,7 +69,7 @@
 .theme-editor-mode-switch {
   display: flex;
   gap: 0;
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   border-radius: var(--radius-md);
   padding: 0.25rem;
   width: fit-content;
@@ -78,7 +78,7 @@
 .mode-btn {
   padding: 0.5rem 1rem;
   background: transparent;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -87,13 +87,13 @@
 }
 
 .mode-btn:hover {
-  background: var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-active);
+  color: var(--color-text);
 }
 
 .mode-btn.active {
-  background: var(--ctp-blue);
-  color: var(--ctp-crust);
+  background: var(--color-accent);
+  color: var(--color-bg-sunken);
 }
 
 .theme-editor-visual {
@@ -103,21 +103,21 @@
 }
 
 .color-group {
-  background: var(--ctp-base);
+  background: var(--color-bg);
   padding: 1.5rem;
   border-radius: var(--radius-md);
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
 }
 
 .color-group h3 {
   margin: 0 0 0.5rem 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.1rem;
 }
 
 .color-group-description {
   margin: 0 0 1rem 0;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.9rem;
 }
 
@@ -134,7 +134,7 @@
 }
 
 .color-picker-item label {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.85rem;
   font-weight: 500;
   text-transform: capitalize;
@@ -149,7 +149,7 @@
 .color-picker {
   width: 50px;
   height: 40px;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
   cursor: pointer;
   background: none;
@@ -167,9 +167,9 @@
 .color-hex-input {
   flex: 1;
   padding: 0.5rem;
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
   font-family: var(--font-mono);
   font-size: 0.9rem;
@@ -177,11 +177,11 @@
 
 .color-hex-input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .color-hex-input:invalid {
-  border-color: var(--ctp-red);
+  border-color: var(--color-error);
 }
 
 .theme-editor-json {
@@ -193,9 +193,9 @@
 .json-editor-textarea {
   min-height: 400px;
   padding: 1rem;
-  background: var(--ctp-base);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
   font-family: var(--font-mono);
   font-size: 0.9rem;
@@ -205,13 +205,13 @@
 
 .json-editor-textarea:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .json-error {
   padding: 0.75rem;
-  background: var(--ctp-red);
-  color: var(--ctp-crust);
+  background: var(--color-error);
+  color: var(--color-bg-sunken);
   border-radius: var(--radius-sm);
   font-size: 0.9rem;
   font-weight: 500;
@@ -219,21 +219,21 @@
 
 .theme-validation-errors {
   padding: 1rem;
-  background: var(--ctp-maroon);
-  border-left: 4px solid var(--ctp-red);
+  background: var(--color-danger);
+  border-left: 4px solid var(--color-error);
   border-radius: var(--radius-sm);
 }
 
 .theme-validation-errors h4 {
   margin: 0 0 0.5rem 0;
-  color: var(--ctp-crust);
+  color: var(--color-bg-sunken);
   font-size: 1rem;
 }
 
 .theme-validation-errors ul {
   margin: 0;
   padding-left: 1.5rem;
-  color: var(--ctp-crust);
+  color: var(--color-bg-sunken);
   font-size: 0.9rem;
 }
 
@@ -244,18 +244,18 @@
 }
 
 .theme-accessibility-report.success {
-  background: var(--ctp-green);
+  background: var(--color-success);
   border-color: var(--ctp-teal);
 }
 
 .theme-accessibility-report.warning {
-  background: var(--ctp-yellow);
-  border-color: var(--ctp-peach);
+  background: var(--color-warning);
+  border-color: var(--color-caution);
 }
 
 .theme-accessibility-report h4 {
   margin: 0 0 0.75rem 0;
-  color: var(--ctp-crust);
+  color: var(--color-bg-sunken);
   font-size: 1rem;
 }
 
@@ -270,7 +270,7 @@
 .recommendations strong {
   display: block;
   margin-bottom: 0.25rem;
-  color: var(--ctp-crust);
+  color: var(--color-bg-sunken);
   font-size: 0.9rem;
 }
 
@@ -279,7 +279,7 @@
 .recommendations ul {
   margin: 0;
   padding-left: 1.5rem;
-  color: var(--ctp-crust);
+  color: var(--color-bg-sunken);
   font-size: 0.85rem;
 }
 
@@ -288,7 +288,7 @@
   justify-content: flex-end;
   gap: 0.75rem;
   padding-top: 1rem;
-  border-top: 1px solid var(--ctp-surface2);
+  border-top: 1px solid var(--color-surface-active);
 }
 
 .btn-primary,
@@ -303,12 +303,12 @@
 }
 
 .btn-primary {
-  background: var(--ctp-blue);
-  color: var(--ctp-crust);
+  background: var(--color-accent);
+  color: var(--color-bg-sunken);
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
   transform: translateY(-1px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
@@ -319,12 +319,12 @@
 }
 
 .btn-secondary {
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  color: var(--color-text);
 }
 
 .btn-secondary:hover:not(:disabled) {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
 }
 
 .btn-secondary:disabled {

--- a/src/components/TilesetSelector.css
+++ b/src/components/TilesetSelector.css
@@ -19,10 +19,10 @@
 }
 
 .tileset-collapse-btn {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   border: none;
   border-radius: var(--radius-sm);
-  color: var(--ctp-text);
+  color: var(--color-text);
   cursor: pointer;
   width: 24px;
   height: 24px;
@@ -37,7 +37,7 @@
 }
 
 .tileset-collapse-btn:hover {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   transform: scale(1.1);
 }
 
@@ -48,7 +48,7 @@
 .tileset-selector-title {
   font-size: 0.8rem;
   font-weight: 600;
-  color: var(--ctp-mauve);
+  color: var(--color-accent-alt);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -64,8 +64,8 @@
   flex-direction: column;
   align-items: center;
   gap: 6px;
-  background: var(--ctp-base);
-  border: 2px solid var(--ctp-surface2);
+  background: var(--color-bg);
+  border: 2px solid var(--color-surface-active);
   border-radius: var(--radius-md);
   padding: 8px;
   cursor: pointer;
@@ -74,14 +74,14 @@
 }
 
 .tileset-button:hover {
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
   transform: translateY(-2px);
   box-shadow: var(--shadow-md);
 }
 
 .tileset-button.active {
-  border-color: var(--ctp-blue);
-  background: color-mix(in srgb, var(--ctp-blue) 15%, var(--ctp-base));
+  border-color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 15%, var(--color-bg));
   box-shadow: var(--shadow-sm);
 }
 
@@ -98,7 +98,7 @@
 .tileset-name {
   font-size: 11px;
   font-weight: 500;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   text-align: center;
   line-height: 1.2;
   max-width: 80px;
@@ -106,7 +106,7 @@
 }
 
 .tileset-button.active .tileset-name {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   font-weight: 600;
 }
 
@@ -114,8 +114,8 @@
   display: inline-block;
   margin-left: 4px;
   padding: 1px 4px;
-  background-color: var(--ctp-blue);
-  color: var(--ctp-base);
+  background-color: var(--color-accent);
+  color: var(--color-bg);
   font-size: 9px;
   font-weight: 600;
   border-radius: var(--radius-xs);
@@ -146,8 +146,8 @@
     width: 100%;
     /* Clear of the home indicator / gesture bar on notched devices. */
     padding-bottom: env(safe-area-inset-bottom, 0px);
-    background-color: var(--ctp-base);
-    border-top: 1px solid var(--ctp-surface1);
+    background-color: var(--color-bg);
+    border-top: 1px solid var(--color-surface-hover);
     box-shadow: 0 -2px 12px rgb(0 0 0 / 35%);
   }
 

--- a/src/components/WaypointEditorModal.css
+++ b/src/components/WaypointEditorModal.css
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
 }
 
@@ -18,15 +18,15 @@
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.8rem;
   font-weight: 500;
 }
 
 .waypoint-editor-form .form-input {
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-sm);
   padding: 0.4rem 0.55rem;
   font-size: 0.9rem;
@@ -40,14 +40,14 @@
 
 .waypoint-editor-form .form-input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .waypoint-editor-form .form-checkbox {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.85rem;
   cursor: pointer;
 }
@@ -71,42 +71,42 @@
 }
 
 .waypoint-editor-form .form-button-primary {
-  background: var(--ctp-blue);
-  color: var(--ctp-base);
+  background: var(--color-accent);
+  color: var(--color-bg);
 }
 
 .waypoint-editor-form .form-button-primary:hover:not(:disabled) {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
 }
 
 .waypoint-editor-form .form-button-secondary {
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
-  border-color: var(--ctp-surface1);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border-color: var(--color-surface-hover);
 }
 
 .waypoint-editor-form .form-button-secondary:hover:not(:disabled) {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .waypoint-editor-form .form-error {
-  background: var(--ctp-surface0);
-  color: var(--ctp-red);
-  border: 1px solid var(--ctp-red);
+  background: var(--color-surface);
+  color: var(--color-error);
+  border: 1px solid var(--color-error);
   border-radius: var(--radius-sm);
   padding: 0.5rem 0.65rem;
   font-size: 0.85rem;
 }
 
 .waypoint-editor-icon-group {
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-sm);
   padding: 0.4rem 0.6rem 0.6rem;
   margin: 0;
 }
 
 .waypoint-editor-icon-group legend {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.8rem;
   padding: 0 0.3rem;
 }
@@ -120,7 +120,7 @@
 
 .waypoint-editor-icon-pick {
   background: transparent;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-sm);
   padding: 0.25rem 0.4rem;
   font-size: 1.05rem;
@@ -131,12 +131,12 @@
 }
 
 .waypoint-editor-icon-pick:hover {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
 }
 
 .waypoint-editor-icon-pick.selected {
-  background: var(--ctp-surface0);
-  border-color: var(--ctp-blue);
+  background: var(--color-surface);
+  border-color: var(--color-accent);
 }
 
 .waypoint-editor-icon-custom {
@@ -161,13 +161,13 @@
   gap: 0.4rem;
   margin-top: 0.5rem;
   padding-top: 0.5rem;
-  border-top: 1px solid var(--ctp-surface0);
+  border-top: 1px solid var(--color-surface);
 }
 
 .waypoint-popup-actions button {
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-sm);
   padding: 0.3rem 0.55rem;
   font-size: 0.8rem;
@@ -175,7 +175,7 @@
 }
 
 .waypoint-popup-actions button:hover:not(:disabled) {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .waypoint-popup-actions button:disabled {
@@ -184,7 +184,7 @@
 }
 
 .waypoint-popup-actions button.danger {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 /* "Create waypoint" button shown inside the Features panel on the per-source map */
@@ -192,9 +192,9 @@
   display: block;
   width: 100%;
   margin-top: 0.4rem;
-  background: var(--ctp-base);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
   padding: 0.45rem 0.75rem;
   font-size: 0.85rem;
@@ -204,8 +204,8 @@
 }
 
 .waypoint-create-button:hover:not(:disabled) {
-  background: var(--ctp-surface0);
-  border-color: var(--ctp-blue);
+  background: var(--color-surface);
+  border-color: var(--color-accent);
 }
 
 .waypoint-create-button:disabled {
@@ -220,9 +220,9 @@
   left: 50%;
   transform: translateX(-50%);
   z-index: 1000;
-  background: var(--ctp-base);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-blue);
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-accent);
   border-radius: var(--radius-md);
   padding: 0.5rem 0.85rem;
   font-size: 0.85rem;
@@ -235,8 +235,8 @@
 
 .waypoint-placement-hint button {
   background: transparent;
-  color: var(--ctp-subtext0);
-  border: 1px solid var(--ctp-surface1);
+  color: var(--color-text-subtle);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-sm);
   padding: 0.2rem 0.45rem;
   font-size: 0.75rem;

--- a/src/components/automations/AutomationsPage.css
+++ b/src/components/automations/AutomationsPage.css
@@ -3,48 +3,48 @@
 .ae-page {
   height: 100dvh;
   overflow-y: auto;
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  background: var(--color-bg);
+  color: var(--color-text);
   padding: 1.5rem 2rem 4rem;
 }
 .ae-container { max-width: 920px; margin: 0 auto; }
 
 .ae-topbar { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1rem; }
 .ae-title { margin: 0; font-size: 1.6rem; font-weight: 700; }
-.ae-subtitle { color: var(--ctp-subtext0); margin: 0.25rem 0 1.25rem; font-size: 0.9rem; }
+.ae-subtitle { color: var(--color-text-subtle); margin: 0.25rem 0 1.25rem; font-size: 0.9rem; }
 
 /* Tabs (Automations / Variables) */
-.ae-tabs { display: flex; gap: 0.5rem; border-bottom: 1px solid var(--ctp-surface1); margin-bottom: 1.25rem; }
+.ae-tabs { display: flex; gap: 0.5rem; border-bottom: 1px solid var(--color-surface-hover); margin-bottom: 1.25rem; }
 .ae-tab {
-  background: none; border: none; color: var(--ctp-subtext1);
+  background: none; border: none; color: var(--color-text-muted);
   padding: 0.55rem 0.9rem; cursor: pointer; font-size: 0.95rem; font-weight: 600;
   border-bottom: 2px solid transparent; margin-bottom: -1px;
 }
-.ae-tab:hover { color: var(--ctp-text); }
+.ae-tab:hover { color: var(--color-text); }
 /* Active tab text uses the blue accent (matches the underline) — it sits on the
    dark tab bar with no background, so the black --ctp-accent-text was unreadable. */
-.ae-tab.is-active { color: var(--ctp-blue); border-bottom-color: var(--ctp-blue); }
+.ae-tab.is-active { color: var(--color-accent); border-bottom-color: var(--color-accent); }
 
 /* Buttons */
 .ae-btn {
   font: inherit; font-size: 0.85rem; font-weight: 600; cursor: pointer;
   padding: 0.4rem 0.8rem; border-radius: var(--radius-md, 8px);
-  border: 1px solid var(--ctp-surface2); background: var(--ctp-surface0); color: var(--ctp-text);
+  border: 1px solid var(--color-surface-active); background: var(--color-surface); color: var(--color-text);
   transition: background 0.12s, border-color 0.12s;
 }
-.ae-btn:hover { background: var(--ctp-surface1); }
+.ae-btn:hover { background: var(--color-surface-hover); }
 .ae-btn:disabled { opacity: 0.5; cursor: not-allowed; }
-.ae-btn--primary { background: var(--ctp-blue); border-color: var(--ctp-blue); color: var(--ctp-accent-text); }
-.ae-btn--primary:hover { filter: brightness(1.08); background: var(--ctp-blue); }
-.ae-btn--danger { color: var(--ctp-red); border-color: var(--ctp-surface2); }
-.ae-btn--danger:hover { background: color-mix(in srgb, var(--ctp-red) 18%, transparent); }
-.ae-btn--ghost { background: none; border-color: transparent; color: var(--ctp-subtext1); }
-.ae-btn--ghost:hover { background: var(--ctp-surface0); color: var(--ctp-text); }
+.ae-btn--primary { background: var(--color-accent); border-color: var(--color-accent); color: var(--color-accent-text); }
+.ae-btn--primary:hover { filter: brightness(1.08); background: var(--color-accent); }
+.ae-btn--danger { color: var(--color-error); border-color: var(--color-surface-active); }
+.ae-btn--danger:hover { background: color-mix(in srgb, var(--color-error) 18%, transparent); }
+.ae-btn--ghost { background: none; border-color: transparent; color: var(--color-text-muted); }
+.ae-btn--ghost:hover { background: var(--color-surface); color: var(--color-text); }
 .ae-btn-row { display: flex; gap: 0.4rem; align-items: center; flex-wrap: wrap; }
 
 /* Cards / list rows */
 .ae-card {
-  background: var(--ctp-mantle); border: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-raised); border: 1px solid var(--color-surface);
   border-radius: var(--radius-lg, 12px); padding: 1rem 1.1rem; margin-bottom: 0.85rem;
 }
 .ae-row { display: flex; justify-content: space-between; align-items: center; gap: 1rem; }
@@ -52,31 +52,31 @@
 .ae-row-title { font-weight: 600; font-size: 0.98rem; }
 .ae-chip {
   display: inline-block; font-size: 0.72rem; font-weight: 600; padding: 0.1rem 0.45rem;
-  border-radius: 999px; background: var(--ctp-surface0); color: var(--ctp-subtext1); margin-left: 0.5rem;
+  border-radius: 999px; background: var(--color-surface); color: var(--color-text-muted); margin-left: 0.5rem;
   font-family: var(--font-mono, monospace);
 }
-.ae-muted { color: var(--ctp-subtext0); font-size: 0.85rem; }
-.ae-empty { color: var(--ctp-subtext0); padding: 2rem 0; text-align: center; }
+.ae-muted { color: var(--color-text-subtle); font-size: 0.85rem; }
+.ae-empty { color: var(--color-text-subtle); padding: 2rem 0; text-align: center; }
 
 /* Switch */
-.ae-switch { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.8rem; color: var(--ctp-subtext1); cursor: pointer; }
+.ae-switch { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.8rem; color: var(--color-text-muted); cursor: pointer; }
 
 /* TX-disabled advisory badge (#4294 P3) — hint only, never disables the checkbox. */
-.ae-tx-warn { color: var(--ctp-yellow); font-size: 0.75rem; display: inline-flex; align-items: center; gap: 0.25rem; margin-left: 0.4rem; }
+.ae-tx-warn { color: var(--color-warning); font-size: 0.75rem; display: inline-flex; align-items: center; gap: 0.25rem; margin-left: 0.4rem; }
 
 /* Form fields */
 .ae-field { margin-bottom: 0.85rem; }
-.ae-field-label { display: flex; align-items: center; gap: 0.35rem; font-size: 0.82rem; font-weight: 600; color: var(--ctp-subtext1); margin-bottom: 0.3rem; }
+.ae-field-label { display: flex; align-items: center; gap: 0.35rem; font-size: 0.82rem; font-weight: 600; color: var(--color-text-muted); margin-bottom: 0.3rem; }
 .ae-input, .ae-select, .ae-textarea {
   width: 100%; box-sizing: border-box; font: inherit; font-size: 0.9rem;
   padding: 0.45rem 0.6rem; border-radius: var(--radius-md, 8px);
-  border: 1px solid var(--ctp-surface2); background: var(--ctp-base); color: var(--ctp-text);
+  border: 1px solid var(--color-surface-active); background: var(--color-bg); color: var(--color-text);
 }
-.ae-input:focus, .ae-select:focus, .ae-textarea:focus { outline: none; border-color: var(--ctp-blue); }
+.ae-input:focus, .ae-select:focus, .ae-textarea:focus { outline: none; border-color: var(--color-accent); }
 .ae-textarea { resize: vertical; min-height: 70px; }
 .ae-textarea--code { font-family: var(--font-mono, monospace); font-size: 0.82rem; min-height: 280px; }
 .ae-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 0.6rem 1rem; }
-.ae-help-text { font-size: 0.76rem; color: var(--ctp-subtext0); margin-top: 0.25rem; }
+.ae-help-text { font-size: 0.76rem; color: var(--color-text-subtle); margin-top: 0.25rem; }
 
 /* Token-highlighting text field: a backdrop renders the chrome + highlighted
    {{ }} tokens; a transparent input/textarea sits on top for editing. Both share
@@ -89,54 +89,54 @@
 .ae-tokenfield--multiline .ae-tokenfield-backdrop { white-space: pre-wrap; overflow-wrap: break-word; word-break: break-word; }
 .ae-tokenfield-input {
   position: relative; background: transparent; color: transparent; border-color: transparent;
-  caret-color: var(--ctp-text);
+  caret-color: var(--color-text);
 }
-.ae-tokenfield-input::placeholder { color: var(--ctp-subtext0); }
-.ae-tokenfield:focus-within .ae-tokenfield-backdrop { border-color: var(--ctp-blue); }
+.ae-tokenfield-input::placeholder { color: var(--color-text-subtle); }
+.ae-tokenfield:focus-within .ae-tokenfield-backdrop { border-color: var(--color-accent); }
 .ae-tokenfield-backdrop .ae-token-ok {
-  background: color-mix(in srgb, var(--ctp-blue) 22%, transparent);
-  color: var(--ctp-text); border-radius: 3px;
+  background: color-mix(in srgb, var(--color-accent) 22%, transparent);
+  color: var(--color-text); border-radius: 3px;
 }
 .ae-tokenfield-backdrop .ae-token-foreign {
-  background: color-mix(in srgb, var(--ctp-yellow) 26%, transparent);
-  color: var(--ctp-text); border-radius: 3px; text-decoration: underline dotted var(--ctp-yellow);
+  background: color-mix(in srgb, var(--color-warning) 26%, transparent);
+  color: var(--color-text); border-radius: 3px; text-decoration: underline dotted var(--color-warning);
 }
 .ae-tokenfield-backdrop .ae-token-bad {
-  background: color-mix(in srgb, var(--ctp-red) 26%, transparent);
-  color: var(--ctp-text); border-radius: 3px; text-decoration: underline wavy var(--ctp-red);
+  background: color-mix(in srgb, var(--color-error) 26%, transparent);
+  color: var(--color-text); border-radius: 3px; text-decoration: underline wavy var(--color-error);
 }
 /* Diagnostics bar below a token field — one line per problematic token. */
 .ae-token-bar { display: flex; flex-direction: column; gap: 0.12rem; margin-top: 0.3rem; }
 .ae-token-diag { font-size: 0.76rem; display: flex; align-items: baseline; gap: 0.35rem; }
 .ae-token-diag code { font-family: var(--font-mono, monospace); }
 .ae-token-diag-icon { flex: none; font-weight: 700; }
-.ae-token-diag--error { color: var(--ctp-red); }
-.ae-token-diag--warn { color: var(--ctp-yellow); }
-.ae-error-list { color: var(--ctp-red); font-size: 0.85rem; margin: 0.5rem 0; padding-left: 1.1rem; }
+.ae-token-diag--error { color: var(--color-error); }
+.ae-token-diag--warn { color: var(--color-warning); }
+.ae-error-list { color: var(--color-error); font-size: 0.85rem; margin: 0.5rem 0; padding-left: 1.1rem; }
 
 /* Builder WHEN / IF / THEN sections */
-.ae-section { border: 1px solid var(--ctp-surface0); border-radius: var(--radius-lg, 12px); margin-bottom: 1rem; overflow: hidden; }
-.ae-section-head { display: flex; align-items: center; gap: 0.6rem; padding: 0.55rem 0.9rem; background: var(--ctp-surface0); }
-.ae-section-kw { font-weight: 800; letter-spacing: 0.05em; font-size: 0.78rem; color: var(--ctp-accent-text); background: var(--ctp-blue); padding: 0.12rem 0.5rem; border-radius: 999px; }
-.ae-section-kw--if { background: var(--ctp-yellow); }
-.ae-section-kw--then { background: var(--ctp-green); }
-.ae-section-hint { color: var(--ctp-subtext0); font-size: 0.8rem; }
+.ae-section { border: 1px solid var(--color-surface); border-radius: var(--radius-lg, 12px); margin-bottom: 1rem; overflow: hidden; }
+.ae-section-head { display: flex; align-items: center; gap: 0.6rem; padding: 0.55rem 0.9rem; background: var(--color-surface); }
+.ae-section-kw { font-weight: 800; letter-spacing: 0.05em; font-size: 0.78rem; color: var(--color-accent-text); background: var(--color-accent); padding: 0.12rem 0.5rem; border-radius: 999px; }
+.ae-section-kw--if { background: var(--color-warning); }
+.ae-section-kw--then { background: var(--color-success); }
+.ae-section-hint { color: var(--color-text-subtle); font-size: 0.8rem; }
 .ae-section-body { padding: 0.9rem; }
-.ae-block { background: var(--ctp-base); border: 1px solid var(--ctp-surface0); border-radius: var(--radius-md, 8px); padding: 0.8rem; margin-bottom: 0.7rem; }
+.ae-block { background: var(--color-bg); border: 1px solid var(--color-surface); border-radius: var(--radius-md, 8px); padding: 0.8rem; margin-bottom: 0.7rem; }
 .ae-block-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.6rem; }
 
 /* Help icon + drawer */
 .ae-help-icon {
   display: inline-flex; align-items: center; justify-content: center;
   width: 16px; height: 16px; border-radius: 999px; font-size: 0.7rem; font-weight: 700;
-  background: var(--ctp-surface1); color: var(--ctp-subtext1); border: none; cursor: pointer; flex: none;
+  background: var(--color-surface-hover); color: var(--color-text-muted); border: none; cursor: pointer; flex: none;
 }
-.ae-help-icon:hover { background: var(--ctp-blue); color: var(--ctp-accent-text); }
+.ae-help-icon:hover { background: var(--color-accent); color: var(--color-accent-text); }
 /* Docked, non-modal reference panel: slides in from the right and stays put (no
    backdrop), so it can remain open while you keep editing the page. */
 .ae-drawer {
   position: fixed; top: 0; right: 0; bottom: 0; width: min(420px, 92vw); z-index: 1001;
-  background: var(--ctp-mantle); border-left: 1px solid var(--ctp-surface1);
+  background: var(--color-bg-raised); border-left: 1px solid var(--color-surface-hover);
   box-shadow: -8px 0 24px rgba(0,0,0,0.35); padding: 1.25rem 1.4rem; overflow-y: auto;
   animation: ae-drawer-slide-in 0.2s ease;
 }
@@ -145,49 +145,49 @@
 .ae-drawer h2 { margin-top: 0; font-size: 1.15rem; }
 /* Drawer headings sit on the dark --ctp-mantle drawer — use the theme foreground,
    not the black --ctp-accent-text (which is meant for bright accent backgrounds). */
-.ae-drawer h3 { margin: 1.1rem 0 0.3rem; font-size: 0.95rem; color: var(--ctp-text); }
-.ae-drawer dt { font-weight: 700; margin-top: 0.7rem; font-family: var(--font-mono, monospace); font-size: 0.85rem; color: var(--ctp-text); }
-.ae-drawer dd { margin: 0.15rem 0 0; color: var(--ctp-subtext1); font-size: 0.85rem; line-height: 1.45; }
+.ae-drawer h3 { margin: 1.1rem 0 0.3rem; font-size: 0.95rem; color: var(--color-text); }
+.ae-drawer dt { font-weight: 700; margin-top: 0.7rem; font-family: var(--font-mono, monospace); font-size: 0.85rem; color: var(--color-text); }
+.ae-drawer dd { margin: 0.15rem 0 0; color: var(--color-text-muted); font-size: 0.85rem; line-height: 1.45; }
 .ae-drawer-close { position: absolute; top: 0.9rem; right: 1rem; }
 
 /* Test / dry-run panel */
-.ae-test { border-color: var(--ctp-blue); }
+.ae-test { border-color: var(--color-accent); }
 .ae-test-inputs { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.6rem; }
-.ae-test-advanced { border-top: 1px dashed var(--ctp-surface1); margin-top: 0.5rem; padding-top: 0.3rem; }
-.ae-test-result { border-top: 1px solid var(--ctp-surface0); margin-top: 0.7rem; padding-top: 0.5rem; }
+.ae-test-advanced { border-top: 1px dashed var(--color-surface-hover); margin-top: 0.5rem; padding-top: 0.3rem; }
+.ae-test-result { border-top: 1px solid var(--color-surface); margin-top: 0.7rem; padding-top: 0.5rem; }
 .ae-test-badge { font-weight: 800; font-size: 0.78rem; padding: 0.18rem 0.6rem; border-radius: 999px; }
-.ae-test-badge--ok { background: var(--ctp-green); color: var(--ctp-accent-text, #11111b); }
-.ae-test-badge--err { background: var(--ctp-red); color: var(--ctp-accent-text, #11111b); }
-.ae-test-badge--no { background: var(--ctp-surface1); color: var(--ctp-subtext1); }
-.ae-test-badge--muted { background: var(--ctp-surface1); color: var(--ctp-subtext1); }
+.ae-test-badge--ok { background: var(--color-success); color: var(--color-accent-text, #11111b); }
+.ae-test-badge--err { background: var(--color-error); color: var(--color-accent-text, #11111b); }
+.ae-test-badge--no { background: var(--color-surface-hover); color: var(--color-text-muted); }
+.ae-test-badge--muted { background: var(--color-surface-hover); color: var(--color-text-muted); }
 .ae-trace { display: flex; flex-direction: column; gap: 0.2rem; }
-.ae-trace-step { display: flex; align-items: baseline; gap: 0.5rem; font-size: 0.84rem; padding: 0.18rem 0.4rem; border-radius: var(--radius-sm, 6px); background: var(--ctp-base); }
+.ae-trace-step { display: flex; align-items: baseline; gap: 0.5rem; font-size: 0.84rem; padding: 0.18rem 0.4rem; border-radius: var(--radius-sm, 6px); background: var(--color-bg); }
 .ae-trace-icon { font-weight: 800; width: 1.1rem; text-align: center; flex: none; }
-.ae-trace-type { font-family: var(--font-mono, monospace); font-size: 0.78rem; color: var(--ctp-text); min-width: 9rem; }
-.ae-trace-step--ok .ae-trace-icon { color: var(--ctp-green); }
-.ae-trace-step--no .ae-trace-icon { color: var(--ctp-yellow); }
-.ae-trace-step--err .ae-trace-icon { color: var(--ctp-red); }
+.ae-trace-type { font-family: var(--font-mono, monospace); font-size: 0.78rem; color: var(--color-text); min-width: 9rem; }
+.ae-trace-step--ok .ae-trace-icon { color: var(--color-success); }
+.ae-trace-step--no .ae-trace-icon { color: var(--color-warning); }
+.ae-trace-step--err .ae-trace-icon { color: var(--color-error); }
 .ae-trace-step--muted .ae-trace-icon { color: var(--ctp-overlay0); }
-.ae-test-action { background: var(--ctp-base); border: 1px solid var(--ctp-surface0); border-radius: var(--radius-sm, 6px); padding: 0.4rem 0.55rem; margin-bottom: 0.4rem; }
-.ae-test-action.is-err { border-color: var(--ctp-red); }
+.ae-test-action { background: var(--color-bg); border: 1px solid var(--color-surface); border-radius: var(--radius-sm, 6px); padding: 0.4rem 0.55rem; margin-bottom: 0.4rem; }
+.ae-test-action.is-err { border-color: var(--color-error); }
 .ae-test-params { margin: 0.3rem 0 0; font-size: 0.72rem; overflow-x: auto; white-space: pre-wrap; }
 
 /* Test panel — expanded "what would be sent" block + raw params toggle */
-.ae-test-sent { background: var(--ctp-mantle); border-left: 3px solid var(--ctp-green); padding: 0.4rem 0.6rem; margin: 0.3rem 0; border-radius: var(--radius-sm, 6px); white-space: pre-wrap; word-break: break-word; font-size: 0.86rem; color: var(--ctp-text); }
+.ae-test-sent { background: var(--color-bg-raised); border-left: 3px solid var(--color-success); padding: 0.4rem 0.6rem; margin: 0.3rem 0; border-radius: var(--radius-sm, 6px); white-space: pre-wrap; word-break: break-word; font-size: 0.86rem; color: var(--color-text); }
 .ae-test-raw { margin-top: 0.25rem; }
 .ae-test-raw summary { cursor: pointer; font-size: 0.74rem; list-style: revert; }
 
 /* Test panel — "no actions ran" guidance note */
-.ae-test-note { background: var(--ctp-surface0); border-left: 3px solid var(--ctp-yellow); padding: 0.4rem 0.6rem; border-radius: var(--radius-sm, 6px); font-size: 0.82rem; color: var(--ctp-subtext1); line-height: 1.45; }
-.ae-test-note code { background: var(--ctp-mantle); padding: 0 0.25rem; border-radius: 3px; }
+.ae-test-note { background: var(--color-surface); border-left: 3px solid var(--color-warning); padding: 0.4rem 0.6rem; border-radius: var(--radius-sm, 6px); font-size: 0.82rem; color: var(--color-text-muted); line-height: 1.45; }
+.ae-test-note code { background: var(--color-bg-raised); padding: 0 0.25rem; border-radius: 3px; }
 
 /* Live trace panel ("view logs" for one rule) */
 .ae-trace-panel { display: flex; flex-direction: column; gap: 0.6rem; }
 .ae-trace-panel-head { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; flex-wrap: wrap; }
 .ae-trace-feed { display: flex; flex-direction: column; gap: 0.4rem; max-height: 60vh; overflow-y: auto; }
-.ae-trace-entry { border: 1px solid var(--ctp-surface1); border-radius: var(--radius-sm, 6px); background: var(--ctp-base); padding: 0.4rem 0.55rem; }
+.ae-trace-entry { border: 1px solid var(--color-surface-hover); border-radius: var(--radius-sm, 6px); background: var(--color-bg); padding: 0.4rem 0.55rem; }
 .ae-trace-entry-head { display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; }
-.ae-trace-entry-summary { font-family: var(--font-mono, monospace); font-size: 0.8rem; color: var(--ctp-text); word-break: break-word; }
+.ae-trace-entry-summary { font-family: var(--font-mono, monospace); font-size: 0.8rem; color: var(--color-text); word-break: break-word; }
 .ae-trace-reason { font-size: 0.8rem; margin-top: 0.2rem; padding-left: 0.4rem; }
 .ae-trace-steps-wrap { margin-top: 0.35rem; }
 .ae-trace-steps-wrap > summary { cursor: pointer; font-size: 0.78rem; }

--- a/src/components/common/ErrorBoundary.css
+++ b/src/components/common/ErrorBoundary.css
@@ -12,32 +12,32 @@
 }
 
 .error-boundary-content h2 {
-  color: var(--ctp-red, #f38ba8);
+  color: var(--color-error, #f38ba8);
   margin: 0 0 var(--spacing-sm, 0.5rem);
   font-size: 1.25rem;
 }
 
 .error-boundary-content p {
-  color: var(--ctp-subtext0, #a6adc8);
+  color: var(--color-text-subtle, #a6adc8);
   margin: 0 0 var(--spacing-lg, 1rem);
 }
 
 .error-boundary-details {
   text-align: left;
   margin-bottom: var(--spacing-lg, 1rem);
-  background: var(--ctp-mantle, #181825);
+  background: var(--color-bg-raised, #181825);
   border-radius: var(--radius-md, 6px);
   padding: var(--spacing-sm, 0.5rem);
 }
 
 .error-boundary-details summary {
   cursor: pointer;
-  color: var(--ctp-subtext1, #bac2de);
+  color: var(--color-text-muted, #bac2de);
   font-size: 0.875rem;
 }
 
 .error-boundary-details pre {
-  color: var(--ctp-red, #f38ba8);
+  color: var(--color-error, #f38ba8);
   font-size: 0.8rem;
   white-space: pre-wrap;
   word-break: break-word;
@@ -45,8 +45,8 @@
 }
 
 .error-boundary-retry {
-  background: var(--ctp-blue, #89b4fa);
-  color: var(--ctp-crust, #11111b);
+  background: var(--color-accent, #89b4fa);
+  color: var(--color-bg-sunken, #11111b);
   border: none;
   border-radius: var(--radius-md, 6px);
   padding: var(--spacing-sm, 0.5rem) var(--spacing-lg, 1rem);

--- a/src/components/common/Modal.css
+++ b/src/components/common/Modal.css
@@ -19,7 +19,7 @@
 }
 
 .modal-content {
-  background: var(--ctp-base);
+  background: var(--color-bg);
   border-radius: var(--radius-lg);
   padding: 0;
   max-width: 500px;
@@ -28,7 +28,7 @@
      area (the desktop case is unaffected — the var defaults to 0px). */
   max-height: calc(80vh - var(--keyboard-inset, 0px));
   overflow: auto;
-  border: 1px solid var(--ctp-surface0);
+  border: 1px solid var(--color-surface);
 }
 
 .modal-header {
@@ -36,12 +36,12 @@
   justify-content: space-between;
   align-items: center;
   padding: 1rem 1.5rem;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 .modal-header h2 {
   margin: 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.25rem;
 }
 
@@ -49,14 +49,14 @@
   background: none;
   border: none;
   font-size: 1.5rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   cursor: pointer;
   padding: 0;
   line-height: 1;
 }
 
 .modal-close:hover {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .modal-body {

--- a/src/components/settings/EmbedSettings.css
+++ b/src/components/settings/EmbedSettings.css
@@ -8,28 +8,28 @@
 }
 
 .embed-table thead tr {
-  border-bottom: 2px solid var(--ctp-surface2);
+  border-bottom: 2px solid var(--color-surface-active);
 }
 
 .embed-table th {
   padding: 0.75rem;
   text-align: left;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.875rem;
   font-weight: 600;
 }
 
 .embed-table tbody tr {
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
 }
 
 .embed-table tbody tr:hover {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
 }
 
 .embed-table td {
   padding: 0.75rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .embed-table-center {
@@ -46,23 +46,23 @@
 }
 
 .embed-status-enabled {
-  color: var(--ctp-green);
+  color: var(--color-success);
   font-weight: 500;
 }
 
 .embed-status-disabled {
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-weight: 500;
 }
 
 /* Danger button variant */
 .embed-button-danger {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .embed-button-danger:hover:not(:disabled) {
-  background: var(--ctp-red);
-  color: var(--ctp-accent-text);
+  background: var(--color-error);
+  color: var(--color-accent-text);
 }
 
 /* Modal override for wider embed form */
@@ -95,7 +95,7 @@
 .embed-checkbox-label input[type="checkbox"] {
   width: 16px;
   height: 16px;
-  accent-color: var(--ctp-blue);
+  accent-color: var(--color-accent);
   cursor: pointer;
   flex-shrink: 0;
 }
@@ -106,7 +106,7 @@
   width: 100%;
   border-radius: var(--radius-lg);
   overflow: hidden;
-  border: 2px solid var(--ctp-surface2);
+  border: 2px solid var(--color-surface-active);
   margin-top: 0.5rem;
 }
 
@@ -115,18 +115,18 @@
   gap: 1rem;
   margin-top: 0.5rem;
   font-size: 0.875rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .embed-map-coords strong {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 /* Info box (security note) */
 .embed-info-box {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface2);
-  border-left: 4px solid var(--ctp-blue);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-active);
+  border-left: 4px solid var(--color-accent);
   border-radius: var(--radius-md);
   padding: 1rem;
   margin-top: 1.5rem;
@@ -134,13 +134,13 @@
 }
 
 .embed-info-box strong {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   display: block;
   margin-bottom: 0.25rem;
 }
 
 .embed-info-box p {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin: 0;
   line-height: 1.5;
 }
@@ -162,15 +162,15 @@
 }
 
 .embed-origin-tag.valid {
-  background: color-mix(in srgb, var(--ctp-green) 15%, transparent);
-  border: 1px solid var(--ctp-green);
-  color: var(--ctp-green);
+  background: color-mix(in srgb, var(--color-success) 15%, transparent);
+  border: 1px solid var(--color-success);
+  color: var(--color-success);
 }
 
 .embed-origin-tag.invalid {
-  background: color-mix(in srgb, var(--ctp-red) 15%, transparent);
-  border: 1px solid var(--ctp-red);
-  color: var(--ctp-red);
+  background: color-mix(in srgb, var(--color-error) 15%, transparent);
+  border: 1px solid var(--color-error);
+  color: var(--color-error);
 }
 
 /* Embed code textarea */
@@ -178,9 +178,9 @@
   width: 100%;
   font-family: var(--font-mono);
   font-size: 0.85rem;
-  background: var(--ctp-surface1);
-  border: 2px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 2px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.75rem;
   border-radius: var(--radius-lg);
   resize: vertical;
@@ -189,7 +189,7 @@
 
 .embed-code-textarea:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 /* Responsive */

--- a/src/pages/UnifiedPacketMonitorPage.css
+++ b/src/pages/UnifiedPacketMonitorPage.css
@@ -6,8 +6,8 @@
   width: 100vw;
   height: 100dvh;
   overflow: hidden;
-  background: var(--bg-primary, var(--ctp-base));
-  color: var(--text-primary, var(--ctp-text));
+  background: var(--bg-primary, var(--color-bg));
+  color: var(--text-primary, var(--color-text));
 }
 
 .unified-packets-header {
@@ -15,29 +15,29 @@
   align-items: center;
   gap: 1rem;
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--ctp-surface0, var(--border-color));
+  border-bottom: 1px solid var(--color-surface, var(--border-color));
   flex-shrink: 0;
   flex-wrap: wrap;
 }
 
 .unified-packets-back {
-  background: var(--ctp-surface0, transparent);
-  color: var(--text-secondary, var(--ctp-subtext0));
-  border: 1px solid var(--ctp-surface1, var(--border-color));
+  background: var(--color-surface, transparent);
+  color: var(--text-secondary, var(--color-text-subtle));
+  border: 1px solid var(--color-surface-hover, var(--border-color));
   border-radius: 6px;
   padding: 0.4rem 0.75rem;
   cursor: pointer;
   font-size: 0.85rem;
 }
-.unified-packets-back:hover { background: var(--ctp-surface1); }
+.unified-packets-back:hover { background: var(--color-surface-hover); }
 
 .unified-packets-title { flex: 1; min-width: 180px; }
 .unified-packets-title h1 { margin: 0; font-size: 1.1rem; }
-.unified-packets-title p { margin: 0.1rem 0 0; font-size: 0.8rem; color: var(--text-secondary, var(--ctp-subtext0)); }
+.unified-packets-title p { margin: 0.1rem 0 0; font-size: 0.8rem; color: var(--text-secondary, var(--color-text-subtle)); }
 
 .unified-packets-count {
   font-size: 0.85rem;
-  color: var(--text-secondary, var(--ctp-subtext0));
+  color: var(--text-secondary, var(--color-text-subtle));
   white-space: nowrap;
 }
 
@@ -45,9 +45,9 @@
 
 /* Reuse the .control-btn look from PacketMonitorPanel.css; add an active state. */
 .unified-packets-controls .control-btn.active {
-  background: var(--ctp-blue, #4a9eff);
-  color: var(--ctp-base, #fff);
-  border-color: var(--ctp-blue, #4a9eff);
+  background: var(--color-accent, #4a9eff);
+  color: var(--color-bg, #fff);
+  border-color: var(--color-accent, #4a9eff);
 }
 
 .unified-packets-filters { flex-shrink: 0; }
@@ -56,7 +56,7 @@
 .unified-packets-charts {
   flex-shrink: 0;
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--ctp-surface0, var(--border-color));
+  border-bottom: 1px solid var(--color-surface, var(--border-color));
   max-height: 38vh;
   overflow-y: auto;
 }
@@ -69,17 +69,17 @@
   overflow: hidden;
 }
 .unified-packets-charts__range button {
-  background: var(--ctp-surface0, transparent);
-  color: var(--text-secondary, var(--ctp-subtext0));
-  border: 1px solid var(--ctp-surface1, var(--border-color));
+  background: var(--color-surface, transparent);
+  color: var(--text-secondary, var(--color-text-subtle));
+  border: 1px solid var(--color-surface-hover, var(--border-color));
   padding: 0.3rem 0.7rem;
   cursor: pointer;
   font-size: 0.8rem;
 }
 .unified-packets-charts__range button.active {
-  background: var(--ctp-blue, #4a9eff);
-  color: var(--ctp-base, #fff);
-  border-color: var(--ctp-blue, #4a9eff);
+  background: var(--color-accent, #4a9eff);
+  color: var(--color-bg, #fff);
+  border-color: var(--color-accent, #4a9eff);
 }
 
 .unified-packets-charts__grid {


### PR DESCRIPTION
Second batch of #4579, following #4581 (CSS modules).

## Scope

Every non-module stylesheet under `src/components` and `src/pages`: **40 files, 1,583 of 1,670 references migrated**.

| Slice | Files | Refs | Status |
| --- | --- | --- | --- |
| CSS modules | 12 | 119 | #4581 ✅ |
| **Non-module component CSS** | **40** | **1,670** | **this PR** |
| Inline styles in `.tsx`/`.ts` | 110 | 2,007 | later |
| Global sheets (`src/styles`) | 10 | 806 | later — frozen, `nodes.css` cascade trap |

## This PR applies existing roles only

No new roles. Every remaining reference needs *role design*, and that deserves its own review rather than being buried in a 40-file diff:

| Left raw | Where | Why |
| --- | --- | --- |
| `overlay0` | 11 files | **Best batch-3 candidate.** Splits cleanly: **28 uses as `color`, 26 as border** — a genuine role pair (`--color-text-faint` / `--color-border-subtle`), not a rename |
| `teal` | 7 uses | Mixed hover backgrounds and borders; no coherent meaning across sites |
| `pink`, `overlay2` | a few | Data-viz and one-off chrome |
| `--ctp-*-rgb` | CustomTilesetManager | Separate mechanism — numeric triplets fed to `rgba()`, outside the 26-key palette |

`CustomTilesetManager.css` holds most of the leftovers and carries a header note so they read as deliberate.

## A role that held up under pressure

`--color-accent-hover` → `sapphire` was justified in #4581 from a *single* site. All three sapphire uses in this batch (`ThemeDocumentation`, `ThemeEditor`, `CustomThemeManagement`) are also `:hover` on an accent button. The role generalises rather than having been fitted to one case — worth noting since a role invented for one caller is exactly what makes a token vocabulary rot.

## Verification

The risk in a 1,583-reference sweep is silently restyling something. Ruled out mechanically: re-expanding every semantic token back to the palette var it points at reproduces the pre-migration CSS **exactly for all 40 files**. This pass also covers the `var(--x, fallback)` form that hid two sites in #4581.

- Full Vitest suite: `success: true`, **13,551 passed, 0 failed, 0 failed suites**
- `npx tsc --noEmit` clean, `npm run lint:ci` no in-repo failures
- `semanticTokens.test.ts` continues to guard every token and catch undefined `--color-*` references

## Not in this PR

The `rgba()` bare-hex sweep raised in #4581's review is [tracked on #4579](https://github.com/Yeraze/meshmonitor/issues/4579). It is deliberately separate because it **breaks color-identity by design** — that is the property making these batches reviewable at this size, so it shouldn't be mixed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX