### PR TITLE
refactor(themes): migrate inline component styles to semantic tokens — batch 4 (#4579)

### DIFF
--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -225,16 +225,16 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
               justifyContent: 'space-between',
               alignItems: 'center',
               padding: '0.75rem 1rem',
-              background: 'var(--ctp-surface0)',
-              border: '1px solid var(--ctp-surface2)',
+              background: 'var(--color-surface)',
+              border: '1px solid var(--color-surface-active)',
               borderRadius: '8px',
               cursor: 'pointer',
               marginBottom: isExpanded ? '1rem' : '0.5rem',
               transition: 'all 0.2s ease',
             }}
             onClick={() => toggleSection(id)}
-            onMouseEnter={(e) => e.currentTarget.style.background = 'var(--ctp-surface1)'}
-            onMouseLeave={(e) => e.currentTarget.style.background = 'var(--ctp-surface0)'}
+            onMouseEnter={(e) => e.currentTarget.style.background = 'var(--color-surface-hover)'}
+            onMouseLeave={(e) => e.currentTarget.style.background = 'var(--color-surface)'}
           >
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flex: 1 }}>
               <span style={{
@@ -2368,8 +2368,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
   // if (!nodes || nodes.length === 0) {
   //   return (
   //     <div style={{ padding: '2rem', maxWidth: '1200px', margin: '0 auto' }}>
-  //       <h2 style={{ marginBottom: '1.5rem', color: 'var(--ctp-text)' }}>{t('admin_commands.title')}</h2>
-  //       <p style={{ color: 'var(--ctp-subtext0)' }}>{t('admin_commands.loading_nodes')}</p>
+  //       <h2 style={{ marginBottom: '1.5rem', color: 'var(--color-text)' }}>{t('admin_commands.title')}</h2>
+  //       <p style={{ color: 'var(--color-text-subtle)' }}>{t('admin_commands.loading_nodes')}</p>
   //     </div>
   //   );
   // }
@@ -2390,8 +2390,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             style={{
               width: '1rem',
               height: '1rem',
-              border: '2px solid var(--ctp-surface2)',
-              borderTopColor: 'var(--ctp-blue)',
+              border: '2px solid var(--color-surface-active)',
+              borderTopColor: 'var(--color-accent)',
               borderRadius: '50%',
               animation: 'spin 1s linear infinite',
               display: 'inline-block'
@@ -2400,10 +2400,10 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
           />
         )}
         {status === 'success' && (
-          <span style={{ color: 'var(--ctp-green)', fontSize: '1rem', fontWeight: 'bold' }} title={t('admin_commands.section_loaded')}><UiIcon name="check" /></span>
+          <span style={{ color: 'var(--color-success)', fontSize: '1rem', fontWeight: 'bold' }} title={t('admin_commands.section_loaded')}><UiIcon name="check" /></span>
         )}
         {status === 'error' && (
-          <span style={{ color: 'var(--ctp-red)', fontSize: '1rem', fontWeight: 'bold' }} title={t('admin_commands.section_load_failed')}><UiIcon name="error" /></span>
+          <span style={{ color: 'var(--color-error)', fontSize: '1rem', fontWeight: 'bold' }} title={t('admin_commands.section_load_failed')}><UiIcon name="error" /></span>
         )}
         <button
           onClick={() => handleLoadSingleConfig(configType)}
@@ -2445,8 +2445,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             padding: '0.75rem 1rem',
             marginBottom: '1rem',
             borderRadius: '4px',
-            backgroundColor: 'var(--ctp-yellow)',
-            color: 'var(--ctp-base)',
+            backgroundColor: 'var(--color-warning)',
+            color: 'var(--color-bg)',
             fontWeight: 500
           }}
         >
@@ -2513,8 +2513,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                 left: 0,
                 right: 0,
                 marginTop: '4px',
-                background: 'var(--ctp-base)',
-                border: '2px solid var(--ctp-surface2)',
+                background: 'var(--color-bg)',
+                border: '2px solid var(--color-surface-active)',
                 borderRadius: '8px',
                 maxHeight: '300px',
                 overflowY: 'auto',
@@ -2528,26 +2528,26 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                     style={{
                       padding: '0.75rem 1rem',
                       cursor: 'pointer',
-                      borderBottom: '1px solid var(--ctp-surface1)',
+                      borderBottom: '1px solid var(--color-surface-hover)',
                       transition: 'background 0.1s',
                       display: 'flex',
                       justifyContent: 'space-between',
                       alignItems: 'center'
                     }}
-                    onMouseEnter={(e) => e.currentTarget.style.background = 'var(--ctp-surface0)'}
+                    onMouseEnter={(e) => e.currentTarget.style.background = 'var(--color-surface)'}
                     onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
                   >
                     <div>
-                      <div style={{ fontWeight: '500', color: 'var(--ctp-text)' }}>
-                        {node.longName} {node.isLocal && <span style={{ color: 'var(--ctp-blue)' }}>({t('admin_commands.local_node_indicator')})</span>}
+                      <div style={{ fontWeight: '500', color: 'var(--color-text)' }}>
+                        {node.longName} {node.isLocal && <span style={{ color: 'var(--color-accent)' }}>({t('admin_commands.local_node_indicator')})</span>}
                       </div>
-                      <div style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)', marginTop: '0.25rem' }}>
+                      <div style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)', marginTop: '0.25rem' }}>
                         {node.shortName && node.shortName !== node.longName && `${node.shortName} • `}
                         {node.nodeId}
                       </div>
                     </div>
                     {selectedNodeNum === node.nodeNum && (
-                      <span style={{ color: 'var(--ctp-blue)', fontSize: '1.2rem' }}><UiIcon name="check" /></span>
+                      <span style={{ color: 'var(--color-accent)', fontSize: '1.2rem' }}><UiIcon name="check" /></span>
                     )}
                   </div>
                 ))}
@@ -2555,11 +2555,11 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             )}
           </div>
           {selectedNode && (
-            <div style={{ marginTop: '0.75rem', fontSize: '0.875rem', color: 'var(--ctp-subtext0)' }}>
+            <div style={{ marginTop: '0.75rem', fontSize: '0.875rem', color: 'var(--color-text-subtle)' }}>
               {selectedNode.isLocal ? (
                 <span>{t('admin_commands.local_node_no_passkey')}</span>
               ) : passkeyStatus?.hasPasskey && passkeyStatus.remainingSeconds !== null ? (
-                <span style={{ color: 'var(--ctp-green)' }}>
+                <span style={{ color: 'var(--color-success)' }}>
                   {t('admin_commands.remote_node_passkey_acquired', { seconds: passkeyStatus.remainingSeconds })}
                 </span>
               ) : (
@@ -2620,7 +2620,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                   flex: 1,
                   opacity: (isLoadingReboot || selectedNodeNum === null || remoteAdminBlocked) ? 0.5 : 1,
                   cursor: (isLoadingReboot || selectedNodeNum === null || remoteAdminBlocked) ? 'not-allowed' : 'pointer',
-                  backgroundColor: 'var(--ctp-red)'
+                  backgroundColor: 'var(--color-error)'
                 }}
               >
                 {isLoadingReboot ? t('common.loading') : t('admin_commands.send_reboot', 'Send Reboot')}
@@ -2645,30 +2645,30 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                 style={{
                   marginTop: '0.75rem',
                   padding: '1rem',
-                  backgroundColor: 'var(--ctp-surface0)',
+                  backgroundColor: 'var(--color-surface)',
                   borderRadius: '8px',
-                  border: '1px solid var(--ctp-overlay0)',
+                  border: '1px solid var(--color-border-subtle)',
                   maxWidth: '600px'
                 }}
               >
-                <h4 style={{ margin: '0 0 0.75rem 0', color: 'var(--ctp-text)' }}>
+                <h4 style={{ margin: '0 0 0.75rem 0', color: 'var(--color-text)' }}>
                   {t('admin_commands.device_metadata_title', 'Device Metadata')}
                 </h4>
                 <div style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '0.5rem 1rem', fontSize: '0.9rem' }}>
-                  <span style={{ color: 'var(--ctp-subtext0)', fontWeight: 500 }}>{t('admin_commands.firmware_version', 'Firmware Version')}:</span>
-                  <span style={{ color: 'var(--ctp-text)' }}>{deviceMetadata.firmwareVersion}</span>
+                  <span style={{ color: 'var(--color-text-subtle)', fontWeight: 500 }}>{t('admin_commands.firmware_version', 'Firmware Version')}:</span>
+                  <span style={{ color: 'var(--color-text)' }}>{deviceMetadata.firmwareVersion}</span>
 
-                  <span style={{ color: 'var(--ctp-subtext0)', fontWeight: 500 }}>{t('admin_commands.hardware_model', 'Hardware Model')}:</span>
-                  <span style={{ color: 'var(--ctp-text)' }}>{getHardwareModelName(deviceMetadata.hwModel) || deviceMetadata.hwModel}</span>
+                  <span style={{ color: 'var(--color-text-subtle)', fontWeight: 500 }}>{t('admin_commands.hardware_model', 'Hardware Model')}:</span>
+                  <span style={{ color: 'var(--color-text)' }}>{getHardwareModelName(deviceMetadata.hwModel) || deviceMetadata.hwModel}</span>
 
-                  <span style={{ color: 'var(--ctp-subtext0)', fontWeight: 500 }}>{t('admin_commands.device_role', 'Device Role')}:</span>
-                  <span style={{ color: 'var(--ctp-text)' }}>{getRoleName(deviceMetadata.role) || deviceMetadata.role}</span>
+                  <span style={{ color: 'var(--color-text-subtle)', fontWeight: 500 }}>{t('admin_commands.device_role', 'Device Role')}:</span>
+                  <span style={{ color: 'var(--color-text)' }}>{getRoleName(deviceMetadata.role) || deviceMetadata.role}</span>
 
-                  <span style={{ color: 'var(--ctp-subtext0)', fontWeight: 500 }}>{t('admin_commands.device_state_version', 'State Version')}:</span>
-                  <span style={{ color: 'var(--ctp-text)' }}>{deviceMetadata.deviceStateVersion}</span>
+                  <span style={{ color: 'var(--color-text-subtle)', fontWeight: 500 }}>{t('admin_commands.device_state_version', 'State Version')}:</span>
+                  <span style={{ color: 'var(--color-text)' }}>{deviceMetadata.deviceStateVersion}</span>
 
-                  <span style={{ color: 'var(--ctp-subtext0)', fontWeight: 500 }}>{t('admin_commands.capabilities', 'Capabilities')}:</span>
-                  <span style={{ color: 'var(--ctp-text)' }}>
+                  <span style={{ color: 'var(--color-text-subtle)', fontWeight: 500 }}>{t('admin_commands.capabilities', 'Capabilities')}:</span>
+                  <span style={{ color: 'var(--color-text)' }}>
                     {[
                       deviceMetadata.hasWifi && 'WiFi',
                       deviceMetadata.hasBluetooth && 'Bluetooth',
@@ -2679,8 +2679,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                     ].filter(Boolean).join(', ') || t('common.none', 'None')}
                   </span>
 
-                  <span style={{ color: 'var(--ctp-subtext0)', fontWeight: 500 }}>{t('admin_commands.position_flags', 'Position Flags')}:</span>
-                  <span style={{ color: 'var(--ctp-text)' }}>{decodePositionFlagNames(deviceMetadata.positionFlags ?? 0)}</span>
+                  <span style={{ color: 'var(--color-text-subtle)', fontWeight: 500 }}>{t('admin_commands.position_flags', 'Position Flags')}:</span>
+                  <span style={{ color: 'var(--color-text)' }}>{decodePositionFlagNames(deviceMetadata.positionFlags ?? 0)}</span>
                 </div>
               </div>
             )}
@@ -2692,17 +2692,17 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
         <div style={{
           padding: '0.75rem 1rem',
           marginBottom: '1rem',
-          backgroundColor: 'var(--ctp-surface0)',
-          border: '1px solid var(--ctp-blue)',
+          backgroundColor: 'var(--color-surface)',
+          border: '1px solid var(--color-accent)',
           borderRadius: '8px',
-          color: 'var(--ctp-subtext1)',
+          color: 'var(--color-text-muted)',
           fontSize: '0.9rem',
           lineHeight: '1.4'
         }}>
           {t('admin_commands.local_node_config_hint', 'All local device configuration, including many features not available in Remote Admin, is available on the')}{' '}
           <a
             href="#configuration"
-            style={{ color: 'var(--ctp-blue)', textDecoration: 'underline', cursor: 'pointer' }}
+            style={{ color: 'var(--color-accent)', textDecoration: 'underline', cursor: 'pointer' }}
           >
             {t('admin_commands.device_configuration_page_link', 'Device Configuration')}
           </a>{' '}
@@ -3033,8 +3033,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                   disabled={isExecuting}
                   style={{
                     padding: '0.5rem 1rem',
-                    backgroundColor: 'var(--ctp-red)',
-                    color: 'var(--ctp-base)',
+                    backgroundColor: 'var(--color-error)',
+                    color: 'var(--color-bg)',
                     border: 'none',
                     borderRadius: '4px',
                     cursor: isExecuting ? 'not-allowed' : 'pointer',
@@ -3158,29 +3158,29 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                 key={index}
                 style={{
                   border: channel?.role === 1
-                    ? '2px solid var(--ctp-blue)'
-                    : '1px solid var(--ctp-surface1)',
+                    ? '2px solid var(--color-accent)'
+                    : '1px solid var(--color-surface-hover)',
                   borderRadius: '8px',
                   padding: '1rem',
-                  backgroundColor: channel ? 'var(--ctp-surface0)' : 'var(--ctp-mantle)',
+                  backgroundColor: channel ? 'var(--color-surface)' : 'var(--color-bg-raised)',
                   opacity: channel?.role === 0 ? 0.5 : 1,
                   boxShadow: channel?.role === 1 ? '0 0 10px rgba(137, 180, 250, 0.3)' : 'none'
                 }}
               >
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '0.75rem' }}>
                   <div>
-                    <h4 style={{ margin: 0, color: 'var(--ctp-text)' }}>
+                    <h4 style={{ margin: 0, color: 'var(--color-text)' }}>
                       {t('admin_commands.channel_slot', { index })}: {channel ? (
                         <>
-                          {channel.name && channel.name.trim().length > 0 ? channel.name : <span style={{ color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>{t('admin_commands.unnamed')}</span>}
-                          {channel.role === 1 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-blue)', fontSize: '0.8rem' }}><UiIcon name="favorite" size={13} /> {t('admin_commands.primary')}</span>}
-                          {channel.role === 2 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-green)', fontSize: '0.8rem' }}><UiIcon name="radio" size={13} /> {t('admin_commands.secondary')}</span>}
-                          {channel.role === 0 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-overlay0)', fontSize: '0.8rem' }}><UiIcon name="power" size={13} /> {t('admin_commands.disabled')}</span>}
+                          {channel.name && channel.name.trim().length > 0 ? channel.name : <span style={{ color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>{t('admin_commands.unnamed')}</span>}
+                          {channel.role === 1 && <span style={{ marginLeft: '0.5rem', color: 'var(--color-accent)', fontSize: '0.8rem' }}><UiIcon name="favorite" size={13} /> {t('admin_commands.primary')}</span>}
+                          {channel.role === 2 && <span style={{ marginLeft: '0.5rem', color: 'var(--color-success)', fontSize: '0.8rem' }}><UiIcon name="radio" size={13} /> {t('admin_commands.secondary')}</span>}
+                          {channel.role === 0 && <span style={{ marginLeft: '0.5rem', color: 'var(--color-text-faint)', fontSize: '0.8rem' }}><UiIcon name="power" size={13} /> {t('admin_commands.disabled')}</span>}
                         </>
-                      ) : <span style={{ color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>{t('admin_commands.empty')}</span>}
+                      ) : <span style={{ color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>{t('admin_commands.empty')}</span>}
                     </h4>
                     {channel && (
-                      <div style={{ marginTop: '0.5rem', fontSize: '0.9rem', color: 'var(--ctp-subtext1)' }}>
+                      <div style={{ marginTop: '0.5rem', fontSize: '0.9rem', color: 'var(--color-text-muted)' }}>
                         <div><UiIcon name={channel.psk && channel.psk !== 'AQ==' ? 'encrypted' : 'unencrypted'} /> {channel.psk && channel.psk !== 'AQ==' ? t('admin_commands.encrypted') : t('admin_commands.unencrypted')}</div>
                         <div>
                           {channel.uplinkEnabled && <><UiIcon name="sortAscending" /> {t('admin_commands.uplink')} </>}
@@ -3197,8 +3197,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                       style={{
                         padding: '0.5rem 0.75rem',
                         fontSize: '0.9rem',
-                        backgroundColor: 'var(--ctp-blue)',
-                        color: 'var(--ctp-base)',
+                        backgroundColor: 'var(--color-accent)',
+                        color: 'var(--color-bg)',
                         border: 'none',
                         borderRadius: '4px',
                         cursor: (isExecuting || selectedNodeNum === null) ? 'not-allowed' : 'pointer',
@@ -3214,8 +3214,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                         style={{
                           padding: '0.5rem 0.75rem',
                           fontSize: '0.9rem',
-                          backgroundColor: 'var(--ctp-green)',
-                          color: 'var(--ctp-base)',
+                          backgroundColor: 'var(--color-success)',
+                          color: 'var(--color-bg)',
                           border: 'none',
                           borderRadius: '4px',
                           cursor: (isExecuting || selectedNodeNum === null) ? 'not-allowed' : 'pointer',
@@ -3231,8 +3231,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                       style={{
                         padding: '0.5rem 0.75rem',
                         fontSize: '0.9rem',
-                        backgroundColor: 'var(--ctp-yellow)',
-                        color: 'var(--ctp-base)',
+                        backgroundColor: 'var(--color-warning)',
+                        color: 'var(--color-bg)',
                         border: 'none',
                         borderRadius: '4px',
                         cursor: (isExecuting || selectedNodeNum === null) ? 'not-allowed' : 'pointer',
@@ -3393,7 +3393,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
         id="admin-import-export"
         title={t('admin_commands.config_import_export')}
       >
-        <p style={{ color: 'var(--ctp-subtext0)', marginBottom: '1rem' }}>
+        <p style={{ color: 'var(--color-text-subtle)', marginBottom: '1rem' }}>
           {t('admin_commands.config_import_export_description')}
         </p>
         <div style={{ display: 'flex', gap: '1rem', marginBottom: '1.5rem' }}>
@@ -3401,7 +3401,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             onClick={() => setShowConfigImportModal(true)}
             disabled={selectedNodeNum === null || isExecuting}
             style={{
-              backgroundColor: 'var(--ctp-blue)',
+              backgroundColor: 'var(--color-accent)',
               color: '#fff',
               padding: '0.75rem 1.5rem',
               border: 'none',
@@ -3427,7 +3427,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             }}
             disabled={selectedNodeNum === null || isExecuting}
             style={{
-              backgroundColor: 'var(--ctp-green)',
+              backgroundColor: 'var(--color-success)',
               color: '#fff',
               padding: '0.75rem 1.5rem',
               border: 'none',
@@ -3449,7 +3449,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
         id="admin-node-management"
         title={t('admin_commands.node_favorites_ignored')}
       >
-        <p style={{ color: 'var(--ctp-subtext0)', marginBottom: '1.5rem' }}>
+        <p style={{ color: 'var(--color-text-subtle)', marginBottom: '1.5rem' }}>
           {t('admin_commands.node_favorites_ignored_description')}
         </p>
         
@@ -3483,8 +3483,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                 left: 0,
                 right: 0,
                 marginTop: '4px',
-                background: 'var(--ctp-base)',
-                border: '2px solid var(--ctp-surface2)',
+                background: 'var(--color-bg)',
+                border: '2px solid var(--color-surface-active)',
                 borderRadius: '8px',
                 maxHeight: '300px',
                 overflowY: 'auto',
@@ -3502,27 +3502,27 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                     style={{
                       padding: '0.75rem 1rem',
                       cursor: 'pointer',
-                      borderBottom: '1px solid var(--ctp-surface1)',
+                      borderBottom: '1px solid var(--color-surface-hover)',
                       transition: 'background 0.1s',
                       display: 'flex',
                       justifyContent: 'space-between',
                       alignItems: 'center'
                     }}
-                    onMouseEnter={(e) => e.currentTarget.style.background = 'var(--ctp-surface0)'}
+                    onMouseEnter={(e) => e.currentTarget.style.background = 'var(--color-surface)'}
                     onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
                   >
                     <div style={{ flex: 1 }}>
-                      <div style={{ fontWeight: '500', color: 'var(--ctp-text)', display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+                      <div style={{ fontWeight: '500', color: 'var(--color-text)', display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
                         <span>{node.longName}</span>
-                        {node.isLocal && <span style={{ color: 'var(--ctp-blue)', fontSize: '0.85rem' }}>({t('admin_commands.local_node_indicator')})</span>}
+                        {node.isLocal && <span style={{ color: 'var(--color-accent)', fontSize: '0.85rem' }}>({t('admin_commands.local_node_indicator')})</span>}
                         {/* These badges come from OUR node's DB. While the admin
                             target is a remote device they describe the wrong
                             device, so hide them rather than mislabel remote
                             state (#4511, the display bug behind #950). */}
                         {!isManagingRemoteNode && node.isFavorite && (
                           <span style={{ 
-                            backgroundColor: 'var(--ctp-yellow)', 
-                            color: 'var(--ctp-base)', 
+                            backgroundColor: 'var(--color-warning)', 
+                            color: 'var(--color-bg)', 
                             padding: '0.125rem 0.5rem', 
                             borderRadius: '4px', 
                             fontSize: '0.75rem',
@@ -3533,8 +3533,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                         )}
                         {!isManagingRemoteNode && node.isIgnored && (
                           <span style={{
-                            backgroundColor: 'var(--ctp-red)',
-                            color: 'var(--ctp-base)', 
+                            backgroundColor: 'var(--color-error)',
+                            color: 'var(--color-bg)', 
                             padding: '0.125rem 0.5rem', 
                             borderRadius: '4px', 
                             fontSize: '0.75rem',
@@ -3544,13 +3544,13 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                           </span>
                         )}
                       </div>
-                      <div style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)', marginTop: '0.25rem' }}>
+                      <div style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)', marginTop: '0.25rem' }}>
                         {node.shortName && node.shortName !== node.longName && `${node.shortName} • `}
                         {node.nodeId}
                       </div>
                     </div>
                     {nodeManagementNodeNum === node.nodeNum && (
-                      <span style={{ color: 'var(--ctp-blue)', fontSize: '1.2rem' }}><UiIcon name="check" /></span>
+                      <span style={{ color: 'var(--color-accent)', fontSize: '1.2rem' }}><UiIcon name="check" /></span>
                     )}
                   </div>
                 ))}
@@ -3572,10 +3572,10 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             const isIgnored = isManagingRemoteNode
               ? (remoteStatus?.isIgnored ?? false)
               : (selectedNode?.isIgnored ?? false);
-            const favoriteBadge = <span style={{ color: 'var(--ctp-yellow)' }}><UiIcon name="favorite" /> {t('admin_commands.favorite')}</span>;
-            const ignoredBadge = <span style={{ color: 'var(--ctp-red)', marginLeft: '0.5rem' }}><UiIcon name="blocked" /> {t('admin_commands.ignored')}</span>;
+            const favoriteBadge = <span style={{ color: 'var(--color-warning)' }}><UiIcon name="favorite" /> {t('admin_commands.favorite')}</span>;
+            const ignoredBadge = <span style={{ color: 'var(--color-error)', marginLeft: '0.5rem' }}><UiIcon name="blocked" /> {t('admin_commands.ignored')}</span>;
             return (
-              <div style={{ marginTop: '0.75rem', fontSize: '0.875rem', color: 'var(--ctp-subtext0)' }}>
+              <div style={{ marginTop: '0.75rem', fontSize: '0.875rem', color: 'var(--color-text-subtle)' }}>
                 {t('admin_commands.selected')}: {selectedNode?.longName || t('admin_commands.node_fallback', { nodeNum: nodeManagementNodeNum })}
                 {isManagingRemoteNode ? (
                   <span style={{ marginLeft: '0.5rem' }}>
@@ -3600,7 +3600,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
 
         <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', marginTop: '1.5rem' }}>
           <div style={{ flex: 1, minWidth: '200px' }}>
-            <h4 style={{ marginBottom: '0.75rem', color: 'var(--ctp-text)' }}><UiIcon name="favorite" /> {t('admin_commands.favorites')}</h4>
+            <h4 style={{ marginBottom: '0.75rem', color: 'var(--color-text)' }}><UiIcon name="favorite" /> {t('admin_commands.favorites')}</h4>
             {(() => {
               const isDisabled = isExecuting || nodeManagementNodeNum === null || remoteAdminBlocked;
               const blockedTitle = remoteAdminBlocked ? t('tx_disabled.remote_admin_notice') : undefined;
@@ -3614,8 +3614,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                     style={{
                       flex: 1,
                       padding: '0.75rem 1rem',
-                      backgroundColor: 'var(--ctp-yellow)',
-                      color: 'var(--ctp-base)',
+                      backgroundColor: 'var(--color-warning)',
+                      color: 'var(--color-bg)',
                       border: 'none',
                       borderRadius: '4px',
                       cursor: isDisabled ? 'not-allowed' : 'pointer',
@@ -3633,8 +3633,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                     style={{
                       flex: 1,
                       padding: '0.75rem 1rem',
-                      backgroundColor: 'var(--ctp-surface2)',
-                      color: 'var(--ctp-text)',
+                      backgroundColor: 'var(--color-surface-active)',
+                      color: 'var(--color-text)',
                       border: 'none',
                       borderRadius: '4px',
                       cursor: isDisabled ? 'not-allowed' : 'pointer',
@@ -3650,7 +3650,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
             })()}
           </div>
           <div style={{ flex: 1, minWidth: '200px' }}>
-            <h4 style={{ marginBottom: '0.75rem', color: 'var(--ctp-text)' }}><UiIcon name="blocked" /> {t('admin_commands.ignored_nodes')}</h4>
+            <h4 style={{ marginBottom: '0.75rem', color: 'var(--color-text)' }}><UiIcon name="blocked" /> {t('admin_commands.ignored_nodes')}</h4>
             {(() => {
               const isDisabled = isExecuting || nodeManagementNodeNum === null || remoteAdminBlocked;
               const blockedTitle = remoteAdminBlocked ? t('tx_disabled.remote_admin_notice') : undefined;
@@ -3664,8 +3664,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                     style={{
                       flex: 1,
                       padding: '0.75rem 1rem',
-                      backgroundColor: 'var(--ctp-red)',
-                      color: 'var(--ctp-base)',
+                      backgroundColor: 'var(--color-error)',
+                      color: 'var(--color-bg)',
                       border: 'none',
                       borderRadius: '4px',
                       cursor: isDisabled ? 'not-allowed' : 'pointer',
@@ -3683,8 +3683,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                     style={{
                       flex: 1,
                       padding: '0.75rem 1rem',
-                      backgroundColor: 'var(--ctp-surface2)',
-                      color: 'var(--ctp-text)',
+                      backgroundColor: 'var(--color-surface-active)',
+                      color: 'var(--color-text)',
                       border: 'none',
                       borderRadius: '4px',
                       cursor: isDisabled ? 'not-allowed' : 'pointer',
@@ -3701,11 +3701,11 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
           </div>
         </div>
         {isManagingRemoteNode && (
-          <p style={{ marginTop: '1rem', fontSize: '0.85rem', color: 'var(--ctp-subtext1)', fontStyle: 'italic' }}>
+          <p style={{ marginTop: '1rem', fontSize: '0.85rem', color: 'var(--color-text-muted)', fontStyle: 'italic' }}>
             {t('admin_commands.remote_status_readback_note')}
           </p>
         )}
-        <p style={{ marginTop: '1rem', fontSize: '0.85rem', color: 'var(--ctp-subtext1)', fontStyle: 'italic' }}>
+        <p style={{ marginTop: '1rem', fontSize: '0.85rem', color: 'var(--color-text-muted)', fontStyle: 'italic' }}>
           {t('admin_commands.firmware_requirement_note')}
         </p>
       </CollapsibleSection>
@@ -3739,18 +3739,18 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
         >
           <div
             style={{
-              background: 'var(--ctp-base)',
+              background: 'var(--color-bg)',
               padding: '2rem',
               borderRadius: '8px',
               maxWidth: '600px',
               width: '90%',
               maxHeight: '90vh',
               overflowY: 'auto',
-              border: '2px solid var(--ctp-surface2)'
+              border: '2px solid var(--color-surface-active)'
             }}
             onClick={(e) => e.stopPropagation()}
           >
-            <h3 style={{ marginTop: 0, marginBottom: '1.5rem', color: 'var(--ctp-text)' }}>
+            <h3 style={{ marginTop: 0, marginBottom: '1.5rem', color: 'var(--color-text)' }}>
               {t('admin_commands.edit_channel', { slot: editingChannelSlot })}
             </h3>
             
@@ -3874,9 +3874,9 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                 disabled={isExecuting}
                 style={{
                   padding: '0.75rem 1.5rem',
-                  backgroundColor: 'var(--ctp-surface0)',
-                  color: 'var(--ctp-text)',
-                  border: '1px solid var(--ctp-surface2)',
+                  backgroundColor: 'var(--color-surface)',
+                  color: 'var(--color-text)',
+                  border: '1px solid var(--color-surface-active)',
                   borderRadius: '4px',
                   cursor: isExecuting ? 'not-allowed' : 'pointer',
                   fontSize: '1rem',
@@ -3909,7 +3909,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
         >
           <div
             style={{
-              backgroundColor: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-bg)',
               borderRadius: '8px',
               padding: '1.5rem',
               maxWidth: '500px',
@@ -3945,7 +3945,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                 <label>{t('admin_commands.preview')}:</label>
                 <pre
                   style={{
-                    backgroundColor: 'var(--ctp-surface0)',
+                    backgroundColor: 'var(--color-surface)',
                     padding: '0.75rem',
                     borderRadius: '4px',
                     fontSize: '0.85rem',
@@ -3965,8 +3965,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-green)',
-                  color: 'var(--ctp-base)',
+                  backgroundColor: 'var(--color-success)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: (isExecuting || !importFileContent) ? 'not-allowed' : 'pointer',
@@ -3981,8 +3981,8 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-surface1)',
-                  color: 'var(--ctp-text)',
+                  backgroundColor: 'var(--color-surface-hover)',
+                  color: 'var(--color-text)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: isExecuting ? 'not-allowed' : 'pointer'
@@ -4010,7 +4010,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
         </p>
         <div style={{ marginTop: '1.5rem', display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
           <div style={{ display: 'flex', gap: '1rem', alignItems: 'center', flexWrap: 'wrap' }}>
-            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', color: 'var(--ctp-text)' }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', color: 'var(--color-text)' }}>
               {t('admin_commands.reboot_delay_label')}:
               <input
                 type="number"

--- a/src/components/AirtimeCutoffSection.tsx
+++ b/src/components/AirtimeCutoffSection.tsx
@@ -155,11 +155,13 @@ const AirtimeCutoffSection: React.FC<AirtimeCutoffSectionProps> = ({ baseUrl }) 
     : t('automation.airtime_cutoff.source_local_label', 'local');
 
   // Banner colour: red when paused, green when active, neutral when disabled/unknown.
+  // The neutral sibling of the error/success roles below. Uses the text role
+  // because the value lands on `color:` as well as the two border rules.
   const bannerColor = disabled
-    ? 'var(--ctp-overlay0)'
+    ? 'var(--color-text-faint)'
     : gated
-      ? 'var(--ctp-red)'
-      : 'var(--ctp-green)';
+      ? 'var(--color-error)'
+      : 'var(--color-success)';
 
   return (
     <>
@@ -168,8 +170,8 @@ const AirtimeCutoffSection: React.FC<AirtimeCutoffSectionProps> = ({ baseUrl }) 
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0 }}>
@@ -178,7 +180,7 @@ const AirtimeCutoffSection: React.FC<AirtimeCutoffSectionProps> = ({ baseUrl }) 
       </div>
 
       <div className="settings-section">
-        <p style={{ marginLeft: '0.25rem', marginBottom: '1rem', color: 'var(--ctp-subtext1)', fontSize: '13px', lineHeight: '1.5' }}>
+        <p style={{ marginLeft: '0.25rem', marginBottom: '1rem', color: 'var(--color-text-muted)', fontSize: '13px', lineHeight: '1.5' }}>
           {t('automation.airtime_cutoff.description',
             'Pauses all automations (auto-traceroute, auto-announce, timers, etc.) whenever the connected node\'s Channel Utilization rises above this threshold, so bots stop adding traffic while the mesh is busy with real activity. Automations resume automatically once utilization drops back below the threshold. Set to 0 to disable.')}
         </p>
@@ -187,7 +189,7 @@ const AirtimeCutoffSection: React.FC<AirtimeCutoffSectionProps> = ({ baseUrl }) 
         <div style={{
           marginBottom: '1.25rem',
           padding: '0.6rem 1rem',
-          background: 'var(--ctp-surface0)',
+          background: 'var(--color-surface)',
           border: `1px solid ${bannerColor}`,
           borderLeft: `4px solid ${bannerColor}`,
           borderRadius: '6px',
@@ -215,7 +217,7 @@ const AirtimeCutoffSection: React.FC<AirtimeCutoffSectionProps> = ({ baseUrl }) 
         {/* Infrastructure nodes contributing to the neighbour-averaged reading */}
         {!disabled && statusSource === 'neighbors' && contributors.length > 0 && (
           <div style={{ marginBottom: '1.25rem' }}>
-            <div style={{ marginBottom: '0.4rem', color: 'var(--ctp-subtext1)', fontSize: '12px', fontWeight: 600 }}>
+            <div style={{ marginBottom: '0.4rem', color: 'var(--color-text-muted)', fontSize: '12px', fontWeight: 600 }}>
               {t('automation.airtime_cutoff.contributors_label', 'Infrastructure nodes in calculation')}
             </div>
             <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
@@ -230,16 +232,16 @@ const AirtimeCutoffSection: React.FC<AirtimeCutoffSectionProps> = ({ baseUrl }) 
                       alignItems: 'center',
                       gap: '1rem',
                       padding: '0.45rem 0.75rem',
-                      background: 'var(--ctp-surface0)',
-                      border: '1px solid var(--ctp-surface2)',
+                      background: 'var(--color-surface)',
+                      border: '1px solid var(--color-surface-active)',
                       borderRadius: '6px',
                       fontSize: '13px',
                     }}
                   >
-                    <span style={{ color: 'var(--ctp-text)', fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    <span style={{ color: 'var(--color-text)', fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                       {name}
                     </span>
-                    <span style={{ color: 'var(--ctp-subtext0)', whiteSpace: 'nowrap' }}>
+                    <span style={{ color: 'var(--color-text-subtle)', whiteSpace: 'nowrap' }}>
                       {t('automation.airtime_cutoff.contributor_detail', '{{util}}% · {{rssi}} dBm', { util: formatPercent(node.channelUtilization), rssi: node.rssi })}
                     </span>
                   </li>

--- a/src/components/Analysis/SolarMonitoringReport.tsx
+++ b/src/components/Analysis/SolarMonitoringReport.tsx
@@ -529,7 +529,7 @@ const SolarNodeCard: React.FC<{
                   data={chartData}
                   margin={{ top: 8, right: 16, bottom: 4, left: 8 }}
                 >
-                  <CartesianGrid strokeDasharray="3 3" stroke="var(--ctp-surface0)" />
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--color-surface)" />
                   <XAxis
                     dataKey="timestamp"
                     type="number"
@@ -540,20 +540,20 @@ const SolarNodeCard: React.FC<{
                         day: 'numeric',
                       })
                     }
-                    stroke="var(--ctp-subtext0)"
+                    stroke="var(--color-text-subtle)"
                     fontSize={11}
                   />
                   <YAxis
                     yAxisId="left"
                     domain={[yMin, yMax]}
-                    stroke="var(--ctp-subtext0)"
+                    stroke="var(--color-text-subtle)"
                     fontSize={11}
                     tickFormatter={(v: number) => (isPercent ? `${v}%` : `${v.toFixed(1)}V`)}
                   />
                   <YAxis
                     yAxisId="right"
                     orientation="right"
-                    stroke="var(--ctp-yellow)"
+                    stroke="var(--color-warning)"
                     fontSize={11}
                     tickFormatter={(v: number) => `${Math.round(v)} Wh`}
                     hide={!hasSolar}
@@ -561,12 +561,12 @@ const SolarNodeCard: React.FC<{
                   <Tooltip
                     labelFormatter={(ts) => new Date(Number(ts)).toLocaleString()}
                     contentStyle={{
-                      background: 'var(--ctp-mantle)',
-                      border: '1px solid var(--ctp-surface1)',
+                      background: 'var(--color-bg-raised)',
+                      border: '1px solid var(--color-surface-hover)',
                       borderRadius: 6,
-                      color: 'var(--ctp-text)',
+                      color: 'var(--color-text)',
                     }}
-                    labelStyle={{ color: 'var(--ctp-subtext0)' }}
+                    labelStyle={{ color: 'var(--color-text-subtle)' }}
                     formatter={(value, name) => {
                       if (name === 'solarWh') return [`${Number(value).toFixed(0)} Wh`, 'Solar'];
                       if (name === 'forecastBattery')
@@ -581,7 +581,7 @@ const SolarNodeCard: React.FC<{
                     }}
                   />
                   <Legend
-                    wrapperStyle={{ fontSize: 11, color: 'var(--ctp-subtext0)' }}
+                    wrapperStyle={{ fontSize: 11, color: 'var(--color-text-subtle)' }}
                   />
 
                   {/* Reference levels — drawn behind the data lines */}
@@ -592,17 +592,17 @@ const SolarNodeCard: React.FC<{
                       y={rl.y}
                       stroke={
                         rl.tone === 'good'
-                          ? 'var(--ctp-green)'
+                          ? 'var(--color-success)'
                           : rl.tone === 'mid'
-                            ? 'var(--ctp-yellow)'
-                            : 'var(--ctp-red)'
+                            ? 'var(--color-warning)'
+                            : 'var(--color-error)'
                       }
                       strokeDasharray="4 4"
                       strokeOpacity={0.5}
                       label={{
                         value: rl.label,
                         position: 'insideRight',
-                        fill: 'var(--ctp-subtext0)',
+                        fill: 'var(--color-text-subtle)',
                         fontSize: 10,
                       }}
                     />
@@ -614,9 +614,9 @@ const SolarNodeCard: React.FC<{
                       yAxisId="right"
                       type="monotone"
                       dataKey="solarWh"
-                      fill="var(--ctp-yellow)"
+                      fill="var(--color-warning)"
                       fillOpacity={0.18}
-                      stroke="var(--ctp-yellow)"
+                      stroke="var(--color-warning)"
                       strokeOpacity={0.4}
                       strokeWidth={1}
                       isAnimationActive={false}
@@ -630,7 +630,7 @@ const SolarNodeCard: React.FC<{
                     yAxisId="left"
                     type="monotone"
                     dataKey="value"
-                    stroke="var(--ctp-blue)"
+                    stroke="var(--color-accent)"
                     dot={false}
                     strokeWidth={2}
                     isAnimationActive={false}
@@ -644,7 +644,7 @@ const SolarNodeCard: React.FC<{
                       yAxisId="left"
                       type="monotone"
                       dataKey="forecastBattery"
-                      stroke="var(--ctp-mauve)"
+                      stroke="var(--color-accent-alt)"
                       strokeDasharray="6 4"
                       strokeWidth={2}
                       dot={{ r: 3 }}

--- a/src/components/AutoAcknowledgeSection.tsx
+++ b/src/components/AutoAcknowledgeSection.tsx
@@ -348,8 +348,8 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
         justifyContent: 'space-between',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -392,9 +392,9 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
             gap: '0.4rem',
             padding: '0.4rem 0.85rem',
             borderRadius: '6px',
-            background: 'var(--ctp-surface2)',
-            color: isConvertDisabled ? 'var(--ctp-subtext0)' : 'var(--ctp-text)',
-            border: '1px solid var(--ctp-surface2)',
+            background: 'var(--color-surface-active)',
+            color: isConvertDisabled ? 'var(--color-text-subtle)' : 'var(--color-text)',
+            border: '1px solid var(--color-surface-active)',
             cursor: isConvertDisabled ? 'not-allowed' : 'pointer',
             opacity: isConvertDisabled ? 0.6 : 1,
             fontSize: '0.85rem',
@@ -491,7 +491,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
               {t('automation.auto_ack.skip_incomplete')}
             </label>
           </div>
-          <div style={{ marginTop: '0.5rem', marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+          <div style={{ marginTop: '0.5rem', marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--color-text-subtle)' }}>
             {t('automation.auto_ack.skip_incomplete_description')}
           </div>
 
@@ -499,7 +499,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
             <label htmlFor="autoAckIgnoredNodes" style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 'bold' }}>
               {t('automation.auto_ack.node_ignore_list')}
             </label>
-            <div style={{ marginBottom: '0.5rem', fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+            <div style={{ marginBottom: '0.5rem', fontSize: '0.9rem', color: 'var(--color-text-subtle)' }}>
               {t('automation.auto_ack.node_ignore_list_description')}
             </div>
             <textarea
@@ -522,7 +522,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
             <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 'bold' }}>
               {t('automation.auto_ack.cooldown_label')}
             </label>
-            <div style={{ marginBottom: '0.5rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+            <div style={{ marginBottom: '0.5rem', fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
               {t('automation.auto_ack.cooldown_description')}
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
@@ -534,7 +534,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
                 disabled={!localEnabled}
                 style={{ width: '80px', padding: '2px 4px' }}
               />
-              <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+              <span style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
                 {t('automation.auto_ack.cooldown_help')}
               </span>
             </div>
@@ -545,7 +545,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
             <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 'bold' }}>
               {t('automation.auto_ack.presend_delay_label', 'Pre-Send Delay')}
             </label>
-            <div style={{ marginBottom: '0.5rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+            <div style={{ marginBottom: '0.5rem', fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
               {t('automation.auto_ack.presend_delay_description', 'Wait this many seconds before sending the acknowledgement. Gives a repeater time to finish its own transmission so a zero-hop ack is not dropped. 0 sends immediately.')}
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
@@ -558,7 +558,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
                 disabled={!localEnabled}
                 style={{ width: '80px', padding: '2px 4px' }}
               />
-              <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+              <span style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
                 {t('automation.auto_ack.presend_delay_help', 'seconds (0 = send immediately, max 120)')}
               </span>
             </div>
@@ -569,7 +569,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
             <label htmlFor="autoAckMaxAttempts" style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 'bold' }}>
               {t('automation.auto_ack.max_attempts_label', 'Auto-Ack Resend Attempts')}
             </label>
-            <div style={{ marginBottom: '0.5rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+            <div style={{ marginBottom: '0.5rem', fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
               {t('automation.auto_ack.max_attempts_description', 'How many times to resend an unacknowledged DM auto-ack reply. Lower values save airtime on busy channels; higher values improve delivery reliability. Channel replies always send once.')}
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
@@ -584,7 +584,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
                 <option value={2}>2</option>
                 <option value={3}>3</option>
               </select>
-              <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+              <span style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
                 {t('automation.auto_ack.max_attempts_help', 'attempts (1 = least airtime, 3 = default)')}
               </span>
             </div>
@@ -611,7 +611,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
             {AUTOACK_CELLS.map((cell) => {
               const config = localMatrix[cell.id];
               const isDirect = cell.type === 'direct';
-              const borderColor = cell.hop === 'zeroHop' ? 'var(--ctp-green)' : 'var(--ctp-blue)';
+              const borderColor = cell.hop === 'zeroHop' ? 'var(--color-success)' : 'var(--color-accent)';
               // Direct replies are inherently DMs: show the "Respond via DM" checkbox
               // checked + disabled. Channel cells gate it on the cell's reply toggle.
               const replyDmChecked = isDirect ? true : config.replyDm;
@@ -624,7 +624,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
                   key={cell.id}
                   style={{
                     padding: '1rem',
-                    background: 'var(--ctp-surface0)',
+                    background: 'var(--color-surface)',
                     border: `2px solid ${borderColor}`,
                     borderRadius: '8px',
                   }}
@@ -706,18 +706,18 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
             }}
           />
           <div style={{ marginTop: '0.5rem' }}>
-            <label style={{ fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+            <label style={{ fontSize: '0.9rem', color: 'var(--color-text-subtle)' }}>
               {t('automation.auto_ack.sample_preview_multihop')}:
             </label>
             <div style={{
               marginTop: '0.25rem',
               padding: '0.5rem',
-              background: 'var(--ctp-base)',
-              border: '1px solid var(--ctp-blue)',
+              background: 'var(--color-bg)',
+              border: '1px solid var(--color-accent)',
               borderRadius: '4px',
               fontFamily: 'monospace',
               fontSize: '0.9rem',
-              color: 'var(--ctp-text)'
+              color: 'var(--color-text)'
             }}>
               {generateSampleMessage(false)}
             </div>
@@ -747,18 +747,18 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
             }}
           />
           <div style={{ marginTop: '0.5rem' }}>
-            <label style={{ fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+            <label style={{ fontSize: '0.9rem', color: 'var(--color-text-subtle)' }}>
               {t('automation.auto_ack.sample_preview_direct')}:
             </label>
             <div style={{
               marginTop: '0.25rem',
               padding: '0.5rem',
-              background: 'var(--ctp-base)',
-              border: '1px solid var(--ctp-green)',
+              background: 'var(--color-bg)',
+              border: '1px solid var(--color-success)',
               borderRadius: '4px',
               fontFamily: 'monospace',
               fontSize: '0.9rem',
-              color: 'var(--ctp-text)'
+              color: 'var(--color-text)'
             }}>
               {generateSampleMessage(true)}
             </div>
@@ -802,7 +802,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
                       padding: '0.25rem 0.5rem',
                       marginBottom: '0.15rem',
                       backgroundColor: matches ? 'rgba(166, 227, 161, 0.1)' : 'rgba(243, 139, 168, 0.1)',
-                      border: `1px solid ${matches ? 'var(--ctp-green)' : 'var(--ctp-red)'}`,
+                      border: `1px solid ${matches ? 'var(--color-success)' : 'var(--color-error)'}`,
                       borderRadius: '4px',
                       fontFamily: 'monospace',
                       fontSize: '0.9rem',
@@ -815,12 +815,12 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
                         width: '16px',
                         height: '16px',
                         borderRadius: '50%',
-                        backgroundColor: matches ? 'var(--ctp-green)' : 'var(--ctp-red)',
+                        backgroundColor: matches ? 'var(--color-success)' : 'var(--color-error)',
                         marginRight: '0.5rem',
                         flexShrink: 0
                       }}
                     />
-                    <span style={{ color: 'var(--ctp-text)', wordBreak: 'break-word' }}>
+                    <span style={{ color: 'var(--color-text)', wordBreak: 'break-word' }}>
                       {message}
                     </span>
                   </div>

--- a/src/components/AutoAnnounceSection.tsx
+++ b/src/components/AutoAnnounceSection.tsx
@@ -330,8 +330,8 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -383,11 +383,11 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
           <div style={{
             marginBottom: '1rem',
             padding: '0.75rem',
-            background: 'var(--ctp-surface0)',
-            border: '1px solid var(--ctp-surface2)',
+            background: 'var(--color-surface)',
+            border: '1px solid var(--color-surface-active)',
             borderRadius: '4px',
             fontSize: '0.9rem',
-            color: 'var(--ctp-subtext0)'
+            color: 'var(--color-text-subtle)'
           }}>
             <strong>{t('automation.auto_announce.last_announcement')}:</strong> {new Date(lastAnnouncementTime).toLocaleString()}
           </div>
@@ -457,12 +457,12 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
               placeholder="0 */6 * * *"
               style={{
                 fontFamily: 'monospace',
-                borderColor: scheduleError ? 'var(--ctp-red)' : undefined
+                borderColor: scheduleError ? 'var(--color-error)' : undefined
               }}
             />
             {scheduleError && (
               <div style={{
-                color: 'var(--ctp-red)',
+                color: 'var(--color-error)',
                 fontSize: '0.875rem',
                 marginTop: '0.25rem'
               }}>
@@ -471,7 +471,7 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
             )}
             {!scheduleError && localSchedule && (
               <div style={{
-                color: 'var(--ctp-green)',
+                color: 'var(--color-success)',
                 fontSize: '0.875rem',
                 marginTop: '0.25rem'
               }}>
@@ -565,8 +565,8 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
               style={{
                 padding: '0.25rem 0.5rem',
                 fontSize: '12px',
-                background: 'var(--ctp-surface2)',
-                border: '1px solid var(--ctp-overlay0)',
+                background: 'var(--color-surface-active)',
+                border: '1px solid var(--color-border-subtle)',
                 borderRadius: '4px',
                 cursor: localEnabled ? 'pointer' : 'not-allowed',
                 opacity: localEnabled ? 1 : 0.5
@@ -581,8 +581,8 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
               style={{
                 padding: '0.25rem 0.5rem',
                 fontSize: '12px',
-                background: 'var(--ctp-surface2)',
-                border: '1px solid var(--ctp-overlay0)',
+                background: 'var(--color-surface-active)',
+                border: '1px solid var(--color-border-subtle)',
                 borderRadius: '4px',
                 cursor: localEnabled ? 'pointer' : 'not-allowed',
                 opacity: localEnabled ? 1 : 0.5
@@ -597,8 +597,8 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
               style={{
                 padding: '0.25rem 0.5rem',
                 fontSize: '12px',
-                background: 'var(--ctp-surface2)',
-                border: '1px solid var(--ctp-overlay0)',
+                background: 'var(--color-surface-active)',
+                border: '1px solid var(--color-border-subtle)',
                 borderRadius: '4px',
                 cursor: localEnabled ? 'pointer' : 'not-allowed',
                 opacity: localEnabled ? 1 : 0.5
@@ -613,8 +613,8 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
               style={{
                 padding: '0.25rem 0.5rem',
                 fontSize: '12px',
-                background: 'var(--ctp-surface2)',
-                border: '1px solid var(--ctp-overlay0)',
+                background: 'var(--color-surface-active)',
+                border: '1px solid var(--color-border-subtle)',
                 borderRadius: '4px',
                 cursor: localEnabled ? 'pointer' : 'not-allowed',
                 opacity: localEnabled ? 1 : 0.5
@@ -629,8 +629,8 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
               style={{
                 padding: '0.25rem 0.5rem',
                 fontSize: '12px',
-                background: 'var(--ctp-surface2)',
-                border: '1px solid var(--ctp-overlay0)',
+                background: 'var(--color-surface-active)',
+                border: '1px solid var(--color-border-subtle)',
                 borderRadius: '4px',
                 cursor: localEnabled ? 'pointer' : 'not-allowed',
                 opacity: localEnabled ? 1 : 0.5
@@ -645,8 +645,8 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
               style={{
                 padding: '0.25rem 0.5rem',
                 fontSize: '12px',
-                background: 'var(--ctp-surface2)',
-                border: '1px solid var(--ctp-overlay0)',
+                background: 'var(--color-surface-active)',
+                border: '1px solid var(--color-border-subtle)',
                 borderRadius: '4px',
                 cursor: localEnabled ? 'pointer' : 'not-allowed',
                 opacity: localEnabled ? 1 : 0.5
@@ -661,8 +661,8 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
               style={{
                 padding: '0.25rem 0.5rem',
                 fontSize: '12px',
-                background: 'var(--ctp-surface2)',
-                border: '1px solid var(--ctp-overlay0)',
+                background: 'var(--color-surface-active)',
+                border: '1px solid var(--color-border-subtle)',
                 borderRadius: '4px',
                 cursor: localEnabled ? 'pointer' : 'not-allowed',
                 opacity: localEnabled ? 1 : 0.5
@@ -677,8 +677,8 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
               style={{
                 padding: '0.25rem 0.5rem',
                 fontSize: '12px',
-                background: 'var(--ctp-surface2)',
-                border: '1px solid var(--ctp-overlay0)',
+                background: 'var(--color-surface-active)',
+                border: '1px solid var(--color-border-subtle)',
                 borderRadius: '4px',
                 cursor: localEnabled ? 'pointer' : 'not-allowed',
                 opacity: localEnabled ? 1 : 0.5
@@ -698,12 +698,12 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
           </label>
           <div style={{
             padding: '0.75rem',
-            background: 'var(--ctp-surface0)',
-            border: '2px solid var(--ctp-blue)',
+            background: 'var(--color-surface)',
+            border: '2px solid var(--color-accent)',
             borderRadius: '4px',
             fontFamily: 'monospace',
             fontSize: '0.95rem',
-            color: 'var(--ctp-text)',
+            color: 'var(--color-text)',
             lineHeight: '1.5',
             minHeight: '50px'
           }}>
@@ -718,11 +718,11 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
         <div style={{
           marginTop: '1rem',
           padding: '0.75rem',
-          background: 'var(--ctp-surface0)',
-          border: '1px solid var(--ctp-surface2)',
+          background: 'var(--color-surface)',
+          border: '1px solid var(--color-surface-active)',
           borderRadius: '4px',
           fontSize: '0.9rem',
-          color: 'var(--ctp-subtext0)'
+          color: 'var(--color-text-subtle)'
         }}>
           <strong>{t('automation.auto_announce.feature_emojis')}:</strong>
           <ul style={{ margin: '0.5rem 0', paddingLeft: '1.5rem' }}>
@@ -744,8 +744,8 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
         <div style={{
           marginTop: '2rem',
           padding: '1rem',
-          background: 'var(--ctp-surface0)',
-          border: '1px solid var(--ctp-surface2)',
+          background: 'var(--color-surface)',
+          border: '1px solid var(--color-surface-active)',
           borderRadius: '8px'
         }}>
           <div style={{ marginBottom: '1rem' }}>
@@ -759,7 +759,7 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
               />
               {t('automation.auto_announce.nodeinfo_title')}
             </label>
-            <p style={{ marginTop: '0.5rem', color: 'var(--ctp-subtext0)', fontSize: '0.9rem' }}>
+            <p style={{ marginTop: '0.5rem', color: 'var(--color-text-subtle)', fontSize: '0.9rem' }}>
               {t('automation.auto_announce.nodeinfo_description')}
             </p>
           </div>
@@ -802,7 +802,7 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
                 {localNodeInfoChannels.length === 0 && localNodeInfoEnabled && (
                   <div style={{
                     marginTop: '0.5rem',
-                    color: 'var(--ctp-yellow)',
+                    color: 'var(--color-warning)',
                     fontSize: '0.875rem'
                   }}>
                     {t('automation.auto_announce.nodeinfo_no_channels_warning')}
@@ -828,7 +828,7 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
                   className="setting-input"
                   style={{ width: '100px' }}
                 />
-                <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-subtext0)' }}>
+                <span style={{ marginLeft: '0.5rem', color: 'var(--color-text-subtle)' }}>
                   {t('automation.auto_announce.seconds')}
                 </span>
               </div>

--- a/src/components/AutoDeleteByDistanceSection.tsx
+++ b/src/components/AutoDeleteByDistanceSection.tsx
@@ -227,8 +227,8 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -394,11 +394,11 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
             marginTop: '0.5rem',
             marginLeft: 0,
             padding: '0.5rem 0.75rem',
-            background: 'var(--ctp-surface0)',
-            border: '1px solid var(--ctp-surface2)',
-            borderLeft: '3px solid var(--ctp-yellow)',
+            background: 'var(--color-surface)',
+            border: '1px solid var(--color-surface-active)',
+            borderLeft: '3px solid var(--color-warning)',
             borderRadius: '4px',
-            color: 'var(--ctp-subtext1)',
+            color: 'var(--color-text-muted)',
             fontSize: '12px',
             lineHeight: '1.5',
           }}>
@@ -409,7 +409,7 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
         </div>
 
         {homeLat == null && (
-          <p style={{ marginTop: '1rem', marginLeft: '1.75rem', color: 'var(--ctp-yellow)', fontSize: '12px' }}>
+          <p style={{ marginTop: '1rem', marginLeft: '1.75rem', color: 'var(--color-warning)', fontSize: '12px' }}>
             {t('automation.distance_delete.no_home_coordinate')}
           </p>
         )}
@@ -423,27 +423,27 @@ const AutoDeleteByDistanceSection: React.FC<AutoDeleteByDistanceSectionProps> = 
             <p className="text-muted">{t('automation.distance_delete.no_log_entries')}</p>
           ) : (
             <div style={{
-              border: '1px solid var(--ctp-surface2)',
+              border: '1px solid var(--color-surface-active)',
               borderRadius: '6px',
               overflow: 'hidden',
             }}>
               <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
                 <thead>
-                  <tr style={{ background: 'var(--ctp-surface0)' }}>
-                    <th style={{ padding: '0.5rem', textAlign: 'left', borderBottom: '1px solid var(--ctp-surface2)' }}>
+                  <tr style={{ background: 'var(--color-surface)' }}>
+                    <th style={{ padding: '0.5rem', textAlign: 'left', borderBottom: '1px solid var(--color-surface-active)' }}>
                       {t('automation.distance_delete.timestamp', 'Time')}
                     </th>
-                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--ctp-surface2)' }}>
+                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--color-surface-active)' }}>
                       {t('automation.distance_delete.nodes_deleted')}
                     </th>
-                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--ctp-surface2)' }}>
+                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--color-surface-active)' }}>
                       {t('automation.distance_delete.threshold_used')} ({unitLabel})
                     </th>
                   </tr>
                 </thead>
                 <tbody>
                   {logEntries.map((entry) => (
-                    <tr key={entry.id} style={{ borderBottom: '1px solid var(--ctp-surface1)' }}>
+                    <tr key={entry.id} style={{ borderBottom: '1px solid var(--color-surface-hover)' }}>
                       <td style={{ padding: '0.5rem' }}>
                         {new Date(Number(entry.timestamp)).toLocaleString()}
                       </td>

--- a/src/components/AutoFavoriteSection.tsx
+++ b/src/components/AutoFavoriteSection.tsx
@@ -132,8 +132,8 @@ const AutoFavoriteSection: React.FC<AutoFavoriteSectionProps> = ({ baseUrl }) =>
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -183,11 +183,11 @@ const AutoFavoriteSection: React.FC<AutoFavoriteSectionProps> = ({ baseUrl }) =>
                 marginLeft: '1.75rem',
                 marginBottom: '1rem',
                 padding: '0.75rem 1rem',
-                background: 'var(--ctp-surface0)',
-                border: '1px solid var(--ctp-yellow)',
-                borderLeft: '4px solid var(--ctp-yellow)',
+                background: 'var(--color-surface)',
+                border: '1px solid var(--color-warning)',
+                borderLeft: '4px solid var(--color-warning)',
                 borderRadius: '6px',
-                color: 'var(--ctp-yellow)',
+                color: 'var(--color-warning)',
                 fontSize: '13px',
                 lineHeight: '1.5',
               }}>
@@ -201,11 +201,11 @@ const AutoFavoriteSection: React.FC<AutoFavoriteSectionProps> = ({ baseUrl }) =>
                 marginLeft: '1.75rem',
                 marginBottom: '1rem',
                 padding: '0.75rem 1rem',
-                background: 'var(--ctp-surface0)',
-                border: '1px solid var(--ctp-yellow)',
-                borderLeft: '4px solid var(--ctp-yellow)',
+                background: 'var(--color-surface)',
+                border: '1px solid var(--color-warning)',
+                borderLeft: '4px solid var(--color-warning)',
                 borderRadius: '6px',
-                color: 'var(--ctp-yellow)',
+                color: 'var(--color-warning)',
                 fontSize: '13px',
                 lineHeight: '1.5',
               }}>
@@ -219,11 +219,11 @@ const AutoFavoriteSection: React.FC<AutoFavoriteSectionProps> = ({ baseUrl }) =>
                 marginLeft: '1.75rem',
                 marginBottom: '1rem',
                 padding: '0.75rem 1rem',
-                background: 'var(--ctp-surface0)',
-                border: '1px solid var(--ctp-green)',
-                borderLeft: '4px solid var(--ctp-green)',
+                background: 'var(--color-surface)',
+                border: '1px solid var(--color-success)',
+                borderLeft: '4px solid var(--color-success)',
                 borderRadius: '6px',
-                color: 'var(--ctp-green)',
+                color: 'var(--color-success)',
                 fontSize: '13px',
                 lineHeight: '1.5',
               }}>
@@ -241,11 +241,11 @@ const AutoFavoriteSection: React.FC<AutoFavoriteSectionProps> = ({ baseUrl }) =>
                 marginLeft: '1.75rem',
                 marginBottom: '1rem',
                 padding: '0.75rem 1rem',
-                background: 'var(--ctp-surface0)',
-                border: '1px solid var(--ctp-sapphire)',
-                borderLeft: '4px solid var(--ctp-sapphire)',
+                background: 'var(--color-surface)',
+                border: '1px solid var(--color-accent-hover)',
+                borderLeft: '4px solid var(--color-accent-hover)',
                 borderRadius: '6px',
-                color: 'var(--ctp-sapphire)',
+                color: 'var(--color-accent-hover)',
                 fontSize: '13px',
                 lineHeight: '1.5',
               }}>
@@ -284,30 +284,30 @@ const AutoFavoriteSection: React.FC<AutoFavoriteSectionProps> = ({ baseUrl }) =>
               {t('automation.auto_favorite.managed_nodes', 'Auto-Favorited Nodes')}
             </h3>
             <div style={{
-              border: '1px solid var(--ctp-surface2)',
+              border: '1px solid var(--color-surface-active)',
               borderRadius: '6px',
               overflow: 'hidden',
             }}>
               <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
                 <thead>
-                  <tr style={{ background: 'var(--ctp-surface0)' }}>
-                    <th style={{ padding: '0.5rem', textAlign: 'left', borderBottom: '1px solid var(--ctp-surface2)' }}>
+                  <tr style={{ background: 'var(--color-surface)' }}>
+                    <th style={{ padding: '0.5rem', textAlign: 'left', borderBottom: '1px solid var(--color-surface-active)' }}>
                       {t('common.node', 'Node')}
                     </th>
-                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--ctp-surface2)' }}>
+                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--color-surface-active)' }}>
                       {t('common.role', 'Role')}
                     </th>
-                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--ctp-surface2)' }}>
+                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--color-surface-active)' }}>
                       {t('common.hops', 'Hops')}
                     </th>
-                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--ctp-surface2)' }}>
+                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--color-surface-active)' }}>
                       {t('automation.auto_favorite.lock_header', 'Lock')}
                     </th>
                   </tr>
                 </thead>
                 <tbody>
                   {status.autoFavoriteNodes.map((node) => (
-                    <tr key={node.nodeNum} style={{ borderBottom: '1px solid var(--ctp-surface1)' }}>
+                    <tr key={node.nodeNum} style={{ borderBottom: '1px solid var(--color-surface-hover)' }}>
                       <td style={{ padding: '0.5rem' }}>{node.longName || node.shortName || node.nodeId}</td>
                       <td style={{ padding: '0.5rem', textAlign: 'center' }}>{ROLE_NAMES[node.role ?? 0] || 'Unknown'}</td>
                       <td style={{ padding: '0.5rem', textAlign: 'center' }}>{node.hopsAway ?? '?'}</td>
@@ -334,12 +334,12 @@ const AutoFavoriteSection: React.FC<AutoFavoriteSectionProps> = ({ baseUrl }) =>
                           disabled={node.favoriteLocked}
                           style={{
                             background: 'none',
-                            border: '1px solid var(--ctp-surface2)',
+                            border: '1px solid var(--color-surface-active)',
                             borderRadius: '4px',
                             padding: '0.2rem 0.5rem',
                             cursor: node.favoriteLocked ? 'default' : 'pointer',
                             fontSize: '11px',
-                            color: node.favoriteLocked ? 'var(--ctp-subtext0)' : 'var(--ctp-text)',
+                            color: node.favoriteLocked ? 'var(--color-text-subtle)' : 'var(--color-text)',
                             opacity: node.favoriteLocked ? 0.5 : 1,
                           }}
                           title={node.favoriteLocked
@@ -357,7 +357,7 @@ const AutoFavoriteSection: React.FC<AutoFavoriteSectionProps> = ({ baseUrl }) =>
           </div>
         )}
         {status && status.autoFavoriteNodes.length === 0 && (
-          <p style={{ marginTop: '1rem', marginLeft: '1.75rem', color: 'var(--ctp-subtext0)', fontSize: '13px' }}>
+          <p style={{ marginTop: '1rem', marginLeft: '1.75rem', color: 'var(--color-text-subtle)', fontSize: '13px' }}>
             {t('automation.auto_favorite.no_nodes', 'No nodes auto-favorited yet.')}
           </p>
         )}

--- a/src/components/AutoHeapManagementSection.tsx
+++ b/src/components/AutoHeapManagementSection.tsx
@@ -118,8 +118,8 @@ const AutoHeapManagementSection: React.FC<AutoHeapManagementSectionProps> = ({ b
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -139,11 +139,11 @@ const AutoHeapManagementSection: React.FC<AutoHeapManagementSectionProps> = ({ b
           marginLeft: '1.75rem',
           marginBottom: '1rem',
           padding: '0.75rem 1rem',
-          background: 'var(--ctp-surface0)',
-          border: '1px solid var(--ctp-yellow)',
-          borderLeft: '4px solid var(--ctp-yellow)',
+          background: 'var(--color-surface)',
+          border: '1px solid var(--color-warning)',
+          borderLeft: '4px solid var(--color-warning)',
           borderRadius: '6px',
-          color: 'var(--ctp-yellow)',
+          color: 'var(--color-warning)',
           fontSize: '13px',
           lineHeight: '1.5',
         }}>
@@ -157,11 +157,11 @@ const AutoHeapManagementSection: React.FC<AutoHeapManagementSectionProps> = ({ b
             marginLeft: '1.75rem',
             marginBottom: '1rem',
             padding: '0.5rem 1rem',
-            background: 'var(--ctp-surface0)',
-            border: '1px solid var(--ctp-surface2)',
+            background: 'var(--color-surface)',
+            border: '1px solid var(--color-surface-active)',
             borderRadius: '6px',
             fontSize: '13px',
-            color: 'var(--ctp-subtext1)',
+            color: 'var(--color-text-muted)',
           }}>
             {t('automation.auto_heap.heap_status', 'Current heap: {{kb}} KB free', {
               kb: Math.round(heapFreeBytes / 1000),

--- a/src/components/AutoKeyManagementSection.tsx
+++ b/src/components/AutoKeyManagementSection.tsx
@@ -212,8 +212,8 @@ const AutoKeyManagementSection: React.FC<AutoKeyManagementSectionProps> = ({
           alignItems: 'center',
           marginBottom: '1.5rem',
           padding: '1rem 1.25rem',
-          background: 'var(--ctp-surface1)',
-          border: '1px solid var(--ctp-surface2)',
+          background: 'var(--color-surface-hover)',
+          border: '1px solid var(--color-surface-active)',
           borderRadius: '8px',
         }}
       >
@@ -351,8 +351,8 @@ const AutoKeyManagementSection: React.FC<AutoKeyManagementSectionProps> = ({
           <label>{t('automation.auto_key_management.activity_log')}</label>
           <div
             style={{
-              background: 'var(--ctp-surface0)',
-              border: '1px solid var(--ctp-surface2)',
+              background: 'var(--color-surface)',
+              border: '1px solid var(--color-surface-active)',
               borderRadius: '4px',
               maxHeight: '250px',
               overflow: 'auto',
@@ -364,7 +364,7 @@ const AutoKeyManagementSection: React.FC<AutoKeyManagementSectionProps> = ({
                 style={{
                   padding: '1rem',
                   textAlign: 'center',
-                  color: 'var(--ctp-subtext0)',
+                  color: 'var(--color-text-subtle)',
                 }}
               >
                 {t('automation.auto_key_management.no_activity')}
@@ -372,7 +372,7 @@ const AutoKeyManagementSection: React.FC<AutoKeyManagementSectionProps> = ({
             ) : (
               <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.85rem' }}>
                 <thead>
-                  <tr style={{ background: 'var(--ctp-surface1)' }}>
+                  <tr style={{ background: 'var(--color-surface-hover)' }}>
                     <th
                       style={{
                         padding: '0.5rem 0.75rem',
@@ -431,8 +431,8 @@ const AutoKeyManagementSection: React.FC<AutoKeyManagementSectionProps> = ({
                 </thead>
                 <tbody>
                   {repairLog.map((entry) => (
-                    <tr key={entry.id} style={{ borderTop: '1px solid var(--ctp-surface1)' }}>
-                      <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-subtext0)' }}>
+                    <tr key={entry.id} style={{ borderTop: '1px solid var(--color-surface-hover)' }}>
+                      <td style={{ padding: '0.4rem 0.75rem', color: 'var(--color-text-subtle)' }}>
                         {new Date(entry.timestamp).toLocaleString()}
                       </td>
                       <td style={{ padding: '0.4rem 0.75rem' }}>

--- a/src/components/AutoLocalStatsSection.tsx
+++ b/src/components/AutoLocalStatsSection.tsx
@@ -400,11 +400,11 @@ const AutoLocalStatsSection: React.FC<AutoLocalStatsSectionProps> = ({
 
   const sectionHeaderStyle: React.CSSProperties = {
     display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-    padding: '0.5rem 0.75rem', background: 'var(--ctp-surface0)',
-    border: '1px solid var(--ctp-surface2)', borderRadius: '4px', cursor: 'pointer', marginBottom: '0.5rem',
+    padding: '0.5rem 0.75rem', background: 'var(--color-surface)',
+    border: '1px solid var(--color-surface-active)', borderRadius: '4px', cursor: 'pointer', marginBottom: '0.5rem',
   };
   const badgeStyle: React.CSSProperties = {
-    background: 'var(--ctp-blue)', color: 'var(--ctp-base)',
+    background: 'var(--color-accent)', color: 'var(--color-bg)',
     padding: '0.1rem 0.5rem', borderRadius: '10px', fontSize: '11px', fontWeight: '600',
   };
 
@@ -412,8 +412,8 @@ const AutoLocalStatsSection: React.FC<AutoLocalStatsSectionProps> = ({
     <>
       <div className="automation-section-header" style={{
         display: 'flex', alignItems: 'center', marginBottom: '1.5rem',
-        padding: '1rem 1.25rem', background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)', borderRadius: '8px'
+        padding: '1rem 1.25rem', background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)', borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
           <input
@@ -511,7 +511,7 @@ const AutoLocalStatsSection: React.FC<AutoLocalStatsSectionProps> = ({
           {filterEnabled && localEnabled && (
             <div style={{
               marginTop: '1rem', marginLeft: '1.75rem', padding: '1rem',
-              background: 'var(--ctp-surface0)', border: '1px solid var(--ctp-surface2)',
+              background: 'var(--color-surface)', border: '1px solid var(--color-surface-active)',
               borderRadius: '6px', display: 'flex', gap: '1rem'
             }}>
               <div style={{ flex: 1, minWidth: 0 }}>
@@ -529,28 +529,28 @@ const AutoLocalStatsSection: React.FC<AutoLocalStatsSectionProps> = ({
                     </span>
                   </div>
                   {expandedSections.nodes && (
-                    <div style={{ padding: '0.5rem', background: 'var(--ctp-base)', borderRadius: '4px' }}>
+                    <div style={{ padding: '0.5rem', background: 'var(--color-bg)', borderRadius: '4px' }}>
                       <input type="text" placeholder={t('automation.auto_localstats.search_nodes')} value={searchTerm}
                         onChange={(e) => setSearchTerm(e.target.value)}
-                        style={{ width: '100%', padding: '0.5rem', marginBottom: '0.5rem', background: 'var(--ctp-surface0)', border: '1px solid var(--ctp-surface2)', borderRadius: '4px', color: 'var(--ctp-text)' }} />
+                        style={{ width: '100%', padding: '0.5rem', marginBottom: '0.5rem', background: 'var(--color-surface)', border: '1px solid var(--color-surface-active)', borderRadius: '4px', color: 'var(--color-text)' }} />
                       <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
                         <button onClick={handleSelectAll} className="btn-secondary" style={{ padding: '0.3rem 0.6rem', fontSize: '11px' }}>{t('common.select_all')}</button>
                         <button onClick={handleDeselectAll} className="btn-secondary" style={{ padding: '0.3rem 0.6rem', fontSize: '11px' }}>{t('common.deselect_all')}</button>
                       </div>
-                      <div style={{ maxHeight: '200px', overflowY: 'auto', border: '1px solid var(--ctp-surface2)', borderRadius: '4px' }}>
+                      <div style={{ maxHeight: '200px', overflowY: 'auto', border: '1px solid var(--color-surface-active)', borderRadius: '4px' }}>
                         {filteredNodes.length === 0 ? (
-                          <div style={{ padding: '0.5rem', textAlign: 'center', color: 'var(--ctp-subtext0)', fontSize: '12px' }}>
+                          <div style={{ padding: '0.5rem', textAlign: 'center', color: 'var(--color-text-subtle)', fontSize: '12px' }}>
                             {searchTerm ? t('automation.auto_localstats.no_nodes_match') : t('automation.auto_localstats.no_nodes_available')}
                           </div>
                         ) : (
                           filteredNodes.map(node => (
                             <div key={node.nodeNum}
-                              style={{ padding: '0.4rem 0.6rem', borderBottom: '1px solid var(--ctp-surface1)', display: 'flex', alignItems: 'center', cursor: 'pointer', fontSize: '12px' }}
+                              style={{ padding: '0.4rem 0.6rem', borderBottom: '1px solid var(--color-surface-hover)', display: 'flex', alignItems: 'center', cursor: 'pointer', fontSize: '12px' }}
                               onClick={() => handleNodeToggle(node.nodeNum)}>
                               <input type="checkbox" checked={selectedNodeNums.includes(node.nodeNum)}
                                 onChange={() => handleNodeToggle(node.nodeNum)} onClick={(e) => e.stopPropagation()}
                                 style={{ width: 'auto', margin: 0, marginRight: '0.5rem', cursor: 'pointer' }} />
-                              <span style={{ color: 'var(--ctp-text)' }}>
+                              <span style={{ color: 'var(--color-text)' }}>
                                 {node.user?.longName || node.longName || node.user?.shortName || node.shortName || node.nodeId || 'Unknown'}
                               </span>
                             </div>
@@ -574,9 +574,9 @@ const AutoLocalStatsSection: React.FC<AutoLocalStatsSectionProps> = ({
                     </span>
                   </div>
                   {expandedSections.roles && (
-                    <div style={{ padding: '0.5rem', background: 'var(--ctp-base)', borderRadius: '4px', display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+                    <div style={{ padding: '0.5rem', background: 'var(--color-bg)', borderRadius: '4px', display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
                       {availableRolesInNodes.length === 0 ? (
-                        <span style={{ color: 'var(--ctp-subtext0)', fontSize: '12px' }}>{t('automation.auto_localstats.no_roles_available')}</span>
+                        <span style={{ color: 'var(--color-text-subtle)', fontSize: '12px' }}>{t('automation.auto_localstats.no_roles_available')}</span>
                       ) : (
                         availableRolesInNodes.map(roleNum => {
                           const count = availableNodes.filter(n => getNodeRole(n) === roleNum).length;
@@ -618,10 +618,10 @@ const AutoLocalStatsSection: React.FC<AutoLocalStatsSectionProps> = ({
                     </span>
                   </div>
                   {expandedSections.regex && (
-                    <div style={{ padding: '0.5rem', background: 'var(--ctp-base)', borderRadius: '4px' }}>
+                    <div style={{ padding: '0.5rem', background: 'var(--color-bg)', borderRadius: '4px' }}>
                       <input type="text" value={filterNameRegex} onChange={(e) => setFilterNameRegex(e.target.value)} placeholder=".*"
-                        style={{ width: '100%', padding: '0.5rem', marginBottom: '0.25rem', background: 'var(--ctp-surface0)', border: '1px solid var(--ctp-surface2)', borderRadius: '4px', color: 'var(--ctp-text)', fontFamily: 'monospace', fontSize: '12px' }} />
-                      <div style={{ fontSize: '11px', color: 'var(--ctp-subtext0)' }}>{t('automation.auto_localstats.regex_help')}</div>
+                        style={{ width: '100%', padding: '0.5rem', marginBottom: '0.25rem', background: 'var(--color-surface)', border: '1px solid var(--color-surface-active)', borderRadius: '4px', color: 'var(--color-text)', fontFamily: 'monospace', fontSize: '12px' }} />
+                      <div style={{ fontSize: '11px', color: 'var(--color-text-subtle)' }}>{t('automation.auto_localstats.regex_help')}</div>
                     </div>
                   )}
                 </div>
@@ -639,7 +639,7 @@ const AutoLocalStatsSection: React.FC<AutoLocalStatsSectionProps> = ({
                     </span>
                   </div>
                   {expandedSections.lastHeard && (
-                    <div style={{ padding: '0.5rem', background: 'var(--ctp-base)', borderRadius: '4px' }}>
+                    <div style={{ padding: '0.5rem', background: 'var(--color-bg)', borderRadius: '4px' }}>
                       <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '12px' }}>
                         {t('automation.auto_localstats.last_heard_within')}
                         <input type="number" value={filterLastHeardHours}
@@ -653,19 +653,19 @@ const AutoLocalStatsSection: React.FC<AutoLocalStatsSectionProps> = ({
               </div>
 
               {/* Right column: matching nodes preview */}
-              <div style={{ width: '280px', flexShrink: 0, background: 'var(--ctp-base)', border: '1px solid var(--ctp-surface2)', borderRadius: '6px', display: 'flex', flexDirection: 'column' }}>
-                <div style={{ padding: '0.5rem 0.75rem', borderBottom: '1px solid var(--ctp-surface2)', background: 'var(--ctp-surface1)', borderRadius: '6px 6px 0 0', fontSize: '13px', fontWeight: 500 }}>
+              <div style={{ width: '280px', flexShrink: 0, background: 'var(--color-bg)', border: '1px solid var(--color-surface-active)', borderRadius: '6px', display: 'flex', flexDirection: 'column' }}>
+                <div style={{ padding: '0.5rem 0.75rem', borderBottom: '1px solid var(--color-surface-active)', background: 'var(--color-surface-hover)', borderRadius: '6px 6px 0 0', fontSize: '13px', fontWeight: 500 }}>
                   {t('automation.auto_localstats.matching_nodes', { count: debouncedMatchingNodes.length })} / {availableNodes.length} {t('common.total')}
                 </div>
                 <div style={{ flex: 1, overflowY: 'auto', maxHeight: '400px', padding: '0.25rem' }}>
                   {debouncedMatchingNodes.length === 0 ? (
-                    <div style={{ padding: '1rem', textAlign: 'center', color: 'var(--ctp-subtext0)', fontSize: '12px' }}>
+                    <div style={{ padding: '1rem', textAlign: 'center', color: 'var(--color-text-subtle)', fontSize: '12px' }}>
                       {t('automation.auto_localstats.no_nodes_match_filters')}
                     </div>
                   ) : (
                     debouncedMatchingNodes.map(node => (
                       <div key={node.nodeNum}
-                        style={{ padding: '0.35rem 0.5rem', borderBottom: '1px solid var(--ctp-surface1)', fontSize: '12px', color: 'var(--ctp-text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
+                        style={{ padding: '0.35rem 0.5rem', borderBottom: '1px solid var(--color-surface-hover)', fontSize: '12px', color: 'var(--color-text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
                         title={node.user?.longName || node.longName || node.user?.shortName || node.shortName || node.nodeId || 'Unknown'}>
                         {node.user?.longName || node.longName || node.user?.shortName || node.shortName || node.nodeId || 'Unknown'}
                       </div>

--- a/src/components/AutoPingSection.tsx
+++ b/src/components/AutoPingSection.tsx
@@ -200,8 +200,8 @@ const AutoPingSection: React.FC<AutoPingSectionProps> = ({ baseUrl }) => {
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -296,18 +296,18 @@ const AutoPingSection: React.FC<AutoPingSectionProps> = ({ baseUrl }) => {
           marginTop: '2rem',
           marginLeft: '1.75rem',
           padding: '1rem',
-          background: 'var(--ctp-surface0)',
-          border: '1px solid var(--ctp-surface2)',
+          background: 'var(--color-surface)',
+          border: '1px solid var(--color-surface-active)',
           borderRadius: '6px',
         }}>
-          <div style={{ fontWeight: 600, marginBottom: '0.5rem', color: 'var(--ctp-text)' }}>
+          <div style={{ fontWeight: 600, marginBottom: '0.5rem', color: 'var(--color-text)' }}>
             {t('automation.auto_ping.dm_commands', 'DM Commands')}
           </div>
-          <div style={{ fontSize: '12px', color: 'var(--ctp-subtext0)', lineHeight: '1.8' }}>
-            <code style={{ background: 'var(--ctp-surface1)', padding: '0.2rem 0.4rem', borderRadius: '3px' }}>ping 5</code>
+          <div style={{ fontSize: '12px', color: 'var(--color-text-subtle)', lineHeight: '1.8' }}>
+            <code style={{ background: 'var(--color-surface-hover)', padding: '0.2rem 0.4rem', borderRadius: '3px' }}>ping 5</code>
             {' '}{t('automation.auto_ping.dm_start_help', '- Start 5 pings at the configured interval')}
             <br />
-            <code style={{ background: 'var(--ctp-surface1)', padding: '0.2rem 0.4rem', borderRadius: '3px' }}>ping stop</code>
+            <code style={{ background: 'var(--color-surface-hover)', padding: '0.2rem 0.4rem', borderRadius: '3px' }}>ping stop</code>
             {' '}{t('automation.auto_ping.dm_stop_help', '- Cancel an active ping session')}
           </div>
         </div>
@@ -319,44 +319,44 @@ const AutoPingSection: React.FC<AutoPingSectionProps> = ({ baseUrl }) => {
               {t('automation.auto_ping.active_sessions', 'Active Sessions')}
             </h3>
             <div style={{
-              border: '1px solid var(--ctp-surface2)',
+              border: '1px solid var(--color-surface-active)',
               borderRadius: '6px',
               overflow: 'hidden',
             }}>
               <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
                 <thead>
-                  <tr style={{ background: 'var(--ctp-surface0)' }}>
-                    <th style={{ padding: '0.5rem', textAlign: 'left', borderBottom: '1px solid var(--ctp-surface2)' }}>
+                  <tr style={{ background: 'var(--color-surface)' }}>
+                    <th style={{ padding: '0.5rem', textAlign: 'left', borderBottom: '1px solid var(--color-surface-active)' }}>
                       {t('automation.auto_ping.requested_by', 'Requested By')}
                     </th>
-                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--ctp-surface2)' }}>
+                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--color-surface-active)' }}>
                       {t('automation.auto_ping.progress', 'Progress')}
                     </th>
-                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--ctp-surface2)' }}>
+                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--color-surface-active)' }}>
                       {t('automation.auto_ping.successful', 'Successful')}
                     </th>
-                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--ctp-surface2)' }}>
+                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--color-surface-active)' }}>
                       {t('automation.auto_ping.failed', 'Failed')}
                     </th>
-                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--ctp-surface2)' }}>
+                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--color-surface-active)' }}>
                       {t('automation.auto_ping.elapsed', 'Elapsed')}
                     </th>
-                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--ctp-surface2)' }}>
+                    <th style={{ padding: '0.5rem', textAlign: 'center', borderBottom: '1px solid var(--color-surface-active)' }}>
                       {t('common.actions', 'Actions')}
                     </th>
                   </tr>
                 </thead>
                 <tbody>
                   {sessions.map(session => (
-                    <tr key={session.requestedBy} style={{ borderBottom: '1px solid var(--ctp-surface1)' }}>
+                    <tr key={session.requestedBy} style={{ borderBottom: '1px solid var(--color-surface-hover)' }}>
                       <td style={{ padding: '0.5rem' }}>{session.requestedByName}</td>
                       <td style={{ padding: '0.5rem', textAlign: 'center' }}>
                         {session.completedPings}/{session.totalPings}
                       </td>
-                      <td style={{ padding: '0.5rem', textAlign: 'center', color: 'var(--ctp-green)' }}>
+                      <td style={{ padding: '0.5rem', textAlign: 'center', color: 'var(--color-success)' }}>
                         {session.successfulPings}
                       </td>
-                      <td style={{ padding: '0.5rem', textAlign: 'center', color: 'var(--ctp-red)' }}>
+                      <td style={{ padding: '0.5rem', textAlign: 'center', color: 'var(--color-error)' }}>
                         {session.failedPings}
                       </td>
                       <td style={{ padding: '0.5rem', textAlign: 'center' }}>

--- a/src/components/AutoResponderSection.tsx
+++ b/src/components/AutoResponderSection.tsx
@@ -557,8 +557,8 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -611,7 +611,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
               {t('auto_responder.skip_incomplete_nodes')}
             </label>
           </div>
-          <div style={{ marginTop: '0.5rem', marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+          <div style={{ marginTop: '0.5rem', marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--color-text-subtle)' }}>
             {t('auto_responder.skip_incomplete_description')}
           </div>
         </div>
@@ -663,7 +663,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   style={{ 
                     width: '100%',
                     fontFamily: 'monospace',
-                    borderColor: newTriggerValidation.valid ? undefined : 'var(--ctp-red)',
+                    borderColor: newTriggerValidation.valid ? undefined : 'var(--color-error)',
                     borderWidth: newTriggerValidation.valid ? undefined : '2px'
                   }}
                   title="Trigger pattern: Use {param} for parameters, separate multiple patterns with commas"
@@ -675,7 +675,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                     top: '50%',
                     transform: 'translateY(-50%)',
                     fontSize: '0.7rem',
-                    color: 'var(--ctp-subtext0)',
+                    color: 'var(--color-text-subtle)',
                     pointerEvents: 'none'
                   }}>
                     {t('auto_responder.pattern_count', { count: splitTriggerPatterns(newTrigger).length })}
@@ -697,7 +697,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
             </select>
             <div style={{ flex: '2' }}>
               {newResponseType === 'mailbox' ? (
-                <span style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+                <span style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                   Built-in async message store ("mesh voicemail"). No response text needed.
                   Set DM-only and use a pattern like:{' '}
                   <code>msg &#123;recipient&#125; &#123;body:.+&#125;,inbox,inbox play &#123;sender&#125;,inbox play,inbox delete &#123;id&#125;,inbox clear</code>
@@ -761,7 +761,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                 className="setting-input"
                 style={{ width: '80px' }}
               />
-              <span style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+              <span style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                 {t('auto_responder.cooldown_help', 'seconds per node (0 = disabled)')}
               </span>
             </div>
@@ -792,7 +792,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
               style={{
                 padding: '0.5rem 1rem',
                 fontSize: '14px',
-                background: 'var(--ctp-red)',
+                background: 'var(--color-error)',
                 color: 'white',
                 border: 'none',
                 borderRadius: '4px',
@@ -807,7 +807,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
             {!newTriggerValidation.valid && newTriggerValidation.error && (
               <div style={{ 
                 fontSize: '0.75rem', 
-                color: 'var(--ctp-red)',
+                color: 'var(--color-error)',
                 display: 'flex',
                 alignItems: 'center',
                 gap: '0.25rem',
@@ -856,10 +856,10 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
               })() : null;
               
               return (
-                <div style={{ marginTop: '0.5rem', padding: '0.75rem', background: 'var(--ctp-surface0)', border: '1px solid var(--ctp-overlay0)', borderRadius: '4px' }}>
+                <div style={{ marginTop: '0.5rem', padding: '0.75rem', background: 'var(--color-surface)', border: '1px solid var(--color-border-subtle)', borderRadius: '4px' }}>
                   <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem' }}>
-                    <span style={{ fontSize: '0.75rem', color: 'var(--ctp-green)', fontWeight: 'bold' }}><UiIcon name="check" size={14} /> {t('auto_responder.valid')}</span>
-                    <span style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)' }}>
+                    <span style={{ fontSize: '0.75rem', color: 'var(--color-success)', fontWeight: 'bold' }}><UiIcon name="check" size={14} /> {t('auto_responder.valid')}</span>
+                    <span style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)' }}>
                       {t('auto_responder.pattern_count', { count: patterns.length })}
                       {uniqueParams.length > 0 && ` • ${t('auto_responder.parameter_count', { count: uniqueParams.length })}`}
                     </span>
@@ -867,10 +867,10 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   
                   {/* Real-time Pattern Preview with Highlighting */}
                   <div style={{ marginTop: '0.75rem', marginBottom: '0.75rem' }}>
-                    <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem', fontWeight: 'bold' }}>{t('auto_responder.pattern_preview')}</div>
+                    <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginBottom: '0.25rem', fontWeight: 'bold' }}>{t('auto_responder.pattern_preview')}</div>
                     <div style={{ 
                       padding: '0.5rem', 
-                      background: 'var(--ctp-surface1)', 
+                      background: 'var(--color-surface-hover)', 
                       borderRadius: '4px', 
                       fontFamily: 'monospace', 
                       fontSize: '0.85rem',
@@ -950,7 +950,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                       padding: '2px 4px',
                                       borderRadius: '2px',
                                       fontWeight: segment.type === 'parameter' ? 'bold' : 'normal',
-                                      color: 'var(--ctp-text)'
+                                      color: 'var(--color-text)'
                                     }}
                                     title={segment.type === 'parameter' ? `Parameter: ${segment.paramName}` : 'Literal text'}
                                   >
@@ -977,7 +977,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                             backgroundColor: segment.type === 'parameter' ? 'rgba(166, 227, 161, 0.4)' : 'rgba(137, 180, 250, 0.4)',
                                             padding: '2px 4px',
                                             fontWeight: segment.type === 'parameter' ? 'bold' : 'normal',
-                                            color: 'var(--ctp-text)'
+                                            color: 'var(--color-text)'
                                           }}
                                         >
                                           {segment.type === 'literal' ? segment.text.trim() : segment.text}
@@ -997,13 +997,13 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                               }
                             })}
                             {patternIdx < patterns.length - 1 && (
-                              <span style={{ color: 'var(--ctp-subtext0)', margin: '0 0.25rem' }}>,</span>
+                              <span style={{ color: 'var(--color-text-subtle)', margin: '0 0.25rem' }}>,</span>
                             )}
                           </div>
                         );
                       })}
                     </div>
-                    <div style={{ marginTop: '0.5rem', fontSize: '0.7rem', color: 'var(--ctp-subtext0)', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                    <div style={{ marginTop: '0.5rem', fontSize: '0.7rem', color: 'var(--color-text-subtle)', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
                       <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.25rem' }}>
                         <span style={{ display: 'inline-block', width: '12px', height: '12px', backgroundColor: 'rgba(137, 180, 250, 0.4)', borderRadius: '2px' }}></span>
                         Literal text
@@ -1017,7 +1017,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   
                   {uniqueParams.length > 0 && (
                     <div style={{ marginTop: '0.5rem' }}>
-                      <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem', fontWeight: 'bold' }}>{t('auto_responder.detected_parameters')}</div>
+                      <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginBottom: '0.25rem', fontWeight: 'bold' }}>{t('auto_responder.detected_parameters')}</div>
                       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem' }}>
                         {uniqueParams.map((paramName, idx) => {
                           const param = allParams.find(p => p.name === paramName);
@@ -1029,8 +1029,8 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                 alignItems: 'center',
                                 gap: '0.25rem',
                                 padding: '0.2rem 0.5rem',
-                                background: 'var(--ctp-blue)',
-                                color: 'var(--ctp-base)',
+                                background: 'var(--color-accent)',
+                                color: 'var(--color-bg)',
                                 borderRadius: '3px',
                                 fontSize: '0.7rem',
                                 fontFamily: 'monospace',
@@ -1047,8 +1047,8 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   )}
                   
                   {/* Test Section - Merged pattern matching and response testing */}
-                  <div style={{ marginTop: '0.75rem', paddingTop: '0.75rem', borderTop: '1px solid var(--ctp-overlay0)' }}>
-                    <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginBottom: '0.5rem', fontWeight: 'bold' }}><UiIcon name="test" size={14} /> Test:</div>
+                  <div style={{ marginTop: '0.75rem', paddingTop: '0.75rem', borderTop: '1px solid var(--color-border-subtle)' }}>
+                    <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginBottom: '0.5rem', fontWeight: 'bold' }}><UiIcon name="test" size={14} /> Test:</div>
                     <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'stretch' }}>
                       <input
                         type="text"
@@ -1064,7 +1064,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                           fontSize: '0.9rem',
                           padding: '0.5rem 0.75rem',
                           fontFamily: 'monospace',
-                          borderColor: newTriggerTestInput.trim() ? (testMatch ? 'var(--ctp-green)' : 'var(--ctp-red)') : undefined,
+                          borderColor: newTriggerTestInput.trim() ? (testMatch ? 'var(--color-success)' : 'var(--color-error)') : undefined,
                           borderWidth: newTriggerTestInput.trim() ? '2px' : undefined
                         }}
                         title="Test if a message matches your trigger pattern and execute the response"
@@ -1152,8 +1152,8 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                           style={{
                             padding: '0.5rem 1rem',
                             fontSize: '0.875rem',
-                            background: (newTriggerLiveTestResult?.loading || !testMatch || !newResponse.trim()) ? 'var(--ctp-surface2)' : 'var(--ctp-blue)',
-                            color: (newTriggerLiveTestResult?.loading || !testMatch || !newResponse.trim()) ? 'var(--ctp-subtext0)' : 'var(--ctp-base)',
+                            background: (newTriggerLiveTestResult?.loading || !testMatch || !newResponse.trim()) ? 'var(--color-surface-active)' : 'var(--color-accent)',
+                            color: (newTriggerLiveTestResult?.loading || !testMatch || !newResponse.trim()) ? 'var(--color-text-subtle)' : 'var(--color-bg)',
                             border: 'none',
                             borderRadius: '4px',
                             cursor: (newTriggerLiveTestResult?.loading || !testMatch || !newResponse.trim()) ? 'not-allowed' : 'pointer',
@@ -1172,12 +1172,12 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                           <div style={{ 
                             padding: '0.75rem', 
                             background: 'rgba(166, 227, 161, 0.1)', 
-                            border: '1px solid var(--ctp-green)', 
+                            border: '1px solid var(--color-success)', 
                             borderRadius: '4px' 
                           }}>
                             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem' }}>
-                              <span style={{ color: 'var(--ctp-green)', fontWeight: 'bold', fontSize: '0.85rem' }}><UiIcon name="check" size={14} /> Match Found!</span>
-                              <span style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)' }}>
+                              <span style={{ color: 'var(--color-success)', fontWeight: 'bold', fontSize: '0.85rem' }}><UiIcon name="check" size={14} /> Match Found!</span>
+                              <span style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)' }}>
                                 Pattern: {testMatch.matchedPattern || formatTriggerPatterns(newTrigger)}
                               </span>
                             </div>
@@ -1185,10 +1185,10 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                             {/* Highlighted Message Preview */}
                             {testMatch.matchPositions && testMatch.matchPositions.length > 0 && (
                               <div style={{ marginBottom: '0.5rem' }}>
-                                <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem', fontWeight: 'bold' }}>Match Highlight:</div>
+                                <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginBottom: '0.25rem', fontWeight: 'bold' }}>Match Highlight:</div>
                                 <div style={{ 
                                   padding: '0.5rem', 
-                                  background: 'var(--ctp-surface2)', 
+                                  background: 'var(--color-surface-active)', 
                                   borderRadius: '4px', 
                                   fontFamily: 'monospace', 
                                   fontSize: '0.85rem',
@@ -1217,15 +1217,15 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                             
                             {testMatch.params && Object.keys(testMatch.params).length > 0 && (
                               <div style={{ marginBottom: '0.5rem' }}>
-                                <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem', fontWeight: 'bold' }}>{t('auto_responder.extracted_parameters')}</div>
+                                <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginBottom: '0.25rem', fontWeight: 'bold' }}>{t('auto_responder.extracted_parameters')}</div>
                                 <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem' }}>
                                   {Object.entries(testMatch.params).map(([key, value]) => (
                                     <span
                                       key={key}
                                       style={{
                                         padding: '0.2rem 0.5rem',
-                                        background: 'var(--ctp-blue)',
-                                        color: 'var(--ctp-base)',
+                                        background: 'var(--color-accent)',
+                                        color: 'var(--color-bg)',
                                         borderRadius: '3px',
                                         fontSize: '0.7rem',
                                         fontFamily: 'monospace',
@@ -1240,14 +1240,14 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                             )}
                             
                             {newResponse.trim() && newResponseType === 'text' && (
-                              <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid var(--ctp-overlay0)' }}>
-                                <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem', fontWeight: 'bold', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                              <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid var(--color-border-subtle)' }}>
+                                <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginBottom: '0.25rem', fontWeight: 'bold', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                                   <span>Response Preview:</span>
                                   <button
                                     onClick={() => setNewResponse('')}
                                     disabled={!localEnabled}
                                     style={{
-                                      background: 'var(--ctp-red)',
+                                      background: 'var(--color-error)',
                                       border: 'none',
                                       borderRadius: '3px',
                                       color: 'white',
@@ -1264,11 +1264,11 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                 </div>
                                 <div style={{
                                   padding: '0.5rem',
-                                  background: 'var(--ctp-surface2)',
+                                  background: 'var(--color-surface-active)',
                                   borderRadius: '4px',
                                   fontFamily: 'monospace',
                                   fontSize: '0.85rem',
-                                  color: 'var(--ctp-text)'
+                                  color: 'var(--color-text)'
                                 }}>
                                   {generateSampleResponse({ trigger: newTrigger, responseType: newResponseType, response: newResponse } as AutoResponderTrigger, newTriggerTestInput.trim())}
                                 </div>
@@ -1277,14 +1277,14 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                             
                             {/* Test Results */}
                             {newTriggerLiveTestResult && !newTriggerLiveTestResult.loading && (
-                              <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid var(--ctp-overlay0)' }}>
-                                <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem', fontWeight: 'bold', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                              <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid var(--color-border-subtle)' }}>
+                                <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginBottom: '0.25rem', fontWeight: 'bold', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                                   <span>Test Result:</span>
                                   <button
                                     onClick={() => setNewTriggerLiveTestResult(null)}
                                     disabled={!localEnabled}
                                     style={{
-                                      background: 'var(--ctp-red)',
+                                      background: 'var(--color-error)',
                                       border: 'none',
                                       borderRadius: '3px',
                                       color: 'white',
@@ -1303,9 +1303,9 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                   <div style={{ 
                                     padding: '0.5rem', 
                                     background: 'rgba(243, 139, 168, 0.1)', 
-                                    border: '1px solid var(--ctp-red)', 
+                                    border: '1px solid var(--color-error)', 
                                     borderRadius: '4px',
-                                    color: 'var(--ctp-red)',
+                                    color: 'var(--color-error)',
                                     fontSize: '0.85rem'
                                   }}>
                                     Error: {newTriggerLiveTestResult.error}
@@ -1314,11 +1314,11 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                   <div>
                                     <div style={{ 
                                       padding: '0.5rem', 
-                                      background: 'var(--ctp-surface2)', 
+                                      background: 'var(--color-surface-active)', 
                                       borderRadius: '4px', 
                                       fontFamily: 'monospace', 
                                       fontSize: '0.85rem',
-                                      color: 'var(--ctp-text)',
+                                      color: 'var(--color-text)',
                                       whiteSpace: 'pre-wrap',
                                       maxHeight: '200px',
                                       overflowY: 'auto'
@@ -1336,9 +1336,9 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                         marginTop: '0.25rem',
                                         padding: '0.2rem 0.4rem',
                                         fontSize: '0.7rem',
-                                        background: 'var(--ctp-surface2)',
-                                        color: 'var(--ctp-text)',
-                                        border: '1px solid var(--ctp-overlay0)',
+                                        background: 'var(--color-surface-active)',
+                                        color: 'var(--color-text)',
+                                        border: '1px solid var(--color-border-subtle)',
                                         borderRadius: '3px',
                                         cursor: 'pointer'
                                       }}
@@ -1354,9 +1354,9 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                           <div style={{ 
                             padding: '0.75rem', 
                             background: 'rgba(243, 139, 168, 0.1)', 
-                            border: '1px solid var(--ctp-red)', 
+                            border: '1px solid var(--color-error)', 
                             borderRadius: '4px',
-                            color: 'var(--ctp-red)',
+                            color: 'var(--color-error)',
                             fontSize: '0.85rem'
                           }}>
                             <UiIcon name="close" size={14} /> No match - This message does not match your trigger pattern
@@ -1370,7 +1370,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
             })()}
           </div>
           <div style={{ marginTop: '0.5rem', paddingLeft: '0.5rem' }}>
-            <label style={{ fontSize: '0.85rem', fontWeight: 'bold', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem', display: 'block' }}>
+            <label style={{ fontSize: '0.85rem', fontWeight: 'bold', color: 'var(--color-text-subtle)', marginBottom: '0.25rem', display: 'block' }}>
               Channels:
             </label>
             <div className="channel-checkbox-list" style={{ marginTop: '0.25rem' }}>
@@ -1420,7 +1420,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
           </div>
           {newResponseType !== 'script' && (
             <div style={{ marginTop: '0.5rem', paddingLeft: '0.5rem' }}>
-              <label style={{ display: 'block', fontSize: '0.85rem', cursor: localEnabled ? 'pointer' : 'not-allowed', color: 'var(--ctp-subtext0)' }}>
+              <label style={{ display: 'block', fontSize: '0.85rem', cursor: localEnabled ? 'pointer' : 'not-allowed', color: 'var(--color-text-subtle)' }}>
                 <input
                   type="checkbox"
                   checked={newMultiline}
@@ -1433,7 +1433,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
             </div>
           )}
           <div style={{ marginTop: '0.5rem', paddingLeft: '0.5rem' }}>
-            <label style={{ display: 'block', fontSize: '0.85rem', cursor: (localEnabled && newChannels.includes('dm')) ? 'pointer' : 'not-allowed', color: 'var(--ctp-subtext0)', opacity: newChannels.includes('dm') ? 1 : 0.5 }}>
+            <label style={{ display: 'block', fontSize: '0.85rem', cursor: (localEnabled && newChannels.includes('dm')) ? 'pointer' : 'not-allowed', color: 'var(--color-text-subtle)', opacity: newChannels.includes('dm') ? 1 : 0.5 }}>
               <input
                 type="checkbox"
                 checked={newVerifyResponse}
@@ -1451,7 +1451,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
           marginTop: '2rem', 
           marginBottom: '1.5rem',
           height: '1px',
-          background: 'linear-gradient(to right, transparent, var(--ctp-overlay0), transparent)',
+          background: 'linear-gradient(to right, transparent, var(--color-surface-inactive), transparent)',
           position: 'relative'
         }}>
           <div style={{
@@ -1459,9 +1459,9 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
             left: '50%',
             top: '50%',
             transform: 'translate(-50%, -50%)',
-            background: 'var(--ctp-base)',
+            background: 'var(--color-bg)',
             padding: '0 1rem',
-            color: 'var(--ctp-subtext0)',
+            color: 'var(--color-text-subtle)',
             fontSize: '0.75rem',
             fontWeight: 'bold'
           }}>
@@ -1505,13 +1505,13 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
               gap: '1rem', 
               marginBottom: '0.75rem', 
               padding: '0.5rem',
-              background: 'var(--ctp-surface0)',
+              background: 'var(--color-surface)',
               borderRadius: '4px',
               fontSize: '0.75rem',
               alignItems: 'center',
               flexWrap: 'wrap'
             }}>
-              <span style={{ color: 'var(--ctp-subtext0)', fontWeight: 'bold' }}>{t('auto_responder.legend')}</span>
+              <span style={{ color: 'var(--color-text-subtle)', fontWeight: 'bold' }}>{t('auto_responder.legend')}</span>
               <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                 <span style={{ 
                   display: 'inline-flex',
@@ -1526,7 +1526,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                     border: '1px solid rgba(137, 180, 250, 0.5)',
                     borderRadius: '2px' 
                   }}></span>
-                  <span style={{ color: 'var(--ctp-text)' }}>{t('auto_responder.literal')}</span>
+                  <span style={{ color: 'var(--color-text)' }}>{t('auto_responder.literal')}</span>
                 </span>
                 <span style={{
                   display: 'inline-flex',
@@ -1541,7 +1541,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                     border: '1px solid rgba(166, 227, 161, 0.5)',
                     borderRadius: '2px'
                   }}></span>
-                  <span style={{ color: 'var(--ctp-text)' }}>{t('auto_responder.parameter')}</span>
+                  <span style={{ color: 'var(--color-text)' }}>{t('auto_responder.parameter')}</span>
                 </span>
               </div>
             </div>
@@ -1582,9 +1582,9 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                 <div style={{ 
                   padding: '1rem', 
                   textAlign: 'center', 
-                  color: 'var(--ctp-subtext0)', 
+                  color: 'var(--color-text-subtle)', 
                   fontStyle: 'italic',
-                  background: 'var(--ctp-surface0)',
+                  background: 'var(--color-surface)',
                   borderRadius: '4px'
                 }}>
                   {t('auto_responder.no_triggers_match')}
@@ -1604,7 +1604,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
             </label>
             {/* Real-time test input */}
             <div style={{ marginTop: '0.5rem', marginBottom: '0.5rem' }}>
-              <label style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem', display: 'block' }}>
+              <label style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)', marginBottom: '0.25rem', display: 'block' }}>
                 {t('auto_responder.quick_test')}
               </label>
               <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'stretch' }}>
@@ -1629,7 +1629,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   style={{
                     fontFamily: 'monospace',
                     flex: '1',
-                    borderColor: currentTestLine.trim() ? (testTriggerMatch(currentTestLine.trim()) ? 'var(--ctp-green)' : 'var(--ctp-red)') : undefined,
+                    borderColor: currentTestLine.trim() ? (testTriggerMatch(currentTestLine.trim()) ? 'var(--color-success)' : 'var(--color-error)') : undefined,
                     borderWidth: currentTestLine.trim() ? '2px' : undefined
                   }}
                 />
@@ -1739,14 +1739,14 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                     marginTop: '0.5rem',
                     padding: '0.5rem',
                     background: realtimeMatch ? 'rgba(166, 227, 161, 0.1)' : 'rgba(243, 139, 168, 0.1)',
-                    border: `1px solid ${realtimeMatch ? 'var(--ctp-green)' : 'var(--ctp-red)'}`,
+                    border: `1px solid ${realtimeMatch ? 'var(--color-success)' : 'var(--color-error)'}`,
                     borderRadius: '4px',
                     fontSize: '0.85rem'
                   }}>
                     {realtimeMatch ? (
                       <div>
                         <div style={{ marginBottom: '0.25rem', display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
-                          <span style={{ color: 'var(--ctp-green)', fontWeight: 'bold' }}><UiIcon name="check" size={14} /> Matches:</span>
+                          <span style={{ color: 'var(--color-success)', fontWeight: 'bold' }}><UiIcon name="check" size={14} /> Matches:</span>
                           {(() => {
                             const pattern = realtimeMatch.matchedPattern || '';
                             const segments: Array<{ text: string; type: 'literal' | 'parameter'; paramName?: string; startPos: number; endPos: number }> = [];
@@ -1814,7 +1814,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                       padding: '0.2rem 0.4rem',
                                       borderRadius: '4px',
                                       fontWeight: segment.type === 'parameter' ? 'bold' : 'normal',
-                                      color: segment.type === 'parameter' ? 'var(--ctp-green)' : 'var(--ctp-blue)',
+                                      color: segment.type === 'parameter' ? 'var(--color-success)' : 'var(--color-accent)',
                                       fontFamily: 'monospace',
                                       fontSize: '0.85rem',
                                       border: segment.type === 'parameter' ? '1px solid rgba(166, 227, 161, 0.5)' : '1px solid rgba(137, 180, 250, 0.3)'
@@ -1844,7 +1844,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                             backgroundColor: segment.type === 'parameter' ? 'rgba(166, 227, 161, 0.3)' : 'rgba(137, 180, 250, 0.2)',
                                             padding: '0.2rem 0.4rem',
                                             fontWeight: segment.type === 'parameter' ? 'bold' : 'normal',
-                                            color: segment.type === 'parameter' ? 'var(--ctp-green)' : 'var(--ctp-blue)'
+                                            color: segment.type === 'parameter' ? 'var(--color-success)' : 'var(--color-accent)'
                                           }}
                                         >
                                           {segment.type === 'literal' ? segment.text.trim() : segment.text}
@@ -1866,21 +1866,21 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                           })()}
                         </div>
                         {allMatches.length > 1 && (
-                          <div style={{ color: 'var(--ctp-peach)', marginTop: '0.25rem', fontSize: '0.75rem' }}>
+                          <div style={{ color: 'var(--color-caution)', marginTop: '0.25rem', fontSize: '0.75rem' }}>
                             <UiIcon name="alert" size={14} /> Warning: {allMatches.length} triggers match this message (conflict!)
                           </div>
                         )}
 
                         {/* Response Preview for text responses */}
                         {realtimeMatch.trigger && realtimeMatch.trigger.responseType === 'text' && (
-                          <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid var(--ctp-overlay0)' }}>
-                            <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem', fontWeight: 'bold', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid var(--color-border-subtle)' }}>
+                            <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginBottom: '0.25rem', fontWeight: 'bold', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                               <span>Response Preview:</span>
                               <button
                                 onClick={() => setCurrentTestLine('')}
                                 disabled={!localEnabled}
                                 style={{
-                                  background: 'var(--ctp-red)',
+                                  background: 'var(--color-error)',
                                   border: 'none',
                                   borderRadius: '3px',
                                   color: 'white',
@@ -1897,11 +1897,11 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                             </div>
                             <div style={{
                               padding: '0.5rem',
-                              background: 'var(--ctp-surface2)',
+                              background: 'var(--color-surface-active)',
                               borderRadius: '4px',
                               fontFamily: 'monospace',
                               fontSize: '0.85rem',
-                              color: 'var(--ctp-text)',
+                              color: 'var(--color-text)',
                               whiteSpace: realtimeMatch.trigger.multiline ? 'pre-wrap' : 'nowrap',
                               overflowX: 'auto'
                             }}>
@@ -1912,14 +1912,14 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
 
                         {/* Test Results for HTTP/script */}
                         {quickTestResult && !quickTestResult.loading && (
-                          <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid var(--ctp-overlay0)' }}>
-                            <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem', fontWeight: 'bold', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                          <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid var(--color-border-subtle)' }}>
+                            <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginBottom: '0.25rem', fontWeight: 'bold', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                               <span>Test Result:</span>
                               <button
                                 onClick={() => setQuickTestResult(null)}
                                 disabled={!localEnabled}
                                 style={{
-                                  background: 'var(--ctp-red)',
+                                  background: 'var(--color-error)',
                                   border: 'none',
                                   borderRadius: '3px',
                                   color: 'white',
@@ -1938,9 +1938,9 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                               <div style={{
                                 padding: '0.5rem',
                                 background: 'rgba(243, 139, 168, 0.1)',
-                                border: '1px solid var(--ctp-red)',
+                                border: '1px solid var(--color-error)',
                                 borderRadius: '4px',
-                                color: 'var(--ctp-red)',
+                                color: 'var(--color-error)',
                                 fontSize: '0.85rem'
                               }}>
                                 Error: {quickTestResult.error}
@@ -1949,11 +1949,11 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                               <div>
                                 <div style={{
                                   padding: '0.5rem',
-                                  background: 'var(--ctp-surface2)',
+                                  background: 'var(--color-surface-active)',
                                   borderRadius: '4px',
                                   fontFamily: 'monospace',
                                   fontSize: '0.85rem',
-                                  color: 'var(--ctp-text)',
+                                  color: 'var(--color-text)',
                                   whiteSpace: 'pre-wrap',
                                   maxHeight: '200px',
                                   overflowY: 'auto'
@@ -1982,7 +1982,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                         )}
                       </div>
                     ) : (
-                      <div style={{ color: 'var(--ctp-red)' }}><UiIcon name="close" size={14} /> No matching trigger</div>
+                      <div style={{ color: 'var(--color-error)' }}><UiIcon name="close" size={14} /> No matching trigger</div>
                     )}
                   </div>
                 );
@@ -2021,7 +2021,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                         padding: '0.5rem',
                         marginBottom: '0.5rem',
                         backgroundColor: match ? 'rgba(166, 227, 161, 0.1)' : 'rgba(243, 139, 168, 0.1)',
-                        border: `1px solid ${match ? (hasConflict ? 'var(--ctp-peach)' : 'var(--ctp-green)') : 'var(--ctp-red)'}`,
+                        border: `1px solid ${match ? (hasConflict ? 'var(--color-caution)' : 'var(--color-success)') : 'var(--color-error)'}`,
                         borderRadius: '4px',
                         fontFamily: 'monospace',
                         fontSize: '0.85rem',
@@ -2035,12 +2035,12 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                             width: '12px',
                             height: '12px',
                             borderRadius: '50%',
-                            backgroundColor: match ? (hasConflict ? 'var(--ctp-peach)' : 'var(--ctp-green)') : 'var(--ctp-red)',
+                            backgroundColor: match ? (hasConflict ? 'var(--color-caution)' : 'var(--color-success)') : 'var(--color-error)',
                             marginRight: '0.5rem',
                             flexShrink: 0
                           }}
                         />
-                        <span style={{ color: 'var(--ctp-text)', fontWeight: 'bold', wordBreak: 'break-word', flex: '1' }}>
+                        <span style={{ color: 'var(--color-text)', fontWeight: 'bold', wordBreak: 'break-word', flex: '1' }}>
                           {message}
                         </span>
                         {match && (
@@ -2049,11 +2049,11 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                             style={{
                               fontSize: '0.7rem',
                               padding: '0.2rem 0.4rem',
-                              background: 'var(--ctp-surface1)',
-                              border: '1px solid var(--ctp-overlay0)',
+                              background: 'var(--color-surface-hover)',
+                              border: '1px solid var(--color-border-subtle)',
                               borderRadius: '3px',
                               cursor: 'pointer',
-                              color: 'var(--ctp-text)'
+                              color: 'var(--color-text)'
                             }}
                           >
                             <UiIcon name={showDetails ? 'chevronDown' : 'forward'} size={14} /> Details
@@ -2065,11 +2065,11 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                             style={{
                               fontSize: '0.7rem',
                               padding: '0.2rem 0.4rem',
-                              background: 'var(--ctp-surface1)',
-                              border: '1px solid var(--ctp-overlay0)',
+                              background: 'var(--color-surface-hover)',
+                              border: '1px solid var(--color-border-subtle)',
                               borderRadius: '3px',
                               cursor: 'pointer',
-                              color: 'var(--ctp-text)'
+                              color: 'var(--color-text)'
                             }}
                           >
                             <UiIcon name={showDebug ? 'chevronDown' : 'forward'} size={14} /> Debug
@@ -2084,20 +2084,20 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                           background: 'rgba(250, 179, 135, 0.2)',
                           borderRadius: '3px',
                           fontSize: '0.75rem',
-                          color: 'var(--ctp-peach)'
+                          color: 'var(--color-caution)'
                         }}>
                           <UiIcon name="alert" size={14} /> Conflict: {allMatches.length} triggers match this message
                         </div>
                       )}
                       {match ? (
                         <div style={{ marginLeft: '1.25rem', fontSize: '0.8rem' }}>
-                          <div style={{ color: 'var(--ctp-blue)', marginBottom: '0.15rem' }}>
+                          <div style={{ color: 'var(--color-accent)', marginBottom: '0.15rem' }}>
                             ▸ {match.matchedPattern ? match.matchedPattern : formatTriggerPatterns(match.trigger?.trigger || (Array.isArray(match.trigger?.trigger) ? match.trigger.trigger : ''))}
                             <span style={{
                               fontSize: '0.65rem',
                               padding: '0.1rem 0.3rem',
-                              background: match.trigger?.responseType === 'text' ? 'var(--ctp-green)' : match.trigger?.responseType === 'script' ? 'var(--ctp-yellow)' : 'var(--ctp-mauve)',
-                              color: 'var(--ctp-base)',
+                              background: match.trigger?.responseType === 'text' ? 'var(--color-success)' : match.trigger?.responseType === 'script' ? 'var(--color-warning)' : 'var(--color-accent-alt)',
+                              color: 'var(--color-bg)',
                               borderRadius: '2px',
                               fontWeight: 'bold',
                               marginLeft: '0.5rem'
@@ -2106,11 +2106,11 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                             </span>
                           </div>
                           {match.params && Object.keys(match.params).length > 0 && (
-                            <div style={{ color: 'var(--ctp-subtext0)', marginBottom: '0.15rem' }}>
+                            <div style={{ color: 'var(--color-text-subtle)', marginBottom: '0.15rem' }}>
                               <UiIcon name="copy" size={14} /> {Object.entries(match.params).map(([k, v]) => `${k}="${v}"`).join(', ')}
                             </div>
                           )}
-                          <div style={{ color: 'var(--ctp-subtext1)', marginBottom: '0.15rem' }}>
+                          <div style={{ color: 'var(--color-text-muted)', marginBottom: '0.15rem' }}>
                             <UiIcon name="messages" size={14} /> {generateSampleResponse(match.trigger!, message)}
                           </div>
                           {(match.trigger?.responseType === 'http' || match.trigger?.responseType === 'script') && (
@@ -2180,8 +2180,8 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                 style={{
                                   padding: '0.25rem 0.5rem',
                                   fontSize: '0.7rem',
-                                  background: liveTestResults[index]?.loading ? 'var(--ctp-surface2)' : 'var(--ctp-blue)',
-                                  color: liveTestResults[index]?.loading ? 'var(--ctp-subtext0)' : 'var(--ctp-base)',
+                                  background: liveTestResults[index]?.loading ? 'var(--color-surface-active)' : 'var(--color-accent)',
+                                  color: liveTestResults[index]?.loading ? 'var(--color-text-subtle)' : 'var(--color-bg)',
                                   border: 'none',
                                   borderRadius: '3px',
                                   cursor: liveTestResults[index]?.loading ? 'not-allowed' : 'pointer',
@@ -2191,9 +2191,9 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                 {liveTestResults[index]?.loading ? 'Testing...' : <><UiIcon name="test" size={14} /> Test</>}
                               </button>
                               {liveTestResults[index] && !liveTestResults[index].loading && (
-                                <div style={{ marginTop: '0.5rem', padding: '0.5rem', background: 'var(--ctp-surface1)', borderRadius: '4px', fontSize: '0.75rem' }}>
+                                <div style={{ marginTop: '0.5rem', padding: '0.5rem', background: 'var(--color-surface-hover)', borderRadius: '4px', fontSize: '0.75rem' }}>
                                   {liveTestResults[index].error ? (
-                                    <div style={{ color: 'var(--ctp-red)' }}>Error: {liveTestResults[index].error}</div>
+                                    <div style={{ color: 'var(--color-error)' }}>Error: {liveTestResults[index].error}</div>
                                   ) : liveTestResults[index].result ? (
                                     <div>
                                       <div style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>Live Test Result:</div>
@@ -2211,9 +2211,9 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                           marginTop: '0.25rem',
                                           padding: '0.2rem 0.4rem',
                                           fontSize: '0.7rem',
-                                          background: 'var(--ctp-surface2)',
-                                          color: 'var(--ctp-text)',
-                                          border: '1px solid var(--ctp-overlay0)',
+                                          background: 'var(--color-surface-active)',
+                                          color: 'var(--color-text)',
+                                          border: '1px solid var(--color-border-subtle)',
                                           borderRadius: '3px',
                                           cursor: 'pointer'
                                         }}
@@ -2230,7 +2230,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                             <div style={{ 
                               marginTop: '0.5rem', 
                               padding: '0.5rem', 
-                              background: 'var(--ctp-surface1)', 
+                              background: 'var(--color-surface-hover)', 
                               borderRadius: '4px',
                               fontSize: '0.75rem'
                             }}>
@@ -2252,12 +2252,12 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                 </div>
                               )}
                               {hasConflict && (
-                                <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid var(--ctp-overlay0)' }}>
-                                  <div style={{ fontWeight: 'bold', marginBottom: '0.25rem', color: 'var(--ctp-peach)' }}>
+                                <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid var(--color-border-subtle)' }}>
+                                  <div style={{ fontWeight: 'bold', marginBottom: '0.25rem', color: 'var(--color-caution)' }}>
                                     All Matching Triggers ({allMatches.length}):
                                   </div>
                                   {allMatches.map((m, idx) => (
-                                    <div key={idx} style={{ marginBottom: '0.25rem', paddingLeft: '0.5rem', borderLeft: '2px solid var(--ctp-peach)' }}>
+                                    <div key={idx} style={{ marginBottom: '0.25rem', paddingLeft: '0.5rem', borderLeft: '2px solid var(--color-caution)' }}>
                                       {m.matchedPattern} ({m.trigger.responseType})
                                     </div>
                                   ))}
@@ -2269,19 +2269,19 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                             <div style={{ 
                               marginTop: '0.5rem', 
                               padding: '0.5rem', 
-                              background: 'var(--ctp-surface1)', 
+                              background: 'var(--color-surface-hover)', 
                               borderRadius: '4px',
                               fontSize: '0.75rem',
                               fontFamily: 'monospace'
                             }}>
                               <div style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>Debug Info:</div>
                               <div style={{ marginBottom: '0.15rem' }}>
-                                <strong>Regex Pattern:</strong> <code style={{ background: 'var(--ctp-surface2)', padding: '2px 4px', borderRadius: '2px' }}>{match.regexPattern}</code>
+                                <strong>Regex Pattern:</strong> <code style={{ background: 'var(--color-surface-active)', padding: '2px 4px', borderRadius: '2px' }}>{match.regexPattern}</code>
                               </div>
                               {match.matchPositions && match.matchPositions.length > 0 && (
                                 <div style={{ marginTop: '0.25rem' }}>
                                   <strong>Match Positions (Highlighted):</strong>
-                                  <div style={{ marginTop: '0.25rem', padding: '0.5rem', background: 'var(--ctp-surface2)', borderRadius: '4px', fontFamily: 'monospace', fontSize: '0.85rem', lineHeight: '1.6' }}>
+                                  <div style={{ marginTop: '0.25rem', padding: '0.5rem', background: 'var(--color-surface-active)', borderRadius: '4px', fontFamily: 'monospace', fontSize: '0.85rem', lineHeight: '1.6' }}>
                                     {message.split('').map((char, pos) => {
                                       const posInfo = match.matchPositions?.find(p => pos >= p.start && pos < p.end);
                                       return (
@@ -2300,7 +2300,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                       );
                                     })}
                                   </div>
-                                  <div style={{ marginTop: '0.5rem', fontSize: '0.7rem', color: 'var(--ctp-subtext0)', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                                  <div style={{ marginTop: '0.5rem', fontSize: '0.7rem', color: 'var(--color-text-subtle)', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
                                     <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.25rem' }}>
                                       <span style={{ display: 'inline-block', width: '12px', height: '12px', backgroundColor: 'rgba(137, 180, 250, 0.4)', borderRadius: '2px' }}></span>
                                       Literal text
@@ -2316,7 +2316,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                           )}
                         </div>
                       ) : (
-                        <div style={{ marginLeft: '1.25rem', fontSize: '0.8rem', color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>
+                        <div style={{ marginLeft: '1.25rem', fontSize: '0.8rem', color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>
                           <UiIcon name="close" size={14} /> No matching trigger
                         </div>
                       )}
@@ -2332,10 +2332,10 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
           <div style={{
             marginTop: '1.5rem',
             padding: '1rem',
-            background: 'var(--ctp-surface0)',
-            border: '1px solid var(--ctp-overlay0)',
+            background: 'var(--color-surface)',
+            border: '1px solid var(--color-border-subtle)',
             borderRadius: '4px',
-            color: 'var(--ctp-subtext0)',
+            color: 'var(--color-text-subtle)',
             textAlign: 'center',
             fontStyle: 'italic'
           }}>
@@ -2358,22 +2358,22 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
             zIndex: 10000
           }}>
             <div style={{
-              background: 'var(--ctp-base)',
+              background: 'var(--color-bg)',
               padding: '1.5rem',
               borderRadius: '8px',
               maxWidth: '500px',
               width: '90%',
-              border: '1px solid var(--ctp-overlay0)'
+              border: '1px solid var(--color-border-subtle)'
             }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
-                <h3 style={{ margin: 0, color: 'var(--ctp-text)' }}>{t('auto_responder.import_script')}</h3>
+                <h3 style={{ margin: 0, color: 'var(--color-text)' }}>{t('auto_responder.import_script')}</h3>
                 <button
                   onClick={() => setShowImportModal(false)}
                   style={{
                     background: 'transparent',
                     border: 'none',
                     fontSize: '1.5rem',
-                    color: 'var(--ctp-subtext0)',
+                    color: 'var(--color-text-subtle)',
                     cursor: 'pointer',
                     padding: '0',
                     lineHeight: '1'
@@ -2382,7 +2382,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   ×
                 </button>
               </div>
-              <p style={{ color: 'var(--ctp-subtext0)', fontSize: '0.875rem', marginBottom: '1rem' }}>
+              <p style={{ color: 'var(--color-text-subtle)', fontSize: '0.875rem', marginBottom: '1rem' }}>
                 Select a script file (.js, .mjs, .py, or .sh) to import into /data/scripts/
               </p>
               <input
@@ -2395,13 +2395,13 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   if (file) {
                     if (filenameDisplay) {
                       filenameDisplay.textContent = `Selected: ${file.name}`;
-                      filenameDisplay.style.color = 'var(--ctp-green)';
+                      filenameDisplay.style.color = 'var(--color-success)';
                     }
                     void handleImportScript(file);
                   } else {
                     if (filenameDisplay) {
                       filenameDisplay.textContent = 'No file selected';
-                      filenameDisplay.style.color = 'var(--ctp-subtext0)';
+                      filenameDisplay.style.color = 'var(--color-text-subtle)';
                     }
                   }
                 }}
@@ -2412,8 +2412,8 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                 style={{
                   display: 'block',
                   padding: '0.75rem 1rem',
-                  background: 'var(--ctp-blue)',
-                  color: 'var(--ctp-base)',
+                  background: 'var(--color-accent)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: 'pointer',
@@ -2424,16 +2424,16 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   transition: 'background 0.2s'
                 }}
                 onMouseEnter={(e) => {
-                  e.currentTarget.style.background = 'var(--ctp-sky)';
+                  e.currentTarget.style.background = 'var(--color-info)';
                 }}
                 onMouseLeave={(e) => {
-                  e.currentTarget.style.background = 'var(--ctp-blue)';
+                  e.currentTarget.style.background = 'var(--color-accent)';
                 }}
               >
                 <UiIcon name="file" size={14} /> Choose File...
               </label>
               <div id="script-import-filename" style={{ 
-                color: 'var(--ctp-subtext0)', 
+                color: 'var(--color-text-subtle)', 
                 fontSize: '0.85rem', 
                 fontStyle: 'italic',
                 marginBottom: '1rem',
@@ -2450,14 +2450,14 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                     if (input) input.value = '';
                     if (filenameDisplay) {
                       filenameDisplay.textContent = 'No file selected';
-                      filenameDisplay.style.color = 'var(--ctp-subtext0)';
+                      filenameDisplay.style.color = 'var(--color-text-subtle)';
                     }
                   }}
                   style={{
                     padding: '0.5rem 1rem',
-                    background: 'var(--ctp-surface1)',
-                    color: 'var(--ctp-text)',
-                    border: '1px solid var(--ctp-overlay0)',
+                    background: 'var(--color-surface-hover)',
+                    color: 'var(--color-text)',
+                    border: '1px solid var(--color-border-subtle)',
                     borderRadius: '4px',
                     cursor: 'pointer'
                   }}
@@ -2484,22 +2484,22 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
             zIndex: 10000
           }}>
             <div style={{
-              background: 'var(--ctp-base)',
+              background: 'var(--color-bg)',
               padding: '1.5rem',
               borderRadius: '8px',
               maxWidth: '500px',
               width: '90%',
-              border: '1px solid var(--ctp-overlay0)'
+              border: '1px solid var(--color-border-subtle)'
             }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
-                <h3 style={{ margin: 0, color: 'var(--ctp-text)' }}>{t('auto_responder.export_scripts')}</h3>
+                <h3 style={{ margin: 0, color: 'var(--color-text)' }}>{t('auto_responder.export_scripts')}</h3>
                 <button
                   onClick={() => setShowExportModal(false)}
                   style={{
                     background: 'transparent',
                     border: 'none',
                     fontSize: '1.5rem',
-                    color: 'var(--ctp-subtext0)',
+                    color: 'var(--color-text-subtle)',
                     cursor: 'pointer',
                     padding: '0',
                     lineHeight: '1'
@@ -2508,19 +2508,19 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   ×
                 </button>
               </div>
-              <p style={{ color: 'var(--ctp-subtext0)', fontSize: '0.875rem', marginBottom: '1rem' }}>
+              <p style={{ color: 'var(--color-text-subtle)', fontSize: '0.875rem', marginBottom: '1rem' }}>
                 {selectedScripts.size > 0
                   ? `Export ${selectedScripts.size} selected script(s) as a zip file?`
                   : `Export all ${availableScripts.length} script(s) as a zip file?`}
               </p>
               {selectedScripts.size > 0 && (
-                <div style={{ marginBottom: '1rem', padding: '0.75rem', background: 'var(--ctp-surface0)', borderRadius: '4px', maxHeight: '200px', overflowY: 'auto' }}>
-                  <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', marginBottom: '0.5rem', fontWeight: 'bold' }}>Selected Scripts:</div>
+                <div style={{ marginBottom: '1rem', padding: '0.75rem', background: 'var(--color-surface)', borderRadius: '4px', maxHeight: '200px', overflowY: 'auto' }}>
+                  <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', marginBottom: '0.5rem', fontWeight: 'bold' }}>Selected Scripts:</div>
                   <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
                     {Array.from(selectedScripts).map((script) => {
                       const filename = script.replace('/data/scripts/', '');
                       return (
-                        <div key={script} style={{ fontSize: '0.75rem', fontFamily: 'monospace', color: 'var(--ctp-text)' }}>
+                        <div key={script} style={{ fontSize: '0.75rem', fontFamily: 'monospace', color: 'var(--color-text)' }}>
                           <UiIcon name={getFileIcon(filename)} size={14} /> {filename}
                         </div>
                       );
@@ -2533,9 +2533,9 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   onClick={() => setShowExportModal(false)}
                   style={{
                     padding: '0.5rem 1rem',
-                    background: 'var(--ctp-surface1)',
-                    color: 'var(--ctp-text)',
-                    border: '1px solid var(--ctp-overlay0)',
+                    background: 'var(--color-surface-hover)',
+                    color: 'var(--color-text)',
+                    border: '1px solid var(--color-border-subtle)',
                     borderRadius: '4px',
                     cursor: 'pointer'
                   }}
@@ -2547,8 +2547,8 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   disabled={isExporting}
                   style={{
                     padding: '0.5rem 1rem',
-                    background: isExporting ? 'var(--ctp-surface2)' : 'var(--ctp-green)',
-                    color: isExporting ? 'var(--ctp-subtext0)' : 'var(--ctp-base)',
+                    background: isExporting ? 'var(--color-surface-active)' : 'var(--color-success)',
+                    color: isExporting ? 'var(--color-text-subtle)' : 'var(--color-bg)',
                     border: 'none',
                     borderRadius: '4px',
                     cursor: isExporting ? 'not-allowed' : 'pointer',
@@ -2577,15 +2577,15 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
             zIndex: 10000
           }}>
             <div style={{
-              background: 'var(--ctp-base)',
+              background: 'var(--color-bg)',
               padding: '1.5rem',
               borderRadius: '8px',
               maxWidth: '500px',
               width: '90%',
-              border: '1px solid var(--ctp-overlay0)'
+              border: '1px solid var(--color-border-subtle)'
             }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
-                <h3 style={{ margin: 0, color: 'var(--ctp-text)' }}>{t('auto_responder.delete_script')}</h3>
+                <h3 style={{ margin: 0, color: 'var(--color-text)' }}>{t('auto_responder.delete_script')}</h3>
                 <button
                   onClick={() => {
                     setShowDeleteModal(false);
@@ -2595,7 +2595,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                     background: 'transparent',
                     border: 'none',
                     fontSize: '1.5rem',
-                    color: 'var(--ctp-subtext0)',
+                    color: 'var(--color-text-subtle)',
                     cursor: 'pointer',
                     padding: '0',
                     lineHeight: '1'
@@ -2604,8 +2604,8 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   ×
                 </button>
               </div>
-              <p style={{ color: 'var(--ctp-subtext0)', fontSize: '0.875rem', marginBottom: '1rem' }}>
-                Are you sure you want to delete <strong style={{ color: 'var(--ctp-text)' }}>{scriptToDelete}</strong>? This action cannot be undone.
+              <p style={{ color: 'var(--color-text-subtle)', fontSize: '0.875rem', marginBottom: '1rem' }}>
+                Are you sure you want to delete <strong style={{ color: 'var(--color-text)' }}>{scriptToDelete}</strong>? This action cannot be undone.
               </p>
               <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
                 <button
@@ -2615,9 +2615,9 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   }}
                   style={{
                     padding: '0.5rem 1rem',
-                    background: 'var(--ctp-surface1)',
-                    color: 'var(--ctp-text)',
-                    border: '1px solid var(--ctp-overlay0)',
+                    background: 'var(--color-surface-hover)',
+                    color: 'var(--color-text)',
+                    border: '1px solid var(--color-border-subtle)',
                     borderRadius: '4px',
                     cursor: 'pointer'
                   }}
@@ -2629,8 +2629,8 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   disabled={isDeleting === scriptToDelete}
                   style={{
                     padding: '0.5rem 1rem',
-                    background: isDeleting === scriptToDelete ? 'var(--ctp-surface2)' : 'var(--ctp-red)',
-                    color: isDeleting === scriptToDelete ? 'var(--ctp-subtext0)' : 'var(--ctp-base)',
+                    background: isDeleting === scriptToDelete ? 'var(--color-surface-active)' : 'var(--color-error)',
+                    color: isDeleting === scriptToDelete ? 'var(--color-text-subtle)' : 'var(--color-bg)',
                     border: 'none',
                     borderRadius: '4px',
                     cursor: isDeleting === scriptToDelete ? 'not-allowed' : 'pointer',

--- a/src/components/AutoTimeSyncSection.tsx
+++ b/src/components/AutoTimeSyncSection.tsx
@@ -221,16 +221,16 @@ const AutoTimeSyncSection: React.FC<AutoTimeSyncSectionProps> = ({
     alignItems: 'center',
     justifyContent: 'space-between',
     padding: '0.5rem 0.75rem',
-    background: 'var(--ctp-surface0)',
-    border: '1px solid var(--ctp-surface2)',
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-surface-active)',
     borderRadius: '4px',
     cursor: 'pointer',
     marginBottom: '0.5rem',
   };
 
   const badgeStyle: React.CSSProperties = {
-    background: 'var(--ctp-blue)',
-    color: 'var(--ctp-base)',
+    background: 'var(--color-accent)',
+    color: 'var(--color-bg)',
     padding: '0.1rem 0.5rem',
     borderRadius: '10px',
     fontSize: '11px',
@@ -244,8 +244,8 @@ const AutoTimeSyncSection: React.FC<AutoTimeSyncSectionProps> = ({
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -340,8 +340,8 @@ const AutoTimeSyncSection: React.FC<AutoTimeSyncSectionProps> = ({
               marginTop: '1rem',
               marginLeft: '1.75rem',
               padding: '1rem',
-              background: 'var(--ctp-surface0)',
-              border: '1px solid var(--ctp-surface2)',
+              background: 'var(--color-surface)',
+              border: '1px solid var(--color-surface-active)',
               borderRadius: '6px',
             }}>
               {/* Specific Nodes Filter */}
@@ -359,7 +359,7 @@ const AutoTimeSyncSection: React.FC<AutoTimeSyncSectionProps> = ({
                   </span>
                 </div>
                 {nodeListExpanded && (
-                  <div style={{ padding: '0.5rem', background: 'var(--ctp-base)', borderRadius: '4px' }}>
+                  <div style={{ padding: '0.5rem', background: 'var(--color-bg)', borderRadius: '4px' }}>
                     <input
                       type="text"
                       placeholder={t('automation.time_sync.search_nodes')}
@@ -370,10 +370,10 @@ const AutoTimeSyncSection: React.FC<AutoTimeSyncSectionProps> = ({
                         width: '100%',
                         padding: '0.5rem',
                         marginBottom: '0.5rem',
-                        background: 'var(--ctp-surface0)',
-                        border: '1px solid var(--ctp-surface2)',
+                        background: 'var(--color-surface)',
+                        border: '1px solid var(--color-surface-active)',
                         borderRadius: '4px',
-                        color: 'var(--ctp-text)'
+                        color: 'var(--color-text)'
                       }}
                     />
                     <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
@@ -384,9 +384,9 @@ const AutoTimeSyncSection: React.FC<AutoTimeSyncSectionProps> = ({
                         {t('common.deselect_all')}
                       </button>
                     </div>
-                    <div style={{ maxHeight: '200px', overflowY: 'auto', border: '1px solid var(--ctp-surface2)', borderRadius: '4px' }}>
+                    <div style={{ maxHeight: '200px', overflowY: 'auto', border: '1px solid var(--color-surface-active)', borderRadius: '4px' }}>
                       {filteredNodes.length === 0 ? (
-                        <div style={{ padding: '0.5rem', textAlign: 'center', color: 'var(--ctp-subtext0)', fontSize: '12px' }}>
+                        <div style={{ padding: '0.5rem', textAlign: 'center', color: 'var(--color-text-subtle)', fontSize: '12px' }}>
                           {searchTerm ? t('automation.time_sync.no_nodes_match') : t('automation.time_sync.no_nodes_available')}
                         </div>
                       ) : (
@@ -395,7 +395,7 @@ const AutoTimeSyncSection: React.FC<AutoTimeSyncSectionProps> = ({
                             key={node.nodeNum}
                             style={{
                               padding: '0.4rem 0.6rem',
-                              borderBottom: '1px solid var(--ctp-surface1)',
+                              borderBottom: '1px solid var(--color-surface-hover)',
                               display: 'flex',
                               alignItems: 'center',
                               cursor: 'pointer',
@@ -410,7 +410,7 @@ const AutoTimeSyncSection: React.FC<AutoTimeSyncSectionProps> = ({
                               style={{ width: 'auto', margin: 0, marginRight: '0.5rem', cursor: 'pointer' }}
                               onClick={(e) => e.stopPropagation()}
                             />
-                            <span style={{ color: 'var(--ctp-text)' }}>
+                            <span style={{ color: 'var(--color-text)' }}>
                               {node.user?.longName || node.longName || node.user?.shortName || node.shortName || node.nodeId || 'Unknown'}
                             </span>
                           </div>
@@ -425,13 +425,13 @@ const AutoTimeSyncSection: React.FC<AutoTimeSyncSectionProps> = ({
               <div style={{
                 marginTop: '1rem',
                 padding: '0.75rem',
-                background: 'var(--ctp-base)',
-                border: '1px solid var(--ctp-surface2)',
+                background: 'var(--color-bg)',
+                border: '1px solid var(--color-surface-active)',
                 borderRadius: '4px',
                 fontSize: '12px'
               }}>
-                <div style={{ color: 'var(--ctp-subtext0)' }}>
-                  {t('automation.time_sync.eligible_nodes')}: <strong style={{ color: 'var(--ctp-text)' }}>
+                <div style={{ color: 'var(--color-text-subtle)' }}>
+                  {t('automation.time_sync.eligible_nodes')}: <strong style={{ color: 'var(--color-text)' }}>
                     {filterEnabled ? selectedNodeNums.length : availableNodes.length}
                   </strong> / {availableNodes.length} {t('automation.time_sync.nodes_with_remote_admin')}
                 </div>
@@ -445,13 +445,13 @@ const AutoTimeSyncSection: React.FC<AutoTimeSyncSectionProps> = ({
               marginTop: '1rem',
               marginLeft: '1.75rem',
               padding: '0.75rem',
-              background: 'var(--ctp-surface0)',
-              border: '1px solid var(--ctp-surface2)',
+              background: 'var(--color-surface)',
+              border: '1px solid var(--color-surface-active)',
               borderRadius: '4px',
               fontSize: '12px'
             }}>
-              <div style={{ color: 'var(--ctp-subtext0)' }}>
-                {t('automation.time_sync.eligible_nodes')}: <strong style={{ color: 'var(--ctp-text)' }}>
+              <div style={{ color: 'var(--color-text-subtle)' }}>
+                {t('automation.time_sync.eligible_nodes')}: <strong style={{ color: 'var(--color-text)' }}>
                   {availableNodes.length}
                 </strong> {t('automation.time_sync.nodes_with_remote_admin')}
               </div>

--- a/src/components/AutoTracerouteSection.tsx
+++ b/src/components/AutoTracerouteSection.tsx
@@ -677,16 +677,16 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
     alignItems: 'center',
     justifyContent: 'space-between',
     padding: '0.5rem 0.75rem',
-    background: 'var(--ctp-surface0)',
-    border: '1px solid var(--ctp-surface2)',
+    background: 'var(--color-surface)',
+    border: '1px solid var(--color-surface-active)',
     borderRadius: '4px',
     cursor: 'pointer',
     marginBottom: '0.5rem',
   };
 
   const badgeStyle: React.CSSProperties = {
-    background: 'var(--ctp-blue)',
-    color: 'var(--ctp-base)',
+    background: 'var(--color-accent)',
+    color: 'var(--color-bg)',
     padding: '0.1rem 0.5rem',
     borderRadius: '10px',
     fontSize: '11px',
@@ -700,8 +700,8 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -860,8 +860,8 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
               marginTop: '1rem',
               marginLeft: '1.75rem',
               padding: '1rem',
-              background: 'var(--ctp-surface0)',
-              border: '1px solid var(--ctp-surface2)',
+              background: 'var(--color-surface)',
+              border: '1px solid var(--color-surface-active)',
               borderRadius: '6px',
               display: 'flex',
               gap: '1rem'
@@ -894,7 +894,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                   </span>
                 </div>
                 {expandedSections.nodes && (
-                  <div style={{ padding: '0.5rem', background: 'var(--ctp-base)', borderRadius: '4px' }}>
+                  <div style={{ padding: '0.5rem', background: 'var(--color-bg)', borderRadius: '4px' }}>
                     <input
                       type="text"
                       placeholder={t('automation.auto_traceroute.search_nodes')}
@@ -904,10 +904,10 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                         width: '100%',
                         padding: '0.5rem',
                         marginBottom: '0.5rem',
-                        background: 'var(--ctp-surface0)',
-                        border: '1px solid var(--ctp-surface2)',
+                        background: 'var(--color-surface)',
+                        border: '1px solid var(--color-surface-active)',
                         borderRadius: '4px',
-                        color: 'var(--ctp-text)'
+                        color: 'var(--color-text)'
                       }}
                     />
                     <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
@@ -918,9 +918,9 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                         {t('common.deselect_all')}
                       </button>
                     </div>
-                    <div style={{ maxHeight: '200px', overflowY: 'auto', border: '1px solid var(--ctp-surface2)', borderRadius: '4px' }}>
+                    <div style={{ maxHeight: '200px', overflowY: 'auto', border: '1px solid var(--color-surface-active)', borderRadius: '4px' }}>
                       {filteredNodes.length === 0 ? (
-                        <div style={{ padding: '0.5rem', textAlign: 'center', color: 'var(--ctp-subtext0)', fontSize: '12px' }}>
+                        <div style={{ padding: '0.5rem', textAlign: 'center', color: 'var(--color-text-subtle)', fontSize: '12px' }}>
                           {searchTerm ? t('automation.auto_traceroute.no_nodes_match') : t('automation.auto_traceroute.no_nodes_available')}
                         </div>
                       ) : (
@@ -929,7 +929,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                             key={node.nodeNum}
                             style={{
                               padding: '0.4rem 0.6rem',
-                              borderBottom: '1px solid var(--ctp-surface1)',
+                              borderBottom: '1px solid var(--color-surface-hover)',
                               display: 'flex',
                               alignItems: 'center',
                               cursor: 'pointer',
@@ -944,7 +944,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                               style={{ width: 'auto', margin: 0, marginRight: '0.5rem', cursor: 'pointer' }}
                               onClick={(e) => e.stopPropagation()}
                             />
-                            <span style={{ color: 'var(--ctp-text)' }}>
+                            <span style={{ color: 'var(--color-text)' }}>
                               {node.user?.longName || node.longName || node.user?.shortName || node.shortName || node.nodeId || 'Unknown'}
                             </span>
                           </div>
@@ -980,9 +980,9 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                   </span>
                 </div>
                 {expandedSections.channels && (
-                  <div style={{ padding: '0.5rem', background: 'var(--ctp-base)', borderRadius: '4px', display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+                  <div style={{ padding: '0.5rem', background: 'var(--color-bg)', borderRadius: '4px', display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
                     {availableChannels.length === 0 ? (
-                      <span style={{ color: 'var(--ctp-subtext0)', fontSize: '12px' }}>{t('automation.auto_traceroute.no_channels')}</span>
+                      <span style={{ color: 'var(--color-text-subtle)', fontSize: '12px' }}>{t('automation.auto_traceroute.no_channels')}</span>
                     ) : (
                       availableChannels.map(channel => (
                         <label key={channel} style={{ display: 'flex', alignItems: 'center', gap: '0.25rem', cursor: 'pointer', fontSize: '12px' }}>
@@ -1025,9 +1025,9 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                   </span>
                 </div>
                 {expandedSections.roles && (
-                  <div style={{ padding: '0.5rem', background: 'var(--ctp-base)', borderRadius: '4px', display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+                  <div style={{ padding: '0.5rem', background: 'var(--color-bg)', borderRadius: '4px', display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
                     {availableRolesInNodes.length === 0 ? (
-                      <span style={{ color: 'var(--ctp-subtext0)', fontSize: '12px' }}>{t('automation.auto_traceroute.no_roles_available')}</span>
+                      <span style={{ color: 'var(--color-text-subtle)', fontSize: '12px' }}>{t('automation.auto_traceroute.no_roles_available')}</span>
                     ) : (
                       availableRolesInNodes.map(roleNum => {
                         const count = availableNodes.filter(n => getNodeRole(n) === roleNum).length;
@@ -1074,9 +1074,9 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                   </span>
                 </div>
                 {expandedSections.hwModels && (
-                  <div style={{ padding: '0.5rem', background: 'var(--ctp-base)', borderRadius: '4px', maxHeight: '200px', overflowY: 'auto' }}>
+                  <div style={{ padding: '0.5rem', background: 'var(--color-bg)', borderRadius: '4px', maxHeight: '200px', overflowY: 'auto' }}>
                     {availableHwModelsInNodes.length === 0 ? (
-                      <span style={{ color: 'var(--ctp-subtext0)', fontSize: '12px' }}>{t('automation.auto_traceroute.no_hardware_available')}</span>
+                      <span style={{ color: 'var(--color-text-subtle)', fontSize: '12px' }}>{t('automation.auto_traceroute.no_hardware_available')}</span>
                     ) : (
                       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
                         {availableHwModelsInNodes.map(hwModel => {
@@ -1124,7 +1124,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                   </span>
                 </div>
                 {expandedSections.regex && (
-                  <div style={{ padding: '0.5rem', background: 'var(--ctp-base)', borderRadius: '4px' }}>
+                  <div style={{ padding: '0.5rem', background: 'var(--color-bg)', borderRadius: '4px' }}>
                     <input
                       type="text"
                       value={filterNameRegex}
@@ -1134,15 +1134,15 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                         width: '100%',
                         padding: '0.5rem',
                         marginBottom: '0.25rem',
-                        background: 'var(--ctp-surface0)',
-                        border: '1px solid var(--ctp-surface2)',
+                        background: 'var(--color-surface)',
+                        border: '1px solid var(--color-surface-active)',
                         borderRadius: '4px',
-                        color: 'var(--ctp-text)',
+                        color: 'var(--color-text)',
                         fontFamily: 'monospace',
                         fontSize: '12px'
                       }}
                     />
-                    <div style={{ fontSize: '11px', color: 'var(--ctp-subtext0)' }}>
+                    <div style={{ fontSize: '11px', color: 'var(--color-text-subtle)' }}>
                       {t('automation.auto_traceroute.regex_help')}
                     </div>
                   </div>
@@ -1174,7 +1174,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                   </span>
                 </div>
                 {expandedSections.lastHeard && (
-                  <div style={{ padding: '0.5rem', background: 'var(--ctp-base)', borderRadius: '4px' }}>
+                  <div style={{ padding: '0.5rem', background: 'var(--color-bg)', borderRadius: '4px' }}>
                     <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '12px' }}>
                       {t('automation.auto_traceroute.last_heard_within')}
                       <input
@@ -1215,7 +1215,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                   </span>
                 </div>
                 {expandedSections.hops && (
-                  <div style={{ padding: '0.5rem', background: 'var(--ctp-base)', borderRadius: '4px', display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '12px' }}>
+                  <div style={{ padding: '0.5rem', background: 'var(--color-bg)', borderRadius: '4px', display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '12px' }}>
                     <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
                       {t('automation.auto_traceroute.min_hops')}
                       <input
@@ -1247,16 +1247,16 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
               <div style={{
                 width: '280px',
                 flexShrink: 0,
-                background: 'var(--ctp-base)',
-                border: '1px solid var(--ctp-surface2)',
+                background: 'var(--color-bg)',
+                border: '1px solid var(--color-surface-active)',
                 borderRadius: '6px',
                 display: 'flex',
                 flexDirection: 'column'
               }}>
                 <div style={{
                   padding: '0.5rem 0.75rem',
-                  borderBottom: '1px solid var(--ctp-surface2)',
-                  background: 'var(--ctp-surface1)',
+                  borderBottom: '1px solid var(--color-surface-active)',
+                  background: 'var(--color-surface-hover)',
                   borderRadius: '6px 6px 0 0',
                   fontSize: '13px',
                   fontWeight: 500
@@ -1273,7 +1273,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                     <div style={{
                       padding: '1rem',
                       textAlign: 'center',
-                      color: 'var(--ctp-subtext0)',
+                      color: 'var(--color-text-subtle)',
                       fontSize: '12px'
                     }}>
                       {t('automation.auto_traceroute.no_nodes_match_filters')}
@@ -1284,9 +1284,9 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                         key={node.nodeNum}
                         style={{
                           padding: '0.35rem 0.5rem',
-                          borderBottom: '1px solid var(--ctp-surface1)',
+                          borderBottom: '1px solid var(--color-surface-hover)',
                           fontSize: '12px',
-                          color: 'var(--ctp-text)',
+                          color: 'var(--color-text)',
                           whiteSpace: 'nowrap',
                           overflow: 'hidden',
                           textOverflow: 'ellipsis'
@@ -1306,11 +1306,11 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
         {/* Auto-Traceroute Log Section */}
         {localEnabled && (
           <div className="setting-item" style={{ marginTop: '2rem' }}>
-            <h4 style={{ marginBottom: '0.75rem', color: 'var(--ctp-text)' }}>
+            <h4 style={{ marginBottom: '0.75rem', color: 'var(--color-text)' }}>
               {t('automation.auto_traceroute.recent_log')}
             </h4>
             <div style={{
-              border: '1px solid var(--ctp-surface2)',
+              border: '1px solid var(--color-surface-active)',
               borderRadius: '6px',
               overflow: 'hidden',
               marginLeft: '1.75rem'
@@ -1319,7 +1319,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                 <div style={{
                   padding: '1rem',
                   textAlign: 'center',
-                  color: 'var(--ctp-subtext0)',
+                  color: 'var(--color-text-subtle)',
                   fontSize: '12px'
                 }}>
                   {t('automation.auto_traceroute.no_log_entries')}
@@ -1331,7 +1331,7 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                   fontSize: '12px'
                 }}>
                   <thead>
-                    <tr style={{ background: 'var(--ctp-surface1)' }}>
+                    <tr style={{ background: 'var(--color-surface-hover)' }}>
                       <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: 500 }}>
                         {t('automation.auto_traceroute.log_timestamp')}
                       </th>
@@ -1345,31 +1345,31 @@ const AutoTracerouteSection: React.FC<AutoTracerouteSectionProps> = ({
                   </thead>
                   <tbody>
                     {tracerouteLog.map((entry) => (
-                      <tr key={entry.id} style={{ borderTop: '1px solid var(--ctp-surface1)' }}>
-                        <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-subtext0)' }}>
+                      <tr key={entry.id} style={{ borderTop: '1px solid var(--color-surface-hover)' }}>
+                        <td style={{ padding: '0.4rem 0.75rem', color: 'var(--color-text-subtle)' }}>
                           {new Date(entry.timestamp).toLocaleString()}
                         </td>
-                        <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-text)' }}>
+                        <td style={{ padding: '0.4rem 0.75rem', color: 'var(--color-text)' }}>
                           {entry.toNodeName || `!${entry.toNodeNum.toString(16).padStart(8, '0')}`}
                         </td>
                         <td style={{ padding: '0.4rem 0.75rem', textAlign: 'center' }}>
                           {entry.success === null ? (
                             <span style={{
-                              color: 'var(--ctp-yellow)',
+                              color: 'var(--color-warning)',
                               fontSize: '14px'
                             }} title={t('automation.auto_traceroute.status_pending')}>
                               <UiIcon name="time" />
                             </span>
                           ) : entry.success ? (
                             <span style={{
-                              color: 'var(--ctp-green)',
+                              color: 'var(--color-success)',
                               fontSize: '14px'
                             }} title={t('automation.auto_traceroute.status_success')}>
                               <UiIcon name="check" />
                             </span>
                           ) : (
                             <span style={{
-                              color: 'var(--ctp-red)',
+                              color: 'var(--color-error)',
                               fontSize: '14px'
                             }} title={t('automation.auto_traceroute.status_failed')}>
                               <UiIcon name="error" />

--- a/src/components/AutoWelcomeSection.tsx
+++ b/src/components/AutoWelcomeSection.tsx
@@ -214,8 +214,8 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -396,8 +396,8 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
                 style={{
                   padding: '0.25rem 0.5rem',
                   fontSize: '12px',
-                  background: 'var(--ctp-surface2)',
-                  border: '1px solid var(--ctp-overlay0)',
+                  background: 'var(--color-surface-active)',
+                  border: '1px solid var(--color-border-subtle)',
                   borderRadius: '4px',
                   cursor: localEnabled ? 'pointer' : 'not-allowed',
                   opacity: localEnabled ? 1 : 0.5
@@ -418,12 +418,12 @@ const AutoWelcomeSection: React.FC<AutoWelcomeSectionProps> = ({
           </label>
           <div style={{
             padding: '0.75rem',
-            background: 'var(--ctp-surface0)',
-            border: '2px solid var(--ctp-blue)',
+            background: 'var(--color-surface)',
+            border: '2px solid var(--color-accent)',
             borderRadius: '4px',
             fontFamily: 'monospace',
             fontSize: '0.95rem',
-            color: 'var(--ctp-text)',
+            color: 'var(--color-text)',
             lineHeight: '1.5',
             minHeight: '50px'
           }}>

--- a/src/components/AutomationTab.tsx
+++ b/src/components/AutomationTab.tsx
@@ -137,7 +137,7 @@ const AutomationTab: React.FC<AutomationTabProps> = ({ baseUrl, channels, nodes,
             footer={
               <>
                 {/* eslint-disable-line meshmonitor-ui/no-hardcoded-ui-glyph -- #3962 5.4 PR6: verbatim move from App.tsx (which predates this components/-scoped rule); UiIcon migration out of scope for this extraction */}💡 {t('automation.tokens.engine_tip', 'Want maximum flexibility? Try the')}{' '}
-                <Link to="/automations" style={{ color: 'var(--ctp-mauve)', fontWeight: 'bold' }}>
+                <Link to="/automations" style={{ color: 'var(--color-accent-alt)', fontWeight: 'bold' }}>
                   {t('automation.engine_link', 'Automation Engine')}
                 </Link>{' '}
                 {t('automation.tokens.engine_tip2', '— build global “when this happens, do that” workflows across every source.')}

--- a/src/components/AutomationTokenReference.tsx
+++ b/src/components/AutomationTokenReference.tsx
@@ -50,14 +50,14 @@ export const AutomationTokenReference: React.FC<AutomationTokenReferenceProps> =
       style={{
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface0)',
-        border: '1px solid var(--ctp-surface1)',
+        background: 'var(--color-surface)',
+        border: '1px solid var(--color-surface-hover)',
         borderRadius: '8px',
       }}
     >
       <h3 style={{ margin: '0 0 0.25rem' }}>{title}</h3>
       {intro && (
-        <p style={{ margin: '0 0 1rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)', lineHeight: 1.5 }}>
+        <p style={{ margin: '0 0 1rem', fontSize: '0.85rem', color: 'var(--color-text-subtle)', lineHeight: 1.5 }}>
           {intro}
         </p>
       )}
@@ -66,7 +66,7 @@ export const AutomationTokenReference: React.FC<AutomationTokenReferenceProps> =
           <div key={group.title} style={{ flex: '1 1 260px', minWidth: '260px' }}>
             <div style={{ fontWeight: 'bold', fontSize: '0.85rem', marginBottom: '0.25rem' }}>{group.title}</div>
             {group.note && (
-              <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', marginBottom: '0.5rem', lineHeight: 1.4 }}>
+              <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', marginBottom: '0.5rem', lineHeight: 1.4 }}>
                 {group.note}
               </div>
             )}
@@ -74,9 +74,9 @@ export const AutomationTokenReference: React.FC<AutomationTokenReferenceProps> =
               {group.tokens.map((tok) => (
                 <React.Fragment key={tok.token}>
                   <dt>
-                    <code style={{ fontFamily: 'monospace', color: 'var(--ctp-mauve)' }}>{tok.token}</code>
+                    <code style={{ fontFamily: 'monospace', color: 'var(--color-accent-alt)' }}>{tok.token}</code>
                   </dt>
-                  <dd style={{ margin: 0, color: 'var(--ctp-subtext1)' }}>{tok.description}</dd>
+                  <dd style={{ margin: 0, color: 'var(--color-text-muted)' }}>{tok.description}</dd>
                 </React.Fragment>
               ))}
             </dl>
@@ -88,8 +88,8 @@ export const AutomationTokenReference: React.FC<AutomationTokenReferenceProps> =
           style={{
             marginTop: '1rem',
             padding: '0.6rem 0.85rem',
-            background: 'var(--ctp-surface1)',
-            border: '1px solid var(--ctp-mauve)',
+            background: 'var(--color-surface-hover)',
+            border: '1px solid var(--color-accent-alt)',
             borderRadius: '6px',
             fontSize: '0.85rem',
             lineHeight: 1.5,

--- a/src/components/BBoxMapEditor.tsx
+++ b/src/components/BBoxMapEditor.tsx
@@ -72,7 +72,7 @@ const Layer: React.FC<{
     () =>
       L.divIcon({
         className: 'bbox-corner-icon',
-        html: '<div style="width:14px;height:14px;background:var(--ctp-blue,#89b4fa);border:2px solid white;border-radius:3px;cursor:move;box-shadow:0 0 4px rgba(0,0,0,0.4);"></div>',
+        html: '<div style="width:14px;height:14px;background:var(--color-accent,#89b4fa);border:2px solid white;border-radius:3px;cursor:move;box-shadow:0 0 4px rgba(0,0,0,0.4);"></div>',
         iconSize: [14, 14],
         iconAnchor: [7, 7],
       }),
@@ -83,7 +83,7 @@ const Layer: React.FC<{
     () =>
       L.divIcon({
         className: 'bbox-pending-icon',
-        html: '<div style="width:12px;height:12px;background:var(--ctp-yellow,#f9e2af);border:2px solid white;border-radius:50%;box-shadow:0 0 4px rgba(0,0,0,0.4);"></div>',
+        html: '<div style="width:12px;height:12px;background:var(--color-warning,#f9e2af);border:2px solid white;border-radius:50%;box-shadow:0 0 4px rgba(0,0,0,0.4);"></div>',
         iconSize: [12, 12],
         iconAnchor: [6, 6],
       }),
@@ -119,8 +119,8 @@ const Layer: React.FC<{
       const se = L.latLng(value.minLat, value.maxLng);
 
       const rect = L.rectangle(L.latLngBounds(sw, ne), {
-        color: 'var(--ctp-blue, #89b4fa)',
-        fillColor: 'var(--ctp-blue, #89b4fa)',
+        color: 'var(--color-accent, #89b4fa)',
+        fillColor: 'var(--color-accent, #89b4fa)',
         fillOpacity: 0.18,
         weight: 2,
       }).addTo(map);
@@ -254,8 +254,8 @@ const Layer: React.FC<{
         previewRectRef.current.setBounds(bounds);
       } else {
         previewRectRef.current = L.rectangle(bounds, {
-          color: 'var(--ctp-yellow, #f9e2af)',
-          fillColor: 'var(--ctp-yellow, #f9e2af)',
+          color: 'var(--color-warning, #f9e2af)',
+          fillColor: 'var(--color-warning, #f9e2af)',
           fillOpacity: 0.1,
           weight: 2,
           dashArray: '5, 5',
@@ -291,7 +291,7 @@ const BBoxMapEditor: React.FC<BBoxMapEditorProps> = ({ bbox, onChange, height = 
       <div
         style={{
           height,
-          border: '1px solid var(--ctp-surface2)',
+          border: '1px solid var(--color-surface-active)',
           borderRadius: 6,
           overflow: 'hidden',
         }}
@@ -314,7 +314,7 @@ const BBoxMapEditor: React.FC<BBoxMapEditorProps> = ({ bbox, onChange, height = 
           justifyContent: 'space-between',
           alignItems: 'center',
           fontSize: 11,
-          color: 'var(--ctp-subtext0)',
+          color: 'var(--color-text-subtle)',
         }}
       >
         <span>
@@ -336,8 +336,8 @@ const BBoxMapEditor: React.FC<BBoxMapEditorProps> = ({ bbox, onChange, height = 
             }}
             style={{
               background: 'transparent',
-              border: '1px solid var(--ctp-surface2)',
-              color: 'var(--ctp-text)',
+              border: '1px solid var(--color-surface-active)',
+              color: 'var(--color-text)',
               padding: '2px 8px',
               borderRadius: 4,
               cursor: 'pointer',

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -676,8 +676,8 @@ export default function ChannelsTab({
                       top: '100%',
                       right: 0,
                       marginTop: '4px',
-                      background: 'var(--ctp-surface0)',
-                      border: '1px solid var(--ctp-surface2)',
+                      background: 'var(--color-surface)',
+                      border: '1px solid var(--color-surface-active)',
                       borderRadius: '4px',
                       zIndex: 1000,
                       minWidth: '180px',
@@ -686,8 +686,8 @@ export default function ChannelsTab({
                     }}>
                       {isChannelMuted(selectedChannel) && (
                         <button
-                          style={{ display: 'block', width: '100%', padding: '0.5rem 1rem', background: 'none', border: 'none', color: 'var(--ctp-text)', cursor: 'pointer', textAlign: 'left', fontSize: '0.85rem' }}
-                          onMouseEnter={e => (e.currentTarget.style.background = 'var(--ctp-surface1)')}
+                          style={{ display: 'block', width: '100%', padding: '0.5rem 1rem', background: 'none', border: 'none', color: 'var(--color-text)', cursor: 'pointer', textAlign: 'left', fontSize: '0.85rem' }}
+                          onMouseEnter={e => (e.currentTarget.style.background = 'var(--color-surface-hover)')}
                           onMouseLeave={e => (e.currentTarget.style.background = 'none')}
                           onClick={() => handleUnmuteChannel(selectedChannel)}
                         >
@@ -695,24 +695,24 @@ export default function ChannelsTab({
                         </button>
                       )}
                       <button
-                        style={{ display: 'block', width: '100%', padding: '0.5rem 1rem', background: 'none', border: 'none', color: 'var(--ctp-text)', cursor: 'pointer', textAlign: 'left', fontSize: '0.85rem' }}
-                        onMouseEnter={e => (e.currentTarget.style.background = 'var(--ctp-surface1)')}
+                        style={{ display: 'block', width: '100%', padding: '0.5rem 1rem', background: 'none', border: 'none', color: 'var(--color-text)', cursor: 'pointer', textAlign: 'left', fontSize: '0.85rem' }}
+                        onMouseEnter={e => (e.currentTarget.style.background = 'var(--color-surface-hover)')}
                         onMouseLeave={e => (e.currentTarget.style.background = 'none')}
                         onClick={() => handleMuteChannel(selectedChannel, null)}
                       >
                         <UiIcon name="muted" /> {t('notifications.mute_indefinite', 'Mute indefinitely')}
                       </button>
                       <button
-                        style={{ display: 'block', width: '100%', padding: '0.5rem 1rem', background: 'none', border: 'none', color: 'var(--ctp-text)', cursor: 'pointer', textAlign: 'left', fontSize: '0.85rem' }}
-                        onMouseEnter={e => (e.currentTarget.style.background = 'var(--ctp-surface1)')}
+                        style={{ display: 'block', width: '100%', padding: '0.5rem 1rem', background: 'none', border: 'none', color: 'var(--color-text)', cursor: 'pointer', textAlign: 'left', fontSize: '0.85rem' }}
+                        onMouseEnter={e => (e.currentTarget.style.background = 'var(--color-surface-hover)')}
                         onMouseLeave={e => (e.currentTarget.style.background = 'none')}
                         onClick={() => handleMuteChannel(selectedChannel, Date.now() + 60 * 60 * 1000)}
                       >
                         <UiIcon name="time" /> {t('notifications.mute_1h', 'Mute for 1 hour')}
                       </button>
                       <button
-                        style={{ display: 'block', width: '100%', padding: '0.5rem 1rem', background: 'none', border: 'none', color: 'var(--ctp-text)', cursor: 'pointer', textAlign: 'left', fontSize: '0.85rem' }}
-                        onMouseEnter={e => (e.currentTarget.style.background = 'var(--ctp-surface1)')}
+                        style={{ display: 'block', width: '100%', padding: '0.5rem 1rem', background: 'none', border: 'none', color: 'var(--color-text)', cursor: 'pointer', textAlign: 'left', fontSize: '0.85rem' }}
+                        onMouseEnter={e => (e.currentTarget.style.background = 'var(--color-surface-hover)')}
                         onMouseLeave={e => (e.currentTarget.style.background = 'none')}
                         onClick={() => handleMuteChannel(selectedChannel, Date.now() + 7 * 24 * 60 * 60 * 1000)}
                       >
@@ -938,8 +938,8 @@ export default function ChannelsTab({
                 {selectedChannel >= CHANNEL_DB_OFFSET && (
                   <div
                     style={{
-                      backgroundColor: 'var(--ctp-surface0)',
-                      color: 'var(--ctp-blue)',
+                      backgroundColor: 'var(--color-surface)',
+                      color: 'var(--color-accent)',
                       padding: '0.5rem 1rem',
                       borderRadius: '0.25rem',
                       marginBottom: '0.5rem',
@@ -972,12 +972,12 @@ export default function ChannelsTab({
                           onClick={scrollToBottom}
                           style={{
                             padding: '0.5rem 1rem',
-                            backgroundColor: 'var(--ctp-blue)',
+                            backgroundColor: 'var(--color-accent)',
                             border: 'none',
                             borderRadius: '20px',
                             cursor: 'pointer',
                             fontSize: '0.85rem',
-                            color: 'var(--ctp-base)',
+                            color: 'var(--color-bg)',
                             fontWeight: 'bold',
                             boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
                             display: 'flex',
@@ -1368,15 +1368,15 @@ export default function ChannelsTab({
                             style={{
                               padding: '0.25rem 0.5rem',
                               fontSize: '0.75rem',
-                              background: 'var(--ctp-surface1)',
-                              border: '1px solid var(--ctp-surface2)',
+                              background: 'var(--color-surface-hover)',
+                              border: '1px solid var(--color-surface-active)',
                               borderRadius: '4px',
-                              color: 'var(--ctp-text)',
+                              color: 'var(--color-text)',
                               cursor: 'pointer',
                               transition: 'all 0.2s',
                             }}
-                            onMouseOver={e => (e.currentTarget.style.background = 'var(--ctp-surface2)')}
-                            onMouseOut={e => (e.currentTarget.style.background = 'var(--ctp-surface1)')}
+                            onMouseOver={e => (e.currentTarget.style.background = 'var(--color-surface-active)')}
+                            onMouseOut={e => (e.currentTarget.style.background = 'var(--color-surface-hover)')}
                           >
                             {showPsk ? t('channels.hide') : t('channels.show')}
                           </button>
@@ -1437,7 +1437,7 @@ export default function ChannelsTab({
                       style={{
                         marginTop: '1.5rem',
                         paddingTop: '1rem',
-                        borderTop: '1px solid var(--ctp-surface2)',
+                        borderTop: '1px solid var(--color-surface-active)',
                       }}
                     >
                       <button
@@ -1464,7 +1464,7 @@ export default function ChannelsTab({
                         style={{
                           marginTop: '0.5rem',
                           fontSize: '0.85rem',
-                          color: 'var(--ctp-subtext0)',
+                          color: 'var(--color-text-subtle)',
                           textAlign: 'center',
                         }}
                       >
@@ -1526,15 +1526,15 @@ export default function ChannelsTab({
                         style={{
                           padding: '0.25rem 0.5rem',
                           fontSize: '0.75rem',
-                          background: 'var(--ctp-surface1)',
-                          border: '1px solid var(--ctp-surface2)',
+                          background: 'var(--color-surface-hover)',
+                          border: '1px solid var(--color-surface-active)',
                           borderRadius: '4px',
-                          color: 'var(--ctp-text)',
+                          color: 'var(--color-text)',
                           cursor: 'pointer',
                           transition: 'all 0.2s',
                         }}
-                        onMouseOver={e => (e.currentTarget.style.background = 'var(--ctp-surface2)')}
-                        onMouseOut={e => (e.currentTarget.style.background = 'var(--ctp-surface1)')}
+                        onMouseOver={e => (e.currentTarget.style.background = 'var(--color-surface-active)')}
+                        onMouseOut={e => (e.currentTarget.style.background = 'var(--color-surface-hover)')}
                       >
                         {showPsk ? t('channels.hide') : t('channels.show')}
                       </button>
@@ -1554,7 +1554,7 @@ export default function ChannelsTab({
                       display: 'inline-flex',
                       alignItems: 'center',
                       gap: '0.25rem',
-                      color: 'var(--ctp-blue)',
+                      color: 'var(--color-accent)',
                     }}>
                       <UiIcon name="key" /> {t('channels.channel_database', 'Channel Database')}
                     </span>
@@ -1563,7 +1563,7 @@ export default function ChannelsTab({
                 <div className="info-row">
                   <span className="info-label">{t('channels.access_mode', 'Access Mode')}</span>
                   <span className="info-value">
-                    <span style={{ color: 'var(--ctp-yellow)' }}>
+                    <span style={{ color: 'var(--color-warning)' }}>
                       {t('channels.read_only', 'Read-only')}
                     </span>
                   </span>

--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -1961,8 +1961,8 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
               onClick={() => setShowChanges(!showChanges)}
               style={{
                 background: 'transparent',
-                border: '1px solid var(--ctp-surface2)',
-                color: 'var(--ctp-text)',
+                border: '1px solid var(--color-surface-active)',
+                color: 'var(--color-text)',
                 padding: '0.5rem 1rem',
                 borderRadius: '4px',
                 cursor: 'pointer',
@@ -1978,24 +1978,24 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
               <div style={{
                 marginTop: '0.5rem',
                 padding: '1rem',
-                backgroundColor: 'var(--ctp-surface0)',
+                backgroundColor: 'var(--color-surface)',
                 borderRadius: '4px',
-                border: '1px solid var(--ctp-surface2)'
+                border: '1px solid var(--color-surface-active)'
               }}>
                 <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                   <thead>
-                    <tr style={{ borderBottom: '1px solid var(--ctp-surface2)' }}>
-                      <th style={{ textAlign: 'left', padding: '0.5rem', color: 'var(--ctp-subtext0)' }}>{t('config.field')}</th>
-                      <th style={{ textAlign: 'left', padding: '0.5rem', color: 'var(--ctp-subtext0)' }}>{t('config.old_value')}</th>
-                      <th style={{ textAlign: 'left', padding: '0.5rem', color: 'var(--ctp-subtext0)' }}>{t('config.new_value')}</th>
+                    <tr style={{ borderBottom: '1px solid var(--color-surface-active)' }}>
+                      <th style={{ textAlign: 'left', padding: '0.5rem', color: 'var(--color-text-subtle)' }}>{t('config.field')}</th>
+                      <th style={{ textAlign: 'left', padding: '0.5rem', color: 'var(--color-text-subtle)' }}>{t('config.old_value')}</th>
+                      <th style={{ textAlign: 'left', padding: '0.5rem', color: 'var(--color-text-subtle)' }}>{t('config.new_value')}</th>
                     </tr>
                   </thead>
                   <tbody>
                     {configChanges.map((change, idx) => (
-                      <tr key={idx} style={{ borderBottom: '1px solid var(--ctp-surface1)' }}>
+                      <tr key={idx} style={{ borderBottom: '1px solid var(--color-surface-hover)' }}>
                         <td style={{ padding: '0.5rem' }}>{change.field}</td>
-                        <td style={{ padding: '0.5rem', color: 'var(--ctp-red)' }}>{change.oldValue}</td>
-                        <td style={{ padding: '0.5rem', color: 'var(--ctp-green)' }}>{change.newValue}</td>
+                        <td style={{ padding: '0.5rem', color: 'var(--color-error)' }}>{change.oldValue}</td>
+                        <td style={{ padding: '0.5rem', color: 'var(--color-success)' }}>{change.newValue}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -2009,14 +2009,14 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
       {/* Import/Export Configuration Section */}
       <div id="config-import-export" className="settings-section" style={{ marginBottom: '2rem' }}>
         <h3>{t('config.import_export_title')}</h3>
-        <p style={{ color: 'var(--ctp-subtext0)', marginBottom: '1rem' }}>
+        <p style={{ color: 'var(--color-text-subtle)', marginBottom: '1rem' }}>
           {t('config.import_export_description')}
         </p>
         <div style={{ display: 'flex', gap: '1rem', marginBottom: '1.5rem' }}>
           <button
             onClick={() => setIsImportModalOpen(true)}
             style={{
-              backgroundColor: 'var(--ctp-blue)',
+              backgroundColor: 'var(--color-accent)',
               color: '#fff',
               padding: '0.75rem 1.5rem',
               border: 'none',
@@ -2031,7 +2031,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
           <button
             onClick={() => setIsExportModalOpen(true)}
             style={{
-              backgroundColor: 'var(--ctp-green)',
+              backgroundColor: 'var(--color-success)',
               color: '#fff',
               padding: '0.75rem 1.5rem',
               border: 'none',

--- a/src/components/CustomTilesetManager.tsx
+++ b/src/components/CustomTilesetManager.tsx
@@ -206,7 +206,7 @@ export function CustomTilesetManager() {
             target="_blank"
             rel="noopener noreferrer"
             style={{
-              color: 'var(--ctp-blue)',
+              color: 'var(--color-accent)',
               textDecoration: 'underline',
               fontWeight: '500'
             }}
@@ -486,28 +486,28 @@ export function CustomTilesetManager() {
             <div style={{
               marginTop: '0.75rem',
               padding: '0.75rem',
-              backgroundColor: 'var(--ctp-surface0)',
-              borderLeft: '3px solid var(--ctp-blue)',
+              backgroundColor: 'var(--color-surface)',
+              borderLeft: '3px solid var(--color-accent)',
               borderRadius: '4px',
               fontSize: '0.85rem'
             }}>
-              <strong style={{ display: 'block', marginBottom: '0.5rem', color: 'var(--ctp-blue)' }}>
+              <strong style={{ display: 'block', marginBottom: '0.5rem', color: 'var(--color-accent)' }}>
                 <UiIcon name="info" /> {t('tileset_manager.tileserver_tip_title')}
               </strong>
-              <div style={{ color: 'var(--ctp-subtext0)', lineHeight: '1.5' }}>
+              <div style={{ color: 'var(--color-text-subtle)', lineHeight: '1.5' }}>
                 {t('tileset_manager.tileserver_tip_desc')}
                 <br />
                 <code style={{
                   display: 'block',
                   marginTop: '0.5rem',
                   padding: '0.25rem 0.5rem',
-                  backgroundColor: 'var(--ctp-base)',
+                  backgroundColor: 'var(--color-bg)',
                   borderRadius: '3px',
                   fontSize: '0.8rem'
                 }}>
                   docker run -p 8080:8080 -v /path/to/tiles:/data maptiler/tileserver-gl-light
                 </code>
-                <div style={{ marginTop: '0.5rem', fontSize: '0.8rem', color: 'var(--ctp-subtext1)' }}>
+                <div style={{ marginTop: '0.5rem', fontSize: '0.8rem', color: 'var(--color-text-muted)' }}>
                   <strong>{t('tileset_manager.tileserver_tip_support')}</strong>
                 </div>
                 <div style={{ marginTop: '0.5rem', fontSize: '0.8rem' }}>
@@ -516,7 +516,7 @@ export function CustomTilesetManager() {
                     target="_blank"
                     rel="noopener noreferrer"
                     style={{
-                      color: 'var(--ctp-blue)',
+                      color: 'var(--color-accent)',
                       textDecoration: 'underline'
                     }}
                   >

--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -334,7 +334,7 @@ const SortableSourceCard: React.FC<{
           width: '1.4rem',
           marginLeft: '8px',
           cursor: isDragging ? 'grabbing' : 'grab',
-          color: isDragging ? 'var(--ctp-blue)' : 'var(--ctp-overlay1)',
+          color: isDragging ? 'var(--color-accent)' : 'var(--color-text-disabled)',
           fontSize: '1.2rem',
           userSelect: 'none',
           flexShrink: 0,

--- a/src/components/DistanceDistributionWidget.tsx
+++ b/src/components/DistanceDistributionWidget.tsx
@@ -127,13 +127,13 @@ const DistanceDistributionWidget: React.FC<DistanceDistributionWidgetProps> = ({
   // Color gradient based on distance
   const getBarColor = (index: number, total: number): string => {
     const colors = [
-      'var(--ctp-green)',
+      'var(--color-success)',
       'var(--ctp-teal)',
-      'var(--ctp-blue)',
-      'var(--ctp-lavender)',
-      'var(--ctp-mauve)',
+      'var(--color-accent)',
+      'var(--color-accent-muted)',
+      'var(--color-accent-alt)',
       'var(--ctp-pink)',
-      'var(--ctp-red)',
+      'var(--color-error)',
     ];
     if (total <= 1) return colors[0];
     const colorIndex = Math.round((index / (total - 1)) * (colors.length - 1));
@@ -243,7 +243,7 @@ const DistanceDistributionWidget: React.FC<DistanceDistributionWidgetProps> = ({
                       className="hop-bar-fill"
                       style={{
                         width: `${(noPositionCount / maxCount) * 100}%`,
-                        backgroundColor: 'var(--ctp-overlay1)',
+                        backgroundColor: 'var(--color-text-disabled)',
                       }}
                     />
                   </div>

--- a/src/components/GeofenceMapEditor.tsx
+++ b/src/components/GeofenceMapEditor.tsx
@@ -51,21 +51,21 @@ const MapDrawingLayer: React.FC<{
 
   const centerIcon = useMemo(() => L.divIcon({
     className: 'custom-center-icon',
-    html: '<div style="width: 12px; height: 12px; background: var(--ctp-blue); border: 2px solid white; border-radius: 50%; cursor: move;"></div>',
+    html: '<div style="width: 12px; height: 12px; background: var(--color-accent); border: 2px solid white; border-radius: 50%; cursor: move;"></div>',
     iconSize: [12, 12],
     iconAnchor: [6, 6],
   }), []);
 
   const radiusIcon = useMemo(() => L.divIcon({
     className: 'custom-radius-icon',
-    html: '<div style="width: 10px; height: 10px; background: var(--ctp-green); border: 2px solid white; border-radius: 50%; cursor: move;"></div>',
+    html: '<div style="width: 10px; height: 10px; background: var(--color-success); border: 2px solid white; border-radius: 50%; cursor: move;"></div>',
     iconSize: [10, 10],
     iconAnchor: [5, 5],
   }), []);
 
   const vertexIcon = useMemo(() => L.divIcon({
     className: 'custom-vertex-icon',
-    html: '<div style="width: 14px; height: 14px; background: var(--ctp-mauve); border: 2px solid white; border-radius: 50%; cursor: move; box-shadow: 0 0 4px rgba(0,0,0,0.4);"></div>',
+    html: '<div style="width: 14px; height: 14px; background: var(--color-accent-alt); border: 2px solid white; border-radius: 50%; cursor: move; box-shadow: 0 0 4px rgba(0,0,0,0.4);"></div>',
     iconSize: [14, 14],
     iconAnchor: [7, 7],
   }), []);
@@ -126,8 +126,8 @@ const MapDrawingLayer: React.FC<{
 
     const circle = L.circle(center, {
       radius: radiusMeters,
-      color: 'var(--ctp-blue)',
-      fillColor: 'var(--ctp-blue)',
+      color: 'var(--color-accent)',
+      fillColor: 'var(--color-accent)',
       fillOpacity: 0.2,
       weight: 2,
     }).addTo(map);
@@ -185,8 +185,8 @@ const MapDrawingLayer: React.FC<{
     const latLngs = polygonData.vertices.map(c => L.latLng(c.lat, c.lng));
 
     const polygon = L.polygon(latLngs, {
-      color: 'var(--ctp-mauve)',
-      fillColor: 'var(--ctp-mauve)',
+      color: 'var(--color-accent-alt)',
+      fillColor: 'var(--color-accent-alt)',
       fillOpacity: 0.2,
       weight: 2,
     }).addTo(map);
@@ -324,8 +324,8 @@ const MapDrawingLayer: React.FC<{
 
       if (polygonVertices.length >= 2) {
         const tempPolygon = L.polygon(polygonVertices, {
-          color: 'var(--ctp-mauve)',
-          fillColor: 'var(--ctp-mauve)',
+          color: 'var(--color-accent-alt)',
+          fillColor: 'var(--color-accent-alt)',
           fillOpacity: 0.1,
           weight: 2,
           dashArray: '5, 5',
@@ -405,7 +405,7 @@ const GeofenceMapEditor: React.FC<GeofenceMapEditorProps> = ({
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-      <div style={{ height: '400px', border: '1px solid var(--ctp-surface2)', borderRadius: '8px', overflow: 'hidden' }}>
+      <div style={{ height: '400px', border: '1px solid var(--color-surface-active)', borderRadius: '8px', overflow: 'hidden' }}>
         <BaseMap center={[30, 0]} zoom={3}>
           <MapDrawingLayer
             shapeType={shapeType}
@@ -423,12 +423,12 @@ const GeofenceMapEditor: React.FC<GeofenceMapEditorProps> = ({
             gridTemplateColumns: '1fr 1fr 1fr',
             gap: '8px',
             padding: '12px',
-            background: 'var(--ctp-surface0)',
+            background: 'var(--color-surface)',
             borderRadius: '8px',
           }}
         >
           <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-            <label style={{ fontSize: '12px', color: 'var(--ctp-subtext0)' }}>
+            <label style={{ fontSize: '12px', color: 'var(--color-text-subtle)' }}>
               {t('automation.geofence_triggers.center_lat')}
             </label>
             <input
@@ -440,10 +440,10 @@ const GeofenceMapEditor: React.FC<GeofenceMapEditorProps> = ({
               onChange={(e) => handleCenterLatChange(e.target.value)}
               style={{
                 padding: '6px 8px',
-                background: 'var(--ctp-base)',
-                border: '1px solid var(--ctp-surface2)',
+                background: 'var(--color-bg)',
+                border: '1px solid var(--color-surface-active)',
                 borderRadius: '4px',
-                color: 'var(--ctp-text)',
+                color: 'var(--color-text)',
                 fontSize: '14px',
               }}
               placeholder="0.000000"
@@ -451,7 +451,7 @@ const GeofenceMapEditor: React.FC<GeofenceMapEditorProps> = ({
           </div>
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-            <label style={{ fontSize: '12px', color: 'var(--ctp-subtext0)' }}>
+            <label style={{ fontSize: '12px', color: 'var(--color-text-subtle)' }}>
               {t('automation.geofence_triggers.center_lng')}
             </label>
             <input
@@ -463,10 +463,10 @@ const GeofenceMapEditor: React.FC<GeofenceMapEditorProps> = ({
               onChange={(e) => handleCenterLngChange(e.target.value)}
               style={{
                 padding: '6px 8px',
-                background: 'var(--ctp-base)',
-                border: '1px solid var(--ctp-surface2)',
+                background: 'var(--color-bg)',
+                border: '1px solid var(--color-surface-active)',
                 borderRadius: '4px',
-                color: 'var(--ctp-text)',
+                color: 'var(--color-text)',
                 fontSize: '14px',
               }}
               placeholder="0.000000"
@@ -474,7 +474,7 @@ const GeofenceMapEditor: React.FC<GeofenceMapEditorProps> = ({
           </div>
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-            <label style={{ fontSize: '12px', color: 'var(--ctp-subtext0)' }}>
+            <label style={{ fontSize: '12px', color: 'var(--color-text-subtle)' }}>
               {t('automation.geofence_triggers.radius_km')}
             </label>
             <input
@@ -485,10 +485,10 @@ const GeofenceMapEditor: React.FC<GeofenceMapEditorProps> = ({
               onChange={(e) => handleRadiusChange(e.target.value)}
               style={{
                 padding: '6px 8px',
-                background: 'var(--ctp-base)',
-                border: '1px solid var(--ctp-surface2)',
+                background: 'var(--color-bg)',
+                border: '1px solid var(--color-surface-active)',
                 borderRadius: '4px',
-                color: 'var(--ctp-text)',
+                color: 'var(--color-text)',
                 fontSize: '14px',
               }}
               placeholder="10.00"
@@ -501,14 +501,14 @@ const GeofenceMapEditor: React.FC<GeofenceMapEditorProps> = ({
         <div
           style={{
             padding: '12px',
-            background: 'var(--ctp-surface0)',
+            background: 'var(--color-surface)',
             borderRadius: '8px',
           }}
         >
-          <div style={{ fontSize: '14px', color: 'var(--ctp-text)' }}>
+          <div style={{ fontSize: '14px', color: 'var(--color-text)' }}>
             {t('automation.geofence_triggers.vertices_count')}: {shape.vertices.length}
           </div>
-          <div style={{ fontSize: '12px', color: 'var(--ctp-subtext0)', marginTop: '4px' }}>
+          <div style={{ fontSize: '12px', color: 'var(--color-text-subtle)', marginTop: '4px' }}>
             {t('automation.geofence_triggers.click_to_add_vertex')}
           </div>
         </div>
@@ -518,10 +518,10 @@ const GeofenceMapEditor: React.FC<GeofenceMapEditorProps> = ({
         <div
           style={{
             padding: '12px',
-            background: 'var(--ctp-surface0)',
+            background: 'var(--color-surface)',
             borderRadius: '8px',
             fontSize: '12px',
-            color: 'var(--ctp-subtext0)',
+            color: 'var(--color-text-subtle)',
           }}
         >
           {t('automation.geofence_triggers.click_map_to_start')}

--- a/src/components/GeofenceNodeSelector.tsx
+++ b/src/components/GeofenceNodeSelector.tsx
@@ -72,7 +72,7 @@ const GeofenceNodeSelector: React.FC<GeofenceNodeSelectorProps> = ({
             onChange={() => handleToggleMode('all')}
             style={{ cursor: 'pointer' }}
           />
-          <span style={{ color: 'var(--ctp-text)' }}>
+          <span style={{ color: 'var(--color-text)' }}>
             {t('automation.geofence_triggers.all_nodes', 'All Nodes')}
           </span>
         </label>
@@ -84,7 +84,7 @@ const GeofenceNodeSelector: React.FC<GeofenceNodeSelectorProps> = ({
             onChange={() => handleToggleMode('selected')}
             style={{ cursor: 'pointer' }}
           />
-          <span style={{ color: 'var(--ctp-text)' }}>
+          <span style={{ color: 'var(--color-text)' }}>
             {t('automation.geofence_triggers.selected_nodes', 'Selected Nodes')}
           </span>
         </label>
@@ -97,9 +97,9 @@ const GeofenceNodeSelector: React.FC<GeofenceNodeSelectorProps> = ({
           flexDirection: 'column',
           gap: '8px',
           padding: '12px',
-          backgroundColor: 'var(--ctp-surface0)',
+          backgroundColor: 'var(--color-surface)',
           borderRadius: '6px',
-          border: '1px solid var(--ctp-surface1)'
+          border: '1px solid var(--color-surface-hover)'
         }}>
           {/* Search Input */}
           <input
@@ -109,9 +109,9 @@ const GeofenceNodeSelector: React.FC<GeofenceNodeSelectorProps> = ({
             onChange={(e) => setSearchTerm(e.target.value)}
             style={{
               padding: '8px 12px',
-              backgroundColor: 'var(--ctp-base)',
-              color: 'var(--ctp-text)',
-              border: '1px solid var(--ctp-surface2)',
+              backgroundColor: 'var(--color-bg)',
+              color: 'var(--color-text)',
+              border: '1px solid var(--color-surface-active)',
               borderRadius: '4px',
               fontSize: '14px',
               outline: 'none'
@@ -129,7 +129,7 @@ const GeofenceNodeSelector: React.FC<GeofenceNodeSelectorProps> = ({
             {filteredNodes.length === 0 ? (
               <div style={{
                 padding: '12px',
-                color: 'var(--ctp-subtext0)',
+                color: 'var(--color-text-subtle)',
                 textAlign: 'center',
                 fontSize: '14px'
               }}>
@@ -152,14 +152,14 @@ const GeofenceNodeSelector: React.FC<GeofenceNodeSelectorProps> = ({
                       alignItems: 'center',
                       gap: '8px',
                       padding: '8px',
-                      backgroundColor: isChecked ? 'var(--ctp-surface1)' : 'transparent',
+                      backgroundColor: isChecked ? 'var(--color-surface-hover)' : 'transparent',
                       borderRadius: '4px',
                       cursor: 'pointer',
                       transition: 'background-color 0.15s ease'
                     }}
                     onMouseEnter={(e) => {
                       if (!isChecked) {
-                        e.currentTarget.style.backgroundColor = 'var(--ctp-surface0)';
+                        e.currentTarget.style.backgroundColor = 'var(--color-surface)';
                       }
                     }}
                     onMouseLeave={(e) => {
@@ -181,14 +181,14 @@ const GeofenceNodeSelector: React.FC<GeofenceNodeSelectorProps> = ({
                       flex: 1
                     }}>
                       <div style={{
-                        color: 'var(--ctp-text)',
+                        color: 'var(--color-text)',
                         fontWeight: 500
                       }}>
                         {displayName}
                         {node.shortName && node.longName && node.shortName !== node.longName && (
                           <span style={{
                             marginLeft: '6px',
-                            color: 'var(--ctp-subtext0)',
+                            color: 'var(--color-text-subtle)',
                             fontWeight: 400
                           }}>
                             ({node.shortName})
@@ -196,7 +196,7 @@ const GeofenceNodeSelector: React.FC<GeofenceNodeSelectorProps> = ({
                         )}
                       </div>
                       <div style={{
-                        color: 'var(--ctp-subtext0)',
+                        color: 'var(--color-text-subtle)',
                         fontSize: '12px'
                       }}>
                         {nodeIdStr}
@@ -212,9 +212,9 @@ const GeofenceNodeSelector: React.FC<GeofenceNodeSelectorProps> = ({
           {selectedNodeNums.length > 0 && (
             <div style={{
               padding: '8px',
-              backgroundColor: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-bg)',
               borderRadius: '4px',
-              color: 'var(--ctp-subtext0)',
+              color: 'var(--color-text-subtle)',
               fontSize: '13px',
               textAlign: 'center'
             }}>

--- a/src/components/GeofenceTriggersSection.tsx
+++ b/src/components/GeofenceTriggersSection.tsx
@@ -320,8 +320,8 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px',
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -337,12 +337,12 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
         {/* Add/Edit Geofence Trigger Form */}
         <div style={{
           padding: '1rem',
-          background: editingTriggerId ? 'var(--ctp-surface1)' : 'var(--ctp-surface0)',
+          background: editingTriggerId ? 'var(--color-surface-hover)' : 'var(--color-surface)',
           borderRadius: '8px',
           marginBottom: '1rem',
-          border: editingTriggerId ? '2px solid var(--ctp-blue)' : 'none',
+          border: editingTriggerId ? '2px solid var(--color-accent)' : 'none',
         }}>
-          <h4 style={{ margin: '0 0 1rem 0', fontSize: '0.95rem', color: 'var(--ctp-text)' }}>
+          <h4 style={{ margin: '0 0 1rem 0', fontSize: '0.95rem', color: 'var(--color-text)' }}>
             {editingTriggerId
               ? t('automation.geofence_triggers.edit_trigger', 'Edit Geofence Trigger')
               : t('automation.geofence_triggers.add_new', 'Add New Geofence Trigger')}
@@ -432,7 +432,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
                   style={{ width: '100px' }}
                   min={1}
                 />
-                <span style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+                <span style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                   {t('automation.geofence_triggers.while_inside_interval_help', 'How often to fire while nodes remain inside')}
                 </span>
               </div>
@@ -451,7 +451,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
                 style={{ width: '100px' }}
                 min={0}
               />
-              <span style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+              <span style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                 {t('automation.geofence_triggers.cooldown_help', 'Minimum time between triggers for each node. 0 = no cooldown.')}
               </span>
             </div>
@@ -533,7 +533,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
                     style={{ width: '100%', fontFamily: 'monospace' }}
                     placeholder="--ip {IP} --dest {NODE_ID} --reboot"
                   />
-                  <span style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+                  <span style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                     {t('automation.geofence_triggers.script_args_help', 'Optional CLI arguments. Tokens: {IP}, {NODE_ID}, {EVENT}, {GEOFENCE_NAME}, etc.')}
                   </span>
                 </div>
@@ -555,12 +555,12 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
                     placeholder={t('automation.geofence_triggers.message_placeholder', 'e.g., {LONG_NAME} entered {GEOFENCE_NAME}')}
                   />
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginTop: '0.25rem' }}>
-                    <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', flex: 1 }}>
+                    <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', flex: 1 }}>
                       {t('automation.geofence_triggers.tokens_help', 'Available tokens:')}
                       {' '}
                       {AVAILABLE_TOKENS.map((tok, i) => (
                         <span key={tok.token}>
-                          <code style={{ background: 'var(--ctp-surface1)', padding: '0 0.25rem', borderRadius: '2px' }}>{tok.token}</code>
+                          <code style={{ background: 'var(--color-surface-hover)', padding: '0 0.25rem', borderRadius: '2px' }}>{tok.token}</code>
                           {i < AVAILABLE_TOKENS.length - 1 && ', '}
                         </span>
                       ))}
@@ -568,7 +568,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
                     <div style={{
                       fontSize: '0.75rem',
                       fontWeight: 'bold',
-                      color: newResponse.length > 200 ? 'var(--ctp-red)' : newResponse.length > 150 ? 'var(--ctp-yellow)' : 'var(--ctp-subtext0)',
+                      color: newResponse.length > 200 ? 'var(--color-error)' : newResponse.length > 150 ? 'var(--color-warning)' : 'var(--color-text-subtle)',
                       marginLeft: '0.5rem',
                       whiteSpace: 'nowrap',
                     }}>
@@ -603,7 +603,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
                   </option>
                 ))}
               </select>
-              <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+              <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                 {newResponseType === 'script' && newChannel === 'none'
                   ? t('automation.geofence_triggers.channel_none_help', 'Script handles its own output (e.g., external integrations)')
                   : t('automation.geofence_triggers.channel_help', 'Output will be sent to this channel')}
@@ -615,7 +615,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
                     display: 'block',
                     fontSize: '0.85rem',
                     cursor: newChannel === 'dm' ? 'pointer' : 'not-allowed',
-                    color: 'var(--ctp-subtext0)',
+                    color: 'var(--color-text-subtle)',
                     opacity: newChannel === 'dm' ? 1 : 0.5
                   }}>
                     <input
@@ -638,9 +638,9 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
                   onClick={handleCancelEdit}
                   className="settings-button"
                   style={{
-                    background: 'var(--ctp-surface1)',
-                    color: 'var(--ctp-text)',
-                    border: '1px solid var(--ctp-overlay0)',
+                    background: 'var(--color-surface-hover)',
+                    color: 'var(--color-text)',
+                    border: '1px solid var(--color-border-subtle)',
                   }}
                 >
                   {t('common.cancel', 'Cancel')}
@@ -666,7 +666,7 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
         {/* Existing Triggers List */}
         {localTriggers.length > 0 && (
           <div style={{ marginBottom: '1rem' }}>
-            <h4 style={{ margin: '0 0 0.75rem 0', fontSize: '0.95rem', color: 'var(--ctp-text)' }}>
+            <h4 style={{ margin: '0 0 0.75rem 0', fontSize: '0.95rem', color: 'var(--color-text)' }}>
               {t('automation.geofence_triggers.existing', 'Existing Geofence Triggers')} ({localTriggers.length})
             </h4>
 
@@ -691,8 +691,8 @@ const GeofenceTriggersSection: React.FC<GeofenceTriggersSectionProps> = ({
           <div style={{
             padding: '2rem',
             textAlign: 'center',
-            color: 'var(--ctp-subtext0)',
-            background: 'var(--ctp-surface0)',
+            color: 'var(--color-text-subtle)',
+            background: 'var(--color-surface)',
             borderRadius: '8px',
           }}>
             {t('automation.geofence_triggers.no_triggers', 'No geofence triggers configured. Add one above to trigger actions based on node location.')}
@@ -739,15 +739,15 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
         gap: '0.5rem',
         padding: '0.75rem',
         marginBottom: '0.5rem',
-        background: 'var(--ctp-surface0)',
-        border: '1px solid var(--ctp-overlay0)',
+        background: 'var(--color-surface)',
+        border: '1px solid var(--color-border-subtle)',
         borderRadius: '4px',
         opacity: trigger.enabled ? 1 : 0.6,
       }}
     >
       <div style={{ flex: 1 }}>
         <div style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>{trigger.name}</div>
-        <div style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+        <div style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
           {shapeLabel(trigger.shape)} | {eventLabel(trigger.event)}
           {trigger.event === 'while_inside' && trigger.whileInsideIntervalMinutes && (
             <> (every {trigger.whileInsideIntervalMinutes}min)</>
@@ -756,7 +756,7 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
             <> | {t('automation.geofence_triggers.cooldown_display', 'Cooldown: {{minutes}}min', { minutes: trigger.cooldownMinutes })}</>
           )}
         </div>
-        <div style={{ fontSize: '0.8rem', color: 'var(--ctp-subtext0)', marginTop: '0.25rem' }}>
+        <div style={{ fontSize: '0.8rem', color: 'var(--color-text-subtle)', marginTop: '0.25rem' }}>
           {trigger.responseType === 'script' ? (
             <>Script: {trigger.scriptPath?.split('/').pop()}</>
           ) : (
@@ -766,16 +766,16 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
             <> <UiIcon name="forward" size={14} /> {trigger.channel === 'dm' ? 'DM' : `Ch ${trigger.channel}: ${channels.find(c => c.id === trigger.channel)?.name || `Channel ${trigger.channel}`}`}</>
           )}
         </div>
-        <div style={{ fontSize: '0.8rem', color: 'var(--ctp-subtext0)', marginTop: '0.15rem' }}>
+        <div style={{ fontSize: '0.8rem', color: 'var(--color-text-subtle)', marginTop: '0.15rem' }}>
           Nodes: {trigger.nodeFilter.type === 'all' ? 'All' : `${trigger.nodeFilter.nodeNums.length} selected`}
         </div>
         {trigger.lastRun && (
-          <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', marginTop: '0.25rem' }}>
+          <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', marginTop: '0.25rem' }}>
             Last run: {formatLastRun(trigger.lastRun)}
             {trigger.lastResult && (
               <span style={{
                 marginLeft: '0.5rem',
-                color: trigger.lastResult === 'success' ? 'var(--ctp-green)' : 'var(--ctp-red)',
+                color: trigger.lastResult === 'success' ? 'var(--color-success)' : 'var(--color-error)',
               }}>
                 ({trigger.lastResult})
               </span>
@@ -787,8 +787,8 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
         <span style={{
           fontSize: '0.7rem',
           padding: '0.15rem 0.4rem',
-          background: trigger.enabled ? 'var(--ctp-green)' : 'var(--ctp-surface2)',
-          color: trigger.enabled ? 'var(--ctp-base)' : 'var(--ctp-subtext0)',
+          background: trigger.enabled ? 'var(--color-success)' : 'var(--color-surface-active)',
+          color: trigger.enabled ? 'var(--color-bg)' : 'var(--color-text-subtle)',
           borderRadius: '3px',
           fontWeight: 'bold',
         }}>
@@ -798,8 +798,8 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
           <span style={{
             fontSize: '0.7rem',
             padding: '0.15rem 0.4rem',
-            background: 'var(--ctp-peach)',
-            color: 'var(--ctp-base)',
+            background: 'var(--color-caution)',
+            color: 'var(--color-bg)',
             borderRadius: '3px',
             fontWeight: 'bold',
           }}>
@@ -811,8 +811,8 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
           style={{
             padding: '0.25rem 0.5rem',
             fontSize: '12px',
-            background: trigger.enabled ? 'var(--ctp-yellow)' : 'var(--ctp-green)',
-            color: 'var(--ctp-base)',
+            background: trigger.enabled ? 'var(--color-warning)' : 'var(--color-success)',
+            color: 'var(--color-bg)',
             border: 'none',
             borderRadius: '4px',
             cursor: 'pointer',
@@ -827,7 +827,7 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
               padding: '0.25rem 0.5rem',
               fontSize: '12px',
               background: 'var(--ctp-teal)',
-              color: 'var(--ctp-base)',
+              color: 'var(--color-bg)',
               border: 'none',
               borderRadius: '4px',
               cursor: 'pointer',
@@ -842,8 +842,8 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
           style={{
             padding: '0.25rem 0.5rem',
             fontSize: '12px',
-            background: 'var(--ctp-blue)',
-            color: 'var(--ctp-base)',
+            background: 'var(--color-accent)',
+            color: 'var(--color-bg)',
             border: 'none',
             borderRadius: '4px',
             cursor: 'pointer',
@@ -856,7 +856,7 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
           style={{
             padding: '0.25rem 0.5rem',
             fontSize: '12px',
-            background: 'var(--ctp-red)',
+            background: 'var(--color-error)',
             color: 'white',
             border: 'none',
             borderRadius: '4px',
@@ -882,15 +882,15 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
           zIndex: 10000,
         }}>
           <div style={{
-            background: 'var(--ctp-base)',
+            background: 'var(--color-bg)',
             borderRadius: '8px',
             padding: '1.5rem',
             maxWidth: '400px',
             width: '90%',
-            border: '1px solid var(--ctp-overlay0)',
+            border: '1px solid var(--color-border-subtle)',
           }}>
-            <h3 style={{ margin: '0 0 1rem 0', color: 'var(--ctp-text)' }}>Remove Geofence Trigger</h3>
-            <p style={{ color: 'var(--ctp-subtext0)', marginBottom: '1rem' }}>
+            <h3 style={{ margin: '0 0 1rem 0', color: 'var(--color-text)' }}>Remove Geofence Trigger</h3>
+            <p style={{ color: 'var(--color-text-subtle)', marginBottom: '1rem' }}>
               Are you sure you want to remove "{trigger.name}"?
             </p>
             <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
@@ -898,9 +898,9 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
                 onClick={() => setShowRemoveModal(false)}
                 style={{
                   padding: '0.5rem 1rem',
-                  background: 'var(--ctp-surface1)',
-                  color: 'var(--ctp-text)',
-                  border: '1px solid var(--ctp-overlay0)',
+                  background: 'var(--color-surface-hover)',
+                  color: 'var(--color-text)',
+                  border: '1px solid var(--color-border-subtle)',
                   borderRadius: '4px',
                   cursor: 'pointer',
                 }}
@@ -914,8 +914,8 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
                 }}
                 style={{
                   padding: '0.5rem 1rem',
-                  background: 'var(--ctp-red)',
-                  color: 'var(--ctp-base)',
+                  background: 'var(--color-error)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: 'pointer',

--- a/src/components/HopDistanceHeatmapWidget.tsx
+++ b/src/components/HopDistanceHeatmapWidget.tsx
@@ -150,12 +150,12 @@ const HopDistanceHeatmapWidget: React.FC<HopDistanceHeatmapWidgetProps> = ({
 
   // Intensity-based color with dark text for readability
   const getCellStyle = (count: number): { backgroundColor: string; color: string; opacity: number } => {
-    if (count === 0) return { backgroundColor: 'transparent', color: 'var(--ctp-text)', opacity: 0 };
+    if (count === 0) return { backgroundColor: 'transparent', color: 'var(--color-text)', opacity: 0 };
     const intensity = count / maxCount;
-    if (intensity <= 0.25) return { backgroundColor: 'var(--ctp-surface1)', color: 'var(--ctp-text)', opacity: 1 };
-    if (intensity <= 0.5) return { backgroundColor: 'var(--ctp-blue)', color: 'var(--ctp-crust)', opacity: 1 };
-    if (intensity <= 0.75) return { backgroundColor: 'var(--ctp-sapphire)', color: 'var(--ctp-crust)', opacity: 1 };
-    return { backgroundColor: 'var(--ctp-teal)', color: 'var(--ctp-crust)', opacity: 1 };
+    if (intensity <= 0.25) return { backgroundColor: 'var(--color-surface-hover)', color: 'var(--color-text)', opacity: 1 };
+    if (intensity <= 0.5) return { backgroundColor: 'var(--color-accent)', color: 'var(--color-bg-sunken)', opacity: 1 };
+    if (intensity <= 0.75) return { backgroundColor: 'var(--color-accent-hover)', color: 'var(--color-bg-sunken)', opacity: 1 };
+    return { backgroundColor: 'var(--ctp-teal)', color: 'var(--color-bg-sunken)', opacity: 1 };
   };
 
   const hasHomePosition = homeNode?.position?.latitude != null && homeNode?.position?.longitude != null;
@@ -266,9 +266,9 @@ const HopDistanceHeatmapWidget: React.FC<HopDistanceHeatmapWidgetProps> = ({
             <div className="heatmap-legend">
               <span className="heatmap-legend-label">{t('dashboard.widget.hop_distance_heatmap.fewer')}</span>
               <div className="heatmap-legend-bar">
-                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--ctp-surface1)' }} />
-                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--ctp-blue)' }} />
-                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--ctp-sapphire)' }} />
+                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--color-surface-hover)' }} />
+                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--color-accent)' }} />
+                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--color-accent-hover)' }} />
                 <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--ctp-teal)' }} />
               </div>
               <span className="heatmap-legend-label">{t('dashboard.widget.hop_distance_heatmap.more')}</span>

--- a/src/components/HopDistributionWidget.tsx
+++ b/src/components/HopDistributionWidget.tsx
@@ -84,15 +84,15 @@ const HopDistributionWidget: React.FC<HopDistributionWidgetProps> = ({
 
   // Color gradient from green (close) to yellow to red (far)
   const getBarColor = (hop: number | string): string => {
-    if (typeof hop === 'string') return 'var(--ctp-overlay1)';
+    if (typeof hop === 'string') return 'var(--color-text-disabled)';
     const colors = [
-      'var(--ctp-green)',
+      'var(--color-success)',
       'var(--ctp-teal)',
-      'var(--ctp-blue)',
-      'var(--ctp-lavender)',
-      'var(--ctp-mauve)',
+      'var(--color-accent)',
+      'var(--color-accent-muted)',
+      'var(--color-accent-alt)',
       'var(--ctp-pink)',
-      'var(--ctp-red)',
+      'var(--color-error)',
     ];
     return colors[Math.min(hop, colors.length - 1)];
   };
@@ -153,7 +153,7 @@ const HopDistributionWidget: React.FC<HopDistributionWidgetProps> = ({
                   className="hop-bar-fill"
                   style={{
                     width: `${(unknownCount / maxCount) * 100}%`,
-                    backgroundColor: 'var(--ctp-overlay1)',
+                    backgroundColor: 'var(--color-text-disabled)',
                   }}
                 />
               </div>

--- a/src/components/IgnoredNodesSection.tsx
+++ b/src/components/IgnoredNodesSection.tsx
@@ -107,8 +107,8 @@ const IgnoredNodesSection: React.FC<IgnoredNodesSectionProps> = ({ baseUrl }) =>
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -140,20 +140,20 @@ const IgnoredNodesSection: React.FC<IgnoredNodesSectionProps> = ({ baseUrl }) =>
           marginLeft: '1.75rem',
           marginBottom: '1.5rem',
           padding: '1rem',
-          background: 'var(--ctp-surface0)',
-          border: '1px solid var(--ctp-surface2)',
+          background: 'var(--color-surface)',
+          border: '1px solid var(--color-surface-active)',
           borderRadius: '6px',
           display: 'flex',
           gap: '2rem',
         }}>
           <div>
-            <div style={{ fontSize: '24px', fontWeight: 600, color: 'var(--ctp-red)' }}>
+            <div style={{ fontSize: '24px', fontWeight: 600, color: 'var(--color-error)' }}>
               {ignoredNodes.length}
             </div>
-            <div style={{ fontSize: '12px', color: 'var(--ctp-subtext0)' }}>
+            <div style={{ fontSize: '12px', color: 'var(--color-text-subtle)' }}>
               {t('automation.ignored_nodes.total_ignored', 'Ignored Nodes')}
             </div>
-            <div style={{ fontSize: '11px', color: 'var(--ctp-subtext0)', marginTop: '0.25rem' }}>
+            <div style={{ fontSize: '11px', color: 'var(--color-text-subtle)', marginTop: '0.25rem' }}>
               {t('automation.ignored_nodes.count_summary', '{{count}} ignored · {{geo}} geo · {{manual}} manual', {
                 count: ignoredNodes.length,
                 geo: geoCount,
@@ -165,7 +165,7 @@ const IgnoredNodesSection: React.FC<IgnoredNodesSectionProps> = ({ baseUrl }) =>
 
         {/* Ignored Nodes Table */}
         <div style={{
-          border: '1px solid var(--ctp-surface2)',
+          border: '1px solid var(--color-surface-active)',
           borderRadius: '6px',
           overflow: 'hidden',
           marginLeft: '1.75rem'
@@ -174,7 +174,7 @@ const IgnoredNodesSection: React.FC<IgnoredNodesSectionProps> = ({ baseUrl }) =>
             <div style={{
               padding: '1rem',
               textAlign: 'center',
-              color: 'var(--ctp-subtext0)',
+              color: 'var(--color-text-subtle)',
               fontSize: '12px'
             }}>
               {t('automation.ignored_nodes.empty', 'No nodes are currently ignored.')}
@@ -186,7 +186,7 @@ const IgnoredNodesSection: React.FC<IgnoredNodesSectionProps> = ({ baseUrl }) =>
               fontSize: '12px'
             }}>
               <thead>
-                <tr style={{ background: 'var(--ctp-surface1)' }}>
+                <tr style={{ background: 'var(--color-surface-hover)' }}>
                   <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: 500 }}>
                     {t('automation.ignored_nodes.col_node_id', 'Node ID')}
                   </th>
@@ -209,25 +209,25 @@ const IgnoredNodesSection: React.FC<IgnoredNodesSectionProps> = ({ baseUrl }) =>
               </thead>
               <tbody>
                 {ignoredNodes.map((node) => (
-                  <tr key={`${node.sourceId}:${node.nodeNum}`} style={{ borderTop: '1px solid var(--ctp-surface1)' }}>
-                    <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-text)', fontFamily: 'monospace' }}>
+                  <tr key={`${node.sourceId}:${node.nodeNum}`} style={{ borderTop: '1px solid var(--color-surface-hover)' }}>
+                    <td style={{ padding: '0.4rem 0.75rem', color: 'var(--color-text)', fontFamily: 'monospace' }}>
                       {node.nodeId}
                     </td>
-                    <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-text)' }}>
+                    <td style={{ padding: '0.4rem 0.75rem', color: 'var(--color-text)' }}>
                       {node.longName || '-'}
                     </td>
-                    <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-text)' }}>
+                    <td style={{ padding: '0.4rem 0.75rem', color: 'var(--color-text)' }}>
                       {node.shortName || '-'}
                     </td>
-                    <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-subtext0)' }}>
+                    <td style={{ padding: '0.4rem 0.75rem', color: 'var(--color-text-subtle)' }}>
                       {new Date(node.ignoredAt).toLocaleString()}
                     </td>
                     <td style={{ padding: '0.4rem 0.75rem' }}>
                       <span style={{
                         fontSize: '11px',
                         padding: '0.15rem 0.4rem',
-                        background: node.reason === 'geo' ? 'var(--ctp-blue)' : 'var(--ctp-surface2)',
-                        color: node.reason === 'geo' ? 'var(--ctp-base)' : 'var(--ctp-subtext0)',
+                        background: node.reason === 'geo' ? 'var(--color-accent)' : 'var(--color-surface-active)',
+                        color: node.reason === 'geo' ? 'var(--color-bg)' : 'var(--color-text-subtle)',
                         borderRadius: '4px',
                         fontWeight: 'bold',
                       }}>
@@ -243,8 +243,8 @@ const IgnoredNodesSection: React.FC<IgnoredNodesSectionProps> = ({ baseUrl }) =>
                         style={{
                           padding: '0.25rem 0.5rem',
                           fontSize: '11px',
-                          background: 'var(--ctp-red)',
-                          color: 'var(--ctp-base)',
+                          background: 'var(--color-error)',
+                          color: 'var(--color-bg)',
                           border: 'none',
                           borderRadius: '4px',
                           cursor: removingNodeNum === node.nodeNum ? 'not-allowed' : 'pointer',

--- a/src/components/InfoTab.tsx
+++ b/src/components/InfoTab.tsx
@@ -417,10 +417,10 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
                           padding: '0.5rem',
                           fontSize: '0.85rem',
                           fontFamily: 'monospace',
-                          backgroundColor: 'var(--ctp-surface0)',
-                          border: '1px solid var(--ctp-surface2)',
+                          backgroundColor: 'var(--color-surface)',
+                          border: '1px solid var(--color-surface-active)',
                           borderRadius: '4px',
-                          color: 'var(--ctp-text)'
+                          color: 'var(--color-text)'
                         }}
                       />
                     </div>
@@ -437,10 +437,10 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
                             paddingRight: '2.5rem',
                             fontSize: '0.85rem',
                             fontFamily: 'monospace',
-                            backgroundColor: 'var(--ctp-surface0)',
-                            border: '1px solid var(--ctp-surface2)',
+                            backgroundColor: 'var(--color-surface)',
+                            border: '1px solid var(--color-surface-active)',
                             borderRadius: '4px',
-                            color: 'var(--ctp-text)'
+                            color: 'var(--color-text)'
                           }}
                         />
                         <button
@@ -457,7 +457,7 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
                             cursor: 'pointer',
                             padding: '0.25rem',
                             fontSize: '1rem',
-                            color: 'var(--ctp-subtext0)',
+                            color: 'var(--color-text-subtle)',
                             lineHeight: 1
                           }}
                         >
@@ -522,7 +522,7 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
                           <div key={client.id} style={{
                             marginTop: '0.5rem',
                             padding: '0.5rem',
-                            backgroundColor: 'var(--ctp-surface0)',
+                            backgroundColor: 'var(--color-surface)',
                             borderRadius: '4px'
                           }}>
                             <p style={{ margin: '0.25rem 0' }}><strong>{t('info.client_id')}</strong> {client.id}</p>
@@ -693,8 +693,8 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
             borderRadius: '4px',
             cursor: 'pointer',
             fontWeight: active ? 600 : 400,
-            background: active ? 'var(--ctp-blue)' : 'var(--ctp-surface1)',
-            color: active ? 'var(--ctp-crust)' : 'var(--ctp-subtext0)',
+            background: active ? 'var(--color-accent)' : 'var(--color-surface-hover)',
+            color: active ? 'var(--color-bg-sunken)' : 'var(--color-text-subtle)',
           });
 
           const timeRangeButtons = (
@@ -733,7 +733,7 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem' }}>
                     <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.75rem' }}>
                       <h3 style={{ margin: 0 }}>{t('info.packet_distribution', 'Packet Distribution')}</h3>
-                      <span style={{ fontSize: '0.9em', color: 'var(--ctp-subtext0)', fontWeight: 600 }}>
+                      <span style={{ fontSize: '0.9em', color: 'var(--color-text-subtle)', fontWeight: 600 }}>
                         {t('info.total_packets', { count: packetDistribution.total, defaultValue: 'Total: {{count}} packets' })}
                       </span>
                     </div>
@@ -786,9 +786,9 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
                   padding: '0.25rem 0.5rem',
                   fontSize: '0.85em',
                   borderRadius: '4px',
-                  border: '1px solid var(--ctp-surface2)',
-                  background: 'var(--ctp-surface0)',
-                  color: 'var(--ctp-text)',
+                  border: '1px solid var(--color-surface-active)',
+                  background: 'var(--color-surface)',
+                  color: 'var(--color-text)',
                 }}
               >
                 <option value="">--</option>
@@ -983,11 +983,11 @@ const InfoTab: React.FC<InfoTabProps> = React.memo(({
           zIndex: 1000
         }}>
           <div style={{
-            backgroundColor: 'var(--ctp-base)',
+            backgroundColor: 'var(--color-bg)',
             padding: '2rem',
             borderRadius: '8px',
             maxWidth: '400px',
-            border: '1px solid var(--ctp-surface2)'
+            border: '1px solid var(--color-surface-active)'
           }}>
             <h3 style={{ marginTop: 0 }}>{t('info.clear_record_title')}</h3>
             <p>{t('info.clear_record_confirm')}</p>

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -146,7 +146,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
         /* MFA Verification Step */
         <form onSubmit={handleMfaSubmit}>
           <div className="mfa-prompt" style={{ textAlign: 'center', marginBottom: '8px' }}>
-            <p style={{ color: 'var(--ctp-subtext0)', fontSize: '14px', margin: 0 }}>
+            <p style={{ color: 'var(--color-text-subtle)', fontSize: '14px', margin: 0 }}>
               {useBackupCode ? t('mfa.backup_code_prompt') : t('mfa.login_prompt')}
             </p>
           </div>
@@ -189,7 +189,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
             <button
               type="button"
               className="button-link"
-              style={{ background: 'none', border: 'none', color: 'var(--ctp-blue)', cursor: 'pointer', fontSize: '13px', textDecoration: 'underline', padding: '4px' }}
+              style={{ background: 'none', border: 'none', color: 'var(--color-accent)', cursor: 'pointer', fontSize: '13px', textDecoration: 'underline', padding: '4px' }}
               onClick={() => {
                 setUseBackupCode(!useBackupCode);
                 setMfaCode('');
@@ -201,7 +201,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
             <button
               type="button"
               className="button-link"
-              style={{ background: 'none', border: 'none', color: 'var(--ctp-blue)', cursor: 'pointer', fontSize: '13px', textDecoration: 'underline', padding: '4px' }}
+              style={{ background: 'none', border: 'none', color: 'var(--color-accent)', cursor: 'pointer', fontSize: '13px', textDecoration: 'underline', padding: '4px' }}
               onClick={handleBackToLogin}
             >
               {t('mfa.back_to_login')}

--- a/src/components/MQTT/MqttBridgeConfigurationView.tsx
+++ b/src/components/MQTT/MqttBridgeConfigurationView.tsx
@@ -79,7 +79,7 @@ function bboxFromForm(g: BridgeConfigForm['geo']): BBoxValue | null {
   return nums;
 }
 
-const labelStyle: React.CSSProperties = { fontSize: 11, color: 'var(--ctp-subtext0)', marginTop: 4 };
+const labelStyle: React.CSSProperties = { fontSize: 11, color: 'var(--color-text-subtle)', marginTop: 4 };
 
 export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewProps> = ({
   sourceId,
@@ -239,7 +239,7 @@ export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewPr
 
   if (loadError) {
     return (
-      <div className="mqtt-bridge-config" style={{ padding: 16, color: 'var(--ctp-red)' }}>
+      <div className="mqtt-bridge-config" style={{ padding: 16, color: 'var(--color-error)' }}>
         {loadError}
       </div>
     );
@@ -378,7 +378,7 @@ export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewPr
             <span className="dashboard-form-label" style={{ display: 'block' }}>
               {t('source.form.mqtt_bridge_ignore_ok_to_mqtt', 'Uplink all packets (ignore ok_to_mqtt bit)')}
             </span>
-            <span style={{ fontSize: 11, color: 'var(--ctp-yellow)' }}>
+            <span style={{ fontSize: 11, color: 'var(--color-warning)' }}>
               {t(
                 'source.form.mqtt_bridge_ignore_ok_to_mqtt_help',
                 'Overrides the originating node\'s "ok_to_mqtt" preference. Only enable for private bridges where every gateway has consented.',
@@ -402,8 +402,8 @@ export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewPr
             onChange={(e) => patch('subscriptions', e.target.value)}
           />
         </label>
-        <fieldset style={{ border: '1px solid var(--ctp-surface1)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
-          <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--ctp-subtext0)' }}>
+        <fieldset style={{ border: '1px solid var(--color-surface-hover)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
+          <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--color-text-subtle)' }}>
             <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
               <input
                 type="checkbox"
@@ -430,8 +430,8 @@ export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewPr
             </label>
           )}
         </fieldset>
-        <fieldset style={{ border: '1px solid var(--ctp-surface1)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
-          <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--ctp-subtext0)' }}>
+        <fieldset style={{ border: '1px solid var(--color-surface-hover)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
+          <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--color-text-subtle)' }}>
             <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
               <input
                 type="checkbox"
@@ -475,7 +475,7 @@ export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewPr
 
       {/* --- Geo filter status (read-only observability, Phase 4 WP2) --- */}
       <CollapsibleSection title={t('mqtt_bridge_config.geo_status.title', 'Geo filter status')}>
-        <div style={{ fontSize: 13, color: 'var(--ctp-text)' }}>
+        <div style={{ fontSize: 13, color: 'var(--color-text)' }}>
           {t(
             'mqtt_bridge_config.geo_status.dropped_summary',
             'Out-of-bbox positions dropped — downlink: {{downlink}} · uplink: {{uplink}}',
@@ -488,7 +488,7 @@ export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewPr
             'Counts plaintext positions only — encrypted positions are evaluated after decryption and are not counted here.',
           )}
         </span>
-        <div style={{ fontSize: 13, color: 'var(--ctp-text)', marginTop: 12 }}>
+        <div style={{ fontSize: 13, color: 'var(--color-text)', marginTop: 12 }}>
           {lastGeoSweep ? (
             t(
               'mqtt_bridge_config.geo_status.last_sweep',
@@ -528,7 +528,7 @@ export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewPr
               gap: 4,
               maxHeight: 200,
               overflowY: 'auto',
-              border: '1px solid var(--ctp-surface1)',
+              border: '1px solid var(--color-surface-hover)',
               borderRadius: 6,
               padding: '8px 12px',
             }}
@@ -716,8 +716,8 @@ export const MqttBridgeConfigurationView: React.FC<MqttBridgeConfigurationViewPr
         >
           {saving ? t('common.saving', 'Saving…') : t('common.save', 'Save')}
         </button>
-        {saved && <span style={{ color: 'var(--ctp-green)' }}><UiIcon name="check" size={14} /> {t('common.saved', 'Saved')}</span>}
-        {saveError && <span style={{ color: 'var(--ctp-red)' }}>{saveError}</span>}
+        {saved && <span style={{ color: 'var(--color-success)' }}><UiIcon name="check" size={14} /> {t('common.saved', 'Saved')}</span>}
+        {saveError && <span style={{ color: 'var(--color-error)' }}>{saveError}</span>}
       </div>
     </div>
   );

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -150,7 +150,7 @@ const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount, s
         </svg>
         <span className="legend-label">{t('map.legend.unidirectional', 'One-way')}</span>
       </div>
-      <span className="legend-sublabel" style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginTop: '2px' }}>
+      <span className="legend-sublabel" style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginTop: '2px' }}>
         {t('map.legend.thickerBrighter', 'Thicker line = stronger signal')}
       </span>
       <div className="legend-divider" />
@@ -212,7 +212,7 @@ const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount, s
       {unmappedCount != null && unmappedCount > 0 && (
         <>
           <div className="legend-divider" />
-          <span className="legend-sublabel" style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+          <span className="legend-sublabel" style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
             {t('map.legend.unmappedNodes', '{{count}} node(s) without location', { count: unmappedCount })}
           </span>
         </>

--- a/src/components/MeshCore/MeshCoreAutoAckSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAckSection.tsx
@@ -262,8 +262,8 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
         marginBottom: '1.5rem',
         marginTop: '2rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px',
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -338,7 +338,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
               </label>
             </div>
             {channels.length === 0 && (
-              <div style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)', marginLeft: '1.5rem' }}>
+              <div style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)', marginLeft: '1.5rem' }}>
                 {t('meshcore.automation.autoack.no_channels', 'No channels loaded yet.')}
               </div>
             )}
@@ -393,7 +393,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
               {t('meshcore.automation.autoack.always_respond_dm', 'Always respond via DM')}
             </label>
           </div>
-          <div style={{ marginTop: '0.5rem', marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+          <div style={{ marginTop: '0.5rem', marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--color-text-subtle)' }}>
             {t(
               'meshcore.automation.autoack.always_respond_dm_description',
               'When enabled, replies are always sent as a DM to the sender, even when the trigger came from a channel. Requires the sender to be in your contact list.',
@@ -422,7 +422,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
               disabled={disabled || !canWrite}
               style={{ width: '100px', padding: '2px 4px' }}
             />
-            <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+            <span style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
               {t('meshcore.automation.autoack.cooldown_help', 'seconds (0 = no cooldown)')}
             </span>
           </div>
@@ -449,7 +449,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
               disabled={disabled || !canWrite}
               style={{ width: '100px', padding: '2px 4px' }}
             />
-            <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+            <span style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
               {t('meshcore.automation.autoack.presend_delay_help', 'seconds (0 = send immediately, max 120)')}
             </span>
           </div>
@@ -520,18 +520,18 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
             style={{ fontFamily: 'monospace', resize: 'vertical', minHeight: '60px' }}
           />
           <div style={{ marginTop: '0.5rem' }}>
-            <label style={{ fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+            <label style={{ fontSize: '0.9rem', color: 'var(--color-text-subtle)' }}>
               {t('meshcore.automation.autoack.sample_preview', 'Sample preview')}:
             </label>
             <div style={{
               marginTop: '0.25rem',
               padding: '0.5rem',
-              background: 'var(--ctp-base)',
-              border: '1px solid var(--ctp-blue)',
+              background: 'var(--color-bg)',
+              border: '1px solid var(--color-accent)',
               borderRadius: '4px',
               fontFamily: 'monospace',
               fontSize: '0.9rem',
-              color: 'var(--ctp-text)',
+              color: 'var(--color-text)',
             }}>
               {sample}
             </div>
@@ -585,7 +585,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
                         padding: '0.25rem 0.5rem',
                         marginBottom: '0.15rem',
                         backgroundColor: matches ? 'rgba(166, 227, 161, 0.1)' : 'rgba(243, 139, 168, 0.1)',
-                        border: `1px solid ${matches ? 'var(--ctp-green)' : 'var(--ctp-red)'}`,
+                        border: `1px solid ${matches ? 'var(--color-success)' : 'var(--color-error)'}`,
                         borderRadius: '4px',
                         fontFamily: 'monospace',
                         fontSize: '0.9rem',
@@ -598,12 +598,12 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
                           width: '16px',
                           height: '16px',
                           borderRadius: '50%',
-                          backgroundColor: matches ? 'var(--ctp-green)' : 'var(--ctp-red)',
+                          backgroundColor: matches ? 'var(--color-success)' : 'var(--color-error)',
                           marginRight: '0.5rem',
                           flexShrink: 0,
                         }}
                       />
-                      <span style={{ color: 'var(--ctp-text)', wordBreak: 'break-word' }}>
+                      <span style={{ color: 'var(--color-text)', wordBreak: 'break-word' }}>
                         {message}
                       </span>
                     </div>

--- a/src/components/MeshCore/MeshCoreAutoAnnounceSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAnnounceSection.tsx
@@ -324,8 +324,8 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
         marginBottom: '1.5rem',
         marginTop: '2rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px',
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -374,7 +374,7 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
               {t('meshcore.automation.announce.on_start', 'Announce on connection')}
             </span>
           </label>
-          <div style={{ marginTop: '0.25rem', marginLeft: '1.75rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+          <div style={{ marginTop: '0.25rem', marginLeft: '1.75rem', fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
             {t(
               'meshcore.automation.announce.on_start_description',
               'Fire a single announcement immediately whenever this source reconnects.',
@@ -396,7 +396,7 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
               {t('meshcore.automation.announce.use_schedule', 'Use cron schedule')}
             </span>
           </label>
-          <div style={{ marginTop: '0.25rem', marginLeft: '1.75rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+          <div style={{ marginTop: '0.25rem', marginLeft: '1.75rem', fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
             {t(
               'meshcore.automation.announce.use_schedule_description',
               'When unchecked, the announcement runs every N hours. When checked, it follows a standard 5-field cron expression.',
@@ -438,7 +438,7 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
               style={{ fontFamily: 'monospace', width: '260px' }}
             />
             {scheduleError && (
-              <div style={{ marginTop: '0.25rem', fontSize: '0.85rem', color: 'var(--ctp-red)' }}>
+              <div style={{ marginTop: '0.25rem', fontSize: '0.85rem', color: 'var(--color-error)' }}>
                 {scheduleError}
               </div>
             )}
@@ -459,7 +459,7 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
           </label>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginTop: '0.5rem' }}>
             {channels.length === 0 && (
-              <div style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+              <div style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
                 {t('meshcore.automation.announce.no_channels', 'No channels loaded yet.')}
               </div>
             )}
@@ -542,18 +542,18 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
             ))}
           </div>
           <div style={{ marginTop: '0.5rem' }}>
-            <label style={{ fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+            <label style={{ fontSize: '0.9rem', color: 'var(--color-text-subtle)' }}>
               {t('meshcore.automation.announce.preview', 'Live preview')}:
             </label>
             <div style={{
               marginTop: '0.25rem',
               padding: '0.5rem',
-              background: 'var(--ctp-base)',
-              border: '1px solid var(--ctp-blue)',
+              background: 'var(--color-bg)',
+              border: '1px solid var(--color-accent)',
               borderRadius: '4px',
               fontFamily: 'monospace',
               fontSize: '0.9rem',
-              color: 'var(--ctp-text)',
+              color: 'var(--color-text)',
               minHeight: '1.5rem',
             }}>
               {preview || settings.message}
@@ -575,7 +575,7 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
               {t('meshcore.automation.announce.advert_enabled', 'Send advert after each announcement')}
             </span>
           </label>
-          <div style={{ marginTop: '0.25rem', marginLeft: '1.75rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+          <div style={{ marginTop: '0.25rem', marginLeft: '1.75rem', fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
             {t(
               'meshcore.automation.announce.advert_description',
               'Fire a MeshCore advert N seconds after each announcement so neighbours rediscover this node.',
@@ -592,7 +592,7 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
                 disabled={disabled || !canWrite}
                 style={{ width: '100px', padding: '2px 4px' }}
               />
-              <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+              <span style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
                 {t('meshcore.automation.announce.advert_delay', 'seconds delay (0–600)')}
               </span>
             </div>
@@ -600,7 +600,7 @@ export const MeshCoreAutoAnnounceSection: React.FC<MeshCoreAutoAnnounceSectionPr
         </div>
 
         {lastRunAt && (
-          <p style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)', marginTop: '1rem' }}>
+          <p style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)', marginTop: '1rem' }}>
             {t('meshcore.automation.announce.last_run', 'Last run')}:{' '}
             {new Date(lastRunAt).toLocaleString()}
           </p>

--- a/src/components/MeshCore/MeshCoreAutoResponderSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoResponderSection.tsx
@@ -266,8 +266,8 @@ export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSection
         marginBottom: '1.5rem',
         marginTop: '2rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px',
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -280,7 +280,7 @@ export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSection
           />
           {t('meshcore.automation.responder.title', 'Auto-Responder')}
         </h2>
-        <span style={{ marginLeft: 'auto', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+        <span style={{ marginLeft: 'auto', fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
           {t('meshcore.automation.responder.count', '{{count}} triggers', { count: triggers.length })}
         </span>
       </div>
@@ -296,7 +296,7 @@ export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSection
         </p>
 
         {triggers.length === 0 && (
-          <p style={{ marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+          <p style={{ marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--color-text-subtle)' }}>
             {t('meshcore.automation.responder.empty', 'No triggers configured yet.')}
           </p>
         )}
@@ -345,7 +345,7 @@ export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSection
                   style={{ width: '100%', marginTop: '0.25rem', fontFamily: 'monospace' }}
                 />
                 {!v.valid && tr.pattern && (
-                  <div style={{ fontSize: '0.8rem', color: 'var(--ctp-red)', marginTop: '0.25rem' }}>
+                  <div style={{ fontSize: '0.8rem', color: 'var(--color-error)', marginTop: '0.25rem' }}>
                     {v.error}
                   </div>
                 )}
@@ -467,12 +467,12 @@ export const MeshCoreAutoResponderSection: React.FC<MeshCoreAutoResponderSection
               </div>
 
               {/* Channels */}
-              <fieldset style={{ border: '1px solid var(--ctp-surface2)', borderRadius: '4px', padding: '0.5rem' }}>
+              <fieldset style={{ border: '1px solid var(--color-surface-active)', borderRadius: '4px', padding: '0.5rem' }}>
                 <legend style={{ fontSize: '0.8rem', padding: '0 0.5rem' }}>
                   {t('meshcore.automation.responder.channels', 'Listen on channels')}
                 </legend>
                 {channels.length === 0 && (
-                  <span style={{ fontSize: '0.8rem', color: 'var(--ctp-subtext0)' }}>
+                  <span style={{ fontSize: '0.8rem', color: 'var(--color-text-subtle)' }}>
                     {t('meshcore.automation.responder.no_channels', 'No channels loaded')}
                   </span>
                 )}

--- a/src/components/MeshCore/MeshCoreAutomationsView.tsx
+++ b/src/components/MeshCore/MeshCoreAutomationsView.tsx
@@ -169,7 +169,7 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
         footer={
           <>
             <UiIcon name="sparkles" size={15} /> {t('meshcore.automation.tokens.engine_tip', 'Want maximum flexibility? Try the')}{' '}
-            <Link to="/automations" style={{ color: 'var(--ctp-mauve)', fontWeight: 'bold' }}>
+            <Link to="/automations" style={{ color: 'var(--color-accent-alt)', fontWeight: 'bold' }}>
               {t('automation.engine_link', 'Automation Engine')}
             </Link>{' '}
             {t('meshcore.automation.tokens.engine_tip2', '— build global “when this happens, do that” workflows across every source.')}
@@ -183,8 +183,8 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px',
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -203,8 +203,8 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
             fontSize: '0.8rem',
             padding: '0.25rem 0.5rem',
             borderRadius: '4px',
-            background: 'var(--ctp-green)',
-            color: 'var(--ctp-base)',
+            background: 'var(--color-success)',
+            color: 'var(--color-bg)',
           }}>
             {t('meshcore.automation.running', 'Running')}
           </span>
@@ -216,7 +216,7 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
         transition: 'opacity 0.2s',
         pointerEvents: settings.enabled ? 'auto' : 'none',
       }}>
-        <p style={{ marginBottom: '1.5rem', color: 'var(--ctp-subtext0)', lineHeight: '1.5', marginLeft: '1.75rem' }}>
+        <p style={{ marginBottom: '1.5rem', color: 'var(--color-text-subtle)', lineHeight: '1.5', marginLeft: '1.75rem' }}>
           {t('meshcore.automation.pathfinding.description',
             'Automatically discover paths and collect neighbor information from your MeshCore contacts on a recurring schedule.')}
         </p>
@@ -225,8 +225,8 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
         <div style={{
           padding: '1rem 1.25rem',
           marginBottom: '1rem',
-          background: 'var(--ctp-surface0)',
-          border: '1px solid var(--ctp-surface1)',
+          background: 'var(--color-surface)',
+          border: '1px solid var(--color-surface-hover)',
           borderRadius: '8px',
         }}>
           <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', cursor: canWrite ? 'pointer' : 'default' }}>
@@ -239,7 +239,7 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
             />
             <div>
               <strong>{t('meshcore.automation.pathfinding.path_discovery', 'Path Discovery for Companions')}</strong>
-              <p style={{ margin: '0.25rem 0 0', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+              <p style={{ margin: '0.25rem 0 0', fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
                 {t('meshcore.automation.pathfinding.path_discovery_desc',
                   'Sends a path discovery request to each Companion contact. The device learns the forwarding route via its normal path return mechanism.')}
               </p>
@@ -251,8 +251,8 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
         <div style={{
           padding: '1rem 1.25rem',
           marginBottom: '1.5rem',
-          background: 'var(--ctp-surface0)',
-          border: '1px solid var(--ctp-surface1)',
+          background: 'var(--color-surface)',
+          border: '1px solid var(--color-surface-hover)',
           borderRadius: '8px',
         }}>
           <label style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', cursor: canWrite ? 'pointer' : 'default' }}>
@@ -265,7 +265,7 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
             />
             <div>
               <strong>{t('meshcore.automation.pathfinding.neighbors', 'Neighbors for Repeaters')}</strong>
-              <p style={{ margin: '0.25rem 0 0', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+              <p style={{ margin: '0.25rem 0 0', fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
                 {t('meshcore.automation.pathfinding.neighbors_desc',
                   'Queries the neighbor list from each Repeater contact. Returns nearby nodes with signal quality information.')}
               </p>
@@ -277,7 +277,7 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
         <div className="setting-item" style={{ marginBottom: '1rem' }}>
           <label htmlFor="pathfindingInterval">
             {t('meshcore.automation.pathfinding.interval', 'Time between commands (minutes)')}
-            <span className="setting-description" style={{ display: 'block', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+            <span className="setting-description" style={{ display: 'block', fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
               {t('meshcore.automation.pathfinding.interval_desc',
                 'Delay between each individual path discovery or neighbor request to avoid flooding the mesh.')}
             </span>
@@ -299,7 +299,7 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
         <div className="setting-item" style={{ marginBottom: '1rem' }}>
           <label htmlFor="pathfindingRepeat">
             {t('meshcore.automation.pathfinding.repeat', 'Repeat every (hours)')}
-            <span className="setting-description" style={{ display: 'block', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+            <span className="setting-description" style={{ display: 'block', fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
               {t('meshcore.automation.pathfinding.repeat_desc',
                 'How often the full cycle runs. All eligible contacts are processed in each cycle.')}
             </span>
@@ -319,7 +319,7 @@ export const MeshCoreAutomationsView: React.FC<MeshCoreAutomationsViewProps> = (
 
         {/* Last run info */}
         {settings.lastRunAt ? (
-          <p style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)', marginTop: '1rem' }}>
+          <p style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)', marginTop: '1rem' }}>
             {t('meshcore.automation.pathfinding.last_run', 'Last run')}: {new Date(settings.lastRunAt).toLocaleString()}
           </p>
         ) : null}

--- a/src/components/MeshCore/MeshCoreChannelsConfigSection.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsConfigSection.tsx
@@ -356,11 +356,11 @@ export const MeshCoreChannelsConfigSection: React.FC<MeshCoreChannelsConfigSecti
               <li
                 key={row.id}
                 style={{
-                  border: '1px solid var(--ctp-surface1)',
+                  border: '1px solid var(--color-surface-hover)',
                   borderRadius: 6,
                   padding: '0.75rem',
                   marginBottom: '0.5rem',
-                  backgroundColor: 'var(--ctp-surface0)',
+                  backgroundColor: 'var(--color-surface)',
                 }}
               >
                 {!isEditing && (
@@ -387,7 +387,7 @@ export const MeshCoreChannelsConfigSection: React.FC<MeshCoreChannelsConfigSecti
                       type="button"
                       onClick={() => handleDelete(row.id)}
                       disabled={!canConfigure}
-                      style={{ color: 'var(--ctp-red)' }}
+                      style={{ color: 'var(--color-error)' }}
                     >
                       {t('common.delete', 'Delete')}
                     </button>
@@ -424,11 +424,11 @@ export const MeshCoreChannelsConfigSection: React.FC<MeshCoreChannelsConfigSecti
       {editingIdx !== null && !channels.some(c => c.id === editingIdx) && (
         <div
           style={{
-            border: '1px dashed var(--ctp-blue)',
+            border: '1px dashed var(--color-accent)',
             borderRadius: 6,
             padding: '0.75rem',
             marginTop: '0.5rem',
-            backgroundColor: 'var(--ctp-surface0)',
+            backgroundColor: 'var(--color-surface)',
           }}
         >
           <div className="hint" style={{ marginBottom: '0.5rem' }}>

--- a/src/components/MeshCore/MeshCoreConfigurationView.tsx
+++ b/src/components/MeshCore/MeshCoreConfigurationView.tsx
@@ -188,7 +188,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
 
   return (
     <div className="meshcore-form-view">
-      <h2 style={{ color: 'var(--ctp-text)', marginBottom: '1rem' }}>
+      <h2 style={{ color: 'var(--color-text)', marginBottom: '1rem' }}>
         {t('meshcore.nav.configuration', 'Configuration')}
       </h2>
 
@@ -201,7 +201,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
       {!canWriteConfig && (
         <div
           className="meshcore-empty-state"
-          style={{ marginBottom: '1rem', color: 'var(--ctp-yellow)' }}
+          style={{ marginBottom: '1rem', color: 'var(--color-warning)' }}
           role="status"
         >
           {t(
@@ -234,7 +234,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
               : t('meshcore.config.save_name', 'Save name')}
           </button>
           {nameSaved && (
-            <span style={{ marginLeft: '0.75rem', color: 'var(--ctp-green)' }}>
+            <span style={{ marginLeft: '0.75rem', color: 'var(--color-success)' }}>
               <UiIcon name="check" size={14} /> {t('meshcore.config.saved', 'Saved')}
             </span>
           )}
@@ -286,7 +286,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
               : t('meshcore.config.save_location', 'Save location')}
           </button>
           {locationSaved && (
-            <span style={{ marginLeft: '0.75rem', color: 'var(--ctp-green)' }}>
+            <span style={{ marginLeft: '0.75rem', color: 'var(--color-success)' }}>
               <UiIcon name="check" size={14} /> {t('meshcore.config.saved', 'Saved')}
             </span>
           )}
@@ -384,7 +384,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
               : t('meshcore.config.save_radio', 'Save radio settings')}
           </button>
           {radioSaved && (
-            <span style={{ marginLeft: '0.75rem', color: 'var(--ctp-green)' }}>
+            <span style={{ marginLeft: '0.75rem', color: 'var(--color-success)' }}>
               <UiIcon name="check" size={14} /> {t('meshcore.config.saved', 'Saved')}
             </span>
           )}
@@ -424,7 +424,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
               : t('meshcore.config.save_tx_power', 'Save TX power')}
           </button>
           {txPowerSaved && (
-            <span style={{ marginLeft: '0.75rem', color: 'var(--ctp-green)' }}>
+            <span style={{ marginLeft: '0.75rem', color: 'var(--color-success)' }}>
               <UiIcon name="check" size={14} /> {t('meshcore.config.saved', 'Saved')}
             </span>
           )}
@@ -437,7 +437,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
             'Control what telemetry this node shares. Always = broadcast on advert; Device only = only respond to direct requests from your contacts; Never = disable.')}
         </p>
         {connected && isCompanionOnly && (
-          <p className="hint" style={{ color: 'var(--ctp-yellow)' }}>
+          <p className="hint" style={{ color: 'var(--color-warning)' }}>
             {t('meshcore.config.telemetry_companion_only',
               'Telemetry mode is only configurable on companion devices.')}
           </p>
@@ -508,7 +508,7 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
               : t('meshcore.config.save_telemetry', 'Save telemetry settings')}
           </button>
           {telemetrySaved && (
-            <span style={{ marginLeft: '0.75rem', color: 'var(--ctp-green)' }}>
+            <span style={{ marginLeft: '0.75rem', color: 'var(--color-success)' }}>
               <UiIcon name="check" size={14} /> {t('meshcore.config.saved', 'Saved')}
             </span>
           )}
@@ -639,8 +639,8 @@ const MeshCoreDeviceManagement: React.FC<{
   };
 
   return (
-    <div className="meshcore-config-section" style={{ borderTop: '2px solid var(--ctp-red, #f38ba8)', marginTop: '1.5rem', paddingTop: '1rem' }}>
-      <h3 style={{ color: 'var(--ctp-red, #f38ba8)' }}>
+    <div className="meshcore-config-section" style={{ borderTop: '2px solid var(--color-error, #f38ba8)', marginTop: '1.5rem', paddingTop: '1rem' }}>
+      <h3 style={{ color: 'var(--color-error, #f38ba8)' }}>
         {t('meshcore.config.device_management', 'Device Management')}
       </h3>
 
@@ -650,7 +650,7 @@ const MeshCoreDeviceManagement: React.FC<{
           className="btn-secondary"
           onClick={handleReboot}
           disabled={rebooting}
-          style={{ color: 'var(--ctp-red)' }}
+          style={{ color: 'var(--color-error)' }}
         >
           {rebooting
             ? t('meshcore.config.rebooting', 'Rebooting…')
@@ -672,7 +672,7 @@ const MeshCoreDeviceManagement: React.FC<{
           type="button"
           className="btn-secondary"
           onClick={() => { setImportKeyDraft(''); setImportKeyError(null); setImportKeyOpen(true); }}
-          style={{ color: 'var(--ctp-red)' }}
+          style={{ color: 'var(--color-error)' }}
         >
           {t('meshcore.config.import_key_button', 'Restore Private Key')}
         </button>
@@ -680,7 +680,7 @@ const MeshCoreDeviceManagement: React.FC<{
 
       {exportedKey && (
         <div style={{
-          background: 'var(--ctp-surface0, #313244)',
+          background: 'var(--color-surface, #313244)',
           padding: '0.75rem',
           borderRadius: '6px',
           marginBottom: '1rem',
@@ -688,7 +688,7 @@ const MeshCoreDeviceManagement: React.FC<{
           fontSize: '0.85em',
           wordBreak: 'break-all',
         }}>
-          <div style={{ marginBottom: '0.5rem', color: 'var(--ctp-yellow, #f9e2af)' }}>
+          <div style={{ marginBottom: '0.5rem', color: 'var(--color-warning, #f9e2af)' }}>
             {t('meshcore.config.export_key_warning', 'Store this key securely. Anyone with it can impersonate this device.')}
           </div>
           <div>{exportedKey}</div>
@@ -705,12 +705,12 @@ const MeshCoreDeviceManagement: React.FC<{
 
       {importKeyOpen && (
         <div style={{
-          background: 'var(--ctp-surface0, #313244)',
+          background: 'var(--color-surface, #313244)',
           padding: '0.75rem',
           borderRadius: '6px',
           marginBottom: '1rem',
         }}>
-          <div style={{ marginBottom: '0.5rem', color: 'var(--ctp-red, #f38ba8)' }}>
+          <div style={{ marginBottom: '0.5rem', color: 'var(--color-error, #f38ba8)' }}>
             {t('meshcore.config.import_key_warning', 'This replaces the device identity. All contacts will need to re-discover this node.')}
           </div>
           <input
@@ -728,14 +728,14 @@ const MeshCoreDeviceManagement: React.FC<{
             }}
           />
           {importKeyError && (
-            <div style={{ color: 'var(--ctp-red)', marginBottom: '0.5rem' }} role="alert">{importKeyError}</div>
+            <div style={{ color: 'var(--color-error)', marginBottom: '0.5rem' }} role="alert">{importKeyError}</div>
           )}
           <div style={{ display: 'flex', gap: '0.5rem' }}>
             <button type="button" className="btn-secondary" onClick={() => setImportKeyOpen(false)} disabled={importingKey}>
               {t('meshcore.config.cancel', 'Cancel')}
             </button>
             <button type="button" className="btn-primary" onClick={handleImportKey} disabled={importingKey || importKeyDraft.trim().length === 0}
-              style={{ color: 'var(--ctp-red)' }}>
+              style={{ color: 'var(--color-error)' }}>
               {importingKey
                 ? t('meshcore.config.importing_key', 'Importing…')
                 : t('meshcore.config.import_key_confirm_button', 'Import Key')}

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -752,7 +752,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     className="btn-secondary"
                     onClick={handleRemoveContact}
                     disabled={removing}
-                    style={{ color: 'var(--ctp-red)' }}
+                    style={{ color: 'var(--color-error)' }}
                     aria-label={t('meshcore.contact_details.remove_contact_button', 'Remove')}
                   >
                     {removing
@@ -761,26 +761,26 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                   </button>
                 )}
                 {resetError && (
-                  <span style={{ color: 'var(--ctp-red)' }} role="alert">{resetError}</span>
+                  <span style={{ color: 'var(--color-error)' }} role="alert">{resetError}</span>
                 )}
                 {shareError && (
-                  <span style={{ color: 'var(--ctp-red)' }} role="alert">{shareError}</span>
+                  <span style={{ color: 'var(--color-error)' }} role="alert">{shareError}</span>
                 )}
                 {removeError && (
-                  <span style={{ color: 'var(--ctp-red)' }} role="alert">{removeError}</span>
+                  <span style={{ color: 'var(--color-error)' }} role="alert">{removeError}</span>
                 )}
                 {shareSuccess && (
-                  <span style={{ color: 'var(--ctp-green)' }} role="status">
+                  <span style={{ color: 'var(--color-success)' }} role="status">
                     {t('meshcore.contact_details.share_contact_success', 'Advert broadcast.')}
                   </span>
                 )}
                 {exportSuccess && (
-                  <span style={{ color: 'var(--ctp-green)' }} role="status">
+                  <span style={{ color: 'var(--color-success)' }} role="status">
                     {t('meshcore.contact_details.export_contact_success', 'Copied to clipboard.')}
                   </span>
                 )}
                 {traceError && (
-                  <span style={{ color: 'var(--ctp-red)' }} role="alert">{traceError}</span>
+                  <span style={{ color: 'var(--color-error)' }} role="alert">{traceError}</span>
                 )}
               </div>
             </div>
@@ -796,7 +796,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
               </div>
               <div className="node-detail-value" role="status">
                 {pingResult.ok ? (
-                  <span style={{ color: 'var(--ctp-green)' }}>
+                  <span style={{ color: 'var(--color-success)' }}>
                     {t('meshcore.contact_details.ping_zero_hop_direct', 'Direct — in range')}
                     {' · '}
                     {t('meshcore.contact_details.ping_zero_hop_rtt', 'RTT')} {pingResult.rttMs} ms
@@ -816,7 +816,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                     </span>
                   </span>
                 ) : (
-                  <span style={{ color: 'var(--ctp-red)' }}>{pingResult.error}</span>
+                  <span style={{ color: 'var(--color-error)' }}>{pingResult.error}</span>
                 )}
               </div>
             </div>
@@ -831,7 +831,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
               <div className="node-detail-value">
                 <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: 'var(--font-mono, monospace)', fontSize: '0.9em' }}>
                   <thead>
-                    <tr style={{ borderBottom: '1px solid var(--ctp-surface1, #45475a)' }}>
+                    <tr style={{ borderBottom: '1px solid var(--color-surface-hover, #45475a)' }}>
                       <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem' }}>
                         {t('meshcore.contact_details.trace_hop', 'Hop')}
                       </th>
@@ -857,7 +857,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                         </tr>
                       );
                     })}
-                    <tr style={{ borderTop: '1px solid var(--ctp-surface1, #45475a)' }}>
+                    <tr style={{ borderTop: '1px solid var(--color-surface-hover, #45475a)' }}>
                       <td style={{ padding: '0.25rem 0.5rem' }} colSpan={2}>
                         {t('meshcore.contact_details.trace_destination', 'Destination')}
                       </td>
@@ -892,7 +892,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                 ) : (
                   <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily: 'var(--font-mono, monospace)', fontSize: '0.9em' }}>
                     <thead>
-                      <tr style={{ borderBottom: '1px solid var(--ctp-surface1, #45475a)' }}>
+                      <tr style={{ borderBottom: '1px solid var(--color-surface-hover, #45475a)' }}>
                         <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem' }}>
                           {t('meshcore.contact_details.neighbours_name', 'Node')}
                         </th>
@@ -1008,8 +1008,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
         >
           <div
             style={{
-              background: 'var(--ctp-base, #1e1e2e)',
-              color: 'var(--ctp-text, #cdd6f4)',
+              background: 'var(--color-bg, #1e1e2e)',
+              color: 'var(--color-text, #cdd6f4)',
               padding: '1.25rem 1.5rem',
               borderRadius: '8px',
               maxWidth: '32rem',
@@ -1028,8 +1028,8 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
             </p>
             <div
               style={{
-                background: 'var(--ctp-surface0, #313244)',
-                color: 'var(--ctp-yellow, #f9e2af)',
+                background: 'var(--color-surface, #313244)',
+                color: 'var(--color-warning, #f9e2af)',
                 padding: '0.6rem 0.8rem',
                 borderRadius: '4px',
                 marginBottom: '0.75rem',
@@ -1084,7 +1084,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
                         gap: '0.5rem',
                         padding: '0.35rem 0.5rem',
                         marginBottom: '0.25rem',
-                        background: 'var(--ctp-surface0, #313244)',
+                        background: 'var(--color-surface, #313244)',
                         borderRadius: '4px',
                       }}
                     >
@@ -1149,7 +1149,7 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
               </button>
             </div>
             {editorError && (
-              <div style={{ color: 'var(--ctp-red)', marginBottom: '0.75rem' }} role="alert">
+              <div style={{ color: 'var(--color-error)', marginBottom: '0.75rem' }} role="alert">
                 {editorError}
               </div>
             )}

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -404,12 +404,12 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
               onClick={scrollToBottom}
               style={{
                 padding: '0.5rem 1rem',
-                backgroundColor: 'var(--ctp-blue)',
+                backgroundColor: 'var(--color-accent)',
                 border: 'none',
                 borderRadius: '20px',
                 cursor: 'pointer',
                 fontSize: '0.85rem',
-                color: 'var(--ctp-base)',
+                color: 'var(--color-bg)',
                 fontWeight: 'bold',
                 boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
                 display: 'flex',

--- a/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
+++ b/src/components/MeshCore/MeshCoreNodeTelemetryConfig.tsx
@@ -209,7 +209,7 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
       {!canWriteConfig && (
         <div
           className="meshcore-empty-state"
-          style={{ marginBottom: '0.75rem', color: 'var(--ctp-yellow)' }}
+          style={{ marginBottom: '0.75rem', color: 'var(--color-warning)' }}
           role="status"
         >
           {t(
@@ -276,7 +276,7 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
         </div>
       )}
 
-      <div style={{ marginTop: '1rem', borderTop: '1px solid var(--ctp-surface0)', paddingTop: '0.75rem' }}>
+      <div style={{ marginTop: '1rem', borderTop: '1px solid var(--color-surface)', paddingTop: '0.75rem' }}>
         <div className="node-details-header">
           <h4 className="node-details-title" style={{ fontSize: '0.95rem' }}>
             {t('meshcore.telemetry_config.poll_title', 'Poll Now')}
@@ -316,7 +316,7 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
         {pollMsg && (
           <div
             className="meshcore-empty-state"
-            style={{ marginTop: '0.5rem', color: pollMsg.kind === 'ok' ? 'var(--ctp-green)' : 'var(--ctp-red)' }}
+            style={{ marginTop: '0.5rem', color: pollMsg.kind === 'ok' ? 'var(--color-success)' : 'var(--color-error)' }}
             role={pollMsg.kind === 'ok' ? 'status' : 'alert'}
           >
             {pollMsg.text}
@@ -325,12 +325,12 @@ export const MeshCoreNodeTelemetryConfig: React.FC<MeshCoreNodeTelemetryConfigPr
       </div>
 
       {error && (
-        <div className="meshcore-empty-state" style={{ marginTop: '0.5rem', color: 'var(--ctp-red)' }} role="alert">
+        <div className="meshcore-empty-state" style={{ marginTop: '0.5rem', color: 'var(--color-error)' }} role="alert">
           {error}
         </div>
       )}
       {saved && (
-        <div className="meshcore-empty-state" style={{ marginTop: '0.5rem', color: 'var(--ctp-green)' }} role="status">
+        <div className="meshcore-empty-state" style={{ marginTop: '0.5rem', color: 'var(--color-success)' }} role="status">
           {t('meshcore.telemetry_config.saved', 'Saved.')}
         </div>
       )}

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -592,8 +592,8 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
         >
           <div
             style={{
-              background: 'var(--ctp-base, #1e1e2e)',
-              color: 'var(--ctp-text, #cdd6f4)',
+              background: 'var(--color-bg, #1e1e2e)',
+              color: 'var(--color-text, #cdd6f4)',
               padding: '1.25rem 1.5rem',
               borderRadius: '8px',
               maxWidth: '32rem',
@@ -628,7 +628,7 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
               autoFocus
             />
             {importError && (
-              <div style={{ color: 'var(--ctp-red)', marginBottom: '0.75rem' }} role="alert">
+              <div style={{ color: 'var(--color-error)', marginBottom: '0.75rem' }} role="alert">
                 {importError}
               </div>
             )}

--- a/src/components/MeshCore/MeshCoreObserverSection.tsx
+++ b/src/components/MeshCore/MeshCoreObserverSection.tsx
@@ -425,7 +425,7 @@ export const MeshCoreObserverSection: React.FC<MeshCoreObserverSectionProps> = (
               : t('meshcore.observer.fetch_button', 'Fetch from device')}
           </button>
           {importedFlash && (
-            <span style={{ color: 'var(--ctp-green)' }}>
+            <span style={{ color: 'var(--color-success)' }}>
               <UiIcon name="check" size={14} /> {t('meshcore.observer.key_imported', 'Key saved')}
             </span>
           )}
@@ -442,7 +442,7 @@ export const MeshCoreObserverSection: React.FC<MeshCoreObserverSectionProps> = (
           <button
             type="button"
             className="btn-secondary"
-            style={{ color: 'var(--ctp-red)' }}
+            style={{ color: 'var(--color-error)' }}
             onClick={() => void handleClear()}
             disabled={busy !== null || !status?.stored}
           >

--- a/src/components/MeshCore/MeshCorePathfindingFilterSection.tsx
+++ b/src/components/MeshCore/MeshCorePathfindingFilterSection.tsx
@@ -110,8 +110,8 @@ const sectionHeaderStyle: React.CSSProperties = {
 };
 
 const badgeStyle: React.CSSProperties = {
-  background: 'var(--ctp-blue)',
-  color: 'var(--ctp-base)',
+  background: 'var(--color-accent)',
+  color: 'var(--color-bg)',
   padding: '0.1rem 0.5rem',
   borderRadius: '10px',
   fontSize: '11px',
@@ -121,8 +121,8 @@ const badgeStyle: React.CSSProperties = {
 const attributeBoxStyle: React.CSSProperties = {
   padding: '0.75rem 1rem',
   marginBottom: '0.75rem',
-  background: 'var(--ctp-surface0)',
-  border: '1px solid var(--ctp-surface1)',
+  background: 'var(--color-surface)',
+  border: '1px solid var(--color-surface-hover)',
   borderRadius: '6px',
 };
 
@@ -396,7 +396,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
         </label>
       </div>
       <MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />
-      <p style={{ margin: '0 0 1rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)', lineHeight: '1.5' }}>
+      <p style={{ margin: '0 0 1rem', fontSize: '0.85rem', color: 'var(--color-text-subtle)', lineHeight: '1.5' }}>
         {t(
           'meshcore.automation.pathfinding.filter.description',
           'Optionally narrow which contacts Auto-Pathfinding targets, instead of every Companion and Repeater contact.',
@@ -448,10 +448,10 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
                 width: '100%',
                 padding: '0.4rem 0.5rem',
                 marginBottom: '0.5rem',
-                background: 'var(--ctp-surface1)',
-                border: '1px solid var(--ctp-surface2)',
+                background: 'var(--color-surface-hover)',
+                border: '1px solid var(--color-surface-active)',
                 borderRadius: '4px',
-                color: 'var(--ctp-text)',
+                color: 'var(--color-text)',
               }}
             />
             <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
@@ -474,9 +474,9 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
                 {t('meshcore.automation.pathfinding.filter.deselect_all', 'Deselect All')}
               </button>
             </div>
-            <div style={{ maxHeight: '200px', overflowY: 'auto', border: '1px solid var(--ctp-surface2)', borderRadius: '4px' }}>
+            <div style={{ maxHeight: '200px', overflowY: 'auto', border: '1px solid var(--color-surface-active)', borderRadius: '4px' }}>
               {filteredContacts.length === 0 ? (
-                <div style={{ padding: '0.5rem', textAlign: 'center', color: 'var(--ctp-subtext0)', fontSize: '12px' }}>
+                <div style={{ padding: '0.5rem', textAlign: 'center', color: 'var(--color-text-subtle)', fontSize: '12px' }}>
                   {t('meshcore.automation.pathfinding.filter.no_contacts', 'No contacts found')}
                 </div>
               ) : (
@@ -486,7 +486,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
                     onClick={() => canWrite && toggleContact(c.publicKey)}
                     style={{
                       padding: '0.4rem 0.6rem',
-                      borderBottom: '1px solid var(--ctp-surface1)',
+                      borderBottom: '1px solid var(--color-surface-hover)',
                       display: 'flex',
                       alignItems: 'center',
                       cursor: canWrite ? 'pointer' : 'default',
@@ -501,7 +501,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
                       disabled={!canWrite}
                       style={{ width: 'auto', margin: 0, marginRight: '0.5rem' }}
                     />
-                    <span style={{ color: 'var(--ctp-text)' }}>{contactDisplayName(c)}</span>
+                    <span style={{ color: 'var(--color-text)' }}>{contactDisplayName(c)}</span>
                   </div>
                 ))
               )}
@@ -523,7 +523,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
                 {t('meshcore.automation.pathfinding.filter.regex_enable', 'Filter by name (regex)')}
               </label>
             </div>
-            <label htmlFor="pfFilterNameRegex" style={{ display: 'block', fontSize: '0.8rem', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem' }}>
+            <label htmlFor="pfFilterNameRegex" style={{ display: 'block', fontSize: '0.8rem', color: 'var(--color-text-subtle)', marginBottom: '0.25rem' }}>
               {t('meshcore.automation.pathfinding.filter.regex_label', 'Name regex')}
             </label>
             <input
@@ -536,7 +536,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
               style={{ width: '100%' }}
             />
             {regexError && (
-              <p style={{ margin: '0.25rem 0 0', fontSize: '0.75rem', color: 'var(--ctp-red)' }}>
+              <p style={{ margin: '0.25rem 0 0', fontSize: '0.75rem', color: 'var(--color-error)' }}>
                 {t('meshcore.automation.pathfinding.filter.regex_invalid', 'Invalid regular expression')}: {regexError}
               </p>
             )}
@@ -563,7 +563,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
                 'Applies only to Auto-Pathfinding targeting. It is separate from the Nodes list / map age filter in Settings → Node Display.',
               )}
             </span>
-            <label htmlFor="pfFilterLastHeardHours" style={{ display: 'block', fontSize: '0.8rem', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem' }}>
+            <label htmlFor="pfFilterLastHeardHours" style={{ display: 'block', fontSize: '0.8rem', color: 'var(--color-text-subtle)', marginBottom: '0.25rem' }}>
               {t('meshcore.automation.pathfinding.filter.last_heard_label', 'Heard within (hours)')}
             </label>
             <input
@@ -595,7 +595,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
               </label>
             </div>
             <div style={{ display: 'flex', gap: '1rem', marginBottom: '0.35rem' }}>
-              <label style={{ fontSize: '0.8rem', color: 'var(--ctp-subtext0)' }}>
+              <label style={{ fontSize: '0.8rem', color: 'var(--color-text-subtle)' }}>
                 {t('meshcore.automation.pathfinding.filter.hops_min_label', 'Min hops')}
                 <input
                   type="number"
@@ -612,7 +612,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
                   style={{ width: '80px', display: 'block', marginTop: '0.25rem' }}
                 />
               </label>
-              <label style={{ fontSize: '0.8rem', color: 'var(--ctp-subtext0)' }}>
+              <label style={{ fontSize: '0.8rem', color: 'var(--color-text-subtle)' }}>
                 {t('meshcore.automation.pathfinding.filter.hops_max_label', 'Max hops')}
                 <input
                   type="number"
@@ -629,7 +629,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
                 />
               </label>
             </div>
-            <p style={{ margin: 0, fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+            <p style={{ margin: 0, fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
               {t('meshcore.automation.pathfinding.filter.hops_unknown_note',
                 'Contacts with an unknown route (flood) are excluded when this is on.')}
             </p>
@@ -651,7 +651,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
               </label>
             </div>
             <div style={{ display: 'flex', gap: '1rem', marginBottom: '0.35rem' }}>
-              <label style={{ fontSize: '0.8rem', color: 'var(--ctp-subtext0)' }}>
+              <label style={{ fontSize: '0.8rem', color: 'var(--color-text-subtle)' }}>
                 {t('meshcore.automation.pathfinding.filter.rssi_min_label', 'Min RSSI (dBm)')}
                 <input
                   type="number"
@@ -664,7 +664,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
                   style={{ width: '90px', display: 'block', marginTop: '0.25rem' }}
                 />
               </label>
-              <label style={{ fontSize: '0.8rem', color: 'var(--ctp-subtext0)' }}>
+              <label style={{ fontSize: '0.8rem', color: 'var(--color-text-subtle)' }}>
                 {t('meshcore.automation.pathfinding.filter.snr_min_label', 'Min SNR (dB)')}
                 <input
                   type="number"
@@ -678,7 +678,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
                 />
               </label>
             </div>
-            <p style={{ margin: 0, fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+            <p style={{ margin: 0, fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
               {t('meshcore.automation.pathfinding.filter.signal_note', 'Leave a threshold at its floor value to ignore it.')}
             </p>
           </div>
@@ -688,8 +688,8 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
         <div style={{
           width: '280px',
           flexShrink: 0,
-          background: 'var(--ctp-base)',
-          border: '1px solid var(--ctp-surface2)',
+          background: 'var(--color-bg)',
+          border: '1px solid var(--color-surface-active)',
           borderRadius: '6px',
           display: 'flex',
           flexDirection: 'column',
@@ -697,8 +697,8 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
         }}>
           <div style={{
             padding: '0.5rem 0.75rem',
-            borderBottom: '1px solid var(--ctp-surface2)',
-            background: 'var(--ctp-surface1)',
+            borderBottom: '1px solid var(--color-surface-active)',
+            background: 'var(--color-surface-hover)',
             borderRadius: '6px 6px 0 0',
             fontSize: '13px',
             fontWeight: 500,
@@ -710,7 +710,7 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
           </div>
           <div style={{ flex: 1, overflowY: 'auto', maxHeight: '400px', padding: '0.25rem' }}>
             {debouncedMatching.length === 0 ? (
-              <div style={{ padding: '1rem', textAlign: 'center', color: 'var(--ctp-subtext0)', fontSize: '12px' }}>
+              <div style={{ padding: '1rem', textAlign: 'center', color: 'var(--color-text-subtle)', fontSize: '12px' }}>
                 {t('meshcore.automation.pathfinding.filter.no_match', 'No contacts match the current filters')}
               </div>
             ) : (
@@ -720,9 +720,9 @@ export const MeshCorePathfindingFilterSection: React.FC<MeshCorePathfindingFilte
                   title={contactDisplayName(c)}
                   style={{
                     padding: '0.35rem 0.5rem',
-                    borderBottom: '1px solid var(--ctp-surface1)',
+                    borderBottom: '1px solid var(--color-surface-hover)',
                     fontSize: '12px',
-                    color: 'var(--ctp-text)',
+                    color: 'var(--color-text)',
                     whiteSpace: 'nowrap',
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',

--- a/src/components/MeshCore/MeshCoreSettingsView.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.tsx
@@ -275,7 +275,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
 
   return (
     <div className="meshcore-form-view">
-      <h2 style={{ color: 'var(--ctp-text)', marginBottom: '1rem' }}>
+      <h2 style={{ color: 'var(--color-text)', marginBottom: '1rem' }}>
         {t('meshcore.nav.settings', 'Settings')}
       </h2>
 
@@ -402,7 +402,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
             <div style={{ marginTop: '0.75rem', overflowX: 'auto' }}>
               <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9em' }}>
                 <thead>
-                  <tr style={{ borderBottom: '1px solid var(--ctp-surface1)', textAlign: 'left' }}>
+                  <tr style={{ borderBottom: '1px solid var(--color-surface-hover)', textAlign: 'left' }}>
                     <th style={{ padding: '0.25rem 0.5rem' }}>
                       {t('meshcore.discover.col_node', 'Node')}
                     </th>
@@ -419,7 +419,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
                 </thead>
                 <tbody>
                   {discoveredNodes.map((node) => (
-                    <tr key={node.publicKey} style={{ borderBottom: '1px solid var(--ctp-surface0)' }}>
+                    <tr key={node.publicKey} style={{ borderBottom: '1px solid var(--color-surface)' }}>
                       <td style={{ padding: '0.25rem 0.5rem' }}>
                         {node.name || (
                           <span style={{ opacity: 0.6 }}>
@@ -431,7 +431,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
                             style={{
                               marginLeft: '0.4rem', padding: '0 0.3rem', borderRadius: 4,
                               fontSize: '0.75em', fontWeight: 600,
-                              color: 'var(--ctp-base)', background: 'var(--ctp-green)',
+                              color: 'var(--color-bg)', background: 'var(--color-success)',
                             }}
                           >
                             {t('meshcore.discover.new_badge', 'NEW')}
@@ -524,8 +524,8 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
                       key={region}
                       style={{
                         display: 'inline-flex', alignItems: 'center', gap: '0.25rem',
-                        padding: '0.1rem 0.3rem', borderRadius: 999, border: '1px solid var(--ctp-blue)',
-                        background: scopeInput.trim().replace(/^#/, '') === region ? 'var(--ctp-blue)' : 'transparent',
+                        padding: '0.1rem 0.3rem', borderRadius: 999, border: '1px solid var(--color-accent)',
+                        background: scopeInput.trim().replace(/^#/, '') === region ? 'var(--color-accent)' : 'transparent',
                       }}
                     >
                       <button
@@ -600,7 +600,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
                 style={{
                   display: 'inline-flex', alignItems: 'center', gap: '0.35rem',
                   padding: '0.2rem 0.5rem', borderRadius: 999,
-                  border: '1px solid var(--ctp-surface2)', background: 'var(--ctp-surface0)',
+                  border: '1px solid var(--color-surface-active)', background: 'var(--color-surface)',
                 }}
               >
                 <span>{region.name}</span>
@@ -622,7 +622,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
       {status?.localNode && (
         <div className="form-section">
           <h3>{t('meshcore.settings.local_node', 'Local node')}</h3>
-          <div style={{ color: 'var(--ctp-subtext0)', fontSize: '0.85rem', lineHeight: 1.7 }}>
+          <div style={{ color: 'var(--color-text-subtle)', fontSize: '0.85rem', lineHeight: 1.7 }}>
             <div>{t('meshcore.settings.name', 'Name')}: {status.localNode.name || '—'}</div>
             <div>{t('meshcore.settings.type', 'Type')}: {status.deviceTypeName}</div>
             <div>
@@ -644,7 +644,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
       {canPurgeMessages && (
         <div className="form-section">
           <h3>{t('meshcore.settings.message_data', 'Message data')}</h3>
-          <p style={{ color: 'var(--ctp-subtext0)', fontSize: '0.85rem', lineHeight: 1.6 }}>
+          <p style={{ color: 'var(--color-text-subtle)', fontSize: '0.85rem', lineHeight: 1.6 }}>
             {t(
               'meshcore.settings.purge_all_messages_desc',
               'Permanently delete every stored MeshCore message (all channels and direct messages) for this source.',

--- a/src/components/MeshCore/MeshCoreTimerTriggersSection.tsx
+++ b/src/components/MeshCore/MeshCoreTimerTriggersSection.tsx
@@ -303,14 +303,14 @@ export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSection
         marginBottom: '1.5rem',
         marginTop: '2rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px',
       }}>
         <h2 style={{ margin: 0 }}>
           {t('meshcore.automation.timers.title', 'Timer Triggers')}
         </h2>
-        <span style={{ marginLeft: 'auto', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+        <span style={{ marginLeft: 'auto', fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
           {t('meshcore.automation.timers.count', '{{count}} triggers', { count: triggers.length })}
         </span>
       </div>
@@ -327,7 +327,7 @@ export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSection
 
         {/* List of existing triggers */}
         {triggers.length === 0 && (
-          <p style={{ marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--ctp-subtext0)' }}>
+          <p style={{ marginLeft: '1.75rem', fontSize: '0.9rem', color: 'var(--color-text-subtle)' }}>
             {t('meshcore.automation.timers.empty', 'No timer triggers configured yet.')}
           </p>
         )}
@@ -543,13 +543,13 @@ export const MeshCoreTimerTriggersSection: React.FC<MeshCoreTimerTriggersSection
             )}
 
             {tr.lastRun && (
-              <div style={{ marginTop: '0.5rem', fontSize: '0.8rem', color: 'var(--ctp-subtext0)' }}>
+              <div style={{ marginTop: '0.5rem', fontSize: '0.8rem', color: 'var(--color-text-subtle)' }}>
                 {t('meshcore.automation.timers.last_run', 'Last run')}: {new Date(tr.lastRun).toLocaleString()}{' '}
                 {tr.lastResult === 'error' && (
-                  <span style={{ color: 'var(--ctp-red)' }}>— {tr.lastError || 'error'}</span>
+                  <span style={{ color: 'var(--color-error)' }}>— {tr.lastError || 'error'}</span>
                 )}
                 {tr.lastResult === 'success' && (
-                  <span style={{ color: 'var(--ctp-green)' }}>— success</span>
+                  <span style={{ color: 'var(--color-success)' }}>— success</span>
                 )}
               </div>
             )}

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -130,7 +130,7 @@ const DistanceDisplay = React.memo<{
       title={t('nodes.distance')}
       style={{
         fontSize: '0.75rem',
-        color: 'var(--ctp-subtext0)',
+        color: 'var(--color-text-subtle)',
         marginLeft: '0.5rem',
       }}
     >
@@ -1209,7 +1209,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             className="last-message-preview"
                             style={{
                               fontSize: '0.85rem',
-                              color: selectedDMNode === node.user?.id ? '#000000' : 'var(--ctp-subtext0)',
+                              color: selectedDMNode === node.user?.id ? '#000000' : 'var(--color-text-subtle)',
                               fontStyle: 'italic',
                               overflow: 'hidden',
                               textOverflow: 'ellipsis',
@@ -1240,10 +1240,10 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                                 style={
                                   node.unreadCount > 0
                                     ? {
-                                        border: '2px solid var(--ctp-red)',
+                                        border: '2px solid var(--color-error)',
                                         borderRadius: '12px',
                                         padding: '2px 6px',
-                                        backgroundColor: 'var(--ctp-surface0)',
+                                        backgroundColor: 'var(--color-surface)',
                                       }
                                     : undefined
                                 }
@@ -1688,9 +1688,9 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
               <div
                 style={{
                   backgroundColor: isDeviceDbWarningMitigatable(selectedNode)
-                    ? 'var(--ctp-yellow, #f9e2af)'
-                    : 'var(--ctp-peach, #fab387)',
-                  color: 'var(--ctp-base, #1e1e2e)',
+                    ? 'var(--color-warning, #f9e2af)'
+                    : 'var(--color-caution, #fab387)',
+                  color: 'var(--color-bg, #1e1e2e)',
                   padding: '10px 12px',
                   marginBottom: '10px',
                   borderRadius: '4px',
@@ -1721,8 +1721,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
             {dmReadOnlyReason === 'unmessageable' && (
               <div
                 style={{
-                  backgroundColor: 'var(--ctp-yellow, #f9e2af)',
-                  color: 'var(--ctp-base, #1e1e2e)',
+                  backgroundColor: 'var(--color-warning, #f9e2af)',
+                  color: 'var(--color-bg, #1e1e2e)',
                   padding: '10px 12px',
                   marginBottom: '10px',
                   borderRadius: '4px',
@@ -1749,7 +1749,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                         background: 'none',
                         border: 'none',
                         padding: 0,
-                        color: 'var(--ctp-blue, #1e66f5)',
+                        color: 'var(--color-accent, #1e66f5)',
                         textDecoration: 'underline',
                         cursor: 'pointer',
                         fontWeight: 'bold',
@@ -1789,12 +1789,12 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                     onClick={scrollToBottom}
                     style={{
                       padding: '0.5rem 1rem',
-                      backgroundColor: 'var(--ctp-blue)',
+                      backgroundColor: 'var(--color-accent)',
                       border: 'none',
                       borderRadius: '20px',
                       cursor: 'pointer',
                       fontSize: '0.85rem',
-                      color: 'var(--ctp-base)',
+                      color: 'var(--color-bg)',
                       fontWeight: 'bold',
                       boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
                       display: 'flex',
@@ -2201,7 +2201,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             {isPending && (
                               <span className="traceroute-pending-badge" style={{
                                 marginLeft: '0.5rem',
-                                color: 'var(--ctp-yellow)',
+                                color: 'var(--color-warning)',
                                 fontWeight: 'bold'
                               }}>
                                 ({t('messages.traceroute_pending', 'Pending')})
@@ -2210,7 +2210,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             {isFailed && (
                               <span className="traceroute-failed-badge" style={{
                                 marginLeft: '0.5rem',
-                                color: 'var(--ctp-red)',
+                                color: 'var(--color-error)',
                                 fontWeight: 'bold'
                               }}>
                                 ({t('messages.traceroute_failed')})
@@ -2265,7 +2265,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                   <div className="neighbor-info-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                     <div>
                       <strong>{t('messages.neighbor_info_title', 'Neighbor Info')}</strong>
-                      <span className="neighbor-info-age" style={{ marginLeft: '0.5rem', fontSize: '0.85em', color: 'var(--ctp-subtext0)' }}>
+                      <span className="neighbor-info-age" style={{ marginLeft: '0.5rem', fontSize: '0.85em', color: 'var(--color-text-subtle)' }}>
                         ({ageStr})
                       </span>
                     </div>
@@ -2276,9 +2276,9 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       style={{
                         padding: '0.25rem 0.5rem',
                         fontSize: '0.8em',
-                        backgroundColor: 'var(--ctp-surface0)',
-                        color: 'var(--ctp-text)',
-                        border: '1px solid var(--ctp-surface1)',
+                        backgroundColor: 'var(--color-surface)',
+                        color: 'var(--color-text)',
+                        border: '1px solid var(--color-surface-hover)',
                         borderRadius: '4px',
                         cursor: purgingNeighbors ? 'not-allowed' : 'pointer',
                         opacity: purgingNeighbors ? 0.6 : 1,
@@ -2306,10 +2306,10 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                           display: 'flex',
                           justifyContent: 'space-between',
                           padding: '0.25rem 0',
-                          borderBottom: idx < nodeNeighbors.length - 1 ? '1px solid var(--ctp-surface0)' : 'none'
+                          borderBottom: idx < nodeNeighbors.length - 1 ? '1px solid var(--color-surface)' : 'none'
                         }}>
                           <span>{neighbor.neighborName || neighbor.neighborNodeId || `!${neighbor.neighborNodeNum.toString(16)}`}</span>
-                          <span style={{ color: 'var(--ctp-subtext0)' }}>
+                          <span style={{ color: 'var(--color-text-subtle)' }}>
                             {neighbor.snr != null && `SNR: ${neighbor.snr.toFixed(1)} dB`}
                             {distanceStr && ` | ${distanceStr}`}
                           </span>
@@ -2338,8 +2338,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                     flex: '1 1 auto',
                     minWidth: '120px',
                     padding: '0.5rem 1rem',
-                    backgroundColor: 'var(--ctp-blue)',
-                    color: 'var(--ctp-base)',
+                    backgroundColor: 'var(--color-accent)',
+                    color: 'var(--color-bg)',
                     border: 'none',
                     borderRadius: '4px',
                     cursor: 'pointer',
@@ -2360,8 +2360,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                     style={{
                       flex: 1,
                       padding: '0.5rem 1rem',
-                      backgroundColor: 'var(--ctp-blue)',
-                      color: 'var(--ctp-base)',
+                      backgroundColor: 'var(--color-accent)',
+                      color: 'var(--color-bg)',
                       border: 'none',
                       borderRadius: channels.length > 1 ? '4px 0 0 4px' : '4px',
                       cursor: connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',
@@ -2382,10 +2382,10 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       aria-label={t('messages.traceroute_channel')}
                       style={{
                         padding: '0.5rem 0.5rem',
-                        backgroundColor: 'var(--ctp-blue)',
-                        color: 'var(--ctp-base)',
+                        backgroundColor: 'var(--color-accent)',
+                        color: 'var(--color-bg)',
                         border: 'none',
-                        borderLeft: '1px solid var(--ctp-base)',
+                        borderLeft: '1px solid var(--color-bg)',
                         borderRadius: '0 4px 4px 0',
                         cursor: connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',
                         opacity: connectionStatus !== 'connected' || tracerouteLoading === selectedDMNode || txDisabled ? 0.5 : 1,
@@ -2401,8 +2401,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       top: '100%',
                       right: 0,
                       marginTop: '4px',
-                      background: 'var(--ctp-surface0)',
-                      border: '1px solid var(--ctp-surface2)',
+                      background: 'var(--color-surface)',
+                      border: '1px solid var(--color-surface-active)',
                       borderRadius: '4px',
                       zIndex: 1000,
                       minWidth: '160px',
@@ -2421,12 +2421,12 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             padding: '0.5rem 1rem',
                             background: 'none',
                             border: 'none',
-                            color: 'var(--ctp-text)',
+                            color: 'var(--color-text)',
                             cursor: 'pointer',
                             textAlign: 'left',
                             fontSize: '0.85rem'
                           }}
-                          onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--ctp-surface1)')}
+                          onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--color-surface-hover)')}
                           onMouseLeave={(e) => (e.currentTarget.style.background = 'none')}
                         >
                           {ch.name || `Channel ${ch.id}`}{ch.id === 0 ? ' (Primary)' : ''}
@@ -2447,8 +2447,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                     style={{
                       flex: 1,
                       padding: '0.5rem 1rem',
-                      backgroundColor: 'var(--ctp-blue)',
-                      color: 'var(--ctp-base)',
+                      backgroundColor: 'var(--color-accent)',
+                      color: 'var(--color-bg)',
                       border: 'none',
                       borderRadius: channels.length > 1 ? '4px 0 0 4px' : '4px',
                       cursor: connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',
@@ -2469,10 +2469,10 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       aria-label={t('messages.exchange_node_info_channel')}
                       style={{
                         padding: '0.5rem 0.5rem',
-                        backgroundColor: 'var(--ctp-blue)',
-                        color: 'var(--ctp-base)',
+                        backgroundColor: 'var(--color-accent)',
+                        color: 'var(--color-bg)',
                         border: 'none',
-                        borderLeft: '1px solid var(--ctp-base)',
+                        borderLeft: '1px solid var(--color-bg)',
                         borderRadius: '0 4px 4px 0',
                         cursor: connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',
                         opacity: connectionStatus !== 'connected' || nodeInfoLoading === selectedDMNode || txDisabled ? 0.5 : 1,
@@ -2488,8 +2488,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       top: '100%',
                       right: 0,
                       marginTop: '4px',
-                      background: 'var(--ctp-surface0)',
-                      border: '1px solid var(--ctp-surface2)',
+                      background: 'var(--color-surface)',
+                      border: '1px solid var(--color-surface-active)',
                       borderRadius: '4px',
                       zIndex: 1000,
                       minWidth: '160px',
@@ -2508,12 +2508,12 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             padding: '0.5rem 1rem',
                             background: 'none',
                             border: 'none',
-                            color: 'var(--ctp-text)',
+                            color: 'var(--color-text)',
                             cursor: 'pointer',
                             textAlign: 'left',
                             fontSize: '0.85rem'
                           }}
-                          onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--ctp-surface1)')}
+                          onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--color-surface-hover)')}
                           onMouseLeave={(e) => (e.currentTarget.style.background = 'none')}
                         >
                           {ch.name || `Channel ${ch.id}`}{ch.id === 0 ? ' (Primary)' : ''}
@@ -2534,8 +2534,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                     style={{
                       flex: 1,
                       padding: '0.5rem 1rem',
-                      backgroundColor: 'var(--ctp-blue)',
-                      color: 'var(--ctp-base)',
+                      backgroundColor: 'var(--color-accent)',
+                      color: 'var(--color-bg)',
                       border: 'none',
                       borderRadius: channels.length > 1 ? '4px 0 0 4px' : '4px',
                       cursor: connectionStatus !== 'connected' || positionLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',
@@ -2556,10 +2556,10 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       aria-label={t('messages.exchange_position_channel')}
                       style={{
                         padding: '0.5rem 0.5rem',
-                        backgroundColor: 'var(--ctp-blue)',
-                        color: 'var(--ctp-base)',
+                        backgroundColor: 'var(--color-accent)',
+                        color: 'var(--color-bg)',
                         border: 'none',
-                        borderLeft: '1px solid var(--ctp-base)',
+                        borderLeft: '1px solid var(--color-bg)',
                         borderRadius: '0 4px 4px 0',
                         cursor: connectionStatus !== 'connected' || positionLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',
                         opacity: connectionStatus !== 'connected' || positionLoading === selectedDMNode || txDisabled ? 0.5 : 1,
@@ -2575,8 +2575,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                       top: '100%',
                       right: 0,
                       marginTop: '4px',
-                      background: 'var(--ctp-surface0)',
-                      border: '1px solid var(--ctp-surface2)',
+                      background: 'var(--color-surface)',
+                      border: '1px solid var(--color-surface-active)',
                       borderRadius: '4px',
                       zIndex: 1000,
                       minWidth: '160px',
@@ -2595,12 +2595,12 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             padding: '0.5rem 1rem',
                             background: 'none',
                             border: 'none',
-                            color: 'var(--ctp-text)',
+                            color: 'var(--color-text)',
                             cursor: 'pointer',
                             textAlign: 'left',
                             fontSize: '0.85rem'
                           }}
-                          onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--ctp-surface1)')}
+                          onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--color-surface-hover)')}
                           onMouseLeave={(e) => (e.currentTarget.style.background = 'none')}
                         >
                           {ch.name || `Channel ${ch.id}`}{ch.id === 0 ? ' (Primary)' : ''}
@@ -2621,8 +2621,8 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                     flex: '1 1 auto',
                     minWidth: '120px',
                     padding: '0.5rem 1rem',
-                    backgroundColor: 'var(--ctp-blue)',
-                    color: 'var(--ctp-base)',
+                    backgroundColor: 'var(--color-accent)',
+                    color: 'var(--color-bg)',
                     border: 'none',
                     borderRadius: '4px',
                     cursor: connectionStatus !== 'connected' || neighborInfoLoading === selectedDMNode || txDisabled ? 'not-allowed' : 'pointer',

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1964,7 +1964,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                     <strong>{ni.neighborName}</strong> <UiIcon name={isBidirectional ? 'bidirectional' : 'forward'} size={14} /> <strong>{ni.nodeName}</strong>
                   </div>
                   {isBidirectional && (
-                    <div className="route-usage" style={{ color: 'var(--ctp-green)' }}>
+                    <div className="route-usage" style={{ color: 'var(--color-success)' }}>
                       <UiIcon name="bidirectional" size={14} /> {t('direct_links.bidirectional', 'Bidirectional')}
                     </div>
                   )}

--- a/src/components/NotificationsTab.tsx
+++ b/src/components/NotificationsTab.tsx
@@ -801,7 +801,7 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
 
                 {preferences.notifyOnLowBattery && !isMeshCore && (
                   <div style={{ marginLeft: '28px', marginTop: '8px', display: 'flex', alignItems: 'center', gap: '8px' }}>
-                    <label htmlFor="lowBatteryThreshold" style={{ margin: 0, fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>
+                    <label htmlFor="lowBatteryThreshold" style={{ margin: 0, fontSize: '0.9em', color: 'var(--color-text-subtle)' }}>
                       {t('notifications.low_battery_threshold_label')}
                     </label>
                     <input
@@ -821,19 +821,19 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
                       style={{
                         width: '70px',
                         padding: '0.35rem 0.5rem',
-                        background: 'var(--ctp-base)',
-                        border: '1px solid var(--ctp-surface2)',
+                        background: 'var(--color-bg)',
+                        border: '1px solid var(--color-surface-active)',
                         borderRadius: '4px',
-                        color: 'var(--ctp-text)'
+                        color: 'var(--color-text)'
                       }}
                     />
-                    <span style={{ fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>%</span>
+                    <span style={{ fontSize: '0.9em', color: 'var(--color-text-subtle)' }}>%</span>
                   </div>
                 )}
 
                 {preferences.notifyOnLowBattery && isMeshCore && (
                   <div style={{ marginLeft: '28px', marginTop: '8px', display: 'flex', alignItems: 'center', gap: '8px' }}>
-                    <label htmlFor="lowBatteryVoltageThreshold" style={{ margin: 0, fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>
+                    <label htmlFor="lowBatteryVoltageThreshold" style={{ margin: 0, fontSize: '0.9em', color: 'var(--color-text-subtle)' }}>
                       {t('notifications.low_battery_voltage_threshold_label')}
                     </label>
                     <input
@@ -854,18 +854,18 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
                       style={{
                         width: '90px',
                         padding: '0.35rem 0.5rem',
-                        background: 'var(--ctp-base)',
-                        border: '1px solid var(--ctp-surface2)',
+                        background: 'var(--color-bg)',
+                        border: '1px solid var(--color-surface-active)',
                         borderRadius: '4px',
-                        color: 'var(--ctp-text)'
+                        color: 'var(--color-text)'
                       }}
                     />
-                    <span style={{ fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>mV</span>
+                    <span style={{ fontSize: '0.9em', color: 'var(--color-text-subtle)' }}>mV</span>
                   </div>
                 )}
 
                 {preferences.notifyOnLowBattery && (
-                  <p style={{ marginLeft: '28px', marginTop: '6px', marginBottom: 0, fontSize: '0.8em', color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>
+                  <p style={{ marginLeft: '28px', marginTop: '6px', marginBottom: 0, fontSize: '0.8em', color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>
                     {isMeshCore
                       ? t('notifications.low_battery_threshold_hint_voltage', 'MeshCore nodes report battery as a voltage (mV) rather than a percentage.')
                       : t('notifications.low_battery_threshold_hint_percent', 'Meshtastic nodes report battery as a percentage of full charge.')}
@@ -877,11 +877,11 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
                     marginLeft: '28px', 
                     marginTop: '12px',
                     padding: '12px',
-                    background: 'var(--ctp-surface0)',
-                    border: '1px solid var(--ctp-surface2)',
+                    background: 'var(--color-surface)',
+                    border: '1px solid var(--color-surface-active)',
                     borderRadius: '6px'
                   }}>
-                    <p style={{ marginBottom: '0.75rem', fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>
+                    <p style={{ marginBottom: '0.75rem', fontSize: '0.9em', color: 'var(--color-text-subtle)' }}>
                       {t('notifications.monitored_nodes_description')}
                     </p>
                     
@@ -895,10 +895,10 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
                         width: '100%',
                         padding: '0.5rem',
                         marginBottom: '0.75rem',
-                        background: 'var(--ctp-base)',
-                        border: '1px solid var(--ctp-surface2)',
+                        background: 'var(--color-bg)',
+                        border: '1px solid var(--color-surface-active)',
                         borderRadius: '4px',
-                        color: 'var(--ctp-text)'
+                        color: 'var(--color-text)'
                       }}
                     />
                     
@@ -943,12 +943,12 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
                     <div style={{
                       maxHeight: '300px',
                       overflowY: 'auto',
-                      border: '1px solid var(--ctp-surface2)',
+                      border: '1px solid var(--color-surface-active)',
                       borderRadius: '4px',
-                      background: 'var(--ctp-base)'
+                      background: 'var(--color-bg)'
                     }}>
                       {filteredNodes.length === 0 ? (
-                        <div style={{ padding: '1rem', textAlign: 'center', color: 'var(--ctp-subtext0)' }}>
+                        <div style={{ padding: '1rem', textAlign: 'center', color: 'var(--color-text-subtle)' }}>
                           {nodeSearchTerm ? t('notifications.no_nodes_match') : t('notifications.no_nodes_available')}
                         </div>
                       ) : (
@@ -959,13 +959,13 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
                               key={nodeId}
                               style={{
                                 padding: '0.5rem 0.75rem',
-                                borderBottom: '1px solid var(--ctp-surface1)',
+                                borderBottom: '1px solid var(--color-surface-hover)',
                                 display: 'flex',
                                 alignItems: 'center',
                                 cursor: 'pointer',
                                 transition: 'background 0.1s'
                               }}
-                              onMouseEnter={(e) => e.currentTarget.style.background = 'var(--ctp-surface0)'}
+                              onMouseEnter={(e) => e.currentTarget.style.background = 'var(--color-surface)'}
                               onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
                               onClick={() => {
                                 setSelectedMonitoredNodes(prev =>
@@ -989,11 +989,11 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
                                 style={{ width: 'auto', margin: 0, marginRight: '0.75rem', cursor: 'pointer' }}
                               />
                               <div style={{ flex: 1 }}>
-                                <div style={{ fontWeight: '500', color: 'var(--ctp-text)' }}>
+                                <div style={{ fontWeight: '500', color: 'var(--color-text)' }}>
                                   {node.user?.longName || node.longName || node.user?.shortName || node.shortName || nodeId || 'Unknown'}
                                 </div>
                                 {(node.user?.longName || node.longName || node.user?.shortName || node.shortName) && (
-                                  <div style={{ fontSize: '12px', color: 'var(--ctp-subtext0)' }}>
+                                  <div style={{ fontSize: '12px', color: 'var(--color-text-subtle)' }}>
                                     {nodeId}
                                   </div>
                                 )}
@@ -1005,10 +1005,10 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
                     </div>
                     
                     {/* Selection count */}
-                    <div style={{ marginTop: '0.75rem', fontSize: '13px', color: 'var(--ctp-subtext0)' }}>
+                    <div style={{ marginTop: '0.75rem', fontSize: '13px', color: 'var(--color-text-subtle)' }}>
                       {t('notifications.monitored_nodes_count', { count: selectedMonitoredNodes.length })}
                       {selectedMonitoredNodes.length === 0 && (
-                        <span style={{ color: 'var(--ctp-yellow)', marginLeft: '0.5rem' }}>
+                        <span style={{ color: 'var(--color-warning)', marginLeft: '0.5rem' }}>
                           ({t('notifications.no_nodes_selected_warning')})
                         </span>
                       )}
@@ -1045,18 +1045,18 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
                     marginLeft: '28px',
                     marginTop: '12px',
                     padding: '12px',
-                    background: 'var(--ctp-surface0)',
-                    border: '1px solid var(--ctp-surface2)',
+                    background: 'var(--color-surface)',
+                    border: '1px solid var(--color-surface-active)',
                     borderRadius: '6px'
                   }}>
-                    <p style={{ marginBottom: '0.5rem', fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>
+                    <p style={{ marginBottom: '0.5rem', fontSize: '0.9em', color: 'var(--color-text-subtle)' }}>
                       {t('notifications.server_events_description')}
                     </p>
                     <ul style={{
                       margin: '0.5rem 0 0 1.5rem',
                       padding: 0,
                       fontSize: '0.85em',
-                      color: 'var(--ctp-subtext1)',
+                      color: 'var(--color-text-muted)',
                       listStyleType: 'disc'
                     }}>
                       <li>{t('notifications.server_events_startup')}</li>
@@ -1095,11 +1095,11 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({ isAdmin }) => {
                     marginLeft: '28px',
                     marginTop: '12px',
                     padding: '12px',
-                    background: 'var(--ctp-surface0)',
-                    border: '1px solid var(--ctp-surface2)',
+                    background: 'var(--color-surface)',
+                    border: '1px solid var(--color-surface-active)',
                     borderRadius: '6px'
                   }}>
-                    <p style={{ marginBottom: '0', fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>
+                    <p style={{ marginBottom: '0', fontSize: '0.9em', color: 'var(--color-text-subtle)' }}>
                       {t('notifications.prefix_with_node_name_description')}
                     </p>
                   </div>

--- a/src/components/PacketMonitorPanel.tsx
+++ b/src/components/PacketMonitorPanel.tsx
@@ -677,7 +677,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
                               cursor: 'pointer',
                             }}
                           >
-                            <td colSpan={14} style={{ textAlign: 'center', color: 'var(--ctp-blue, var(--text-secondary))' }}>
+                            <td colSpan={14} style={{ textAlign: 'center', color: 'var(--color-accent, var(--text-secondary))' }}>
                               {loadingMore ? t('packet_monitor.loading_more') : t('packet_monitor.load_more_click', 'Click to load more packets...')}
                             </td>
                           </tr>
@@ -840,7 +840,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
                                     title={t('packet_monitor.decrypted_by_server')}
                                     style={{
                                       marginRight: '0.25rem',
-                                      color: 'var(--ctp-blue)',
+                                      color: 'var(--color-accent)',
                                       cursor: 'help'
                                     }}
                                   >
@@ -853,7 +853,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
                                     title={t('packet_monitor.decrypted_by_node')}
                                     style={{
                                       marginRight: '0.25rem',
-                                      color: 'var(--ctp-green)',
+                                      color: 'var(--color-success)',
                                       cursor: 'help'
                                     }}
                                   >

--- a/src/components/PacketStatsChart.tsx
+++ b/src/components/PacketStatsChart.tsx
@@ -63,13 +63,13 @@ const PacketStatsChart: React.FC<PacketStatsChartProps> = React.memo(({ title, d
               return [`${numValue.toLocaleString()} (${pct}%)`, entryName];
             }}
             contentStyle={{
-              backgroundColor: 'var(--ctp-surface0)',
-              border: '1px solid var(--ctp-surface2)',
+              backgroundColor: 'var(--color-surface)',
+              border: '1px solid var(--color-surface-active)',
               borderRadius: '4px',
               fontSize: '0.85em',
             }}
             itemStyle={{
-              color: 'var(--ctp-text)',
+              color: 'var(--color-text)',
             }}
           />
         </PieChart>

--- a/src/components/PositionEstimationSection.tsx
+++ b/src/components/PositionEstimationSection.tsx
@@ -168,8 +168,8 @@ const PositionEstimationSection: React.FC<PositionEstimationSectionProps> = ({ b
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -250,14 +250,14 @@ const PositionEstimationSection: React.FC<PositionEstimationSectionProps> = ({ b
             disabled={!localEnabled}
             className="setting-input"
           />
-          <p style={{ fontSize: '12px', color: 'var(--ctp-subtext0)', margin: '0.35rem 0 0 0' }}>
+          <p style={{ fontSize: '12px', color: 'var(--color-text-subtle)', margin: '0.35rem 0 0 0' }}>
             {t('automation.position_estimation.max_uncertainty_help',
               'Estimates with an uncertainty radius larger than this are discarded rather than stored, so low-confidence guesses don’t draw huge circles on the map. Set 0 for no limit.')}
           </p>
         </div>
 
         {status && (
-          <div style={{ marginTop: '1.5rem', marginLeft: '1.75rem', fontSize: '13px', color: 'var(--ctp-subtext1)' }}>
+          <div style={{ marginTop: '1.5rem', marginLeft: '1.75rem', fontSize: '13px', color: 'var(--color-text-muted)' }}>
             <div>
               {t('automation.position_estimation.last_run', 'Last run')}:{' '}
               {status.lastRunTime ? new Date(status.lastRunTime).toLocaleString() : t('automation.position_estimation.never', 'never')}

--- a/src/components/RebootModal.tsx
+++ b/src/components/RebootModal.tsx
@@ -217,24 +217,24 @@ export const RebootModal: React.FC<RebootModalProps> = ({ isOpen, onClose }) => 
       <div
         style={{
           maxWidth: '500px',
-          background: 'var(--ctp-base)',
+          background: 'var(--color-bg)',
           borderRadius: '8px',
           padding: '2rem',
-          border: '2px solid var(--ctp-blue)',
+          border: '2px solid var(--color-accent)',
           boxShadow: '0 0 20px rgba(137, 180, 250, 0.5)'
         }}
       >
         <div style={{ textAlign: 'center' }}>
-          <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--ctp-blue)', marginBottom: '1rem' }}>
+          <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--color-accent)', marginBottom: '1rem' }}>
             <UiIcon name={isVerifying ? 'check' : 'refresh'} /> {t('reboot.title')}
           </div>
 
-          <div style={{ fontSize: '1rem', color: 'var(--ctp-text)', marginBottom: '1.5rem' }}>
+          <div style={{ fontSize: '1rem', color: 'var(--color-text)', marginBottom: '1.5rem' }}>
             {t(statusKey, statusParams)}
           </div>
 
           {!isVerifying && elapsedSeconds > 0 && (
-            <div style={{ fontSize: '0.875rem', color: 'var(--ctp-subtext0)', marginBottom: '1.5rem' }}>
+            <div style={{ fontSize: '0.875rem', color: 'var(--color-text-subtle)', marginBottom: '1.5rem' }}>
               {t('reboot.elapsed', { seconds: elapsedSeconds })}
             </div>
           )}
@@ -244,7 +244,7 @@ export const RebootModal: React.FC<RebootModalProps> = ({ isOpen, onClose }) => 
               style={{
                 width: '100%',
                 height: '4px',
-                background: 'var(--ctp-surface1)',
+                background: 'var(--color-surface-hover)',
                 borderRadius: '2px',
                 overflow: 'hidden',
                 marginBottom: '1rem'
@@ -253,7 +253,7 @@ export const RebootModal: React.FC<RebootModalProps> = ({ isOpen, onClose }) => 
               <div
                 style={{
                   height: '100%',
-                  background: 'var(--ctp-blue)',
+                  background: 'var(--color-accent)',
                   animation: 'progress-bar 2s ease-in-out infinite',
                   width: '30%'
                 }}
@@ -269,7 +269,7 @@ export const RebootModal: React.FC<RebootModalProps> = ({ isOpen, onClose }) => 
             }
           `}</style>
 
-          <div style={{ fontSize: '0.875rem', color: 'var(--ctp-subtext1)', marginTop: '1rem' }}>
+          <div style={{ fontSize: '0.875rem', color: 'var(--color-text-muted)', marginTop: '1rem' }}>
             {t('reboot.do_not_close')}
           </div>
         </div>

--- a/src/components/RemoteAdminScannerSection.tsx
+++ b/src/components/RemoteAdminScannerSection.tsx
@@ -256,8 +256,8 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -295,33 +295,33 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
           marginLeft: '1.75rem',
           marginBottom: '1.5rem',
           padding: '1rem',
-          background: 'var(--ctp-surface0)',
-          border: '1px solid var(--ctp-surface2)',
+          background: 'var(--color-surface)',
+          border: '1px solid var(--color-surface-active)',
           borderRadius: '6px',
           display: 'flex',
           gap: '2rem',
         }}>
           <div>
-            <div style={{ fontSize: '24px', fontWeight: 600, color: 'var(--ctp-blue)' }}>
+            <div style={{ fontSize: '24px', fontWeight: 600, color: 'var(--color-accent)' }}>
               {stats.nodesWithAdmin}
             </div>
-            <div style={{ fontSize: '12px', color: 'var(--ctp-subtext0)' }}>
+            <div style={{ fontSize: '12px', color: 'var(--color-text-subtle)' }}>
               {t('automation.remote_admin_scanner.nodes_with_admin')}
             </div>
           </div>
           <div>
-            <div style={{ fontSize: '24px', fontWeight: 600, color: 'var(--ctp-text)' }}>
+            <div style={{ fontSize: '24px', fontWeight: 600, color: 'var(--color-text)' }}>
               {stats.nodesChecked}
             </div>
-            <div style={{ fontSize: '12px', color: 'var(--ctp-subtext0)' }}>
+            <div style={{ fontSize: '12px', color: 'var(--color-text-subtle)' }}>
               {t('automation.remote_admin_scanner.nodes_checked')}
             </div>
           </div>
           <div>
-            <div style={{ fontSize: '24px', fontWeight: 600, color: 'var(--ctp-subtext0)' }}>
+            <div style={{ fontSize: '24px', fontWeight: 600, color: 'var(--color-text-subtle)' }}>
               {stats.totalNodes}
             </div>
-            <div style={{ fontSize: '12px', color: 'var(--ctp-subtext0)' }}>
+            <div style={{ fontSize: '12px', color: 'var(--color-text-subtle)' }}>
               {t('automation.remote_admin_scanner.eligible_nodes')}
             </div>
           </div>
@@ -412,11 +412,11 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
         {/* Scan Log */}
         {localEnabled && (
           <div className="setting-item" style={{ marginTop: '2rem' }}>
-            <h4 style={{ marginBottom: '0.75rem', color: 'var(--ctp-text)' }}>
+            <h4 style={{ marginBottom: '0.75rem', color: 'var(--color-text)' }}>
               {t('automation.remote_admin_scanner.recent_log')}
             </h4>
             <div style={{
-              border: '1px solid var(--ctp-surface2)',
+              border: '1px solid var(--color-surface-active)',
               borderRadius: '6px',
               overflow: 'hidden',
               marginLeft: '1.75rem'
@@ -425,7 +425,7 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
                 <div style={{
                   padding: '1rem',
                   textAlign: 'center',
-                  color: 'var(--ctp-subtext0)',
+                  color: 'var(--color-text-subtle)',
                   fontSize: '12px'
                 }}>
                   {t('automation.remote_admin_scanner.no_log_entries')}
@@ -437,7 +437,7 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
                   fontSize: '12px'
                 }}>
                   <thead>
-                    <tr style={{ background: 'var(--ctp-surface1)' }}>
+                    <tr style={{ background: 'var(--color-surface-hover)' }}>
                       <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', fontWeight: 500 }}>
                         {t('automation.remote_admin_scanner.log_timestamp')}
                       </th>
@@ -454,31 +454,31 @@ const RemoteAdminScannerSection: React.FC<RemoteAdminScannerSectionProps> = ({
                   </thead>
                   <tbody>
                     {scanLog.map((entry) => (
-                      <tr key={`${entry.nodeNum}-${entry.timestamp}`} style={{ borderTop: '1px solid var(--ctp-surface1)' }}>
-                        <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-subtext0)' }}>
+                      <tr key={`${entry.nodeNum}-${entry.timestamp}`} style={{ borderTop: '1px solid var(--color-surface-hover)' }}>
+                        <td style={{ padding: '0.4rem 0.75rem', color: 'var(--color-text-subtle)' }}>
                           {formatDateTime(new Date(entry.timestamp), timeFormat, dateFormat)}
                         </td>
-                        <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-text)' }}>
+                        <td style={{ padding: '0.4rem 0.75rem', color: 'var(--color-text)' }}>
                           {entry.nodeName || `!${entry.nodeNum.toString(16).padStart(8, '0')}`}
                         </td>
                         <td style={{ padding: '0.4rem 0.75rem', textAlign: 'center' }}>
                           {entry.hasRemoteAdmin ? (
                             <span style={{
-                              color: 'var(--ctp-green)',
+                              color: 'var(--color-success)',
                               fontSize: '14px'
                             }} title={t('automation.remote_admin_scanner.status_has_admin')}>
                               <UiIcon name="check" size={14} />
                             </span>
                           ) : (
                             <span style={{
-                              color: 'var(--ctp-red)',
+                              color: 'var(--color-error)',
                               fontSize: '14px'
                             }} title={t('automation.remote_admin_scanner.status_no_admin')}>
                               <UiIcon name="close" size={14} />
                             </span>
                           )}
                         </td>
-                        <td style={{ padding: '0.4rem 0.75rem', color: 'var(--ctp-subtext0)' }}>
+                        <td style={{ padding: '0.4rem 0.75rem', color: 'var(--color-text-subtle)' }}>
                           {entry.firmwareVersion || '-'}
                         </td>
                       </tr>

--- a/src/components/RouteSegmentTraceroutesModal.tsx
+++ b/src/components/RouteSegmentTraceroutesModal.tsx
@@ -85,14 +85,14 @@ const RouteSegmentTraceroutesModal: React.FC<RouteSegmentTraceroutesModalProps> 
         </div>
 
         {relevantTraceroutes.length === 0 && (
-          <div style={{ textAlign: 'center', padding: '2rem', color: 'var(--ctp-subtext0)' }}>
+          <div style={{ textAlign: 'center', padding: '2rem', color: 'var(--color-text-subtle)' }}>
             {t('route_segment.no_traceroutes')}
           </div>
         )}
 
         {relevantTraceroutes.length > 0 && (
           <div>
-            <p style={{ marginBottom: '1rem', color: 'var(--ctp-subtext0)' }}>
+            <p style={{ marginBottom: '1rem', color: 'var(--color-text-subtle)' }}>
               {t('route_segment.showing_count', { count: relevantTraceroutes.length })}
             </p>
 
@@ -115,28 +115,28 @@ const RouteSegmentTraceroutesModal: React.FC<RouteSegmentTraceroutesModalProps> 
                   style={{
                     marginBottom: '1.5rem',
                     padding: '1rem',
-                    background: 'var(--ctp-surface0)',
-                    border: '1px solid var(--ctp-surface2)',
+                    background: 'var(--color-surface)',
+                    border: '1px solid var(--color-surface-active)',
                     borderRadius: '8px',
                   }}
                 >
                   <div style={{ marginBottom: '0.75rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                     <div>
                       <strong>#{relevantTraceroutes.length - index}</strong>{' '}
-                      <span style={{ color: 'var(--ctp-subtext0)' }}>
+                      <span style={{ color: 'var(--color-text-subtle)' }}>
                         {fromName} <UiIcon name="forward" size={14} /> {toName}
                       </span>
-                      <span style={{ marginLeft: '1rem', color: 'var(--ctp-subtext0)' }}>
+                      <span style={{ marginLeft: '1rem', color: 'var(--color-text-subtle)' }}>
                         {formatDateTime(new Date(tr.timestamp || tr.createdAt || Date.now()), timeFormat, dateFormat)}
                       </span>
                     </div>
-                    <span style={{ fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>
+                    <span style={{ fontSize: '0.9em', color: 'var(--color-text-subtle)' }}>
                       {ageStr}
                     </span>
                   </div>
 
                   <div style={{ marginBottom: '0.5rem' }}>
-                    <strong style={{ color: 'var(--ctp-green)' }}><UiIcon name="forward" size={14} /> {t('traceroute_history.forward')}:</strong>{' '}
+                    <strong style={{ color: 'var(--color-success)' }}><UiIcon name="forward" size={14} /> {t('traceroute_history.forward')}:</strong>{' '}
                     <span style={{ fontFamily: 'monospace', fontSize: '0.95em' }}>
                       {formatTracerouteRoute(
                         tr.route,
@@ -155,7 +155,7 @@ const RouteSegmentTraceroutesModal: React.FC<RouteSegmentTraceroutesModalProps> 
                   </div>
 
                   <div>
-                    <strong style={{ color: 'var(--ctp-yellow)' }}><UiIcon name="back" size={14} /> {t('traceroute_history.return')}:</strong>{' '}
+                    <strong style={{ color: 'var(--color-warning)' }}><UiIcon name="back" size={14} /> {t('traceroute_history.return')}:</strong>{' '}
                     <span style={{ fontFamily: 'monospace', fontSize: '0.95em' }}>
                       {formatTracerouteRoute(
                         tr.routeBack,

--- a/src/components/ScriptTestModal.tsx
+++ b/src/components/ScriptTestModal.tsx
@@ -195,7 +195,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
     >
       <div
         style={{
-          background: 'var(--ctp-base)',
+          background: 'var(--color-bg)',
           borderRadius: '8px',
           width: '90%',
           maxWidth: '700px',
@@ -203,7 +203,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
           overflow: 'hidden',
           display: 'flex',
           flexDirection: 'column',
-          border: '1px solid var(--ctp-overlay0)',
+          border: '1px solid var(--color-border-subtle)',
         }}
       >
         {/* Header */}
@@ -213,11 +213,11 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
             justifyContent: 'space-between',
             alignItems: 'center',
             padding: '1rem 1.25rem',
-            borderBottom: '1px solid var(--ctp-surface1)',
-            background: 'var(--ctp-surface0)',
+            borderBottom: '1px solid var(--color-surface-hover)',
+            background: 'var(--color-surface)',
           }}
         >
-          <h3 style={{ margin: 0, color: 'var(--ctp-text)', fontSize: '1.1rem' }}>
+          <h3 style={{ margin: 0, color: 'var(--color-text)', fontSize: '1.1rem' }}>
             {t('script_test.title', 'Test Script')}: {scriptFilename}
           </h3>
           <button
@@ -226,7 +226,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
               background: 'transparent',
               border: 'none',
               fontSize: '1.5rem',
-              color: 'var(--ctp-subtext0)',
+              color: 'var(--color-text-subtle)',
               cursor: 'pointer',
               padding: '0',
               lineHeight: '1',
@@ -240,13 +240,13 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
         <div style={{ padding: '1.25rem', overflowY: 'auto', flex: 1 }}>
           {/* Mock Context Section */}
           <div style={{ marginBottom: '1rem' }}>
-            <h4 style={{ margin: '0 0 0.75rem 0', color: 'var(--ctp-text)', fontSize: '0.95rem' }}>
+            <h4 style={{ margin: '0 0 0.75rem 0', color: 'var(--color-text)', fontSize: '0.95rem' }}>
               {t('script_test.mock_context', 'Test Context')}
             </h4>
 
             <div
               style={{
-                background: 'var(--ctp-surface0)',
+                background: 'var(--color-surface)',
                 borderRadius: '6px',
                 padding: '1rem',
               }}
@@ -254,7 +254,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
               {/* Auto-responder fields */}
               {triggerType === 'auto-responder' && (
                 <div style={{ marginBottom: '0.75rem' }}>
-                  <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--ctp-subtext0)' }}>
+                  <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--color-text-subtle)' }}>
                     {t('script_test.mock.message', 'Test Message')} *
                   </label>
                   <input
@@ -265,8 +265,8 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                     style={{ width: '100%' }}
                     placeholder={t('script_test.mock.message_hint', 'Enter a message that would trigger this script')}
                   />
-                  <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', marginTop: '0.25rem' }}>
-                    {t('script_test.mock.trigger_pattern', 'Trigger pattern')}: <code style={{ background: 'var(--ctp-surface1)', padding: '0 0.25rem', borderRadius: '2px' }}>
+                  <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', marginTop: '0.25rem' }}>
+                    {t('script_test.mock.trigger_pattern', 'Trigger pattern')}: <code style={{ background: 'var(--color-surface-hover)', padding: '0 0.25rem', borderRadius: '2px' }}>
                       {Array.isArray(trigger) ? trigger.join(' | ') : trigger}
                     </code>
                   </div>
@@ -276,7 +276,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
               {/* Geofence fields */}
               {triggerType === 'geofence' && (
                 <div style={{ marginBottom: '0.75rem' }}>
-                  <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--ctp-subtext0)' }}>
+                  <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--color-text-subtle)' }}>
                     {t('script_test.mock.event_type', 'Geofence Event')}
                   </label>
                   <select
@@ -295,7 +295,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
               {/* Common mock node fields */}
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem' }}>
                 <div>
-                  <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--ctp-subtext0)' }}>
+                  <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--color-text-subtle)' }}>
                     {t('script_test.mock.from_node', 'From Node Number')}
                   </label>
                   <input
@@ -307,7 +307,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                   />
                 </div>
                 <div>
-                  <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--ctp-subtext0)' }}>
+                  <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--color-text-subtle)' }}>
                     {t('script_test.mock.from_short_name', 'From Short Name')}
                   </label>
                   <input
@@ -319,7 +319,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                   />
                 </div>
                 <div>
-                  <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--ctp-subtext0)' }}>
+                  <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--color-text-subtle)' }}>
                     {t('script_test.mock.from_long_name', 'From Long Name')}
                   </label>
                   <input
@@ -333,7 +333,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                 {(triggerType === 'geofence' || triggerType === 'auto-responder') && (
                   <>
                     <div>
-                      <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--ctp-subtext0)' }}>
+                      <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--color-text-subtle)' }}>
                         {t('script_test.mock.node_lat', 'Node Latitude')}
                       </label>
                       <input
@@ -345,7 +345,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                       />
                     </div>
                     <div>
-                      <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--ctp-subtext0)' }}>
+                      <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem', color: 'var(--color-text-subtle)' }}>
                         {t('script_test.mock.node_lon', 'Node Longitude')}
                       </label>
                       <input
@@ -388,23 +388,23 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                   marginBottom: '1rem',
                   borderRadius: '6px',
                   background: testResult.success ? 'rgba(166, 227, 161, 0.15)' : 'rgba(243, 139, 168, 0.15)',
-                  border: `1px solid ${testResult.success ? 'var(--ctp-green)' : 'var(--ctp-red)'}`,
+                  border: `1px solid ${testResult.success ? 'var(--color-success)' : 'var(--color-error)'}`,
                 }}
               >
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <span style={{ color: testResult.success ? 'var(--ctp-green)' : 'var(--ctp-red)', fontWeight: 'bold' }}>
+                  <span style={{ color: testResult.success ? 'var(--color-success)' : 'var(--color-error)', fontWeight: 'bold' }}>
                     {testResult.success
                       ? t('script_test.success', 'Script executed successfully')
                       : t('script_test.error', 'Script execution failed')}
                   </span>
                   {testResult.executionTimeMs !== undefined && (
-                    <span style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+                    <span style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
                       {t('script_test.execution_time', 'Execution time: {{time}}ms', { time: testResult.executionTimeMs })}
                     </span>
                   )}
                 </div>
                 {testResult.error && (
-                  <div style={{ marginTop: '0.5rem', color: 'var(--ctp-red)', fontSize: '0.9rem' }}>
+                  <div style={{ marginTop: '0.5rem', color: 'var(--color-error)', fontSize: '0.9rem' }}>
                     {testResult.error}
                   </div>
                 )}
@@ -422,7 +422,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                     display: 'flex',
                     alignItems: 'center',
                     gap: '0.5rem',
-                    color: 'var(--ctp-text)',
+                    color: 'var(--color-text)',
                     fontSize: '0.95rem',
                     fontWeight: 'bold',
                     marginBottom: '0.5rem',
@@ -436,7 +436,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                 {showConsole && (
                   <div
                     style={{
-                      background: 'var(--ctp-crust)',
+                      background: 'var(--color-bg-sunken)',
                       borderRadius: '4px',
                       padding: '0.75rem',
                       fontFamily: 'monospace',
@@ -446,17 +446,17 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                     }}
                   >
                     {testResult.stdout && (
-                      <div style={{ color: 'var(--ctp-text)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-                        <span style={{ color: 'var(--ctp-green)', fontWeight: 'bold' }}>stdout:</span> {testResult.stdout}
+                      <div style={{ color: 'var(--color-text)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                        <span style={{ color: 'var(--color-success)', fontWeight: 'bold' }}>stdout:</span> {testResult.stdout}
                       </div>
                     )}
                     {testResult.stderr && (
-                      <div style={{ color: 'var(--ctp-yellow)', whiteSpace: 'pre-wrap', wordBreak: 'break-word', marginTop: testResult.stdout ? '0.5rem' : 0 }}>
+                      <div style={{ color: 'var(--color-warning)', whiteSpace: 'pre-wrap', wordBreak: 'break-word', marginTop: testResult.stdout ? '0.5rem' : 0 }}>
                         <span style={{ fontWeight: 'bold' }}>stderr:</span> {testResult.stderr}
                       </div>
                     )}
                     {!testResult.stdout && !testResult.stderr && (
-                      <span style={{ color: 'var(--ctp-subtext0)' }}>(no output)</span>
+                      <span style={{ color: 'var(--color-text-subtle)' }}>(no output)</span>
                     )}
                   </div>
                 )}
@@ -474,7 +474,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                     display: 'flex',
                     alignItems: 'center',
                     gap: '0.5rem',
-                    color: 'var(--ctp-text)',
+                    color: 'var(--color-text)',
                     fontSize: '0.95rem',
                     fontWeight: 'bold',
                     marginBottom: '0.5rem',
@@ -488,12 +488,12 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                 {showWouldSend && (
                   <div
                     style={{
-                      background: 'var(--ctp-surface0)',
+                      background: 'var(--color-surface)',
                       borderRadius: '4px',
                       padding: '0.75rem',
                     }}
                   >
-                    <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', marginBottom: '0.5rem' }}>
+                    <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', marginBottom: '0.5rem' }}>
                       {t('script_test.would_send_note', 'These messages would be sent if this were a real trigger (NOT sent during test)')}
                     </div>
                     {testResult.wouldSendMessages && testResult.wouldSendMessages.length > 0 ? (
@@ -501,21 +501,21 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                         <div
                           key={idx}
                           style={{
-                            background: 'var(--ctp-surface1)',
+                            background: 'var(--color-surface-hover)',
                             padding: '0.5rem 0.75rem',
                             borderRadius: '4px',
                             marginBottom: idx < testResult.wouldSendMessages!.length - 1 ? '0.5rem' : 0,
                             fontFamily: 'monospace',
                             fontSize: '0.9rem',
-                            color: 'var(--ctp-text)',
-                            border: '1px solid var(--ctp-blue)',
+                            color: 'var(--color-text)',
+                            border: '1px solid var(--color-accent)',
                           }}
                         >
                           {msg}
                         </div>
                       ))
                     ) : (
-                      <div style={{ color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>
+                      <div style={{ color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>
                         {t('script_test.no_messages', 'No messages to send')}
                       </div>
                     )}
@@ -526,21 +526,21 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
               {/* Extracted Params (auto-responder only) */}
               {triggerType === 'auto-responder' && testResult.extractedParams && Object.keys(testResult.extractedParams).length > 0 && (
                 <div style={{ marginBottom: '1rem' }}>
-                  <h4 style={{ margin: '0 0 0.5rem 0', color: 'var(--ctp-text)', fontSize: '0.95rem' }}>
+                  <h4 style={{ margin: '0 0 0.5rem 0', color: 'var(--color-text)', fontSize: '0.95rem' }}>
                     Extracted Parameters
                   </h4>
                   <div
                     style={{
-                      background: 'var(--ctp-surface0)',
+                      background: 'var(--color-surface)',
                       borderRadius: '4px',
                       padding: '0.75rem',
                     }}
                   >
                     {Object.entries(testResult.extractedParams).map(([key, value]) => (
                       <div key={key} style={{ marginBottom: '0.25rem' }}>
-                        <code style={{ color: 'var(--ctp-blue)' }}>PARAM_{key}</code>
-                        <span style={{ color: 'var(--ctp-subtext0)' }}> = </span>
-                        <code style={{ color: 'var(--ctp-green)' }}>{value}</code>
+                        <code style={{ color: 'var(--color-accent)' }}>PARAM_{key}</code>
+                        <span style={{ color: 'var(--color-text-subtle)' }}> = </span>
+                        <code style={{ color: 'var(--color-success)' }}>{value}</code>
                       </div>
                     ))}
                   </div>
@@ -561,7 +561,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                 display: 'flex',
                 alignItems: 'center',
                 gap: '0.5rem',
-                color: 'var(--ctp-subtext0)',
+                color: 'var(--color-text-subtle)',
                 fontSize: '0.9rem',
                 marginBottom: '0.5rem',
               }}
@@ -574,7 +574,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
             {showEnvVars && (
               <div
                 style={{
-                  background: 'var(--ctp-crust)',
+                  background: 'var(--color-bg-sunken)',
                   borderRadius: '4px',
                   padding: '0.75rem',
                   fontFamily: 'monospace',
@@ -585,9 +585,9 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
               >
                 {Object.entries(getEnvironmentVariables()).map(([key, value]) => (
                   <div key={key} style={{ marginBottom: '0.15rem' }}>
-                    <span style={{ color: 'var(--ctp-blue)' }}>{key}</span>
-                    <span style={{ color: 'var(--ctp-subtext0)' }}>=</span>
-                    <span style={{ color: 'var(--ctp-text)' }}>{value}</span>
+                    <span style={{ color: 'var(--color-accent)' }}>{key}</span>
+                    <span style={{ color: 'var(--color-text-subtle)' }}>=</span>
+                    <span style={{ color: 'var(--color-text)' }}>{value}</span>
                   </div>
                 ))}
               </div>

--- a/src/components/SecurityTab.tsx
+++ b/src/components/SecurityTab.tsx
@@ -968,8 +968,8 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ onTabChange, onSelectD
                       style={{
                         padding: '0.4rem 0.75rem',
                         fontSize: '0.85rem',
-                        backgroundColor: 'var(--ctp-surface1)',
-                        color: 'var(--ctp-text)',
+                        backgroundColor: 'var(--color-surface-hover)',
+                        color: 'var(--color-text)',
                         border: 'none',
                         borderRadius: '4px',
                         cursor: 'pointer'
@@ -986,8 +986,8 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ onTabChange, onSelectD
                         style={{
                           padding: '0.4rem 0.75rem',
                           fontSize: '0.85rem',
-                          backgroundColor: 'var(--ctp-red)',
-                          color: 'var(--ctp-base)',
+                          backgroundColor: 'var(--color-error)',
+                          color: 'var(--color-bg)',
                           border: 'none',
                           borderRadius: '4px',
                           cursor: isDeletingNodes ? 'not-allowed' : 'pointer',
@@ -1022,9 +1022,9 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ onTabChange, onSelectD
                             />
                           </td>
                           <td>
-                            {node.longName || node.shortName || <span style={{ color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>Unknown</span>}
+                            {node.longName || node.shortName || <span style={{ color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>Unknown</span>}
                             {node.shortName && node.longName && (
-                              <span style={{ color: 'var(--ctp-subtext0)', marginLeft: '0.5rem', fontSize: '0.8rem' }}>({node.shortName})</span>
+                              <span style={{ color: 'var(--color-text-subtle)', marginLeft: '0.5rem', fontSize: '0.8rem' }}>({node.shortName})</span>
                             )}
                           </td>
                           <td style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}>{node.nodeId}</td>
@@ -1032,11 +1032,11 @@ export const SecurityTab: React.FC<SecurityTabProps> = ({ onTabChange, onSelectD
                           <td>{formatLastHeard(node.lastHeard)}</td>
                           <td>
                             {node.inDeviceDb ? (
-                              <span title={t('security.dead_nodes_in_both', 'In both local and device database')} style={{ color: 'var(--ctp-yellow)' }}>
+                              <span title={t('security.dead_nodes_in_both', 'In both local and device database')} style={{ color: 'var(--color-warning)' }}>
                                 <UiIcon name="radioSignal" /> {t('security.dead_nodes_local_and_device', 'Local + Device')}
                               </span>
                             ) : (
-                              <span title={t('security.dead_nodes_local_only', 'Only in local database')} style={{ color: 'var(--ctp-subtext0)' }}>
+                              <span title={t('security.dead_nodes_local_only', 'Only in local database')} style={{ color: 'var(--color-text-subtle)' }}>
                                 <UiIcon name="database" /> {t('security.dead_nodes_local_only_short', 'Local Only')}
                               </span>
                             )}

--- a/src/components/TapbackEmojiSettings.tsx
+++ b/src/components/TapbackEmojiSettings.tsx
@@ -116,7 +116,7 @@ const TapbackEmojiSettings: React.FC = () => {
         gap: '8px',
         marginBottom: '16px',
         padding: '12px',
-        backgroundColor: 'var(--ctp-surface0)',
+        backgroundColor: 'var(--color-surface)',
         borderRadius: '8px',
         maxHeight: '200px',
         overflowY: 'auto'
@@ -132,7 +132,7 @@ const TapbackEmojiSettings: React.FC = () => {
               justifyContent: 'center',
               fontSize: '1.5rem',
               padding: '8px',
-              backgroundColor: 'var(--ctp-surface1)',
+              backgroundColor: 'var(--color-surface-hover)',
               borderRadius: '6px',
               cursor: 'pointer',
               transition: 'background-color 0.2s'
@@ -153,8 +153,8 @@ const TapbackEmojiSettings: React.FC = () => {
                 padding: 0,
                 border: 'none',
                 borderRadius: '50%',
-                backgroundColor: 'var(--ctp-red)',
-                color: 'var(--ctp-base)',
+                backgroundColor: 'var(--color-error)',
+                color: 'var(--color-bg)',
                 fontSize: '12px',
                 lineHeight: '18px',
                 cursor: 'pointer',
@@ -192,9 +192,9 @@ const TapbackEmojiSettings: React.FC = () => {
             fontSize: '1.2rem',
             textAlign: 'center',
             borderRadius: '6px',
-            border: '1px solid var(--ctp-surface2)',
-            backgroundColor: 'var(--ctp-surface0)',
-            color: 'var(--ctp-text)'
+            border: '1px solid var(--color-surface-active)',
+            backgroundColor: 'var(--color-surface)',
+            color: 'var(--color-text)'
           }}
         />
         <input
@@ -209,9 +209,9 @@ const TapbackEmojiSettings: React.FC = () => {
             minWidth: '150px',
             padding: '8px 12px',
             borderRadius: '6px',
-            border: '1px solid var(--ctp-surface2)',
-            backgroundColor: 'var(--ctp-surface0)',
-            color: 'var(--ctp-text)'
+            border: '1px solid var(--color-surface-active)',
+            backgroundColor: 'var(--color-surface)',
+            color: 'var(--color-text)'
           }}
         />
         <button
@@ -243,13 +243,13 @@ const TapbackEmojiSettings: React.FC = () => {
       {/* CSS for hover effects */}
       <style>{`
         .tapback-emoji-item:hover {
-          background-color: var(--ctp-surface2) !important;
+          background-color: var(--color-surface-active) !important;
         }
         .tapback-emoji-item:hover .tapback-emoji-remove {
           opacity: 1 !important;
         }
         .tapback-emoji-remove:hover {
-          background-color: var(--ctp-maroon) !important;
+          background-color: var(--color-danger) !important;
         }
       `}</style>
     </div>

--- a/src/components/TelemetryGauge.tsx
+++ b/src/components/TelemetryGauge.tsx
@@ -87,7 +87,7 @@ const TelemetryGauge: React.FC<TelemetryGaugeProps> = ({
     <div className="telemetry-gauge">
       <svg viewBox="0 0 200 160" width="100%" aria-label={`Gauge: ${displayValue}${unit ? ` ${unit}` : ''}`}>
         {/* Background arc */}
-        <path d={bgPath} fill="none" stroke="var(--ctp-surface0)" strokeWidth={14} strokeLinecap="round" />
+        <path d={bgPath} fill="none" stroke="var(--color-surface)" strokeWidth={14} strokeLinecap="round" />
         {/* Value arc */}
         {valuePath && (
           <path d={valuePath} fill="none" stroke={color} strokeWidth={14} strokeLinecap="round" />
@@ -98,7 +98,7 @@ const TelemetryGauge: React.FC<TelemetryGaugeProps> = ({
           y={minLabel.y}
           textAnchor="middle"
           fontSize="9"
-          fill="var(--ctp-subtext0)"
+          fill="var(--color-text-subtle)"
         >
           {displayMin}
         </text>
@@ -108,20 +108,20 @@ const TelemetryGauge: React.FC<TelemetryGaugeProps> = ({
           y={maxLabel.y}
           textAnchor="middle"
           fontSize="9"
-          fill="var(--ctp-subtext0)"
+          fill="var(--color-text-subtle)"
         >
           {displayMax}
         </text>
         {/* Value */}
-        <text x={cx} y={cy + 4} textAnchor="middle" fontSize="26" fontWeight="bold" fill="var(--ctp-text)">
+        <text x={cx} y={cy + 4} textAnchor="middle" fontSize="26" fontWeight="bold" fill="var(--color-text)">
           {displayValue}
         </text>
         {/* Unit */}
-        <text x={cx} y={cy + 18} textAnchor="middle" fontSize="11" fill="var(--ctp-subtext0)">
+        <text x={cx} y={cy + 18} textAnchor="middle" fontSize="11" fill="var(--color-text-subtle)">
           {unit}
         </text>
         {/* Timestamp */}
-        <text x={cx} y={148} textAnchor="middle" fontSize="9" fontStyle="italic" fill="var(--ctp-subtext0)">
+        <text x={cx} y={148} textAnchor="middle" fontSize="9" fontStyle="italic" fill="var(--color-text-subtle)">
           {timeStr}
         </text>
       </svg>

--- a/src/components/TimerTriggersSection.tsx
+++ b/src/components/TimerTriggersSection.tsx
@@ -247,8 +247,8 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
         alignItems: 'center',
         marginBottom: '1.5rem',
         padding: '1rem 1.25rem',
-        background: 'var(--ctp-surface1)',
-        border: '1px solid var(--ctp-surface2)',
+        background: 'var(--color-surface-hover)',
+        border: '1px solid var(--color-surface-active)',
         borderRadius: '8px'
       }}>
         <h2 style={{ margin: 0, display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
@@ -277,11 +277,11 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
         {/* Add New Timer Form */}
         <div style={{
           padding: '1rem',
-          background: 'var(--ctp-surface0)',
+          background: 'var(--color-surface)',
           borderRadius: '8px',
           marginBottom: '1rem',
         }}>
-          <h4 style={{ margin: '0 0 1rem 0', fontSize: '0.95rem', color: 'var(--ctp-text)' }}>
+          <h4 style={{ margin: '0 0 1rem 0', fontSize: '0.95rem', color: 'var(--color-text)' }}>
             {t('automation.timer_triggers.add_new', 'Add New Timer')}
           </h4>
 
@@ -313,23 +313,23 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
                   style={{
                     width: '100%',
                     fontFamily: 'monospace',
-                    borderColor: cronError ? 'var(--ctp-red)' : undefined,
+                    borderColor: cronError ? 'var(--color-error)' : undefined,
                   }}
                   placeholder="0 */6 * * *"
                 />
                 {cronError && (
-                  <div style={{ color: 'var(--ctp-red)', fontSize: '0.75rem', marginTop: '0.25rem' }}>
+                  <div style={{ color: 'var(--color-error)', fontSize: '0.75rem', marginTop: '0.25rem' }}>
                     {cronError}
                   </div>
                 )}
-                <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', marginTop: '0.25rem' }}>
+                <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', marginTop: '0.25rem' }}>
                   {t('automation.timer_triggers.cron_help', 'Format: minute hour day month weekday')}
                   {' '}
                   <a
                     href="https://crontab.guru/"
                     target="_blank"
                     rel="noopener noreferrer"
-                    style={{ color: 'var(--ctp-blue)' }}
+                    style={{ color: 'var(--color-accent)' }}
                   >
                     crontab.guru
                   </a>
@@ -404,7 +404,7 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
                     style={{ width: '100%', fontFamily: 'monospace' }}
                     placeholder="--ip {IP} --count {NODECOUNT}"
                   />
-                  <span style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+                  <span style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                     {t('automation.timer_triggers.script_args_help', 'Optional CLI arguments. Tokens: {IP}, {PORT}, {VERSION}, {NODECOUNT}, etc.')}
                   </span>
                 </div>
@@ -425,12 +425,12 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
                     placeholder={t('automation.timer_triggers.message_placeholder', 'e.g., MeshMonitor {VERSION} - {NODECOUNT} nodes online')}
                   />
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginTop: '0.25rem' }}>
-                    <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', flex: 1 }}>
+                    <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', flex: 1 }}>
                       {t('automation.timer_triggers.tokens_help', 'Available tokens:')}
                       {' '}
                       {AVAILABLE_TOKENS.map((tok, i) => (
                         <span key={tok.token}>
-                          <code style={{ background: 'var(--ctp-surface1)', padding: '0 0.25rem', borderRadius: '2px' }}>{tok.token}</code>
+                          <code style={{ background: 'var(--color-surface-hover)', padding: '0 0.25rem', borderRadius: '2px' }}>{tok.token}</code>
                           {i < AVAILABLE_TOKENS.length - 1 && ', '}
                         </span>
                       ))}
@@ -438,7 +438,7 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
                     <div style={{
                       fontSize: '0.75rem',
                       fontWeight: 'bold',
-                      color: newResponse.length > 200 ? 'var(--ctp-red)' : newResponse.length > 150 ? 'var(--ctp-yellow)' : 'var(--ctp-subtext0)',
+                      color: newResponse.length > 200 ? 'var(--color-error)' : newResponse.length > 150 ? 'var(--color-warning)' : 'var(--color-text-subtle)',
                       marginLeft: '0.5rem',
                       whiteSpace: 'nowrap',
                     }}>
@@ -471,7 +471,7 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
                   </option>
                 ))}
               </select>
-              <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+              <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                 {newResponseType === 'script' && newChannel === 'none'
                   ? t('automation.timer_triggers.channel_none_help', 'Script handles its own output (e.g., external integrations)')
                   : t('automation.timer_triggers.channel_help_generic', 'Output will be sent to this channel')}
@@ -497,7 +497,7 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
         {/* Existing Timers List */}
         {localTriggers.length > 0 && (
           <div style={{ marginBottom: '1rem' }}>
-            <h4 style={{ margin: '0 0 0.75rem 0', fontSize: '0.95rem', color: 'var(--ctp-text)' }}>
+            <h4 style={{ margin: '0 0 0.75rem 0', fontSize: '0.95rem', color: 'var(--color-text)' }}>
               {t('automation.timer_triggers.existing', 'Existing Timers')} ({localTriggers.length})
             </h4>
 
@@ -528,8 +528,8 @@ const TimerTriggersSection: React.FC<TimerTriggersSectionProps> = ({
           <div style={{
             padding: '2rem',
             textAlign: 'center',
-            color: 'var(--ctp-subtext0)',
-            background: 'var(--ctp-surface0)',
+            color: 'var(--color-text-subtle)',
+            background: 'var(--color-surface)',
             borderRadius: '8px',
           }}>
             {t('automation.timer_triggers.no_timers', 'No timer triggers configured. Add one above to schedule automatic script execution.')}
@@ -635,8 +635,8 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
         gap: '0.5rem',
         padding: '0.75rem',
         marginBottom: '0.5rem',
-        background: isEditing ? 'var(--ctp-surface1)' : 'var(--ctp-surface0)',
-        border: isEditing ? '2px solid var(--ctp-blue)' : '1px solid var(--ctp-overlay0)',
+        background: isEditing ? 'var(--color-surface-hover)' : 'var(--color-surface)',
+        border: isEditing ? '2px solid var(--color-accent)' : '1px solid var(--color-border-subtle)',
         borderRadius: '4px',
         opacity: trigger.enabled ? 1 : 0.6,
       }}
@@ -665,11 +665,11 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
                   style={{
                     width: '100%',
                     fontFamily: 'monospace',
-                    borderColor: editCronError ? 'var(--ctp-red)' : undefined,
+                    borderColor: editCronError ? 'var(--color-error)' : undefined,
                   }}
                 />
                 {editCronError && (
-                  <div style={{ color: 'var(--ctp-red)', fontSize: '0.75rem', marginTop: '0.25rem' }}>
+                  <div style={{ color: 'var(--color-error)', fontSize: '0.75rem', marginTop: '0.25rem' }}>
                     {editCronError}
                   </div>
                 )}
@@ -729,7 +729,7 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
                     style={{ width: '100%', fontFamily: 'monospace' }}
                     placeholder="--ip {IP} --count {NODECOUNT}"
                   />
-                  <span style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)' }}>
+                  <span style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)' }}>
                     {t('automation.timer_triggers.script_args_help', 'Optional CLI arguments. Tokens: {IP}, {PORT}, {VERSION}, {NODECOUNT}, etc.')}
                   </span>
                 </div>
@@ -746,13 +746,13 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
                     style={{ width: '100%', minHeight: '60px', resize: 'vertical' }}
                   />
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '0.25rem' }}>
-                    <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)' }}>
+                    <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)' }}>
                       Tokens: {AVAILABLE_TOKENS.map(tok => tok.token).join(', ')}
                     </div>
                     <div style={{
                       fontSize: '0.7rem',
                       fontWeight: 'bold',
-                      color: editResponse.length > 200 ? 'var(--ctp-red)' : editResponse.length > 150 ? 'var(--ctp-yellow)' : 'var(--ctp-subtext0)',
+                      color: editResponse.length > 200 ? 'var(--color-error)' : editResponse.length > 150 ? 'var(--color-warning)' : 'var(--color-text-subtle)',
                     }}>
                       {editResponse.length}/200
                     </div>
@@ -789,7 +789,7 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
               style={{
                 padding: '0.25rem 0.75rem',
                 fontSize: '12px',
-                background: 'var(--ctp-green)',
+                background: 'var(--color-success)',
                 color: 'white',
                 border: 'none',
                 borderRadius: '4px',
@@ -804,8 +804,8 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
               style={{
                 padding: '0.25rem 0.75rem',
                 fontSize: '12px',
-                background: 'var(--ctp-surface2)',
-                color: 'var(--ctp-text)',
+                background: 'var(--color-surface-active)',
+                color: 'var(--color-text)',
                 border: 'none',
                 borderRadius: '4px',
                 cursor: 'pointer',
@@ -819,10 +819,10 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
         <>
           <div style={{ flex: 1 }}>
             <div style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>{trigger.name}</div>
-            <div style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)', fontFamily: 'monospace' }}>
+            <div style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)', fontFamily: 'monospace' }}>
               {trigger.cronExpression}
             </div>
-            <div style={{ fontSize: '0.8rem', color: 'var(--ctp-subtext0)', marginTop: '0.25rem' }}>
+            <div style={{ fontSize: '0.8rem', color: 'var(--color-text-subtle)', marginTop: '0.25rem' }}>
               {responseType === 'script' ? (
                 <>{scriptEmoji || <UiIcon name="fileCode" size={14} />} {scriptDisplayName}</>
               ) : (
@@ -831,12 +831,12 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
               {' '}<UiIcon name="forward" size={14} /> Ch {trigger.channel ?? 0}: {channels.find(c => c.id === (trigger.channel ?? 0))?.name || `Channel ${trigger.channel ?? 0}`}
             </div>
             {trigger.lastRun && (
-              <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', marginTop: '0.25rem' }}>
+              <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', marginTop: '0.25rem' }}>
                 Last run: {formatLastRun(trigger.lastRun)}
                 {trigger.lastResult && (
                   <span style={{
                     marginLeft: '0.5rem',
-                    color: trigger.lastResult === 'success' ? 'var(--ctp-green)' : 'var(--ctp-red)',
+                    color: trigger.lastResult === 'success' ? 'var(--color-success)' : 'var(--color-error)',
                   }}>
                     ({trigger.lastResult})
                   </span>
@@ -848,8 +848,8 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
             <span style={{
               fontSize: '0.7rem',
               padding: '0.15rem 0.4rem',
-              background: trigger.enabled ? 'var(--ctp-green)' : 'var(--ctp-surface2)',
-              color: trigger.enabled ? 'var(--ctp-base)' : 'var(--ctp-subtext0)',
+              background: trigger.enabled ? 'var(--color-success)' : 'var(--color-surface-active)',
+              color: trigger.enabled ? 'var(--color-bg)' : 'var(--color-text-subtle)',
               borderRadius: '3px',
               fontWeight: 'bold',
             }}>
@@ -860,8 +860,8 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
               style={{
                 padding: '0.25rem 0.5rem',
                 fontSize: '12px',
-                background: trigger.enabled ? 'var(--ctp-yellow)' : 'var(--ctp-green)',
-                color: 'var(--ctp-base)',
+                background: trigger.enabled ? 'var(--color-warning)' : 'var(--color-success)',
+                color: 'var(--color-bg)',
                 border: 'none',
                 borderRadius: '4px',
                 cursor: 'pointer',
@@ -876,7 +876,7 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
                   padding: '0.25rem 0.5rem',
                   fontSize: '12px',
                   background: 'var(--ctp-teal)',
-                  color: 'var(--ctp-base)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: 'pointer',
@@ -891,7 +891,7 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
               style={{
                 padding: '0.25rem 0.5rem',
                 fontSize: '12px',
-                background: 'var(--ctp-blue)',
+                background: 'var(--color-accent)',
                 color: 'white',
                 border: 'none',
                 borderRadius: '4px',
@@ -905,7 +905,7 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
               style={{
                 padding: '0.25rem 0.5rem',
                 fontSize: '12px',
-                background: 'var(--ctp-red)',
+                background: 'var(--color-error)',
                 color: 'white',
                 border: 'none',
                 borderRadius: '4px',
@@ -933,15 +933,15 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
           zIndex: 10000,
         }}>
           <div style={{
-            background: 'var(--ctp-base)',
+            background: 'var(--color-bg)',
             borderRadius: '8px',
             padding: '1.5rem',
             maxWidth: '400px',
             width: '90%',
-            border: '1px solid var(--ctp-overlay0)',
+            border: '1px solid var(--color-border-subtle)',
           }}>
-            <h3 style={{ margin: '0 0 1rem 0', color: 'var(--ctp-text)' }}>Remove Timer</h3>
-            <p style={{ color: 'var(--ctp-subtext0)', marginBottom: '1rem' }}>
+            <h3 style={{ margin: '0 0 1rem 0', color: 'var(--color-text)' }}>Remove Timer</h3>
+            <p style={{ color: 'var(--color-text-subtle)', marginBottom: '1rem' }}>
               Are you sure you want to remove "{trigger.name}"?
             </p>
             <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
@@ -949,9 +949,9 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
                 onClick={() => setShowRemoveModal(false)}
                 style={{
                   padding: '0.5rem 1rem',
-                  background: 'var(--ctp-surface1)',
-                  color: 'var(--ctp-text)',
-                  border: '1px solid var(--ctp-overlay0)',
+                  background: 'var(--color-surface-hover)',
+                  color: 'var(--color-text)',
+                  border: '1px solid var(--color-border-subtle)',
                   borderRadius: '4px',
                   cursor: 'pointer',
                 }}
@@ -965,8 +965,8 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
                 }}
                 style={{
                   padding: '0.5rem 1rem',
-                  background: 'var(--ctp-red)',
-                  color: 'var(--ctp-base)',
+                  background: 'var(--color-error)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: 'pointer',

--- a/src/components/Toast.test.tsx
+++ b/src/components/Toast.test.tsx
@@ -141,25 +141,25 @@ describe('Toast Component', () => {
       const { container } = render(<Toast {...defaultProps} type="success" />);
       const toastDiv = container.firstChild as HTMLElement;
       // Component uses Catppuccin CSS variables
-      expect(toastDiv.style.backgroundColor).toBe('var(--ctp-green)');
+      expect(toastDiv.style.backgroundColor).toBe('var(--color-success)');
     });
 
     it('should apply error background color', () => {
       const { container } = render(<Toast {...defaultProps} type="error" />);
       const toastDiv = container.firstChild as HTMLElement;
-      expect(toastDiv.style.backgroundColor).toBe('var(--ctp-red)');
+      expect(toastDiv.style.backgroundColor).toBe('var(--color-error)');
     });
 
     it('should apply warning background color', () => {
       const { container } = render(<Toast {...defaultProps} type="warning" />);
       const toastDiv = container.firstChild as HTMLElement;
-      expect(toastDiv.style.backgroundColor).toBe('var(--ctp-peach)');
+      expect(toastDiv.style.backgroundColor).toBe('var(--color-caution)');
     });
 
     it('should apply info background color', () => {
       const { container } = render(<Toast {...defaultProps} type="info" />);
       const toastDiv = container.firstChild as HTMLElement;
-      expect(toastDiv.style.backgroundColor).toBe('var(--ctp-blue)');
+      expect(toastDiv.style.backgroundColor).toBe('var(--color-accent)');
     });
 
     it('should have slideIn animation', () => {

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -19,10 +19,10 @@ const Toast: React.FC<ToastProps> = ({ id, message, type, duration = 5000, onClo
   }, [id, duration, onClose]);
 
   const backgroundColor = {
-    success: 'var(--ctp-green)',
-    error: 'var(--ctp-red)',
-    warning: 'var(--ctp-peach)',
-    info: 'var(--ctp-blue)'
+    success: 'var(--color-success)',
+    error: 'var(--color-error)',
+    warning: 'var(--color-caution)',
+    info: 'var(--color-accent)'
   }[type];
 
   const icons: Record<ToastProps['type'], UiIconName> = {
@@ -37,7 +37,7 @@ const Toast: React.FC<ToastProps> = ({ id, message, type, duration = 5000, onClo
     <div
       style={{
         backgroundColor,
-        color: 'var(--ctp-crust, #1e1e2e)',
+        color: 'var(--color-bg-sunken, #1e1e2e)',
         padding: '1rem 1.5rem',
         borderRadius: '4px',
         boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
@@ -58,7 +58,7 @@ const Toast: React.FC<ToastProps> = ({ id, message, type, duration = 5000, onClo
         style={{
           background: 'none',
           border: 'none',
-          color: 'var(--ctp-crust, #1e1e2e)',
+          color: 'var(--color-bg-sunken, #1e1e2e)',
           fontSize: '1.25rem',
           cursor: 'pointer',
           padding: '0 0.25rem',

--- a/src/components/TracerouteHistoryModal.tsx
+++ b/src/components/TracerouteHistoryModal.tsx
@@ -132,20 +132,20 @@ const TracerouteHistoryModal: React.FC<TracerouteHistoryModalProps> = ({
         )}
 
         {error && (
-          <div style={{ padding: '1rem', background: 'var(--ctp-red)', color: 'var(--ctp-base)', borderRadius: '4px' }}>
+          <div style={{ padding: '1rem', background: 'var(--color-error)', color: 'var(--color-bg)', borderRadius: '4px' }}>
             {error}
           </div>
         )}
 
         {!loading && !error && filteredTraceroutes.length === 0 && (
-          <div style={{ textAlign: 'center', padding: '2rem', color: 'var(--ctp-subtext0)' }}>
+          <div style={{ textAlign: 'center', padding: '2rem', color: 'var(--color-text-subtle)' }}>
             {traceroutes.length === 0 ? t('traceroute_history.no_history') : t('traceroute_history.no_matches')}
           </div>
         )}
 
         {!loading && !error && filteredTraceroutes.length > 0 && (
           <div>
-            <p style={{ marginBottom: '1rem', color: 'var(--ctp-subtext0)' }}>
+            <p style={{ marginBottom: '1rem', color: 'var(--color-text-subtle)' }}>
               {t('traceroute_history.showing_count', { count: filteredTraceroutes.length })}
               {!showFailedTraceroutes && traceroutes.length > filteredTraceroutes.length && (
                 <span> {t('traceroute_history.failed_hidden', { count: traceroutes.length - filteredTraceroutes.length })}</span>
@@ -166,32 +166,32 @@ const TracerouteHistoryModal: React.FC<TracerouteHistoryModalProps> = ({
                   style={{
                     marginBottom: '1.5rem',
                     padding: '1rem',
-                    background: 'var(--ctp-surface0)',
-                    border: '1px solid var(--ctp-surface2)',
+                    background: 'var(--color-surface)',
+                    border: '1px solid var(--color-surface-active)',
                     borderRadius: '8px',
                   }}
                 >
                   <div style={{ marginBottom: '0.75rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                     <div>
                       <strong>#{filteredTraceroutes.length - index}</strong>
-                      <span style={{ marginLeft: '1rem', color: 'var(--ctp-subtext0)' }}>
+                      <span style={{ marginLeft: '1rem', color: 'var(--color-text-subtle)' }}>
                         {formatDateTime(new Date(tr.timestamp), timeFormat, dateFormat)}
                       </span>
                     </div>
-                    <span style={{ fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>
+                    <span style={{ fontSize: '0.9em', color: 'var(--color-text-subtle)' }}>
                       {ageStr}
                     </span>
                   </div>
 
                   <div style={{ marginBottom: '0.5rem' }}>
-                    <strong style={{ color: 'var(--ctp-green)' }}><UiIcon name="forward" size={14} /> {t('traceroute_history.forward')}:</strong>{' '}
+                    <strong style={{ color: 'var(--color-success)' }}><UiIcon name="forward" size={14} /> {t('traceroute_history.forward')}:</strong>{' '}
                     <span style={{ fontFamily: 'monospace', fontSize: '0.95em' }}>
                       {formatTracerouteRoute(tr.route, tr.snrTowards, tr.fromNodeNum, tr.toNodeNum, nodes, distanceUnit)}
                     </span>
                   </div>
 
                   <div>
-                    <strong style={{ color: 'var(--ctp-yellow)' }}><UiIcon name="back" size={14} /> {t('traceroute_history.return')}:</strong>{' '}
+                    <strong style={{ color: 'var(--color-warning)' }}><UiIcon name="back" size={14} /> {t('traceroute_history.return')}:</strong>{' '}
                     <span style={{ fontFamily: 'monospace', fontSize: '0.95em' }}>
                       {formatTracerouteRoute(tr.routeBack, tr.snrBack, tr.toNodeNum, tr.fromNodeNum, nodes, distanceUnit)}
                     </span>

--- a/src/components/UsersTab.tsx
+++ b/src/components/UsersTab.tsx
@@ -722,7 +722,7 @@ const UsersTab: React.FC = () => {
                 <div>
                   @{selectedUser.username}
                   {selectedUser.username === 'anonymous' && (
-                    <span style={{ marginLeft: '8px', padding: '2px 6px', background: 'var(--ctp-surface2)', borderRadius: '4px', fontSize: '0.8em', color: 'var(--ctp-subtext0)' }}>
+                    <span style={{ marginLeft: '8px', padding: '2px 6px', background: 'var(--color-surface-active)', borderRadius: '4px', fontSize: '0.8em', color: 'var(--color-text-subtle)' }}>
                       {t('users.special_user')}
                     </span>
                   )}
@@ -733,7 +733,7 @@ const UsersTab: React.FC = () => {
                 <div>
                   {selectedUser.displayName || '-'}
                   {selectedUser.username === 'anonymous' && (
-                    <div style={{ marginTop: '4px', fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>
+                    <div style={{ marginTop: '4px', fontSize: '0.9em', color: 'var(--color-text-subtle)' }}>
                       <UiIcon name="info" /> {t('users.anonymous_hint')}
                     </div>
                   )}
@@ -792,7 +792,7 @@ const UsersTab: React.FC = () => {
                 className="button button-secondary"
                 onClick={() => handleDeactivateUser(selectedUser)}
                 disabled={selectedUser.id === authStatus.user?.id || selectedUser.username === 'anonymous'}
-                style={{ color: 'var(--ctp-red)' }}
+                style={{ color: 'var(--color-error)' }}
                 title={selectedUser.username === 'anonymous' ? t('users.cannot_deactivate_anonymous') : ''}
               >
                 {t('users.deactivate_user')}
@@ -801,7 +801,7 @@ const UsersTab: React.FC = () => {
                 className="button button-secondary"
                 onClick={() => handlePermanentDeleteUser(selectedUser)}
                 disabled={selectedUser.id === authStatus.user?.id || selectedUser.username === 'anonymous'}
-                style={{ color: 'var(--ctp-red)', backgroundColor: 'var(--ctp-surface0)' }}
+                style={{ color: 'var(--color-error)', backgroundColor: 'var(--color-surface)' }}
                 title={selectedUser.username === 'anonymous' ? t('users.cannot_delete_anonymous') : t('users.permanently_delete_hint')}
               >
                 {t('users.permanently_delete')}
@@ -928,9 +928,9 @@ const UsersTab: React.FC = () => {
                     style={{
                       margin: '8px 0 12px',
                       padding: '8px 12px',
-                      background: 'var(--ctp-surface0)',
-                      color: 'var(--ctp-text)',
-                      borderLeft: '3px solid var(--ctp-blue)',
+                      background: 'var(--color-surface)',
+                      color: 'var(--color-text)',
+                      borderLeft: '3px solid var(--color-accent)',
                       borderRadius: '4px',
                       fontSize: '0.9em',
                     }}
@@ -1393,7 +1393,7 @@ const UsersTab: React.FC = () => {
 
             <div className="modal-body">
               <p><Trans i18nKey="users.deactivate_confirm_text" values={{ username: userToDeactivate.username }} components={{ strong: <strong /> }} /></p>
-              <p style={{ color: 'var(--ctp-red)', marginTop: '1rem' }}>
+              <p style={{ color: 'var(--color-error)', marginTop: '1rem' }}>
                 {t('users.deactivate_warning')}
               </p>
 
@@ -1410,7 +1410,7 @@ const UsersTab: React.FC = () => {
                 <button
                   className="button button-primary"
                   onClick={confirmDeactivateUser}
-                  style={{ backgroundColor: 'var(--ctp-red)', borderColor: 'var(--ctp-red)' }}
+                  style={{ backgroundColor: 'var(--color-error)', borderColor: 'var(--color-error)' }}
                 >
                   {t('users.deactivate_user')}
                 </button>
@@ -1431,10 +1431,10 @@ const UsersTab: React.FC = () => {
 
             <div className="modal-body">
               <p><Trans i18nKey="users.permanent_delete_confirm_text" values={{ username: userToPermanentlyDelete.username }} components={{ strong: <strong /> }} /></p>
-              <p style={{ color: 'var(--ctp-red)', marginTop: '1rem', fontWeight: 'bold' }}>
+              <p style={{ color: 'var(--color-error)', marginTop: '1rem', fontWeight: 'bold' }}>
                 {t('users.permanent_delete_warning')}
               </p>
-              <p style={{ marginTop: '0.5rem', fontSize: '0.9em', color: 'var(--ctp-subtext0)' }}>
+              <p style={{ marginTop: '0.5rem', fontSize: '0.9em', color: 'var(--color-text-subtle)' }}>
                 {t('users.permanent_delete_details')}
               </p>
 
@@ -1451,7 +1451,7 @@ const UsersTab: React.FC = () => {
                 <button
                   className="button button-primary"
                   onClick={confirmPermanentDeleteUser}
-                  style={{ backgroundColor: 'var(--ctp-red)', borderColor: 'var(--ctp-red)' }}
+                  style={{ backgroundColor: 'var(--color-error)', borderColor: 'var(--color-error)' }}
                 >
                   {t('users.permanently_delete')}
                 </button>

--- a/src/components/admin-commands/AutoFavoriteManagementSection.tsx
+++ b/src/components/admin-commands/AutoFavoriteManagementSection.tsx
@@ -174,9 +174,9 @@ const AutoFavoriteManagementSection: React.FC<AutoFavoriteManagementSectionProps
     let color: string;
     let label: string;
     let icon: UiIconName;
-    if (status === 'confirmed') { color = 'var(--ctp-green)'; icon = 'check'; label = t('auto_favorite.ack_confirmed', 'confirmed'); }
-    else if (status === 'timeout') { color = 'var(--ctp-yellow)'; icon = 'timer'; label = t('auto_favorite.ack_timeout', 'no ack'); }
-    else { color = 'var(--ctp-red)'; icon = 'error'; label = status; }
+    if (status === 'confirmed') { color = 'var(--color-success)'; icon = 'check'; label = t('auto_favorite.ack_confirmed', 'confirmed'); }
+    else if (status === 'timeout') { color = 'var(--color-warning)'; icon = 'timer'; label = t('auto_favorite.ack_timeout', 'no ack'); }
+    else { color = 'var(--color-error)'; icon = 'error'; label = status; }
     return (
       <span title={t('auto_favorite.ack_tooltip', 'Result of the last favorite command’s routing ACK')}
         style={{ color, fontSize: '0.75rem', fontWeight: 600, whiteSpace: 'nowrap' }}>
@@ -228,18 +228,18 @@ const AutoFavoriteManagementSection: React.FC<AutoFavoriteManagementSectionProps
     <div id="admin-auto-favorites" className="settings-section">
       <h3><UiIcon name="favorite" /> {t('auto_favorite.title', 'Automatic Favorites Management')}</h3>
 
-      <p style={{ color: 'var(--ctp-subtext0)', marginBottom: '0.75rem' }}>
+      <p style={{ color: 'var(--color-text-subtle)', marginBottom: '0.75rem' }}>
         {t('auto_favorite.description',
           'Automatically keep the favorites list up to date on this remote node. MeshMonitor discovers the node’s neighbors (from NeighborInfo broadcasts and/or traceroutes that pass through it) and sends set-favorite commands via Remote Admin, preserving zero-hop routing as your mesh changes.')}
       </p>
 
       <div style={{
-        border: '1px solid var(--ctp-surface2)',
-        background: 'var(--ctp-mantle)',
+        border: '1px solid var(--color-surface-active)',
+        background: 'var(--color-bg-raised)',
         borderRadius: '8px',
         padding: '0.75rem 1rem',
         marginBottom: '1.25rem',
-        color: 'var(--ctp-subtext1)',
+        color: 'var(--color-text-muted)',
         fontSize: '0.9rem',
         lineHeight: 1.5,
       }}>
@@ -257,11 +257,11 @@ const AutoFavoriteManagementSection: React.FC<AutoFavoriteManagementSectionProps
       </div>
 
       {selectedNodeNum === null || !sourceId ? (
-        <p style={{ color: 'var(--ctp-subtext0)' }}>
+        <p style={{ color: 'var(--color-text-subtle)' }}>
           {t('auto_favorite.select_target', 'Select a target node above to configure automatic favorites management.')}
         </p>
       ) : isLoading || !config ? (
-        <p style={{ color: 'var(--ctp-subtext0)' }}>{t('auto_favorite.loading', 'Loading…')}</p>
+        <p style={{ color: 'var(--color-text-subtle)' }}>{t('auto_favorite.loading', 'Loading…')}</p>
       ) : (
         <>
           {checkboxRow(
@@ -271,7 +271,7 @@ const AutoFavoriteManagementSection: React.FC<AutoFavoriteManagementSectionProps
             (v) => update({ enabled: v })
           )}
 
-          <h4 style={{ marginTop: '1.25rem', marginBottom: '0.5rem', color: 'var(--ctp-text)' }}>
+          <h4 style={{ marginTop: '1.25rem', marginBottom: '0.5rem', color: 'var(--color-text)' }}>
             {t('auto_favorite.discovery_modes', 'Discovery modes')}
           </h4>
           {checkboxRow(
@@ -293,7 +293,7 @@ const AutoFavoriteManagementSection: React.FC<AutoFavoriteManagementSectionProps
             (v) => update({ useTraceroutes: v })
           )}
 
-          <h4 style={{ marginTop: '1.25rem', marginBottom: '0.5rem', color: 'var(--ctp-text)' }}>
+          <h4 style={{ marginTop: '1.25rem', marginBottom: '0.5rem', color: 'var(--color-text)' }}>
             {t('auto_favorite.timing_limits', 'Timing & limits')}
           </h4>
           {numberRow(
@@ -315,7 +315,7 @@ const AutoFavoriteManagementSection: React.FC<AutoFavoriteManagementSectionProps
             (v) => update({ maxRefavoritePerCycle: v })
           )}
 
-          <h4 style={{ marginTop: '1.25rem', marginBottom: '0.5rem', color: 'var(--ctp-text)' }}>
+          <h4 style={{ marginTop: '1.25rem', marginBottom: '0.5rem', color: 'var(--color-text)' }}>
             {t('auto_favorite.eligible_roles', 'Eligible neighbor roles')}
           </h4>
           <p className="setting-description" style={{ marginTop: 0 }}>
@@ -334,7 +334,7 @@ const AutoFavoriteManagementSection: React.FC<AutoFavoriteManagementSectionProps
             ))}
           </div>
 
-          <h4 style={{ marginTop: '1.25rem', marginBottom: '0.5rem', color: 'var(--ctp-text)' }}>
+          <h4 style={{ marginTop: '1.25rem', marginBottom: '0.5rem', color: 'var(--color-text)' }}>
             {t('auto_favorite.status', 'Status')}
           </h4>
           <div className="setting-description" style={{ marginBottom: '0.75rem' }}>
@@ -346,7 +346,7 @@ const AutoFavoriteManagementSection: React.FC<AutoFavoriteManagementSectionProps
             <div style={{
               maxHeight: '180px',
               overflowY: 'auto',
-              border: '1px solid var(--ctp-surface1)',
+              border: '1px solid var(--color-surface-hover)',
               borderRadius: '6px',
               marginBottom: '1rem',
             }}>
@@ -355,13 +355,13 @@ const AutoFavoriteManagementSection: React.FC<AutoFavoriteManagementSectionProps
                   display: 'flex',
                   justifyContent: 'space-between',
                   padding: '0.4rem 0.75rem',
-                  borderBottom: '1px solid var(--ctp-surface0)',
+                  borderBottom: '1px solid var(--color-surface)',
                   fontSize: '0.85rem',
                 }}>
                   <span>{nodeLabel(a.favoriteNodeNum)}</span>
                   <span style={{ display: 'flex', gap: '0.6rem', alignItems: 'center' }}>
                     {ackBadge(a.lastAckStatus)}
-                    <span style={{ color: 'var(--ctp-subtext0)' }}>
+                    <span style={{ color: 'var(--color-text-subtle)' }}>
                       {t('auto_favorite.last_sent', 'last sent')}: {formatTime(a.lastAssignedAt)}
                     </span>
                   </span>

--- a/src/components/admin-commands/CollapsibleSection.tsx
+++ b/src/components/admin-commands/CollapsibleSection.tsx
@@ -36,27 +36,27 @@ const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
           alignItems: 'center',
           justifyContent: 'space-between',
           padding: '0.75rem 1rem',
-          backgroundColor: nested ? 'var(--ctp-surface0)' : 'var(--ctp-mantle)',
+          backgroundColor: nested ? 'var(--color-surface)' : 'var(--color-bg-raised)',
           borderRadius: '8px',
           cursor: 'pointer',
           userSelect: 'none',
           marginBottom: expanded ? '0.5rem' : '0',
           transition: 'background-color 0.2s',
-          border: `1px solid ${nested ? 'var(--ctp-surface1)' : 'var(--ctp-surface2)'}`,
+          border: `1px solid ${nested ? 'var(--color-surface-hover)' : 'var(--color-surface-active)'}`,
           paddingLeft: nested ? '2rem' : '1rem',
         }}
         onMouseEnter={(e) => {
-          e.currentTarget.style.backgroundColor = nested ? 'var(--ctp-surface1)' : 'var(--ctp-surface0)';
+          e.currentTarget.style.backgroundColor = nested ? 'var(--color-surface-hover)' : 'var(--color-surface)';
         }}
         onMouseLeave={(e) => {
-          e.currentTarget.style.backgroundColor = nested ? 'var(--ctp-surface0)' : 'var(--ctp-mantle)';
+          e.currentTarget.style.backgroundColor = nested ? 'var(--color-surface)' : 'var(--color-bg-raised)';
         }}
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flex: 1 }}>
           <span style={{ fontSize: '0.875rem', transition: 'transform 0.2s', transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)' }}>
             <UiIcon name="forward" size={15} />
           </span>
-          <h3 style={{ margin: 0, fontSize: nested ? '0.95rem' : '1rem', fontWeight: nested ? 500 : 600, color: 'var(--ctp-text)' }}>
+          <h3 style={{ margin: 0, fontSize: nested ? '0.95rem' : '1rem', fontWeight: nested ? 500 : 600, color: 'var(--color-text)' }}>
             {title}
           </h3>
         </div>

--- a/src/components/admin-commands/DeviceConfigurationSection.tsx
+++ b/src/components/admin-commands/DeviceConfigurationSection.tsx
@@ -294,13 +294,13 @@ export const DeviceConfigurationSection: React.FC<DeviceConfigurationSectionProp
               }}
             >
               <div style={{ flex: 1 }}>
-                <div style={{ fontWeight: 'bold', fontSize: '1.1em', color: 'var(--ctp-text)', marginBottom: '0.5rem' }}>
+                <div style={{ fontWeight: 'bold', fontSize: '1.1em', color: 'var(--color-text)', marginBottom: '0.5rem' }}>
                   {ROLE_OPTIONS.find(opt => opt.value === deviceRole)?.name || 'CLIENT'}
                 </div>
-                <div style={{ fontSize: '0.9em', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem', lineHeight: '1.4' }}>
+                <div style={{ fontSize: '0.9em', color: 'var(--color-text-subtle)', marginBottom: '0.25rem', lineHeight: '1.4' }}>
                   {ROLE_OPTIONS.find(opt => opt.value === deviceRole)?.shortDesc || ''}
                 </div>
-                <div style={{ fontSize: '0.85em', color: 'var(--ctp-subtext1)', fontStyle: 'italic', lineHeight: '1.4' }}>
+                <div style={{ fontSize: '0.85em', color: 'var(--color-text-muted)', fontStyle: 'italic', lineHeight: '1.4' }}>
                   {ROLE_OPTIONS.find(opt => opt.value === deviceRole)?.description || ''}
                 </div>
               </div>
@@ -315,8 +315,8 @@ export const DeviceConfigurationSection: React.FC<DeviceConfigurationSectionProp
                   left: 0,
                   width: '100%',
                   maxWidth: '800px',
-                  background: 'var(--ctp-base)',
-                  border: '2px solid var(--ctp-surface2)',
+                  background: 'var(--color-bg)',
+                  border: '2px solid var(--color-surface-active)',
                   borderRadius: '8px',
                   maxHeight: '500px',
                   overflowY: 'auto',
@@ -331,13 +331,13 @@ export const DeviceConfigurationSection: React.FC<DeviceConfigurationSectionProp
                     style={{
                       padding: '0.75rem 1rem',
                       cursor: 'pointer',
-                      borderBottom: '1px solid var(--ctp-surface1)',
-                      background: option.value === deviceRole ? 'var(--ctp-surface0)' : 'transparent',
+                      borderBottom: '1px solid var(--color-surface-hover)',
+                      background: option.value === deviceRole ? 'var(--color-surface)' : 'transparent',
                       transition: 'background 0.2s'
                     }}
                     onMouseEnter={(e) => {
                       if (option.value !== deviceRole) {
-                        e.currentTarget.style.background = 'var(--ctp-surface0)';
+                        e.currentTarget.style.background = 'var(--color-surface)';
                       }
                     }}
                     onMouseLeave={(e) => {
@@ -346,13 +346,13 @@ export const DeviceConfigurationSection: React.FC<DeviceConfigurationSectionProp
                       }
                     }}
                   >
-                    <div style={{ fontWeight: 'bold', fontSize: '1em', color: 'var(--ctp-text)', marginBottom: '0.4rem' }}>
+                    <div style={{ fontWeight: 'bold', fontSize: '1em', color: 'var(--color-text)', marginBottom: '0.4rem' }}>
                       {option.name}
                     </div>
-                    <div style={{ fontSize: '0.9em', color: 'var(--ctp-subtext0)', marginBottom: '0.3rem', lineHeight: '1.4' }}>
+                    <div style={{ fontSize: '0.9em', color: 'var(--color-text-subtle)', marginBottom: '0.3rem', lineHeight: '1.4' }}>
                       {option.shortDesc}
                     </div>
-                    <div style={{ fontSize: '0.85em', color: 'var(--ctp-subtext1)', fontStyle: 'italic', lineHeight: '1.4' }}>
+                    <div style={{ fontSize: '0.85em', color: 'var(--color-text-muted)', fontStyle: 'italic', lineHeight: '1.4' }}>
                       {option.description}
                     </div>
                   </div>
@@ -368,10 +368,10 @@ export const DeviceConfigurationSection: React.FC<DeviceConfigurationSectionProp
                 marginTop: '0.75rem',
                 padding: '0.75rem 1rem',
                 background: 'var(--ctp-yellow-soft, rgba(249, 226, 175, 0.15))',
-                border: '1px solid var(--ctp-yellow, #f9e2af)',
-                borderLeft: '4px solid var(--ctp-yellow, #f9e2af)',
+                border: '1px solid var(--color-warning, #f9e2af)',
+                borderLeft: '4px solid var(--color-warning, #f9e2af)',
                 borderRadius: '6px',
-                color: 'var(--ctp-text)',
+                color: 'var(--color-text)',
                 fontSize: '0.9em',
                 lineHeight: '1.5',
                 display: 'flex',
@@ -1096,10 +1096,10 @@ export const DeviceConfigurationSection: React.FC<DeviceConfigurationSectionProp
               <div style={{
                 marginLeft: '1rem',
                 paddingLeft: '1rem',
-                borderLeft: '2px solid var(--ctp-surface2)',
+                borderLeft: '2px solid var(--color-surface-active)',
                 marginTop: '1rem'
               }}>
-                <h4 style={{ marginBottom: '1rem', color: 'var(--ctp-subtext0)' }}>
+                <h4 style={{ marginBottom: '1rem', color: 'var(--color-text-subtle)' }}>
                   {t('admin_commands.static_ip_settings', 'Static IP Settings')}
                 </h4>
 

--- a/src/components/admin-commands/ModuleConfigurationSection.tsx
+++ b/src/components/admin-commands/ModuleConfigurationSection.tsx
@@ -359,7 +359,7 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
         headerActions={telemetryHeaderActions}
       >
         {/* Device Telemetry */}
-        <h4 style={{ margin: '0.5rem 0 0.75rem', color: 'var(--ctp-subtext0)' }}>
+        <h4 style={{ margin: '0.5rem 0 0.75rem', color: 'var(--color-text-subtle)' }}>
           {t('telemetry_config.device_section', 'Device Telemetry')}
         </h4>
         <div className="setting-item">
@@ -397,7 +397,7 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
         )}
 
         {/* Environment Telemetry */}
-        <h4 style={{ margin: '1rem 0 0.75rem', color: 'var(--ctp-subtext0)' }}>
+        <h4 style={{ margin: '1rem 0 0.75rem', color: 'var(--color-text-subtle)' }}>
           {t('telemetry_config.environment_section', 'Environment Telemetry')}
         </h4>
         <div className="setting-item">
@@ -473,7 +473,7 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
           nested={true}
         >
           {/* Air Quality */}
-          <h4 style={{ margin: '0.5rem 0 0.75rem', color: 'var(--ctp-subtext0)' }}>
+          <h4 style={{ margin: '0.5rem 0 0.75rem', color: 'var(--color-text-subtle)' }}>
             {t('telemetry_config.air_quality_section', 'Air Quality Metrics')}
           </h4>
           <div className="setting-item">
@@ -511,7 +511,7 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
           )}
 
           {/* Power Metrics */}
-          <h4 style={{ margin: '1rem 0 0.75rem', color: 'var(--ctp-subtext0)' }}>
+          <h4 style={{ margin: '1rem 0 0.75rem', color: 'var(--color-text-subtle)' }}>
             {t('telemetry_config.power_section', 'Power Metrics')}
           </h4>
           <div className="setting-item">
@@ -566,7 +566,7 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
           )}
 
           {/* Health Metrics */}
-          <h4 style={{ margin: '1rem 0 0.75rem', color: 'var(--ctp-subtext0)' }}>
+          <h4 style={{ margin: '1rem 0 0.75rem', color: 'var(--color-text-subtle)' }}>
             {t('telemetry_config.health_section', 'Health Metrics')}
           </h4>
           <div className="setting-item">
@@ -645,9 +645,9 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
         {statusMessageIsDisabled && (
           <div style={{
             padding: '1rem',
-            backgroundColor: 'var(--ctp-surface0)',
+            backgroundColor: 'var(--color-surface)',
             borderRadius: '0.5rem',
-            color: 'var(--ctp-subtext0)',
+            color: 'var(--color-text-subtle)',
             fontStyle: 'italic',
             marginBottom: '1rem'
           }}>
@@ -677,7 +677,7 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
                 right: '0.5rem',
                 bottom: '-1.2rem',
                 fontSize: '0.75rem',
-                color: statusMessageNodeStatus.length >= 70 ? 'var(--ctp-peach)' : 'var(--ctp-subtext0)'
+                color: statusMessageNodeStatus.length >= 70 ? 'var(--color-caution)' : 'var(--color-text-subtle)'
               }}>
                 {statusMessageNodeStatus.length}/80
               </span>
@@ -708,9 +708,9 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
         {trafficManagementIsDisabled && (
           <div style={{
             padding: '1rem',
-            backgroundColor: 'var(--ctp-surface0)',
+            backgroundColor: 'var(--color-surface)',
             borderRadius: '0.5rem',
-            color: 'var(--ctp-subtext0)',
+            color: 'var(--color-text-subtle)',
             fontStyle: 'italic',
             marginBottom: '1rem'
           }}>
@@ -737,8 +737,8 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
           {(trafficManagementEnabled || trafficManagementIsDisabled) && (
             <>
               {/* Position Dedup */}
-              <div style={{ marginLeft: '1rem', paddingLeft: '1rem', borderLeft: '2px solid var(--ctp-surface1)', marginBottom: '0.5rem' }}>
-                <div style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--ctp-text)', marginBottom: '0.5rem' }}>{t('trafficmanagement_config.position_dedup', 'Position Deduplication')}</div>
+              <div style={{ marginLeft: '1rem', paddingLeft: '1rem', borderLeft: '2px solid var(--color-surface-hover)', marginBottom: '0.5rem' }}>
+                <div style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--color-text)', marginBottom: '0.5rem' }}>{t('trafficmanagement_config.position_dedup', 'Position Deduplication')}</div>
                 <div className="setting-item">
                   <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
                     <input type="checkbox" checked={trafficManagementPositionDedupEnabled} onChange={(e) => onTrafficManagementConfigChange('positionDedupEnabled', e.target.checked)} disabled={isExecuting || trafficManagementIsDisabled} style={{ width: 'auto', margin: 0, flexShrink: 0 }} />
@@ -762,8 +762,8 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
               </div>
 
               {/* NodeInfo Direct Response */}
-              <div style={{ marginLeft: '1rem', paddingLeft: '1rem', borderLeft: '2px solid var(--ctp-surface1)', marginBottom: '0.5rem' }}>
-                <div style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--ctp-text)', marginBottom: '0.5rem' }}>{t('trafficmanagement_config.nodeinfo_direct_response', 'NodeInfo Direct Response')}</div>
+              <div style={{ marginLeft: '1rem', paddingLeft: '1rem', borderLeft: '2px solid var(--color-surface-hover)', marginBottom: '0.5rem' }}>
+                <div style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--color-text)', marginBottom: '0.5rem' }}>{t('trafficmanagement_config.nodeinfo_direct_response', 'NodeInfo Direct Response')}</div>
                 <div className="setting-item">
                   <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
                     <input type="checkbox" checked={trafficManagementNodeinfoDirectResponse} onChange={(e) => onTrafficManagementConfigChange('nodeinfoDirectResponse', e.target.checked)} disabled={isExecuting || trafficManagementIsDisabled} style={{ width: 'auto', margin: 0, flexShrink: 0 }} />
@@ -780,8 +780,8 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
               </div>
 
               {/* Rate Limiting */}
-              <div style={{ marginLeft: '1rem', paddingLeft: '1rem', borderLeft: '2px solid var(--ctp-surface1)', marginBottom: '0.5rem' }}>
-                <div style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--ctp-text)', marginBottom: '0.5rem' }}>{t('trafficmanagement_config.rate_limiting', 'Rate Limiting')}</div>
+              <div style={{ marginLeft: '1rem', paddingLeft: '1rem', borderLeft: '2px solid var(--color-surface-hover)', marginBottom: '0.5rem' }}>
+                <div style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--color-text)', marginBottom: '0.5rem' }}>{t('trafficmanagement_config.rate_limiting', 'Rate Limiting')}</div>
                 <div className="setting-item">
                   <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
                     <input type="checkbox" checked={trafficManagementRateLimitEnabled} onChange={(e) => onTrafficManagementConfigChange('rateLimitEnabled', e.target.checked)} disabled={isExecuting || trafficManagementIsDisabled} style={{ width: 'auto', margin: 0, flexShrink: 0 }} />
@@ -803,8 +803,8 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
               </div>
 
               {/* Drop Unknown */}
-              <div style={{ marginLeft: '1rem', paddingLeft: '1rem', borderLeft: '2px solid var(--ctp-surface1)', marginBottom: '0.5rem' }}>
-                <div style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--ctp-text)', marginBottom: '0.5rem' }}>{t('trafficmanagement_config.drop_unknown', 'Drop Unknown Packets')}</div>
+              <div style={{ marginLeft: '1rem', paddingLeft: '1rem', borderLeft: '2px solid var(--color-surface-hover)', marginBottom: '0.5rem' }}>
+                <div style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--color-text)', marginBottom: '0.5rem' }}>{t('trafficmanagement_config.drop_unknown', 'Drop Unknown Packets')}</div>
                 <div className="setting-item">
                   <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
                     <input type="checkbox" checked={trafficManagementDropUnknownEnabled} onChange={(e) => onTrafficManagementConfigChange('dropUnknownEnabled', e.target.checked)} disabled={isExecuting || trafficManagementIsDisabled} style={{ width: 'auto', margin: 0, flexShrink: 0 }} />
@@ -821,8 +821,8 @@ export const ModuleConfigurationSection: React.FC<ModuleConfigurationSectionProp
               </div>
 
               {/* Hop Limit Exhaustion */}
-              <div style={{ marginLeft: '1rem', paddingLeft: '1rem', borderLeft: '2px solid var(--ctp-surface1)', marginBottom: '0.5rem' }}>
-                <div style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--ctp-text)', marginBottom: '0.5rem' }}>{t('trafficmanagement_config.hop_exhaustion', 'Hop Limit Exhaustion')}</div>
+              <div style={{ marginLeft: '1rem', paddingLeft: '1rem', borderLeft: '2px solid var(--color-surface-hover)', marginBottom: '0.5rem' }}>
+                <div style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--color-text)', marginBottom: '0.5rem' }}>{t('trafficmanagement_config.hop_exhaustion', 'Hop Limit Exhaustion')}</div>
                 <div className="setting-item">
                   <label style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
                     <input type="checkbox" checked={trafficManagementExhaustHopTelemetry} onChange={(e) => onTrafficManagementConfigChange('exhaustHopTelemetry', e.target.checked)} disabled={isExecuting || trafficManagementIsDisabled} style={{ width: 'auto', margin: 0, flexShrink: 0 }} />

--- a/src/components/admin-commands/RadioConfigurationSection.tsx
+++ b/src/components/admin-commands/RadioConfigurationSection.tsx
@@ -233,10 +233,10 @@ export const RadioConfigurationSection: React.FC<RadioConfigurationSectionProps>
               style={{
                 marginTop: '0.5rem',
                 padding: '0.6rem 0.75rem',
-                border: '1px solid var(--ctp-yellow)',
+                border: '1px solid var(--color-warning)',
                 borderRadius: '4px',
                 backgroundColor: 'rgba(249, 226, 175, 0.12)',
-                color: 'var(--ctp-yellow)',
+                color: 'var(--color-warning)',
                 lineHeight: '1.4'
               }}
             >
@@ -370,8 +370,8 @@ export const RadioConfigurationSection: React.FC<RadioConfigurationSectionProps>
                   disabled={isExecuting}
                   style={{
                     padding: '0.5rem 1rem',
-                    backgroundColor: 'var(--ctp-red)',
-                    color: 'var(--ctp-base)',
+                    backgroundColor: 'var(--color-error)',
+                    color: 'var(--color-bg)',
                     border: 'none',
                     borderRadius: '4px',
                     cursor: isExecuting ? 'not-allowed' : 'pointer',
@@ -484,29 +484,29 @@ export const RadioConfigurationSection: React.FC<RadioConfigurationSectionProps>
                 key={index}
                 style={{
                   border: channel?.role === 1
-                    ? '2px solid var(--ctp-blue)'
-                    : '1px solid var(--ctp-surface1)',
+                    ? '2px solid var(--color-accent)'
+                    : '1px solid var(--color-surface-hover)',
                   borderRadius: '8px',
                   padding: '1rem',
-                  backgroundColor: channel ? 'var(--ctp-surface0)' : 'var(--ctp-mantle)',
+                  backgroundColor: channel ? 'var(--color-surface)' : 'var(--color-bg-raised)',
                   opacity: channel?.role === 0 ? 0.5 : 1,
                   boxShadow: channel?.role === 1 ? '0 0 10px rgba(137, 180, 250, 0.3)' : 'none'
                 }}
               >
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '0.75rem' }}>
                   <div>
-                    <h4 style={{ margin: 0, color: 'var(--ctp-text)' }}>
+                    <h4 style={{ margin: 0, color: 'var(--color-text)' }}>
                       {t('admin_commands.channel_slot', { index })}: {channel ? (
                         <>
-                          {channel.name && channel.name.trim().length > 0 ? channel.name : <span style={{ color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>{t('admin_commands.unnamed')}</span>}
-                          {channel.role === 1 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-blue)', fontSize: '0.8rem' }}><UiIcon name="favorite" size={13} /> {t('admin_commands.primary')}</span>}
-                          {channel.role === 2 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-green)', fontSize: '0.8rem' }}><UiIcon name="statusOn" size={13} /> {t('admin_commands.secondary')}</span>}
-                          {channel.role === 0 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-overlay0)', fontSize: '0.8rem' }}><UiIcon name="blocked" size={13} /> {t('admin_commands.disabled')}</span>}
+                          {channel.name && channel.name.trim().length > 0 ? channel.name : <span style={{ color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>{t('admin_commands.unnamed')}</span>}
+                          {channel.role === 1 && <span style={{ marginLeft: '0.5rem', color: 'var(--color-accent)', fontSize: '0.8rem' }}><UiIcon name="favorite" size={13} /> {t('admin_commands.primary')}</span>}
+                          {channel.role === 2 && <span style={{ marginLeft: '0.5rem', color: 'var(--color-success)', fontSize: '0.8rem' }}><UiIcon name="statusOn" size={13} /> {t('admin_commands.secondary')}</span>}
+                          {channel.role === 0 && <span style={{ marginLeft: '0.5rem', color: 'var(--color-text-faint)', fontSize: '0.8rem' }}><UiIcon name="blocked" size={13} /> {t('admin_commands.disabled')}</span>}
                         </>
-                      ) : <span style={{ color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>{t('admin_commands.empty')}</span>}
+                      ) : <span style={{ color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>{t('admin_commands.empty')}</span>}
                     </h4>
                     {channel && (
-                      <div style={{ marginTop: '0.5rem', fontSize: '0.9rem', color: 'var(--ctp-subtext1)' }}>
+                      <div style={{ marginTop: '0.5rem', fontSize: '0.9rem', color: 'var(--color-text-muted)' }}>
                         <div><UiIcon name={channel.psk && channel.psk !== 'AQ==' ? 'encrypted' : 'unencrypted'} /> {channel.psk && channel.psk !== 'AQ==' ? t('admin_commands.encrypted') : t('admin_commands.unencrypted')}</div>
                         <div>
                           {channel.uplinkEnabled && <><UiIcon name="sortAscending" /> {t('admin_commands.uplink')} </>}
@@ -523,8 +523,8 @@ export const RadioConfigurationSection: React.FC<RadioConfigurationSectionProps>
                       style={{
                         padding: '0.5rem 0.75rem',
                         fontSize: '0.9rem',
-                        backgroundColor: 'var(--ctp-blue)',
-                        color: 'var(--ctp-base)',
+                        backgroundColor: 'var(--color-accent)',
+                        color: 'var(--color-bg)',
                         border: 'none',
                         borderRadius: '4px',
                         cursor: (isExecuting || selectedNodeNum === null) ? 'not-allowed' : 'pointer',
@@ -540,8 +540,8 @@ export const RadioConfigurationSection: React.FC<RadioConfigurationSectionProps>
                         style={{
                           padding: '0.5rem 0.75rem',
                           fontSize: '0.9rem',
-                          backgroundColor: 'var(--ctp-green)',
-                          color: 'var(--ctp-base)',
+                          backgroundColor: 'var(--color-success)',
+                          color: 'var(--color-bg)',
                           border: 'none',
                           borderRadius: '4px',
                           cursor: (isExecuting || selectedNodeNum === null) ? 'not-allowed' : 'pointer',
@@ -557,8 +557,8 @@ export const RadioConfigurationSection: React.FC<RadioConfigurationSectionProps>
                       style={{
                         padding: '0.5rem 0.75rem',
                         fontSize: '0.9rem',
-                        backgroundColor: 'var(--ctp-yellow)',
-                        color: 'var(--ctp-base)',
+                        backgroundColor: 'var(--color-warning)',
+                        color: 'var(--color-bg)',
                         border: 'none',
                         borderRadius: '4px',
                         cursor: (isExecuting || selectedNodeNum === null) ? 'not-allowed' : 'pointer',

--- a/src/components/auto-responder/PatternExamples.tsx
+++ b/src/components/auto-responder/PatternExamples.tsx
@@ -13,8 +13,8 @@ const PatternExamples: React.FC<PatternExamplesProps> = ({ onSelectPattern }) =>
       marginBottom: '1.5rem',
       marginLeft: '1.75rem',
       marginRight: '1.75rem',
-      background: 'var(--ctp-surface0)',
-      border: '1px solid var(--ctp-overlay0)',
+      background: 'var(--color-surface)',
+      border: '1px solid var(--color-border-subtle)',
       borderRadius: '6px',
       overflow: 'hidden'
     }}>
@@ -23,16 +23,16 @@ const PatternExamples: React.FC<PatternExamplesProps> = ({ onSelectPattern }) =>
         style={{
           width: '100%',
           padding: '0.75rem 1rem',
-          background: 'var(--ctp-surface1)',
+          background: 'var(--color-surface-hover)',
           border: 'none',
-          borderBottom: showExamples ? '1px solid var(--ctp-overlay0)' : 'none',
+          borderBottom: showExamples ? '1px solid var(--color-border-subtle)' : 'none',
           cursor: 'pointer',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
           fontSize: '0.9rem',
           fontWeight: 'bold',
-          color: 'var(--ctp-blue)'
+          color: 'var(--color-accent)'
         }}
       >
         <span><UiIcon name="sparkles" size={15} /> Pattern Examples & Templates</span>
@@ -42,7 +42,7 @@ const PatternExamples: React.FC<PatternExamplesProps> = ({ onSelectPattern }) =>
         <div style={{ padding: '1rem', fontSize: '0.85rem' }}>
           {/* Common Meshtastic Commands */}
           <div style={{ marginBottom: '1rem' }}>
-            <div style={{ fontWeight: 'bold', color: 'var(--ctp-blue)', marginBottom: '0.5rem', fontSize: '0.9rem' }}>
+            <div style={{ fontWeight: 'bold', color: 'var(--color-accent)', marginBottom: '0.5rem', fontSize: '0.9rem' }}>
               <UiIcon name="radio" size={15} /> Common Meshtastic Commands
             </div>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.5rem', marginBottom: '0.5rem' }}>
@@ -50,109 +50,109 @@ const PatternExamples: React.FC<PatternExamplesProps> = ({ onSelectPattern }) =>
                 onClick={() => onSelectPattern('weather, weather {location}, w {location}')}
                 style={{
                   padding: '0.4rem 0.6rem',
-                  background: 'var(--ctp-surface1)',
-                  border: '1px solid var(--ctp-overlay0)',
+                  background: 'var(--color-surface-hover)',
+                  border: '1px solid var(--color-border-subtle)',
                   borderRadius: '4px',
                   cursor: 'pointer',
                   textAlign: 'left',
                   fontFamily: 'monospace',
                   fontSize: '0.8rem',
-                  color: 'var(--ctp-text)',
+                  color: 'var(--color-text)',
                   transition: 'all 0.2s'
                 }}
                 onMouseEnter={(e) => {
-                  e.currentTarget.style.background = 'var(--ctp-surface2)';
-                  e.currentTarget.style.borderColor = 'var(--ctp-blue)';
+                  e.currentTarget.style.background = 'var(--color-surface-active)';
+                  e.currentTarget.style.borderColor = 'var(--color-accent)';
                 }}
                 onMouseLeave={(e) => {
-                  e.currentTarget.style.background = 'var(--ctp-surface1)';
-                  e.currentTarget.style.borderColor = 'var(--ctp-overlay0)';
+                  e.currentTarget.style.background = 'var(--color-surface-hover)';
+                  e.currentTarget.style.borderColor = 'var(--color-border-subtle)';
                 }}
                 title="Click to use this pattern"
               >
-                <code style={{ color: 'var(--ctp-blue)' }}>weather, weather {`{location}`}, w {`{location}`}</code>
-                <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginTop: '0.2rem' }}>Multi-pattern weather command</div>
+                <code style={{ color: 'var(--color-accent)' }}>weather, weather {`{location}`}, w {`{location}`}</code>
+                <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginTop: '0.2rem' }}>Multi-pattern weather command</div>
               </button>
               <button
                 onClick={() => onSelectPattern('status, status {nodeid}')}
                 style={{
                   padding: '0.4rem 0.6rem',
-                  background: 'var(--ctp-surface1)',
-                  border: '1px solid var(--ctp-overlay0)',
+                  background: 'var(--color-surface-hover)',
+                  border: '1px solid var(--color-border-subtle)',
                   borderRadius: '4px',
                   cursor: 'pointer',
                   textAlign: 'left',
                   fontFamily: 'monospace',
                   fontSize: '0.8rem',
-                  color: 'var(--ctp-text)',
+                  color: 'var(--color-text)',
                   transition: 'all 0.2s'
                 }}
                 onMouseEnter={(e) => {
-                  e.currentTarget.style.background = 'var(--ctp-surface2)';
-                  e.currentTarget.style.borderColor = 'var(--ctp-blue)';
+                  e.currentTarget.style.background = 'var(--color-surface-active)';
+                  e.currentTarget.style.borderColor = 'var(--color-accent)';
                 }}
                 onMouseLeave={(e) => {
-                  e.currentTarget.style.background = 'var(--ctp-surface1)';
-                  e.currentTarget.style.borderColor = 'var(--ctp-overlay0)';
+                  e.currentTarget.style.background = 'var(--color-surface-hover)';
+                  e.currentTarget.style.borderColor = 'var(--color-border-subtle)';
                 }}
                 title="Click to use this pattern"
               >
-                <code style={{ color: 'var(--ctp-blue)' }}>status, status {`{nodeid}`}</code>
-                <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginTop: '0.2rem' }}>Node status check</div>
+                <code style={{ color: 'var(--color-accent)' }}>status, status {`{nodeid}`}</code>
+                <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginTop: '0.2rem' }}>Node status check</div>
               </button>
               <button
                 onClick={() => onSelectPattern('ping')}
                 style={{
                   padding: '0.4rem 0.6rem',
-                  background: 'var(--ctp-surface1)',
-                  border: '1px solid var(--ctp-overlay0)',
+                  background: 'var(--color-surface-hover)',
+                  border: '1px solid var(--color-border-subtle)',
                   borderRadius: '4px',
                   cursor: 'pointer',
                   textAlign: 'left',
                   fontFamily: 'monospace',
                   fontSize: '0.8rem',
-                  color: 'var(--ctp-text)',
+                  color: 'var(--color-text)',
                   transition: 'all 0.2s'
                 }}
                 onMouseEnter={(e) => {
-                  e.currentTarget.style.background = 'var(--ctp-surface2)';
-                  e.currentTarget.style.borderColor = 'var(--ctp-blue)';
+                  e.currentTarget.style.background = 'var(--color-surface-active)';
+                  e.currentTarget.style.borderColor = 'var(--color-accent)';
                 }}
                 onMouseLeave={(e) => {
-                  e.currentTarget.style.background = 'var(--ctp-surface1)';
-                  e.currentTarget.style.borderColor = 'var(--ctp-overlay0)';
+                  e.currentTarget.style.background = 'var(--color-surface-hover)';
+                  e.currentTarget.style.borderColor = 'var(--color-border-subtle)';
                 }}
                 title="Click to use this pattern"
               >
-                <code style={{ color: 'var(--ctp-blue)' }}>ping</code>
-                <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginTop: '0.2rem' }}>Simple ping command</div>
+                <code style={{ color: 'var(--color-accent)' }}>ping</code>
+                <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginTop: '0.2rem' }}>Simple ping command</div>
               </button>
               <button
                 onClick={() => onSelectPattern('help, help {topic}')}
                 style={{
                   padding: '0.4rem 0.6rem',
-                  background: 'var(--ctp-surface1)',
-                  border: '1px solid var(--ctp-overlay0)',
+                  background: 'var(--color-surface-hover)',
+                  border: '1px solid var(--color-border-subtle)',
                   borderRadius: '4px',
                   cursor: 'pointer',
                   textAlign: 'left',
                   fontFamily: 'monospace',
                   fontSize: '0.8rem',
-                  color: 'var(--ctp-text)',
+                  color: 'var(--color-text)',
                   transition: 'all 0.2s'
                 }}
                 onMouseEnter={(e) => {
-                  e.currentTarget.style.background = 'var(--ctp-surface2)';
-                  e.currentTarget.style.borderColor = 'var(--ctp-blue)';
+                  e.currentTarget.style.background = 'var(--color-surface-active)';
+                  e.currentTarget.style.borderColor = 'var(--color-accent)';
                 }}
                 onMouseLeave={(e) => {
-                  e.currentTarget.style.background = 'var(--ctp-surface1)';
-                  e.currentTarget.style.borderColor = 'var(--ctp-overlay0)';
+                  e.currentTarget.style.background = 'var(--color-surface-hover)';
+                  e.currentTarget.style.borderColor = 'var(--color-border-subtle)';
                 }}
                 title="Click to use this pattern"
               >
-                <code style={{ color: 'var(--ctp-blue)' }}>help, help {`{topic}`}</code>
-                <div style={{ fontSize: '0.7rem', color: 'var(--ctp-subtext0)', marginTop: '0.2rem' }}>Help system</div>
+                <code style={{ color: 'var(--color-accent)' }}>help, help {`{topic}`}</code>
+                <div style={{ fontSize: '0.7rem', color: 'var(--color-text-subtle)', marginTop: '0.2rem' }}>Help system</div>
               </button>
             </div>
           </div>
@@ -160,31 +160,31 @@ const PatternExamples: React.FC<PatternExamplesProps> = ({ onSelectPattern }) =>
           {/* Regex Pattern Examples */}
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem', fontFamily: 'monospace' }}>
             <div>
-              <div style={{ fontWeight: 'bold', color: 'var(--ctp-mauve)', marginBottom: '0.5rem' }}>Node & Network Patterns</div>
+              <div style={{ fontWeight: 'bold', color: 'var(--color-accent-alt)', marginBottom: '0.5rem' }}>Node & Network Patterns</div>
               <div style={{ lineHeight: '1.8', fontSize: '0.8rem' }}>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('node {nodeid:![a-f0-9]+}')}
                     title="Click to use"
                   >node {`{nodeid:![a-f0-9]+}`}</code>
                   {' '}- Meshtastic node ID (e.g., !a1b2c3d4)
                 </div>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('node {nodenum:\\d+}')}
                     title="Click to use"
                   >node {`{nodenum:\\d+}`}</code>
                   {' '}- Node number (integer)
                 </div>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('channel {ch:\\d}')}
                     title="Click to use"
                   >channel {`{ch:\\d}`}</code>
                   {' '}- Channel number (0-7)
                 </div>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('temp {value:\\d+}')}
                     title="Click to use"
                   >temp {`{value:\\d+}`}</code>
@@ -193,31 +193,31 @@ const PatternExamples: React.FC<PatternExamplesProps> = ({ onSelectPattern }) =>
               </div>
             </div>
             <div>
-              <div style={{ fontWeight: 'bold', color: 'var(--ctp-mauve)', marginBottom: '0.5rem' }}>Location & Coordinates</div>
+              <div style={{ fontWeight: 'bold', color: 'var(--color-accent-alt)', marginBottom: '0.5rem' }}>Location & Coordinates</div>
               <div style={{ lineHeight: '1.8', fontSize: '0.8rem' }}>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('loc {lat:-?\\d+\\.?\\d*},{lon:-?\\d+\\.?\\d*}')}
                     title="Click to use"
                   >loc {`{lat:-?\\d+\\.?\\d*}`},{`{lon:-?\\d+\\.?\\d*}`}</code>
                   {' '}- Latitude/longitude
                 </div>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('grid {square:[A-R]{2}\\d{2}[a-x]{2}}')}
                     title="Click to use"
                   >grid {`{square:[A-R]{2}\\d{2}[a-x]{2}}`}</code>
                   {' '}- Maidenhead grid square
                 </div>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('zip {code:\\d{5}}')}
                     title="Click to use"
                   >zip {`{code:\\d{5}}`}</code>
                   {' '}- 5-digit zip code
                 </div>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('weather {location}')}
                     title="Click to use"
                   >weather {`{location}`}</code>
@@ -226,53 +226,53 @@ const PatternExamples: React.FC<PatternExamplesProps> = ({ onSelectPattern }) =>
               </div>
             </div>
             <div>
-              <div style={{ fontWeight: 'bold', color: 'var(--ctp-mauve)', marginBottom: '0.5rem' }}>Time & Date</div>
+              <div style={{ fontWeight: 'bold', color: 'var(--color-accent-alt)', marginBottom: '0.5rem' }}>Time & Date</div>
               <div style={{ lineHeight: '1.8', fontSize: '0.8rem' }}>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('time')}
                     title="Click to use - Scripts receive TZ env var for timezone-aware time"
                   >time</code>
                   {' '}- Current time (timezone-aware via TZ env var)
                 </div>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('date')}
                     title="Click to use"
                   >date</code>
                   {' '}- Current date (timezone-aware)
                 </div>
-                <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', marginTop: '0.3rem', fontStyle: 'italic' }}>
-                  <UiIcon name="info" size={13} /> Scripts can access <code style={{ background: 'var(--ctp-surface1)', padding: '1px 3px', borderRadius: '2px' }}>TZ</code> environment variable for server's configured timezone
+                <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', marginTop: '0.3rem', fontStyle: 'italic' }}>
+                  <UiIcon name="info" size={13} /> Scripts can access <code style={{ background: 'var(--color-surface-hover)', padding: '1px 3px', borderRadius: '2px' }}>TZ</code> environment variable for server's configured timezone
                 </div>
               </div>
             </div>
             <div>
-              <div style={{ fontWeight: 'bold', color: 'var(--ctp-mauve)', marginBottom: '0.5rem' }}>Text & Messages</div>
+              <div style={{ fontWeight: 'bold', color: 'var(--color-accent-alt)', marginBottom: '0.5rem' }}>Text & Messages</div>
               <div style={{ lineHeight: '1.8', fontSize: '0.8rem' }}>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('msg {text:[\\w\\s]+}')}
                     title="Click to use"
                   >msg {`{text:[\\w\\s]+}`}</code>
                   {' '}- Multiple words (letters, numbers, spaces)
                 </div>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('say {text:.+}')}
                     title="Click to use"
                   >say {`{text:.+}`}</code>
                   {' '}- Any text (including punctuation)
                 </div>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('alert {message}')}
                     title="Click to use"
                   >alert {`{message}`}</code>
                   {' '}- Alert message (default: single word)
                 </div>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('log {data:[a-zA-Z0-9]+}')}
                     title="Click to use"
                   >log {`{data:[a-zA-Z0-9]+}`}</code>
@@ -281,31 +281,31 @@ const PatternExamples: React.FC<PatternExamplesProps> = ({ onSelectPattern }) =>
               </div>
             </div>
             <div>
-              <div style={{ fontWeight: 'bold', color: 'var(--ctp-mauve)', marginBottom: '0.5rem' }}>Numeric & Data</div>
+              <div style={{ fontWeight: 'bold', color: 'var(--color-accent-alt)', marginBottom: '0.5rem' }}>Numeric & Data</div>
               <div style={{ lineHeight: '1.8', fontSize: '0.8rem' }}>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('set {value:-?\\d+}')}
                     title="Click to use"
                   >set {`{value:-?\\d+}`}</code>
                   {' '}- Positive/negative integer
                 </div>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('battery {level:\\d{1,3}}')}
                     title="Click to use"
                   >battery {`{level:\\d{1,3}}`}</code>
                   {' '}- Battery level (0-100)
                 </div>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('rssi {dbm:-?\\d+}')}
                     title="Click to use"
                   >rssi {`{dbm:-?\\d+}`}</code>
                   {' '}- RSSI value (can be negative)
                 </div>
                 <div>
-                  <code style={{ background: 'var(--ctp-surface2)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
+                  <code style={{ background: 'var(--color-surface-active)', padding: '2px 6px', borderRadius: '3px', cursor: 'pointer' }}
                     onClick={() => onSelectPattern('snr {value:-?\\d+}')}
                     title="Click to use"
                   >snr {`{value:-?\\d+}`}</code>
@@ -317,20 +317,20 @@ const PatternExamples: React.FC<PatternExamplesProps> = ({ onSelectPattern }) =>
           <div style={{
             marginTop: '1rem',
             paddingTop: '1rem',
-            borderTop: '1px solid var(--ctp-overlay0)',
-            color: 'var(--ctp-subtext0)',
+            borderTop: '1px solid var(--color-border-subtle)',
+            color: 'var(--color-text-subtle)',
             fontSize: '0.8rem',
             lineHeight: '1.6'
           }}>
             <strong><UiIcon name="info" size={13} /> Quick Tips:</strong><br/>
             • <strong>Click any pattern</strong> above to insert it into the trigger field<br/>
-            • Use <code style={{ background: 'var(--ctp-surface2)', padding: '2px 4px', borderRadius: '2px' }}>{`{param}`}</code> for default matching (single word, no spaces)<br/>
-            • Use <code style={{ background: 'var(--ctp-surface2)', padding: '2px 4px', borderRadius: '2px' }}>{`{param:regex}`}</code> for custom regex patterns<br/>
-            • Separate multiple patterns with commas: <code style={{ background: 'var(--ctp-surface2)', padding: '2px 4px', borderRadius: '2px' }}>pattern1, pattern2 {`{param}`}</code><br/>
-            • Default pattern <code style={{ background: 'var(--ctp-surface2)', padding: '2px 4px', borderRadius: '2px' }}>[^\\s]+</code> matches any single word (no spaces)<br/>
-            • Use <code style={{ background: 'var(--ctp-surface2)', padding: '2px 4px', borderRadius: '2px' }}>[\\w\\s]+</code> for multiple words with spaces<br/>
-            • Escape special regex characters: <code style={{ background: 'var(--ctp-surface2)', padding: '2px 4px', borderRadius: '2px' }}>\ . + * ? ^ $ {'{ }'} [ ] ( ) |</code><br/>
-            • <strong>Timezone Support:</strong> Scripts receive <code style={{ background: 'var(--ctp-surface2)', padding: '2px 4px', borderRadius: '2px' }}>TZ</code> environment variable for timezone-aware time (configure via <code style={{ background: 'var(--ctp-surface2)', padding: '2px 4px', borderRadius: '2px' }}>TZ=America/New_York</code> in docker-compose.yaml)
+            • Use <code style={{ background: 'var(--color-surface-active)', padding: '2px 4px', borderRadius: '2px' }}>{`{param}`}</code> for default matching (single word, no spaces)<br/>
+            • Use <code style={{ background: 'var(--color-surface-active)', padding: '2px 4px', borderRadius: '2px' }}>{`{param:regex}`}</code> for custom regex patterns<br/>
+            • Separate multiple patterns with commas: <code style={{ background: 'var(--color-surface-active)', padding: '2px 4px', borderRadius: '2px' }}>pattern1, pattern2 {`{param}`}</code><br/>
+            • Default pattern <code style={{ background: 'var(--color-surface-active)', padding: '2px 4px', borderRadius: '2px' }}>[^\\s]+</code> matches any single word (no spaces)<br/>
+            • Use <code style={{ background: 'var(--color-surface-active)', padding: '2px 4px', borderRadius: '2px' }}>[\\w\\s]+</code> for multiple words with spaces<br/>
+            • Escape special regex characters: <code style={{ background: 'var(--color-surface-active)', padding: '2px 4px', borderRadius: '2px' }}>\ . + * ? ^ $ {'{ }'} [ ] ( ) |</code><br/>
+            • <strong>Timezone Support:</strong> Scripts receive <code style={{ background: 'var(--color-surface-active)', padding: '2px 4px', borderRadius: '2px' }}>TZ</code> environment variable for timezone-aware time (configure via <code style={{ background: 'var(--color-surface-active)', padding: '2px 4px', borderRadius: '2px' }}>TZ=America/New_York</code> in docker-compose.yaml)
           </div>
         </div>
       )}

--- a/src/components/auto-responder/ScriptDependenciesPanel.tsx
+++ b/src/components/auto-responder/ScriptDependenciesPanel.tsx
@@ -34,7 +34,7 @@ const KindRow: React.FC<{ title: string; manifest: string; status: KindStatus }>
         : `no ${manifest}`}
     </span>
     {status.packages.length > 0 && (
-      <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', marginTop: '0.15rem' }}>
+      <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', marginTop: '0.15rem' }}>
         {status.packages.join(', ')}
       </div>
     )}
@@ -91,7 +91,7 @@ const ScriptDependenciesPanel: React.FC = () => {
   const nothingDeclared = !status.python.manifestPresent && !status.node.manifestPresent;
 
   return (
-    <div className="setting-item" style={{ marginTop: '1.5rem', borderTop: '1px solid var(--ctp-surface1)', paddingTop: '1rem' }}>
+    <div className="setting-item" style={{ marginTop: '1.5rem', borderTop: '1px solid var(--color-surface-hover)', paddingTop: '1rem' }}>
       <h4 style={{ margin: '0 0 0.25rem 0' }}><UiIcon name="package" size={15} /> {t('scripts.deps.title', 'Script Dependencies')}</h4>
       <p className="setting-description" style={{ marginTop: 0 }}>
         {t('scripts.deps.description', 'Install Python/Node packages your scripts need. Add a requirements.txt (Python) or package.json (Node) to the scripts directory, then install. Packages are installed next to your scripts and persist across restarts.')}
@@ -113,15 +113,15 @@ const ScriptDependenciesPanel: React.FC = () => {
           style={{
             marginTop: '0.5rem', padding: '0.4rem 1rem', borderRadius: '4px', border: 'none',
             cursor: installing || nothingDeclared ? 'not-allowed' : 'pointer', fontWeight: 'bold',
-            background: installing || nothingDeclared ? 'var(--ctp-surface2)' : 'var(--ctp-blue)',
-            color: installing || nothingDeclared ? 'var(--ctp-subtext0)' : 'var(--ctp-base)',
+            background: installing || nothingDeclared ? 'var(--color-surface-active)' : 'var(--color-accent)',
+            color: installing || nothingDeclared ? 'var(--color-text-subtle)' : 'var(--color-bg)',
           }}
         >
           {installing ? t('scripts.deps.installing', 'Installing…') : <><UiIcon name="download" size={14} /> {t('scripts.deps.install', 'Install / Update dependencies')}</>}
         </button>
       )}
 
-      <p className="setting-description" style={{ marginTop: '0.5rem', color: 'var(--ctp-yellow)' }}>
+      <p className="setting-description" style={{ marginTop: '0.5rem', color: 'var(--color-warning)' }}>
         <UiIcon name="alert" size={14} /> {t('scripts.deps.warning', 'Installing downloads and runs third-party code, and requires internet access. On the slim Docker image, packages without a prebuilt musl wheel will fail unless SCRIPT_DEPS_ALLOW_SOURCE_BUILD=true.')}
       </p>
 
@@ -130,7 +130,7 @@ const ScriptDependenciesPanel: React.FC = () => {
       {log && (
         <pre style={{
           marginTop: '0.5rem', maxHeight: '240px', overflow: 'auto', fontSize: '0.7rem',
-          background: 'var(--ctp-mantle)', color: 'var(--ctp-subtext1)', padding: '0.5rem', borderRadius: '4px',
+          background: 'var(--color-bg-raised)', color: 'var(--color-text-muted)', padding: '0.5rem', borderRadius: '4px',
           whiteSpace: 'pre-wrap', wordBreak: 'break-word',
         }}>{log}</pre>
       )}

--- a/src/components/auto-responder/ScriptManagement.tsx
+++ b/src/components/auto-responder/ScriptManagement.tsx
@@ -62,16 +62,16 @@ const ScriptManagement: React.FC<ScriptManagementProps> = ({
         style={{
           width: '100%',
           padding: '0.75rem 1rem',
-          background: 'var(--ctp-surface1)',
+          background: 'var(--color-surface-hover)',
           border: 'none',
-          borderBottom: showScriptManagement ? '1px solid var(--ctp-overlay0)' : 'none',
+          borderBottom: showScriptManagement ? '1px solid var(--color-border-subtle)' : 'none',
           cursor: 'pointer',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
           fontSize: '0.9rem',
           fontWeight: 'bold',
-          color: 'var(--ctp-blue)'
+          color: 'var(--color-accent)'
         }}
       >
         <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem' }}><UiIcon name="list" size={16} /> Script Management</span>
@@ -82,8 +82,8 @@ const ScriptManagement: React.FC<ScriptManagementProps> = ({
         <div style={{ 
           marginTop: '0.75rem', 
           padding: '1rem', 
-          background: 'var(--ctp-surface0)', 
-          border: '1px solid var(--ctp-overlay0)', 
+          background: 'var(--color-surface)', 
+          border: '1px solid var(--color-border-subtle)', 
           borderRadius: '4px' 
         }}>
           <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem', flexWrap: 'wrap' }}>
@@ -93,8 +93,8 @@ const ScriptManagement: React.FC<ScriptManagementProps> = ({
               style={{
                 padding: '0.5rem 1rem',
                 fontSize: '0.875rem',
-                background: isImporting ? 'var(--ctp-surface2)' : 'var(--ctp-blue)',
-                color: isImporting ? 'var(--ctp-subtext0)' : 'var(--ctp-base)',
+                background: isImporting ? 'var(--color-surface-active)' : 'var(--color-accent)',
+                color: isImporting ? 'var(--color-text-subtle)' : 'var(--color-bg)',
                 border: 'none',
                 borderRadius: '4px',
                 cursor: isImporting ? 'not-allowed' : 'pointer',
@@ -109,8 +109,8 @@ const ScriptManagement: React.FC<ScriptManagementProps> = ({
               style={{
                 padding: '0.5rem 1rem',
                 fontSize: '0.875rem',
-                background: (isExporting || availableScripts.length === 0) ? 'var(--ctp-surface2)' : 'var(--ctp-green)',
-                color: (isExporting || availableScripts.length === 0) ? 'var(--ctp-subtext0)' : 'var(--ctp-base)',
+                background: (isExporting || availableScripts.length === 0) ? 'var(--color-surface-active)' : 'var(--color-success)',
+                color: (isExporting || availableScripts.length === 0) ? 'var(--color-text-subtle)' : 'var(--color-bg)',
                 border: 'none',
                 borderRadius: '4px',
                 cursor: (isExporting || availableScripts.length === 0) ? 'not-allowed' : 'pointer',
@@ -126,9 +126,9 @@ const ScriptManagement: React.FC<ScriptManagementProps> = ({
                   style={{
                     padding: '0.5rem 1rem',
                     fontSize: '0.875rem',
-                    background: 'var(--ctp-surface1)',
-                    color: 'var(--ctp-text)',
-                    border: '1px solid var(--ctp-overlay0)',
+                    background: 'var(--color-surface-hover)',
+                    color: 'var(--color-text)',
+                    border: '1px solid var(--color-border-subtle)',
                     borderRadius: '4px',
                     cursor: 'pointer'
                   }}
@@ -140,9 +140,9 @@ const ScriptManagement: React.FC<ScriptManagementProps> = ({
                   style={{
                     padding: '0.5rem 1rem',
                     fontSize: '0.875rem',
-                    background: 'var(--ctp-surface1)',
-                    color: 'var(--ctp-text)',
-                    border: '1px solid var(--ctp-overlay0)',
+                    background: 'var(--color-surface-hover)',
+                    color: 'var(--color-text)',
+                    border: '1px solid var(--color-border-subtle)',
                     borderRadius: '4px',
                     cursor: 'pointer'
                   }}
@@ -158,8 +158,8 @@ const ScriptManagement: React.FC<ScriptManagementProps> = ({
               style={{
                 padding: '0.5rem 1rem',
                 fontSize: '0.875rem',
-                background: 'var(--ctp-mauve)',
-                color: 'var(--ctp-base)',
+                background: 'var(--color-accent-alt)',
+                color: 'var(--color-bg)',
                 border: 'none',
                 borderRadius: '4px',
                 cursor: 'pointer',
@@ -177,7 +177,7 @@ const ScriptManagement: React.FC<ScriptManagementProps> = ({
             <div style={{ 
               padding: '1rem', 
               textAlign: 'center', 
-              color: 'var(--ctp-subtext0)', 
+              color: 'var(--color-text-subtle)', 
               fontStyle: 'italic' 
             }}>
               No scripts found in /data/scripts/
@@ -194,8 +194,8 @@ const ScriptManagement: React.FC<ScriptManagementProps> = ({
                       alignItems: 'center',
                       gap: '0.75rem',
                       padding: '0.75rem',
-                      background: isSelected ? 'var(--ctp-surface1)' : 'transparent',
-                      border: '1px solid var(--ctp-overlay0)',
+                      background: isSelected ? 'var(--color-surface-hover)' : 'transparent',
+                      border: '1px solid var(--color-border-subtle)',
                       borderRadius: '4px'
                     }}
                   >
@@ -215,8 +215,8 @@ const ScriptManagement: React.FC<ScriptManagementProps> = ({
                       style={{
                         padding: '0.25rem 0.75rem',
                         fontSize: '0.75rem',
-                        background: isDeleting === script.filename ? 'var(--ctp-surface2)' : 'var(--ctp-red)',
-                        color: isDeleting === script.filename ? 'var(--ctp-subtext0)' : 'var(--ctp-base)',
+                        background: isDeleting === script.filename ? 'var(--color-surface-active)' : 'var(--color-error)',
+                        color: isDeleting === script.filename ? 'var(--color-text-subtle)' : 'var(--color-bg)',
                         border: 'none',
                         borderRadius: '3px',
                         cursor: isDeleting === script.filename ? 'not-allowed' : 'pointer',

--- a/src/components/auto-responder/TriggerItem.tsx
+++ b/src/components/auto-responder/TriggerItem.tsx
@@ -146,8 +146,8 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
         gap: '0.5rem',
         padding: '0.75rem',
         marginBottom: '0.5rem',
-        background: isEditing ? 'var(--ctp-surface1)' : 'var(--ctp-surface0)',
-        border: isEditing ? '2px solid var(--ctp-blue)' : '1px solid var(--ctp-overlay0)',
+        background: isEditing ? 'var(--color-surface-hover)' : 'var(--color-surface)',
+        border: isEditing ? '2px solid var(--color-accent)' : '1px solid var(--color-border-subtle)',
         borderRadius: '4px'
       }}
     >
@@ -165,7 +165,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                   style={{ 
                     flex: '1', 
                     fontFamily: 'monospace',
-                    borderColor: triggerValidation.valid ? undefined : 'var(--ctp-red)',
+                    borderColor: triggerValidation.valid ? undefined : 'var(--color-error)',
                     borderWidth: triggerValidation.valid ? undefined : '2px'
                   }}
                   placeholder="e.g., weather, weather {location}, w {location}"
@@ -175,7 +175,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                 <div style={{ 
                   marginLeft: '88px', 
                   fontSize: '0.75rem', 
-                  color: 'var(--ctp-red)',
+                  color: 'var(--color-error)',
                   display: 'flex',
                   alignItems: 'center',
                   gap: '0.25rem'
@@ -188,7 +188,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                 <div style={{ 
                   marginLeft: '88px', 
                   fontSize: '0.75rem', 
-                  color: 'var(--ctp-green)',
+                  color: 'var(--color-success)',
                   display: 'flex',
                   alignItems: 'center',
                   gap: '0.25rem'
@@ -226,7 +226,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                       style={{ width: '100%', fontFamily: 'monospace' }}
                       placeholder="e.g., {node} or MyNode"
                     />
-                    <span style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+                    <span style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                       Node name, short name, or node ID to traceroute to. Use <code>&#123;node&#125;</code> to capture from the trigger pattern.
                     </span>
                   </div>
@@ -261,7 +261,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                     ))}
                   </select>
                 ) : editResponseType === 'mailbox' ? (
-                  <span style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+                  <span style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                     Built-in async message store ("mesh voicemail"). No response text needed — the
                     mailbox handles <code>msg &lt;name&gt; &lt;text&gt;</code>, <code>inbox</code>,
                     {' '}<code>inbox play</code>, <code>inbox delete &lt;id&gt;</code> and <code>inbox clear</code>.
@@ -291,7 +291,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                     style={{ width: '100%', fontFamily: 'monospace' }}
                     placeholder="--ip {IP} --dest {NODE_ID} --flag"
                   />
-                  <span style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+                  <span style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                     {t('auto_responder.script_args_help', 'Optional CLI arguments. Tokens: {NODE_ID}, {IP}, {VERSION}, etc.')}
                   </span>
                 </div>
@@ -316,7 +316,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                         }
                       }}
                     />
-                    <label htmlFor={`edit-channel-none-${trigger.id}`} style={{ color: 'var(--ctp-subtext0)' }}>
+                    <label htmlFor={`edit-channel-none-${trigger.id}`} style={{ color: 'var(--color-text-subtle)' }}>
                       {t('auto_responder.channel_none', 'None (no mesh output)')}
                     </label>
                   </div>
@@ -367,7 +367,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
             </div>
             {editResponseType !== 'script' && editResponseType !== 'traceroute' && editResponseType !== 'mailbox' && (
               <div style={{ paddingLeft: '0.5rem', marginTop: '0.25rem' }}>
-                <label style={{ display: 'block', fontSize: '0.85rem', cursor: 'pointer', color: 'var(--ctp-subtext0)' }}>
+                <label style={{ display: 'block', fontSize: '0.85rem', cursor: 'pointer', color: 'var(--color-text-subtle)' }}>
                   <input
                     type="checkbox"
                     checked={editMultiline}
@@ -393,13 +393,13 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
               };
               
               return (
-                <div style={{ marginTop: '0.5rem', padding: '0.5rem', background: 'var(--ctp-surface1)', borderRadius: '4px' }}>
-                  <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', marginBottom: '0.25rem', fontWeight: 'bold', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div style={{ marginTop: '0.5rem', padding: '0.5rem', background: 'var(--color-surface-hover)', borderRadius: '4px' }}>
+                  <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', marginBottom: '0.25rem', fontWeight: 'bold', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                     <span>Response Preview:</span>
                     <button
                       onClick={() => setEditResponse('')}
                       style={{
-                        background: 'var(--ctp-red)',
+                        background: 'var(--color-error)',
                         border: 'none',
                         borderRadius: '3px',
                         color: 'white',
@@ -416,9 +416,9 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                   <div style={{
                     fontFamily: 'monospace',
                     fontSize: '0.85rem',
-                    color: 'var(--ctp-text)',
+                    color: 'var(--color-text)',
                     padding: '0.5rem',
-                    background: 'var(--ctp-surface2)',
+                    background: 'var(--color-surface-active)',
                     borderRadius: '3px',
                     whiteSpace: editMultiline ? 'pre-wrap' : 'nowrap',
                     overflowX: editMultiline ? 'visible' : 'auto'
@@ -429,7 +429,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
               );
             })()}
             <div style={{ paddingLeft: '0.5rem', marginTop: '0.25rem' }}>
-              <label style={{ display: 'block', fontSize: '0.85rem', cursor: editChannels.includes('dm') ? 'pointer' : 'not-allowed', color: 'var(--ctp-subtext0)', opacity: editChannels.includes('dm') ? 1 : 0.5 }}>
+              <label style={{ display: 'block', fontSize: '0.85rem', cursor: editChannels.includes('dm') ? 'pointer' : 'not-allowed', color: 'var(--color-text-subtle)', opacity: editChannels.includes('dm') ? 1 : 0.5 }}>
                 <input
                   type="checkbox"
                   checked={editVerifyResponse}
@@ -452,11 +452,11 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                   className="setting-input"
                   style={{ width: '80px' }}
                 />
-                <span style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+                <span style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                   {t('auto_responder.cooldown_help', 'seconds per node (0 = disabled)')}
                 </span>
               </div>
-              <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', marginTop: '0.25rem', marginLeft: '85px' }}>
+              <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', marginTop: '0.25rem', marginLeft: '85px' }}>
                 {t('auto_responder.cooldown_description', 'After this trigger responds to a node, ignore further matches from that node for this duration.')}
               </div>
             </div>
@@ -467,7 +467,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
               style={{
                 padding: '0.25rem 0.75rem',
                 fontSize: '12px',
-                background: 'var(--ctp-green)',
+                background: 'var(--color-success)',
                 color: 'white',
                 border: 'none',
                 borderRadius: '4px',
@@ -481,8 +481,8 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
               style={{
                 padding: '0.25rem 0.75rem',
                 fontSize: '12px',
-                background: 'var(--ctp-surface2)',
-                color: 'var(--ctp-text)',
+                background: 'var(--color-surface-active)',
+                color: 'var(--color-text)',
                 border: 'none',
                 borderRadius: '4px',
                 cursor: 'pointer'
@@ -511,7 +511,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                   }}>
                     {isMultiPattern && (
                       <span style={{ 
-                        color: 'var(--ctp-subtext0)', 
+                        color: 'var(--color-text-subtle)', 
                         fontSize: '1rem',
                         fontWeight: 'normal',
                         marginRight: '0',
@@ -606,7 +606,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                                       padding: '0.2rem 0.4rem',
                                       borderRadius: '4px',
                                       fontWeight: segment.type === 'parameter' ? 'bold' : 'normal',
-                                      color: segment.type === 'parameter' ? 'var(--ctp-green)' : 'var(--ctp-blue)',
+                                      color: segment.type === 'parameter' ? 'var(--color-success)' : 'var(--color-accent)',
                                       fontFamily: 'monospace',
                                       fontSize: '0.85rem',
                                       border: segment.type === 'parameter'
@@ -643,7 +643,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                                               : 'rgba(137, 180, 250, 0.2)',
                                             padding: '0.2rem 0.4rem',
                                             fontWeight: segment.type === 'parameter' ? 'bold' : 'normal',
-                                            color: segment.type === 'parameter' ? 'var(--ctp-green)' : 'var(--ctp-blue)'
+                                            color: segment.type === 'parameter' ? 'var(--color-success)' : 'var(--color-accent)'
                                           }}
                                         >
                                           {segment.type === 'literal' ? segment.text.trim() : segment.text}
@@ -665,7 +665,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                           </div>
                           {patternIdx < patterns.length - 1 && (
                             <span style={{ 
-                              color: 'var(--ctp-subtext0)', 
+                              color: 'var(--color-text-subtle)', 
                               fontSize: '0.9rem',
                               margin: '0',
                               padding: '0 0.1rem'
@@ -676,7 +676,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                     })}
                     {isMultiPattern && (
                       <span style={{ 
-                        color: 'var(--ctp-subtext0)', 
+                        color: 'var(--color-text-subtle)', 
                         fontSize: '1rem',
                         fontWeight: 'normal',
                         marginLeft: '0',
@@ -688,11 +688,11 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
               })()}
             </div>
             {(trigger.responseType === 'script' || trigger.responseType === 'traceroute') && (
-              <div style={{ color: 'var(--ctp-subtext0)', fontSize: '0.75rem', fontFamily: 'monospace', marginTop: '0.25rem' }}>
+              <div style={{ color: 'var(--color-text-subtle)', fontSize: '0.75rem', fontFamily: 'monospace', marginTop: '0.25rem' }}>
                 {trigger.responseType === 'traceroute' && <UiIcon name="forward" size={13} />} {trigger.response}
               </div>
             )}
-            <div style={{ color: 'var(--ctp-subtext0)', fontSize: '0.85rem', marginTop: '0.25rem', whiteSpace: 'pre-wrap' }}>
+            <div style={{ color: 'var(--color-text-subtle)', fontSize: '0.85rem', marginTop: '0.25rem', whiteSpace: 'pre-wrap' }}>
               {trigger.responseType !== 'script' && trigger.responseType !== 'traceroute' && trigger.responseType !== 'mailbox' ? trigger.response : null}
             </div>
           </div>
@@ -704,7 +704,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                     fontSize: '0.7rem',
                     padding: '0.15rem 0.4rem',
                     background: 'var(--ctp-teal)',
-                    color: 'var(--ctp-base)',
+                    color: 'var(--color-bg)',
                     borderRadius: '3px',
                     fontWeight: 'bold'
                   }}>
@@ -715,8 +715,8 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                   <span style={{
                     fontSize: '0.7rem',
                     padding: '0.15rem 0.4rem',
-                    background: 'var(--ctp-peach)',
-                    color: 'var(--ctp-base)',
+                    background: 'var(--color-caution)',
+                    color: 'var(--color-bg)',
                     borderRadius: '3px',
                     fontWeight: 'bold'
                   }}>
@@ -726,8 +726,8 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                 <span style={{
                   fontSize: '0.7rem',
                   padding: '0.15rem 0.4rem',
-                  background: trigger.responseType === 'text' ? 'var(--ctp-green)' : trigger.responseType === 'script' ? 'var(--ctp-yellow)' : trigger.responseType === 'traceroute' ? 'var(--ctp-sapphire)' : trigger.responseType === 'mailbox' ? 'var(--ctp-pink)' : 'var(--ctp-mauve)',
-                  color: 'var(--ctp-base)',
+                  background: trigger.responseType === 'text' ? 'var(--color-success)' : trigger.responseType === 'script' ? 'var(--color-warning)' : trigger.responseType === 'traceroute' ? 'var(--color-accent-hover)' : trigger.responseType === 'mailbox' ? 'var(--ctp-pink)' : 'var(--color-accent-alt)',
+                  color: 'var(--color-bg)',
                   borderRadius: '3px',
                   fontWeight: 'bold'
                 }}>
@@ -739,8 +739,8 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                     <span style={{
                       fontSize: '0.7rem',
                       padding: '0.15rem 0.4rem',
-                      background: triggerCh.includes('dm') ? 'var(--ctp-sky)' : 'var(--ctp-lavender)',
-                      color: 'var(--ctp-base)',
+                      background: triggerCh.includes('dm') ? 'var(--color-info)' : 'var(--color-accent-muted)',
+                      color: 'var(--color-bg)',
                       borderRadius: '3px',
                       fontWeight: 'bold'
                     }}>
@@ -753,7 +753,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                   );
                 })()}
                 {trigger.cooldownSeconds != null && trigger.cooldownSeconds > 0 && (
-                  <span style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+                  <span style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                     <UiIcon name="timer" size={13} /> {trigger.cooldownSeconds}s {t('auto_responder.cooldown_badge', 'cooldown')}
                   </span>
                 )}
@@ -767,7 +767,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                     padding: '0.25rem 0.5rem',
                     fontSize: '12px',
                     background: 'var(--ctp-teal)',
-                    color: 'var(--ctp-base)',
+                    color: 'var(--color-bg)',
                     border: 'none',
                     borderRadius: '4px',
                     cursor: 'pointer'
@@ -783,7 +783,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                 style={{
                   padding: '0.25rem 0.5rem',
                   fontSize: '12px',
-                  background: 'var(--ctp-blue)',
+                  background: 'var(--color-accent)',
                   color: 'white',
                   border: 'none',
                   borderRadius: '4px',
@@ -799,7 +799,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                 style={{
                   padding: '0.25rem 0.5rem',
                   fontSize: '12px',
-                  background: 'var(--ctp-red)',
+                  background: 'var(--color-error)',
                   color: 'white',
                   border: 'none',
                   borderRadius: '4px',
@@ -828,22 +828,22 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
           zIndex: 10000
         }}>
           <div style={{
-            background: 'var(--ctp-base)',
+            background: 'var(--color-bg)',
             borderRadius: '8px',
             padding: '1.5rem',
             maxWidth: '500px',
             width: '90%',
-            border: '1px solid var(--ctp-overlay0)'
+            border: '1px solid var(--color-border-subtle)'
           }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
-              <h3 style={{ margin: 0, color: 'var(--ctp-text)' }}>Remove Trigger</h3>
+              <h3 style={{ margin: 0, color: 'var(--color-text)' }}>Remove Trigger</h3>
               <button
                 onClick={() => setShowRemoveModal(false)}
                 style={{
                   background: 'transparent',
                   border: 'none',
                   fontSize: '1.5rem',
-                  color: 'var(--ctp-subtext0)',
+                  color: 'var(--color-text-subtle)',
                   cursor: 'pointer',
                   padding: '0',
                   lineHeight: '1'
@@ -852,17 +852,17 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                 ×
               </button>
             </div>
-            <p style={{ color: 'var(--ctp-subtext0)', fontSize: '0.875rem', marginBottom: '1rem' }}>
+            <p style={{ color: 'var(--color-text-subtle)', fontSize: '0.875rem', marginBottom: '1rem' }}>
               Are you sure you want to remove this trigger? This action cannot be undone.
             </p>
             <div style={{ 
               marginBottom: '1rem',
               padding: '0.75rem',
-              background: 'var(--ctp-surface0)',
+              background: 'var(--color-surface)',
               borderRadius: '4px',
               fontFamily: 'monospace',
               fontSize: '0.85rem',
-              color: 'var(--ctp-text)'
+              color: 'var(--color-text)'
             }}>
               {formatTriggerPatterns(trigger.trigger)}
             </div>
@@ -871,9 +871,9 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                 onClick={() => setShowRemoveModal(false)}
                 style={{
                   padding: '0.5rem 1rem',
-                  background: 'var(--ctp-surface1)',
-                  color: 'var(--ctp-text)',
-                  border: '1px solid var(--ctp-overlay0)',
+                  background: 'var(--color-surface-hover)',
+                  color: 'var(--color-text)',
+                  border: '1px solid var(--color-border-subtle)',
                   borderRadius: '4px',
                   cursor: 'pointer'
                 }}
@@ -890,8 +890,8 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                 }}
                 style={{
                   padding: '0.5rem 1rem',
-                  background: 'var(--ctp-red)',
-                  color: 'var(--ctp-base)',
+                  background: 'var(--color-error)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: 'pointer',

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -300,7 +300,7 @@ function RunLog({ automation, onClose }: { automation: Automation; onClose: () =
         <div className="ae-card" key={r.id}>
           <div className="ae-row">
             <div className="ae-row-main">
-              <span style={{ fontWeight: 700, color: r.status === 'completed' ? 'var(--ctp-green)' : r.status === 'failed' ? 'var(--ctp-red)' : 'inherit' }}>{r.status}</span>
+              <span style={{ fontWeight: 700, color: r.status === 'completed' ? 'var(--color-success)' : r.status === 'failed' ? 'var(--color-error)' : 'inherit' }}>{r.status}</span>
               <span className="ae-chip">{r.sourceId ?? '—'}</span>
             </div>
             <span className="ae-muted">{new Date(r.startedAt).toLocaleString()}</span>

--- a/src/components/configuration/AmbientLightingConfigSection.tsx
+++ b/src/components/configuration/AmbientLightingConfigSection.tsx
@@ -139,7 +139,7 @@ const AmbientLightingConfigSection: React.FC<AmbientLightingConfigSectionProps> 
           </div>
 
           {/* Color Controls */}
-          <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--ctp-subtext0)' }}>
+          <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--color-text-subtle)' }}>
             {t('ambientlighting_config.color_section')}
           </h4>
 
@@ -151,12 +151,12 @@ const AmbientLightingConfigSection: React.FC<AmbientLightingConfigSectionProps> 
                 height: '60px',
                 backgroundColor: previewColor,
                 borderRadius: '8px',
-                border: '2px solid var(--ctp-surface2)',
+                border: '2px solid var(--color-surface-active)',
                 boxShadow: ledState ? `0 0 20px ${previewColor}` : 'none'
               }}
               title={t('ambientlighting_config.preview')}
             />
-            <div style={{ flex: 1, color: 'var(--ctp-subtext0)', fontSize: '0.9rem' }}>
+            <div style={{ flex: 1, color: 'var(--color-text-subtle)', fontSize: '0.9rem' }}>
               {t('ambientlighting_config.preview')}: {previewColor}
             </div>
           </div>

--- a/src/components/configuration/AudioConfigSection.tsx
+++ b/src/components/configuration/AudioConfigSection.tsx
@@ -171,8 +171,8 @@ const AudioConfigSection: React.FC<AudioConfigSectionProps> = ({
               className="advanced-toggle-btn"
               style={{
                 background: 'transparent',
-                border: '1px solid var(--ctp-surface2)',
-                color: 'var(--ctp-subtext0)',
+                border: '1px solid var(--color-surface-active)',
+                color: 'var(--color-text-subtle)',
                 padding: '0.5rem 1rem',
                 borderRadius: '4px',
                 cursor: 'pointer',
@@ -191,7 +191,7 @@ const AudioConfigSection: React.FC<AudioConfigSectionProps> = ({
             <div className="advanced-section" style={{
               marginLeft: '1rem',
               paddingLeft: '1rem',
-              borderLeft: '2px solid var(--ctp-surface2)'
+              borderLeft: '2px solid var(--color-surface-active)'
             }}>
               {/* PTT Pin */}
               <div className="setting-item">
@@ -212,7 +212,7 @@ const AudioConfigSection: React.FC<AudioConfigSectionProps> = ({
               </div>
 
               {/* I2S Pins */}
-              <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--ctp-subtext0)' }}>
+              <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--color-text-subtle)' }}>
                 {t('audio_config.i2s_section')}
               </h4>
 

--- a/src/components/configuration/BackupManagementSection.tsx
+++ b/src/components/configuration/BackupManagementSection.tsx
@@ -217,13 +217,13 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
       <h3>{t('backup_management.title')}</h3>
 
       <div style={{
-        backgroundColor: 'var(--ctp-surface0)',
+        backgroundColor: 'var(--color-surface)',
         padding: '1rem',
         borderRadius: '8px',
         marginBottom: '1.5rem'
       }}>
         <h4 style={{ marginTop: 0, marginBottom: '0.5rem' }}>{t('backup_management.about_title')}</h4>
-        <p style={{ color: 'var(--ctp-subtext0)', margin: 0, fontSize: '0.9rem', lineHeight: '1.6' }}>
+        <p style={{ color: 'var(--color-text-subtle)', margin: 0, fontSize: '0.9rem', lineHeight: '1.6' }}>
           {t('backup_management.about_description')}
         </p>
       </div>
@@ -231,13 +231,13 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
       {/* Manual Backup */}
       <div style={{ marginBottom: '1.5rem' }}>
         <h4 style={{ marginBottom: '0.5rem' }}>{t('backup_management.manual_title')}</h4>
-        <p style={{ color: 'var(--ctp-subtext0)', marginBottom: '1rem', fontSize: '0.9rem' }}>
+        <p style={{ color: 'var(--color-text-subtle)', marginBottom: '1rem', fontSize: '0.9rem' }}>
           {t('backup_management.manual_description')}
         </p>
         <button
           onClick={handleManualBackup}
           style={{
-            backgroundColor: 'var(--ctp-mauve)',
+            backgroundColor: 'var(--color-accent-alt)',
             color: '#fff',
             padding: '0.75rem 1.5rem',
             border: 'none',
@@ -254,7 +254,7 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
           onClick={handleShowBackups}
           disabled={isLoadingBackups}
           style={{
-            backgroundColor: 'var(--ctp-blue)',
+            backgroundColor: 'var(--color-accent)',
             color: '#fff',
             padding: '0.75rem 1.5rem',
             border: 'none',
@@ -272,7 +272,7 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
       {/* Automated Backup Settings */}
       <div>
         <h4 style={{ marginBottom: '0.5rem' }}>{t('backup_management.auto_title')}</h4>
-        <p style={{ color: 'var(--ctp-subtext0)', marginBottom: '1rem', fontSize: '0.9rem' }}>
+        <p style={{ color: 'var(--color-text-subtle)', marginBottom: '1rem', fontSize: '0.9rem' }}>
           {t('backup_management.auto_description')}
         </p>
 
@@ -303,14 +303,14 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
               style={{
                 padding: '0.5rem',
                 borderRadius: '4px',
-                border: '1px solid var(--ctp-surface2)',
-                backgroundColor: 'var(--ctp-surface0)',
-                color: 'var(--ctp-text)',
+                border: '1px solid var(--color-surface-active)',
+                backgroundColor: 'var(--color-surface)',
+                color: 'var(--color-text)',
                 width: '100px',
                 opacity: autoBackupEnabled ? 1 : 0.5
               }}
             />
-            <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-subtext0)', fontSize: '0.9rem' }}>
+            <span style={{ marginLeft: '0.5rem', color: 'var(--color-text-subtle)', fontSize: '0.9rem' }}>
               {t('backup_management.max_backups_hint')}
             </span>
           </div>
@@ -328,14 +328,14 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
               style={{
                 padding: '0.5rem',
                 borderRadius: '4px',
-                border: '1px solid var(--ctp-surface2)',
-                backgroundColor: 'var(--ctp-surface0)',
-                color: 'var(--ctp-text)',
+                border: '1px solid var(--color-surface-active)',
+                backgroundColor: 'var(--color-surface)',
+                color: 'var(--color-text)',
                 width: '150px',
                 opacity: autoBackupEnabled ? 1 : 0.5
               }}
             />
-            <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-subtext0)', fontSize: '0.9rem' }}>
+            <span style={{ marginLeft: '0.5rem', color: 'var(--color-text-subtle)', fontSize: '0.9rem' }}>
               {t('backup_management.backup_time_hint')}
             </span>
           </div>
@@ -355,7 +355,7 @@ const BackupManagementSection: React.FC<BackupManagementSectionProps> = ({ onBac
             <h3>{t('backup_management.modal_title')}</h3>
 
             {backupList.length === 0 ? (
-              <p style={{ color: 'var(--ctp-subtext0)' }}>
+              <p style={{ color: 'var(--color-text-subtle)' }}>
                 {t('backup_management.no_backups')}
               </p>
             ) : (

--- a/src/components/configuration/CannedMessageConfigSection.tsx
+++ b/src/components/configuration/CannedMessageConfigSection.tsx
@@ -255,8 +255,8 @@ const CannedMessageConfigSection: React.FC<CannedMessageConfigSectionProps> = ({
               className="advanced-toggle-btn"
               style={{
                 background: 'transparent',
-                border: '1px solid var(--ctp-surface2)',
-                color: 'var(--ctp-subtext0)',
+                border: '1px solid var(--color-surface-active)',
+                color: 'var(--color-text-subtle)',
                 padding: '0.5rem 1rem',
                 borderRadius: '4px',
                 cursor: 'pointer',
@@ -275,10 +275,10 @@ const CannedMessageConfigSection: React.FC<CannedMessageConfigSectionProps> = ({
             <div className="advanced-section" style={{
               marginLeft: '1rem',
               paddingLeft: '1rem',
-              borderLeft: '2px solid var(--ctp-surface2)'
+              borderLeft: '2px solid var(--color-surface-active)'
             }}>
           {/* GPIO Settings */}
-          <h4 style={{ marginTop: '0.5rem', marginBottom: '0.5rem', color: 'var(--ctp-subtext0)' }}>
+          <h4 style={{ marginTop: '0.5rem', marginBottom: '0.5rem', color: 'var(--color-text-subtle)' }}>
             {t('cannedmsg_config.gpio_section')}
           </h4>
 
@@ -337,7 +337,7 @@ const CannedMessageConfigSection: React.FC<CannedMessageConfigSectionProps> = ({
           </div>
 
           {/* Event Mappings */}
-          <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--ctp-subtext0)' }}>
+          <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--color-text-subtle)' }}>
             {t('cannedmsg_config.events_section')}
           </h4>
 

--- a/src/components/configuration/ChannelDatabaseSection.tsx
+++ b/src/components/configuration/ChannelDatabaseSection.tsx
@@ -94,11 +94,11 @@ const SortableChannelCard: React.FC<SortableChannelCardProps> = ({
     transform: CSS.Transform.toString(transform),
     transition,
     border: channel.isEnabled
-      ? '2px solid var(--ctp-green)'
-      : '1px solid var(--ctp-surface1)',
+      ? '2px solid var(--color-success)'
+      : '1px solid var(--color-surface-hover)',
     borderRadius: '8px',
     padding: '1rem',
-    backgroundColor: channel.isEnabled ? 'var(--ctp-surface0)' : 'var(--ctp-mantle)',
+    backgroundColor: channel.isEnabled ? 'var(--color-surface)' : 'var(--color-bg-raised)',
     opacity: isDragging ? 0.5 : (channel.isEnabled ? 1 : 0.7),
     cursor: isDragging ? 'grabbing' : 'default'
   };
@@ -116,7 +116,7 @@ const SortableChannelCard: React.FC<SortableChannelCardProps> = ({
             marginRight: '0.5rem',
             display: 'flex',
             alignItems: 'center',
-            color: 'var(--ctp-overlay0)',
+            color: 'var(--color-text-faint)',
             touchAction: 'none'
           }}
           title={t('channel_database.drag_to_reorder')}
@@ -131,20 +131,20 @@ const SortableChannelCard: React.FC<SortableChannelCardProps> = ({
           </svg>
         </div>
         <div style={{ flex: 1 }}>
-          <h4 style={{ margin: 0, color: 'var(--ctp-text)', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <h4 style={{ margin: 0, color: 'var(--color-text)', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             {channel.name}
             {channel.isEnabled ? (
-              <span style={{ color: 'var(--ctp-green)', fontSize: '0.8rem' }}>{t('channel_database.enabled')}</span>
+              <span style={{ color: 'var(--color-success)', fontSize: '0.8rem' }}>{t('channel_database.enabled')}</span>
             ) : (
-              <span style={{ color: 'var(--ctp-overlay0)', fontSize: '0.8rem' }}>{t('channel_database.disabled')}</span>
+              <span style={{ color: 'var(--color-text-faint)', fontSize: '0.8rem' }}>{t('channel_database.disabled')}</span>
             )}
           </h4>
           {channel.description && (
-            <p style={{ margin: '0.25rem 0', fontSize: '0.9rem', color: 'var(--ctp-subtext1)' }}>
+            <p style={{ margin: '0.25rem 0', fontSize: '0.9rem', color: 'var(--color-text-muted)' }}>
               {channel.description}
             </p>
           )}
-          <div style={{ marginTop: '0.5rem', fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+          <div style={{ marginTop: '0.5rem', fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
             <div>
               {channel.pskLength === 0
                 ? 'PSK: (none) (None)'
@@ -168,8 +168,8 @@ const SortableChannelCard: React.FC<SortableChannelCardProps> = ({
             style={{
               padding: '0.4rem 0.6rem',
               fontSize: '0.85rem',
-              backgroundColor: channel.isEnabled ? 'var(--ctp-yellow)' : 'var(--ctp-green)',
-              color: 'var(--ctp-base)',
+              backgroundColor: channel.isEnabled ? 'var(--color-warning)' : 'var(--color-success)',
+              color: 'var(--color-bg)',
               border: 'none',
               borderRadius: '4px',
               cursor: 'pointer'
@@ -183,8 +183,8 @@ const SortableChannelCard: React.FC<SortableChannelCardProps> = ({
             style={{
               padding: '0.4rem 0.6rem',
               fontSize: '0.85rem',
-              backgroundColor: 'var(--ctp-blue)',
-              color: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-accent)',
+              color: 'var(--color-bg)',
               border: 'none',
               borderRadius: '4px',
               cursor: 'pointer'
@@ -199,8 +199,8 @@ const SortableChannelCard: React.FC<SortableChannelCardProps> = ({
               style={{
                 padding: '0.4rem 0.6rem',
                 fontSize: '0.85rem',
-                backgroundColor: 'var(--ctp-mauve)',
-                color: 'var(--ctp-base)',
+                backgroundColor: 'var(--color-accent-alt)',
+                color: 'var(--color-bg)',
                 border: 'none',
                 borderRadius: '4px',
                 cursor: decryptionRunning ? 'not-allowed' : 'pointer',
@@ -216,8 +216,8 @@ const SortableChannelCard: React.FC<SortableChannelCardProps> = ({
             style={{
               padding: '0.4rem 0.6rem',
               fontSize: '0.85rem',
-              backgroundColor: 'var(--ctp-red)',
-              color: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-error)',
+              color: 'var(--color-bg)',
               border: 'none',
               borderRadius: '4px',
               cursor: 'pointer'
@@ -788,8 +788,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
         {rebroadcastMode !== undefined && rebroadcastMode !== 0 && (
           <div
             style={{
-              backgroundColor: 'var(--ctp-peach)',
-              color: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-caution)',
+              color: 'var(--color-bg)',
               padding: '1rem',
               borderRadius: '8px',
               marginBottom: '1rem',
@@ -817,8 +817,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
         {decryptionProgress && (decryptionProgress.status === 'running' || decryptionProgress.status === 'pending') && (
           <div
             style={{
-              backgroundColor: 'var(--ctp-blue)',
-              color: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-accent)',
+              color: 'var(--color-bg)',
               padding: '1rem',
               borderRadius: '8px',
               marginBottom: '1rem'
@@ -843,7 +843,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 style={{
                   height: '100%',
                   width: `${decryptionProgress.total > 0 ? (decryptionProgress.processed / decryptionProgress.total) * 100 : 0}%`,
-                  backgroundColor: 'var(--ctp-green)',
+                  backgroundColor: 'var(--color-success)',
                   transition: 'width 0.3s ease'
                 }}
               />
@@ -857,8 +857,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
             onClick={handleAddChannel}
             style={{
               padding: '0.5rem 1rem',
-              backgroundColor: 'var(--ctp-green)',
-              color: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-success)',
+              color: 'var(--color-bg)',
               border: 'none',
               borderRadius: '4px',
               cursor: 'pointer'
@@ -870,8 +870,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
             onClick={() => setShowImportModal(true)}
             style={{
               padding: '0.5rem 1rem',
-              backgroundColor: 'var(--ctp-yellow)',
-              color: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-warning)',
+              color: 'var(--color-bg)',
               border: 'none',
               borderRadius: '4px',
               cursor: 'pointer'
@@ -884,8 +884,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
             title={t('channel_database.import_from_url_title')}
             style={{
               padding: '0.5rem 1rem',
-              backgroundColor: 'var(--ctp-peach)',
-              color: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-caution)',
+              color: 'var(--color-bg)',
               border: 'none',
               borderRadius: '4px',
               cursor: 'pointer'
@@ -898,8 +898,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
             disabled={channels.length === 0}
             style={{
               padding: '0.5rem 1rem',
-              backgroundColor: 'var(--ctp-sapphire)',
-              color: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-accent-hover)',
+              color: 'var(--color-bg)',
               border: 'none',
               borderRadius: '4px',
               cursor: channels.length === 0 ? 'not-allowed' : 'pointer',
@@ -915,8 +915,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
         {channels.length > 1 && (
           <div
             style={{
-              backgroundColor: 'var(--ctp-surface0)',
-              color: 'var(--ctp-subtext1)',
+              backgroundColor: 'var(--color-surface)',
+              color: 'var(--color-text-muted)',
               padding: '0.75rem 1rem',
               borderRadius: '8px',
               marginBottom: '1rem',
@@ -941,8 +941,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
             style={{
               textAlign: 'center',
               padding: '2rem',
-              color: 'var(--ctp-subtext0)',
-              backgroundColor: 'var(--ctp-mantle)',
+              color: 'var(--color-text-subtle)',
+              backgroundColor: 'var(--color-bg-raised)',
               borderRadius: '8px'
             }}
           >
@@ -997,7 +997,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
         >
           <div
             style={{
-              backgroundColor: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-bg)',
               borderRadius: '8px',
               padding: '1.5rem',
               maxWidth: '500px',
@@ -1046,8 +1046,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                   type="button"
                   style={{
                     padding: '0.5rem 1rem',
-                    backgroundColor: 'var(--ctp-green)',
-                    color: 'var(--ctp-base)',
+                    backgroundColor: 'var(--color-success)',
+                    color: 'var(--color-bg)',
                     border: 'none',
                     borderRadius: '4px',
                     cursor: 'pointer',
@@ -1115,8 +1115,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-blue)',
-                  color: 'var(--ctp-base)',
+                  backgroundColor: 'var(--color-accent)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: isSaving ? 'not-allowed' : 'pointer',
@@ -1131,8 +1131,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-surface1)',
-                  color: 'var(--ctp-text)',
+                  backgroundColor: 'var(--color-surface-hover)',
+                  color: 'var(--color-text)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: isSaving ? 'not-allowed' : 'pointer'
@@ -1164,7 +1164,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
         >
           <div
             style={{
-              backgroundColor: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-bg)',
               borderRadius: '8px',
               padding: '1.5rem',
               maxWidth: '500px',
@@ -1200,7 +1200,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 <label>{t('channel_database.preview')}:</label>
                 <pre
                   style={{
-                    backgroundColor: 'var(--ctp-surface0)',
+                    backgroundColor: 'var(--color-surface)',
                     padding: '0.75rem',
                     borderRadius: '4px',
                     fontSize: '0.85rem',
@@ -1220,8 +1220,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-green)',
-                  color: 'var(--ctp-base)',
+                  backgroundColor: 'var(--color-success)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: (isSaving || !importFileContent) ? 'not-allowed' : 'pointer',
@@ -1236,8 +1236,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-surface1)',
-                  color: 'var(--ctp-text)',
+                  backgroundColor: 'var(--color-surface-hover)',
+                  color: 'var(--color-text)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: isSaving ? 'not-allowed' : 'pointer'
@@ -1273,7 +1273,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
         >
           <div
             style={{
-              backgroundColor: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-bg)',
               borderRadius: '8px',
               padding: '1.5rem',
               maxWidth: '640px',
@@ -1315,8 +1315,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 style={{
                   marginTop: '0.5rem',
                   padding: '0.5rem 1rem',
-                  backgroundColor: 'var(--ctp-blue)',
-                  color: 'var(--ctp-base)',
+                  backgroundColor: 'var(--color-accent)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: (isDecodingUrl || isSaving || !urlImportInput.trim()) ? 'not-allowed' : 'pointer',
@@ -1332,8 +1332,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 style={{
                   marginTop: '1rem',
                   padding: '0.5rem 0.75rem',
-                  backgroundColor: 'var(--ctp-red)',
-                  color: 'var(--ctp-base)',
+                  backgroundColor: 'var(--color-error)',
+                  color: 'var(--color-bg)',
                   borderRadius: '4px',
                   fontSize: '0.9rem'
                 }}
@@ -1349,7 +1349,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 </label>
                 <div
                   style={{
-                    backgroundColor: 'var(--ctp-surface0)',
+                    backgroundColor: 'var(--color-surface)',
                     padding: '0.5rem',
                     borderRadius: '4px',
                     maxHeight: '320px',
@@ -1378,7 +1378,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                           display: 'flex',
                           gap: '0.5rem',
                           padding: '0.5rem',
-                          borderBottom: idx < urlDecodedChannels.length - 1 ? '1px solid var(--ctp-surface1)' : 'none',
+                          borderBottom: idx < urlDecodedChannels.length - 1 ? '1px solid var(--color-surface-hover)' : 'none',
                           opacity: isImportable ? 1 : 0.55
                         }}
                       >
@@ -1405,7 +1405,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                               fontSize: '0.95rem'
                             }}
                           />
-                          <div style={{ fontSize: '0.8rem', color: 'var(--ctp-subtext0)', marginTop: '0.25rem' }}>
+                          <div style={{ fontSize: '0.8rem', color: 'var(--color-text-subtle)', marginTop: '0.25rem' }}>
                             <span>{roleLabel}</span>
                             {' · '}
                             {normalizedPsk
@@ -1427,8 +1427,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-green)',
-                  color: 'var(--ctp-base)',
+                  backgroundColor: 'var(--color-success)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: (isSaving || urlSelectedIndexes.size === 0) ? 'not-allowed' : 'pointer',
@@ -1448,8 +1448,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-surface1)',
-                  color: 'var(--ctp-text)',
+                  backgroundColor: 'var(--color-surface-hover)',
+                  color: 'var(--color-text)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: (isSaving || isDecodingUrl) ? 'not-allowed' : 'pointer'
@@ -1481,7 +1481,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
         >
           <div
             style={{
-              backgroundColor: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-bg)',
               borderRadius: '8px',
               padding: '1.5rem',
               maxWidth: '400px',
@@ -1489,7 +1489,7 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
             }}
             onClick={(e) => e.stopPropagation()}
           >
-            <h3 style={{ marginTop: 0, color: 'var(--ctp-red)' }}>{t('channel_database.confirm_delete')}</h3>
+            <h3 style={{ marginTop: 0, color: 'var(--color-error)' }}>{t('channel_database.confirm_delete')}</h3>
             <p>{t('channel_database.confirm_delete_message')}</p>
 
             <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.5rem' }}>
@@ -1499,8 +1499,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-red)',
-                  color: 'var(--ctp-base)',
+                  backgroundColor: 'var(--color-error)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: isSaving ? 'not-allowed' : 'pointer',
@@ -1515,8 +1515,8 @@ const ChannelDatabaseSection: React.FC<ChannelDatabaseSectionProps> = ({ isAdmin
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-surface1)',
-                  color: 'var(--ctp-text)',
+                  backgroundColor: 'var(--color-surface-hover)',
+                  color: 'var(--color-text)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: isSaving ? 'not-allowed' : 'pointer'

--- a/src/components/configuration/ChannelsConfigSection.tsx
+++ b/src/components/configuration/ChannelsConfigSection.tsx
@@ -118,11 +118,11 @@ const SortableChannelCard: React.FC<{
             width: '2.5rem',
             minHeight: '100%',
             cursor: isDragging ? 'grabbing' : 'grab',
-            backgroundColor: isDragging ? 'var(--ctp-surface2)' : 'var(--ctp-surface0)',
+            backgroundColor: isDragging ? 'var(--color-surface-active)' : 'var(--color-surface)',
             borderRadius: '8px 0 0 8px',
-            borderRight: '1px solid var(--ctp-surface1)',
+            borderRight: '1px solid var(--color-surface-hover)',
             fontSize: '1.4rem',
-            color: isDragging ? 'var(--ctp-blue)' : 'var(--ctp-overlay1)',
+            color: isDragging ? 'var(--color-accent)' : 'var(--color-text-disabled)',
             userSelect: 'none',
             flexShrink: 0,
             transition: 'background-color 0.15s, color 0.15s',
@@ -479,12 +479,12 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
             gap: '0.5rem',
             marginBottom: '1rem',
             padding: '0.75rem',
-            backgroundColor: 'var(--ctp-surface0)',
+            backgroundColor: 'var(--color-surface)',
             borderRadius: '8px',
-            border: '1px solid var(--ctp-blue)',
+            border: '1px solid var(--color-accent)',
             alignItems: 'center'
           }}>
-            <span style={{ flex: 1, color: 'var(--ctp-text)' }}>
+            <span style={{ flex: 1, color: 'var(--color-text)' }}>
               {t('channels_config.reorder_pending', 'Channel order changed. Apply to device?')}
             </span>
             <button
@@ -492,8 +492,8 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
               disabled={isReordering}
               style={{
                 padding: '0.5rem 1rem',
-                backgroundColor: 'var(--ctp-blue)',
-                color: 'var(--ctp-base)',
+                backgroundColor: 'var(--color-accent)',
+                color: 'var(--color-bg)',
                 border: 'none',
                 borderRadius: '4px',
                 cursor: isReordering ? 'not-allowed' : 'pointer',
@@ -507,8 +507,8 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
               disabled={isReordering}
               style={{
                 padding: '0.5rem 1rem',
-                backgroundColor: 'var(--ctp-surface1)',
-                color: 'var(--ctp-text)',
+                backgroundColor: 'var(--color-surface-hover)',
+                color: 'var(--color-text)',
                 border: 'none',
                 borderRadius: '4px',
                 cursor: isReordering ? 'not-allowed' : 'pointer'
@@ -527,11 +527,11 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                   <div
                     style={{
                       border: (hasReorderChanges ? displaySlot === 0 : channel?.role === 1)
-                        ? '2px solid var(--ctp-blue)'
-                        : '1px solid var(--ctp-surface1)',
+                        ? '2px solid var(--color-accent)'
+                        : '1px solid var(--color-surface-hover)',
                       borderRadius: '8px',
                       padding: '1rem',
-                      backgroundColor: channel ? 'var(--ctp-surface0)' : 'var(--ctp-mantle)',
+                      backgroundColor: channel ? 'var(--color-surface)' : 'var(--color-bg-raised)',
                       opacity: channel?.role === 0 ? 0.5 : 1,
                       boxShadow: (hasReorderChanges ? displaySlot === 0 : channel?.role === 1)
                         ? '0 0 10px rgba(137, 180, 250, 0.3)' : 'none'
@@ -539,18 +539,18 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                   >
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '0.75rem' }}>
                       <div>
-                        <h4 style={{ margin: 0, color: 'var(--ctp-text)' }}>
+                        <h4 style={{ margin: 0, color: 'var(--color-text)' }}>
                           {t('channels_config.slot', { slot: hasReorderChanges ? displaySlot : slotId })}: {channel ? (
                             <>
-                              {channel.name || <span style={{ color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>{t('channels_config.unnamed')}</span>}
-                              {!hasReorderChanges && channel.role === 1 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-blue)', fontSize: '0.8rem' }}><UiIcon name="favorite" size={13} /> {t('channels_config.primary')}</span>}
-                              {hasReorderChanges && displaySlot === 0 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-blue)', fontSize: '0.8rem' }}><UiIcon name="favorite" size={13} /> {t('channels_config.primary')}</span>}
-                              {channel.role === 0 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-overlay0)', fontSize: '0.8rem' }}><UiIcon name="blocked" size={13} /> {t('channels_config.disabled')}</span>}
+                              {channel.name || <span style={{ color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>{t('channels_config.unnamed')}</span>}
+                              {!hasReorderChanges && channel.role === 1 && <span style={{ marginLeft: '0.5rem', color: 'var(--color-accent)', fontSize: '0.8rem' }}><UiIcon name="favorite" size={13} /> {t('channels_config.primary')}</span>}
+                              {hasReorderChanges && displaySlot === 0 && <span style={{ marginLeft: '0.5rem', color: 'var(--color-accent)', fontSize: '0.8rem' }}><UiIcon name="favorite" size={13} /> {t('channels_config.primary')}</span>}
+                              {channel.role === 0 && <span style={{ marginLeft: '0.5rem', color: 'var(--color-text-faint)', fontSize: '0.8rem' }}><UiIcon name="blocked" size={13} /> {t('channels_config.disabled')}</span>}
                             </>
-                          ) : <span style={{ color: 'var(--ctp-subtext0)', fontStyle: 'italic' }}>{t('channels_config.empty')}</span>}
+                          ) : <span style={{ color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>{t('channels_config.empty')}</span>}
                         </h4>
                   {channel && (
-                    <div style={{ marginTop: '0.5rem', fontSize: '0.9rem', color: 'var(--ctp-subtext1)' }}>
+                    <div style={{ marginTop: '0.5rem', fontSize: '0.9rem', color: 'var(--color-text-muted)' }}>
                       {(() => {
                         const status = channelEncryptionStatus(channel);
                         if (status === 'secure') {
@@ -576,7 +576,7 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                       )}
                       {collisionDbNamesByChannelId.has(channel.id) && (
                         <div
-                          style={{ marginTop: '0.5rem', color: 'var(--ctp-yellow)', fontSize: '0.85rem' }}
+                          style={{ marginTop: '0.5rem', color: 'var(--color-warning)', fontSize: '0.85rem' }}
                           title={t('channels_config.collision_tooltip', 'This channel shares its encryption key with a Channel Database (server-side decryption) entry under a different name, so its messages are filed under that entry instead.')}
                         >
                           <UiIcon name="alert" /> {t('channels_config.collision_warning', {
@@ -594,8 +594,8 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                     style={{
                       padding: '0.5rem 0.75rem',
                       fontSize: '0.9rem',
-                      backgroundColor: 'var(--ctp-blue)',
-                      color: 'var(--ctp-base)',
+                      backgroundColor: 'var(--color-accent)',
+                      color: 'var(--color-bg)',
                       border: 'none',
                       borderRadius: '4px',
                       cursor: 'pointer'
@@ -609,8 +609,8 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                       style={{
                         padding: '0.5rem 0.75rem',
                         fontSize: '0.9rem',
-                        backgroundColor: 'var(--ctp-green)',
-                        color: 'var(--ctp-base)',
+                        backgroundColor: 'var(--color-success)',
+                        color: 'var(--color-bg)',
                         border: 'none',
                         borderRadius: '4px',
                         cursor: 'pointer'
@@ -624,8 +624,8 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                     style={{
                       padding: '0.5rem 0.75rem',
                       fontSize: '0.9rem',
-                      backgroundColor: 'var(--ctp-yellow)',
-                      color: 'var(--ctp-base)',
+                      backgroundColor: 'var(--color-warning)',
+                      color: 'var(--color-bg)',
                       border: 'none',
                       borderRadius: '4px',
                       cursor: 'pointer'
@@ -639,8 +639,8 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                       style={{
                         padding: '0.5rem 0.75rem',
                         fontSize: '0.9rem',
-                        backgroundColor: 'var(--ctp-red)',
-                        color: 'var(--ctp-base)',
+                        backgroundColor: 'var(--color-error)',
+                        color: 'var(--color-bg)',
                         border: 'none',
                         borderRadius: '4px',
                         cursor: 'pointer'
@@ -661,16 +661,16 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
               const ch = channels.find(c => c.id === activeDragId);
               return (
                 <div style={{
-                  border: '2px solid var(--ctp-blue)',
+                  border: '2px solid var(--color-accent)',
                   borderRadius: '8px',
                   padding: '1rem',
-                  backgroundColor: 'var(--ctp-surface0)',
+                  backgroundColor: 'var(--color-surface)',
                   boxShadow: '0 12px 32px rgba(0, 0, 0, 0.5)',
                   opacity: 0.95,
                 }}>
-                  <h4 style={{ margin: 0, color: 'var(--ctp-text)' }}>
+                  <h4 style={{ margin: 0, color: 'var(--color-text)' }}>
                     {ch?.name || t('channels_config.empty')}
-                    {ch?.role === 1 && <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-blue)', fontSize: '0.8rem' }}><UiIcon name="favorite" size={13} /> {t('channels_config.primary')}</span>}
+                    {ch?.role === 1 && <span style={{ marginLeft: '0.5rem', color: 'var(--color-accent)', fontSize: '0.8rem' }}><UiIcon name="favorite" size={13} /> {t('channels_config.primary')}</span>}
                   </h4>
                 </div>
               );
@@ -698,7 +698,7 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
         >
           <div
             style={{
-              backgroundColor: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-bg)',
               borderRadius: '8px',
               padding: '1.5rem',
               maxWidth: '500px',
@@ -748,8 +748,8 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                   type="button"
                   style={{
                     padding: '0.5rem 1rem',
-                    backgroundColor: 'var(--ctp-green)',
-                    color: 'var(--ctp-base)',
+                    backgroundColor: 'var(--color-success)',
+                    color: 'var(--color-bg)',
                     border: 'none',
                     borderRadius: '4px',
                     cursor: 'pointer',
@@ -842,8 +842,8 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-blue)',
-                  color: 'var(--ctp-base)',
+                  backgroundColor: 'var(--color-accent)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: isSaving ? 'not-allowed' : 'pointer',
@@ -858,8 +858,8 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-surface1)',
-                  color: 'var(--ctp-text)',
+                  backgroundColor: 'var(--color-surface-hover)',
+                  color: 'var(--color-text)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: isSaving ? 'not-allowed' : 'pointer'
@@ -891,7 +891,7 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
         >
           <div
             style={{
-              backgroundColor: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-bg)',
               borderRadius: '8px',
               padding: '1.5rem',
               maxWidth: '500px',
@@ -927,7 +927,7 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                 <label>{t('channels_config.preview')}:</label>
                 <pre
                   style={{
-                    backgroundColor: 'var(--ctp-surface0)',
+                    backgroundColor: 'var(--color-surface)',
                     padding: '0.75rem',
                     borderRadius: '4px',
                     fontSize: '0.85rem',
@@ -947,8 +947,8 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-green)',
-                  color: 'var(--ctp-base)',
+                  backgroundColor: 'var(--color-success)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: (isSaving || !importFileContent) ? 'not-allowed' : 'pointer',
@@ -963,8 +963,8 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                 style={{
                   flex: 1,
                   padding: '0.75rem',
-                  backgroundColor: 'var(--ctp-surface1)',
-                  color: 'var(--ctp-text)',
+                  backgroundColor: 'var(--color-surface-hover)',
+                  color: 'var(--color-text)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: isSaving ? 'not-allowed' : 'pointer'

--- a/src/components/configuration/DatabaseMaintenanceSection.tsx
+++ b/src/components/configuration/DatabaseMaintenanceSection.tsx
@@ -261,13 +261,13 @@ const DatabaseMaintenanceSection: React.FC = () => {
       <h3>{t('maintenance.title')}</h3>
 
       <div style={{
-        backgroundColor: 'var(--ctp-surface0)',
+        backgroundColor: 'var(--color-surface)',
         padding: '1rem',
         borderRadius: '8px',
         marginBottom: '1.5rem'
       }}>
         <h4 style={{ marginTop: 0, marginBottom: '0.5rem' }}>{t('maintenance.about_title')}</h4>
-        <p style={{ color: 'var(--ctp-subtext0)', margin: 0, fontSize: '0.9rem', lineHeight: '1.6' }}>
+        <p style={{ color: 'var(--color-text-subtle)', margin: 0, fontSize: '0.9rem', lineHeight: '1.6' }}>
           {t('maintenance.about_description')}
         </p>
       </div>
@@ -275,11 +275,11 @@ const DatabaseMaintenanceSection: React.FC = () => {
       {/* Database Size */}
       <div style={{ marginBottom: '1.5rem' }}>
         <h4 style={{ marginBottom: '0.5rem' }}>{t('maintenance.database_size')}</h4>
-        <p style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--ctp-blue)', margin: 0 }}>
+        <p style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--color-accent)', margin: 0 }}>
           {databaseSize !== null ? formatBytes(databaseSize) : '...'}
         </p>
         {status?.lastRunStats && (
-          <p style={{ color: 'var(--ctp-subtext0)', fontSize: '0.85rem', marginTop: '0.5rem' }}>
+          <p style={{ color: 'var(--color-text-subtle)', fontSize: '0.85rem', marginTop: '0.5rem' }}>
             {t('maintenance.last_run')}: {formatLastRun()}
             {status.lastRunStats && ` (${t('maintenance.deleted_records', { count:
               status.lastRunStats.messagesDeleted +
@@ -294,7 +294,7 @@ const DatabaseMaintenanceSection: React.FC = () => {
       {/* Manual Run */}
       <div style={{ marginBottom: '1.5rem' }}>
         <h4 style={{ marginBottom: '0.5rem' }}>{t('maintenance.manual_title')}</h4>
-        <p style={{ color: 'var(--ctp-subtext0)', marginBottom: '1rem', fontSize: '0.9rem' }}>
+        <p style={{ color: 'var(--color-text-subtle)', marginBottom: '1rem', fontSize: '0.9rem' }}>
           {t('maintenance.manual_description')}
         </p>
         <button
@@ -311,7 +311,7 @@ const DatabaseMaintenanceSection: React.FC = () => {
       {/* Automated Maintenance */}
       <div style={{ marginBottom: '1.5rem' }}>
         <h4 style={{ marginBottom: '0.5rem' }}>{t('maintenance.auto_title')}</h4>
-        <p style={{ color: 'var(--ctp-subtext0)', marginBottom: '1rem', fontSize: '0.9rem' }}>
+        <p style={{ color: 'var(--color-text-subtle)', marginBottom: '1rem', fontSize: '0.9rem' }}>
           {t('maintenance.auto_description')}
         </p>
 
@@ -339,13 +339,13 @@ const DatabaseMaintenanceSection: React.FC = () => {
                   style={{
                     padding: '0.5rem',
                     borderRadius: '4px',
-                    border: '1px solid var(--ctp-surface2)',
-                    backgroundColor: 'var(--ctp-surface0)',
-                    color: 'var(--ctp-text)',
+                    border: '1px solid var(--color-surface-active)',
+                    backgroundColor: 'var(--color-surface)',
+                    color: 'var(--color-text)',
                     fontSize: '1rem'
                   }}
                 />
-                <p style={{ color: 'var(--ctp-subtext0)', fontSize: '0.85rem', marginTop: '0.25rem' }}>
+                <p style={{ color: 'var(--color-text-subtle)', fontSize: '0.85rem', marginTop: '0.25rem' }}>
                   {t('maintenance.next_run')}: {formatNextRun()}
                 </p>
               </div>
@@ -368,14 +368,14 @@ const DatabaseMaintenanceSection: React.FC = () => {
                     style={{
                       padding: '0.5rem',
                       borderRadius: '4px',
-                      border: '1px solid var(--ctp-surface2)',
-                      backgroundColor: 'var(--ctp-surface0)',
-                      color: 'var(--ctp-text)',
+                      border: '1px solid var(--color-surface-active)',
+                      backgroundColor: 'var(--color-surface)',
+                      color: 'var(--color-text)',
                       fontSize: '1rem',
                       width: '100px'
                     }}
                   />
-                  <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-subtext0)' }}>{t('common.days')}</span>
+                  <span style={{ marginLeft: '0.5rem', color: 'var(--color-text-subtle)' }}>{t('common.days')}</span>
                 </div>
 
                 <div>
@@ -391,14 +391,14 @@ const DatabaseMaintenanceSection: React.FC = () => {
                     style={{
                       padding: '0.5rem',
                       borderRadius: '4px',
-                      border: '1px solid var(--ctp-surface2)',
-                      backgroundColor: 'var(--ctp-surface0)',
-                      color: 'var(--ctp-text)',
+                      border: '1px solid var(--color-surface-active)',
+                      backgroundColor: 'var(--color-surface)',
+                      color: 'var(--color-text)',
                       fontSize: '1rem',
                       width: '100px'
                     }}
                   />
-                  <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-subtext0)' }}>{t('common.days')}</span>
+                  <span style={{ marginLeft: '0.5rem', color: 'var(--color-text-subtle)' }}>{t('common.days')}</span>
                 </div>
 
                 <div>
@@ -414,14 +414,14 @@ const DatabaseMaintenanceSection: React.FC = () => {
                     style={{
                       padding: '0.5rem',
                       borderRadius: '4px',
-                      border: '1px solid var(--ctp-surface2)',
-                      backgroundColor: 'var(--ctp-surface0)',
-                      color: 'var(--ctp-text)',
+                      border: '1px solid var(--color-surface-active)',
+                      backgroundColor: 'var(--color-surface)',
+                      color: 'var(--color-text)',
                       fontSize: '1rem',
                       width: '100px'
                     }}
                   />
-                  <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-subtext0)' }}>{t('common.days')}</span>
+                  <span style={{ marginLeft: '0.5rem', color: 'var(--color-text-subtle)' }}>{t('common.days')}</span>
                 </div>
 
                 <div>
@@ -437,18 +437,18 @@ const DatabaseMaintenanceSection: React.FC = () => {
                     style={{
                       padding: '0.5rem',
                       borderRadius: '4px',
-                      border: '1px solid var(--ctp-surface2)',
-                      backgroundColor: 'var(--ctp-surface0)',
-                      color: 'var(--ctp-text)',
+                      border: '1px solid var(--color-surface-active)',
+                      backgroundColor: 'var(--color-surface)',
+                      color: 'var(--color-text)',
                       fontSize: '1rem',
                       width: '100px'
                     }}
                   />
-                  <span style={{ marginLeft: '0.5rem', color: 'var(--ctp-subtext0)' }}>{t('common.days')}</span>
+                  <span style={{ marginLeft: '0.5rem', color: 'var(--color-text-subtle)' }}>{t('common.days')}</span>
                 </div>
               </div>
 
-              <p style={{ color: 'var(--ctp-subtext0)', fontSize: '0.85rem', margin: 0 }}>
+              <p style={{ color: 'var(--color-text-subtle)', fontSize: '0.85rem', margin: 0 }}>
                 {t('maintenance.retention_hint')}
               </p>
             </>

--- a/src/components/configuration/DetectionSensorConfigSection.tsx
+++ b/src/components/configuration/DetectionSensorConfigSection.tsx
@@ -248,8 +248,8 @@ const DetectionSensorConfigSection: React.FC<DetectionSensorConfigSectionProps> 
               className="advanced-toggle-btn"
               style={{
                 background: 'transparent',
-                border: '1px solid var(--ctp-surface2)',
-                color: 'var(--ctp-subtext0)',
+                border: '1px solid var(--color-surface-active)',
+                color: 'var(--color-text-subtle)',
                 padding: '0.5rem 1rem',
                 borderRadius: '4px',
                 cursor: 'pointer',
@@ -268,7 +268,7 @@ const DetectionSensorConfigSection: React.FC<DetectionSensorConfigSectionProps> 
             <div className="advanced-section" style={{
               marginLeft: '1rem',
               paddingLeft: '1rem',
-              borderLeft: '2px solid var(--ctp-surface2)'
+              borderLeft: '2px solid var(--color-surface-active)'
             }}>
               {/* Minimum Broadcast Interval */}
               <div className="setting-item">

--- a/src/components/configuration/DeviceConfigSection.tsx
+++ b/src/components/configuration/DeviceConfigSection.tsx
@@ -500,8 +500,8 @@ const DeviceConfigSection: React.FC<DeviceConfigSectionProps> = ({
         {rebroadcastMode !== 0 && (
           <div
             style={{
-              backgroundColor: 'var(--ctp-peach)',
-              color: 'var(--ctp-base)',
+              backgroundColor: 'var(--color-caution)',
+              color: 'var(--color-bg)',
               padding: '0.75rem',
               borderRadius: '6px',
               marginTop: '0.5rem',
@@ -600,8 +600,8 @@ const DeviceConfigSection: React.FC<DeviceConfigSectionProps> = ({
           className="advanced-toggle-btn"
           style={{
             background: 'transparent',
-            border: '1px solid var(--ctp-surface2)',
-            color: 'var(--ctp-subtext0)',
+            border: '1px solid var(--color-surface-active)',
+            color: 'var(--color-text-subtle)',
             padding: '0.5rem 1rem',
             borderRadius: '4px',
             cursor: 'pointer',
@@ -620,7 +620,7 @@ const DeviceConfigSection: React.FC<DeviceConfigSectionProps> = ({
         <div className="advanced-section" style={{
           marginLeft: '1rem',
           paddingLeft: '1rem',
-          borderLeft: '2px solid var(--ctp-surface2)'
+          borderLeft: '2px solid var(--color-surface-active)'
         }}>
           {/* Button GPIO */}
           <div className="setting-item">

--- a/src/components/configuration/DisplayConfigSection.tsx
+++ b/src/components/configuration/DisplayConfigSection.tsx
@@ -324,8 +324,8 @@ const DisplayConfigSection: React.FC<DisplayConfigSectionProps> = ({
           className="advanced-toggle-btn"
           style={{
             background: 'transparent',
-            border: '1px solid var(--ctp-surface2)',
-            color: 'var(--ctp-subtext0)',
+            border: '1px solid var(--color-surface-active)',
+            color: 'var(--color-text-subtle)',
             padding: '0.5rem 1rem',
             borderRadius: '4px',
             cursor: 'pointer',
@@ -344,7 +344,7 @@ const DisplayConfigSection: React.FC<DisplayConfigSectionProps> = ({
         <div className="advanced-section" style={{
           marginLeft: '1rem',
           paddingLeft: '1rem',
-          borderLeft: '2px solid var(--ctp-surface2)'
+          borderLeft: '2px solid var(--color-surface-active)'
         }}>
           {/* OLED Type */}
           <div className="setting-item">

--- a/src/components/configuration/ExportConfigModal.tsx
+++ b/src/components/configuration/ExportConfigModal.tsx
@@ -191,7 +191,7 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
         onClick={(e) => e.stopPropagation()}
         style={{
           maxWidth: '600px',
-          background: 'var(--ctp-base)',
+          background: 'var(--color-bg)',
           borderRadius: '8px',
           padding: '1.5rem',
           maxHeight: '90vh',
@@ -200,16 +200,16 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
       >
         <h2>{t('export_config.title')}</h2>
 
-        <p style={{ color: 'var(--ctp-subtext0)', marginBottom: '1rem' }}>
+        <p style={{ color: 'var(--color-text-subtle)', marginBottom: '1rem' }}>
           {t('export_config.description')}
         </p>
 
         <div style={{ marginBottom: '1rem' }}>
           <h3>{t('export_config.select_channels')}</h3>
           {channels.length === 0 ? (
-            <div style={{ padding: '1.5rem', background: 'var(--ctp-surface0)', borderRadius: '4px', border: '1px solid var(--ctp-surface2)' }}>
-              <div style={{ color: 'var(--ctp-subtext0)', marginBottom: '1rem' }}>
-                <div style={{ fontWeight: 'bold', color: 'var(--ctp-text)', marginBottom: '0.5rem' }}>
+            <div style={{ padding: '1.5rem', background: 'var(--color-surface)', borderRadius: '4px', border: '1px solid var(--color-surface-active)' }}>
+              <div style={{ color: 'var(--color-text-subtle)', marginBottom: '1rem' }}>
+                <div style={{ fontWeight: 'bold', color: 'var(--color-text)', marginBottom: '0.5rem' }}>
                   {t('export_config.no_channels_title')}
                 </div>
                 <div style={{ marginBottom: '0.75rem', lineHeight: '1.6' }}>
@@ -230,7 +230,7 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
                     }}
                     disabled={isLoadingChannels}
                     style={{
-                      backgroundColor: isLoadingChannels ? 'var(--ctp-surface1)' : 'var(--ctp-blue)',
+                      backgroundColor: isLoadingChannels ? 'var(--color-surface-hover)' : 'var(--color-accent)',
                       color: '#fff',
                       border: 'none',
                       borderRadius: '4px',
@@ -263,10 +263,10 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
                 key={channel.id}
                 style={{
                   padding: '0.75rem',
-                  background: 'var(--ctp-surface0)',
+                  background: 'var(--color-surface)',
                   borderRadius: '4px',
                   marginBottom: '0.5rem',
-                  border: selectedChannels.has(channel.id) ? '2px solid var(--ctp-blue)' : '2px solid transparent'
+                  border: selectedChannels.has(channel.id) ? '2px solid var(--color-accent)' : '2px solid transparent'
                 }}
               >
                 <label style={{ display: 'flex', alignItems: 'flex-start', cursor: 'pointer' }}>
@@ -280,7 +280,7 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
                     <div style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>
                       {t('export_config.channel_label', { id: channel.id, name: channel.name })}
                     </div>
-                    <div style={{ fontSize: '0.875rem', color: 'var(--ctp-subtext0)' }}>
+                    <div style={{ fontSize: '0.875rem', color: 'var(--color-text-subtle)' }}>
                       PSK: {channel.psk ? t('export_config.psk_set') : t('export_config.psk_none')}
                       {channel.positionPrecision !== undefined && channel.positionPrecision !== null && ` | ${t('export_config.position_precision', { bits: channel.positionPrecision })}`}
                       {` | ${channel.uplinkEnabled ? t('export_config.uplink_enabled') : t('export_config.uplink_disabled')}`}
@@ -298,9 +298,9 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
               <div
                 style={{
                   padding: '0.75rem',
-                  background: 'var(--ctp-surface0)',
+                  background: 'var(--color-surface)',
                   borderRadius: '4px',
-                  border: includeLoraConfig ? '2px solid var(--ctp-blue)' : '2px solid transparent'
+                  border: includeLoraConfig ? '2px solid var(--color-accent)' : '2px solid transparent'
                 }}
               >
                 <label style={{ display: 'flex', alignItems: 'flex-start', cursor: 'pointer' }}>
@@ -314,7 +314,7 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
                     <div style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>
                       {t('export_config.lora_config')}
                     </div>
-                    <div style={{ fontSize: '0.875rem', color: 'var(--ctp-subtext0)' }}>
+                    <div style={{ fontSize: '0.875rem', color: 'var(--color-text-subtle)' }}>
                       {t('export_config.lora_config_description')}
                     </div>
                   </div>
@@ -325,7 +325,7 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
         </div>
 
         {error && (
-          <div style={{ color: 'var(--ctp-red)', marginBottom: '1rem', padding: '0.5rem', background: 'var(--ctp-surface0)', borderRadius: '4px' }}>
+          <div style={{ color: 'var(--color-error)', marginBottom: '1rem', padding: '0.5rem', background: 'var(--color-surface)', borderRadius: '4px' }}>
             {error}
           </div>
         )}
@@ -343,8 +343,8 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
                 style={{
                   flex: 1,
                   padding: '0.5rem',
-                  background: 'var(--ctp-surface0)',
-                  border: '1px solid var(--ctp-surface2)',
+                  background: 'var(--color-surface)',
+                  border: '1px solid var(--color-surface-active)',
                   borderRadius: '4px',
                   fontFamily: 'monospace',
                   fontSize: '0.875rem'
@@ -353,8 +353,8 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
               <button
                 onClick={handleCopy}
                 style={{
-                  background: copied ? 'var(--ctp-green)' : 'var(--ctp-blue)',
-                  color: 'var(--ctp-base)',
+                  background: copied ? 'var(--color-success)' : 'var(--color-accent)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   padding: '0.5rem 1rem',
@@ -376,7 +376,7 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
                 {copied ? <><UiIcon name="check" /> {t('export_config.copied')}</> : t('export_config.copy')}
               </button>
             </div>
-            <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', marginTop: '0.5rem' }}>
+            <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', marginTop: '0.5rem' }}>
               {t('export_config.share_url_description')}
             </div>
 
@@ -386,7 +386,7 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
               </label>
               <div style={{
                 padding: '1rem',
-                background: 'var(--ctp-surface0)',
+                background: 'var(--color-surface)',
                 borderRadius: '8px',
                 display: 'inline-block'
               }}>
@@ -397,20 +397,20 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
                   onError={(err) => console.error('Failed to generate QR code:', err)}
                 />
               </div>
-              <div style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)', marginTop: '0.5rem', textAlign: 'center' }}>
+              <div style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)', marginTop: '0.5rem', textAlign: 'center' }}>
                 {t('export_config.scan_qr_description')}
               </div>
             </div>
           </div>
         )}
 
-        <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end', marginTop: '1rem', paddingTop: '1rem', borderTop: '1px solid var(--ctp-surface0)' }}>
+        <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end', marginTop: '1rem', paddingTop: '1rem', borderTop: '1px solid var(--color-surface)' }}>
           <button
             onClick={handleClose}
             style={{
-              background: 'var(--ctp-surface1)',
-              color: 'var(--ctp-text)',
-              border: '1px solid var(--ctp-surface2)',
+              background: 'var(--color-surface-hover)',
+              color: 'var(--color-text)',
+              border: '1px solid var(--color-surface-active)',
               borderRadius: '4px',
               padding: '0.5rem 1rem',
               cursor: 'pointer',
@@ -418,8 +418,8 @@ export const ExportConfigModal: React.FC<ExportConfigModalProps> = ({
               fontWeight: '500',
               transition: 'all 0.2s ease'
             }}
-            onMouseOver={(e) => e.currentTarget.style.background = 'var(--ctp-surface2)'}
-            onMouseOut={(e) => e.currentTarget.style.background = 'var(--ctp-surface1)'}
+            onMouseOver={(e) => e.currentTarget.style.background = 'var(--color-surface-active)'}
+            onMouseOut={(e) => e.currentTarget.style.background = 'var(--color-surface-hover)'}
           >
             {t('export_config.close')}
           </button>

--- a/src/components/configuration/ExternalNotificationConfigSection.tsx
+++ b/src/components/configuration/ExternalNotificationConfigSection.tsx
@@ -228,7 +228,7 @@ const ExternalNotificationConfigSection: React.FC<ExternalNotificationConfigSect
           </div>
 
           {/* Alert Settings Section */}
-          <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--ctp-subtext0)' }}>
+          <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--color-text-subtle)' }}>
             {t('extnotif_config.alert_section')}
           </h4>
 
@@ -342,8 +342,8 @@ const ExternalNotificationConfigSection: React.FC<ExternalNotificationConfigSect
               className="advanced-toggle-btn"
               style={{
                 background: 'transparent',
-                border: '1px solid var(--ctp-surface2)',
-                color: 'var(--ctp-subtext0)',
+                border: '1px solid var(--color-surface-active)',
+                color: 'var(--color-text-subtle)',
                 padding: '0.5rem 1rem',
                 borderRadius: '4px',
                 cursor: 'pointer',
@@ -362,7 +362,7 @@ const ExternalNotificationConfigSection: React.FC<ExternalNotificationConfigSect
             <div className="advanced-section" style={{
               marginLeft: '1rem',
               paddingLeft: '1rem',
-              borderLeft: '2px solid var(--ctp-surface2)'
+              borderLeft: '2px solid var(--color-surface-active)'
             }}>
               {/* Use PWM */}
               <div className="setting-item">
@@ -417,7 +417,7 @@ const ExternalNotificationConfigSection: React.FC<ExternalNotificationConfigSect
               </div>
 
               {/* GPIO Settings */}
-              <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--ctp-subtext0)' }}>
+              <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--color-text-subtle)' }}>
                 {t('extnotif_config.gpio_section')}
               </h4>
 

--- a/src/components/configuration/FirmwareUpdateSection.tsx
+++ b/src/components/configuration/FirmwareUpdateSection.tsx
@@ -478,7 +478,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
           style={{
             marginTop: '0.5rem',
             padding: '0.5rem 0.75rem',
-            border: '1px solid var(--ctp-yellow, #d4a017)',
+            border: '1px solid var(--color-warning, #d4a017)',
             borderRadius: '4px',
           }}
         >
@@ -565,7 +565,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
 
       {/* Check Now + Last Checked */}
       <div className="setting-item" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <span style={{ color: 'var(--ctp-text)', fontSize: '0.9rem' }}>
+        <span style={{ color: 'var(--color-text)', fontSize: '0.9rem' }}>
           {t('firmware.last_checked', 'Last Checked')}: {formatTimestamp(lastChecked)}
         </span>
         <button
@@ -583,18 +583,18 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
         <div style={{
           padding: '1.5rem',
           borderRadius: '8px',
-          backgroundColor: 'var(--ctp-base)',
+          backgroundColor: 'var(--color-bg)',
           border: effectiveStatus.state === 'error'
-            ? '2px solid var(--ctp-red)'
+            ? '2px solid var(--color-error)'
             : effectiveStatus.state === 'success'
               ? '2px solid #10b981'
-              : '2px solid var(--ctp-blue)',
+              : '2px solid var(--color-accent)',
           width: '90%',
           maxWidth: '600px',
           maxHeight: '85vh',
           overflow: 'auto',
         }}>
-          <h3 style={{ margin: '0 0 1rem', color: 'var(--ctp-text)' }}>
+          <h3 style={{ margin: '0 0 1rem', color: 'var(--color-text)' }}>
             {t('firmware.update_wizard', 'Firmware Update')}
           </h3>
 
@@ -614,10 +614,10 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
               const isCurrent = s.key === effectiveStatus.step;
               const isFailed = isCurrent && effectiveStatus.state === 'error';
 
-              let dotColor = 'var(--ctp-surface2)'; // future
+              let dotColor = 'var(--color-surface-active)'; // future
               if (isComplete) dotColor = '#10b981'; // green
-              if (isCurrent && !isFailed) dotColor = 'var(--ctp-blue)';
-              if (isFailed) dotColor = 'var(--ctp-red)';
+              if (isCurrent && !isFailed) dotColor = 'var(--color-accent)';
+              if (isFailed) dotColor = 'var(--color-error)';
 
               return (
                 <React.Fragment key={s.key}>
@@ -625,7 +625,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
                     <div style={{
                       flex: 1,
                       height: '2px',
-                      backgroundColor: isComplete ? '#10b981' : 'var(--ctp-surface2)',
+                      backgroundColor: isComplete ? '#10b981' : 'var(--color-surface-active)',
                     }} />
                   )}
                   <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', minWidth: '48px' }}>
@@ -634,12 +634,12 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
                       height: isCurrent ? '14px' : '10px',
                       borderRadius: '50%',
                       backgroundColor: dotColor,
-                      border: isCurrent ? '2px solid var(--ctp-text)' : 'none',
+                      border: isCurrent ? '2px solid var(--color-text)' : 'none',
                       transition: 'all 0.2s',
                     }} />
                     <span style={{
                       fontSize: '0.7rem',
-                      color: isCurrent ? 'var(--ctp-text)' : 'var(--ctp-subtext0)',
+                      color: isCurrent ? 'var(--color-text)' : 'var(--color-text-subtle)',
                       fontWeight: isCurrent ? 600 : 400,
                       marginTop: '4px',
                     }}>
@@ -653,10 +653,10 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
 
           {/* Step title & message */}
           <div style={{ marginBottom: '0.75rem' }}>
-            <h4 style={{ margin: 0, color: 'var(--ctp-text)' }}>
+            <h4 style={{ margin: 0, color: 'var(--color-text)' }}>
               {getStepTitle(effectiveStatus.step)}
             </h4>
-            <p style={{ margin: '0.25rem 0 0', color: 'var(--ctp-text)', fontSize: '0.9rem' }}>
+            <p style={{ margin: '0.25rem 0 0', color: 'var(--color-text)', fontSize: '0.9rem' }}>
               {effectiveStatus.message}
             </p>
           </div>
@@ -670,7 +670,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
                 alignItems: 'center',
                 marginBottom: '0.35rem',
                 fontSize: '0.85rem',
-                color: 'var(--ctp-text)',
+                color: 'var(--color-text)',
               }}>
                 <span>{t('firmware.uploading', 'Uploading firmware...')}</span>
                 <span style={{ fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>
@@ -680,14 +680,14 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
               <div style={{
                 width: '100%',
                 height: '16px',
-                backgroundColor: 'var(--ctp-surface2)',
+                backgroundColor: 'var(--color-surface-active)',
                 borderRadius: '8px',
                 overflow: 'hidden',
               }}>
                 <div style={{
                   width: `${Math.min(effectiveStatus.progress, 100)}%`,
                   height: '100%',
-                  backgroundColor: 'var(--ctp-blue)',
+                  backgroundColor: 'var(--color-accent)',
                   borderRadius: '8px',
                   transition: 'width 0.5s ease',
                 }} />
@@ -700,7 +700,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
             <div style={{
               padding: '0.75rem',
               borderRadius: '6px',
-              backgroundColor: 'var(--ctp-surface1)',
+              backgroundColor: 'var(--color-surface-hover)',
               marginBottom: '0.75rem',
               fontSize: '0.85rem',
               lineHeight: '1.6',
@@ -721,8 +721,8 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
               padding: '0.5rem 0.75rem',
               borderRadius: '4px',
               backgroundColor: 'rgba(250, 179, 40, 0.1)',
-              border: '1px solid var(--ctp-peach)',
-              color: 'var(--ctp-text)',
+              border: '1px solid var(--color-caution)',
+              color: 'var(--color-text)',
               fontSize: '0.85rem',
               marginBottom: '0.75rem',
               lineHeight: '1.5',
@@ -745,7 +745,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
           {effectiveStatus.matchedFile && (
             <div style={{ marginBottom: '0.5rem', fontSize: '0.85rem' }}>
               <strong>{t('firmware.matched_file', 'Selected Firmware')}:</strong>{' '}
-              <code style={{ color: 'var(--ctp-blue)' }}>{effectiveStatus.matchedFile}</code>
+              <code style={{ color: 'var(--color-accent)' }}>{effectiveStatus.matchedFile}</code>
             </div>
           )}
 
@@ -757,7 +757,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
                 style={{
                   background: 'none',
                   border: 'none',
-                  color: 'var(--ctp-text)',
+                  color: 'var(--color-text)',
                   cursor: 'pointer',
                   padding: 0,
                   fontSize: '0.85rem',
@@ -772,7 +772,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
                   margin: '0.25rem 0 0 1rem',
                   padding: 0,
                   listStyle: 'disc',
-                  color: 'var(--ctp-text)',
+                  color: 'var(--color-text)',
                   opacity: 0.8,
                 }}>
                   {effectiveStatus.rejectedFiles.map((f, i) => (
@@ -792,8 +792,8 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
                 overflow: 'auto',
                 padding: '0.5rem',
                 borderRadius: '4px',
-                backgroundColor: 'var(--ctp-base)',
-                color: 'var(--ctp-text)',
+                backgroundColor: 'var(--color-bg)',
+                color: 'var(--color-text)',
                 fontSize: '0.8rem',
                 fontFamily: 'monospace',
                 marginBottom: '0.75rem',
@@ -811,7 +811,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
               padding: '0.5rem 0.75rem',
               borderRadius: '4px',
               backgroundColor: 'rgba(235, 87, 87, 0.1)',
-              color: 'var(--ctp-red)',
+              color: 'var(--color-error)',
               fontSize: '0.85rem',
               marginBottom: '0.75rem',
             }}>
@@ -823,7 +823,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
           {effectiveStatus.step === 'extract' &&
             effectiveStatus.state === 'awaiting-confirm' && (
             <p style={{
-              color: 'var(--ctp-peach)',
+              color: 'var(--color-caution)',
               fontSize: '0.85rem',
               margin: '0 0 0.75rem',
             }}>
@@ -839,8 +839,8 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
               padding: '0.75rem',
               borderRadius: '6px',
               backgroundColor: 'rgba(250, 179, 40, 0.1)',
-              border: '1px solid var(--ctp-peach)',
-              color: 'var(--ctp-text)',
+              border: '1px solid var(--color-caution)',
+              color: 'var(--color-text)',
               fontSize: '0.85rem',
               marginBottom: '0.75rem',
               lineHeight: '1.5',
@@ -860,7 +860,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
                   width: '10px',
                   height: '10px',
                   borderRadius: '50%',
-                  backgroundColor: isGatewayOnline ? '#10b981' : 'var(--ctp-red)',
+                  backgroundColor: isGatewayOnline ? '#10b981' : 'var(--color-error)',
                   flexShrink: 0,
                 }} />
                 <span>
@@ -937,7 +937,7 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
       {!isUpdateActive && (
         <div style={{ marginTop: '1rem' }}>
           {releases.length === 0 ? (
-            <p style={{ color: 'var(--ctp-text)', fontStyle: 'italic', fontSize: '0.9rem' }}>
+            <p style={{ color: 'var(--color-text)', fontStyle: 'italic', fontSize: '0.9rem' }}>
               {t('firmware.no_releases', "No releases found. Click 'Check Now' to fetch available firmware versions.")}
             </p>
           ) : (
@@ -947,23 +947,23 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
               fontSize: '0.9rem',
             }}>
               <thead>
-                <tr style={{ borderBottom: '1px solid var(--ctp-surface2)' }}>
-                  <th style={{ textAlign: 'left', padding: '0.5rem', color: 'var(--ctp-text)' }}>
+                <tr style={{ borderBottom: '1px solid var(--color-surface-active)' }}>
+                  <th style={{ textAlign: 'left', padding: '0.5rem', color: 'var(--color-text)' }}>
                     {t('firmware.version', 'Version')}
                   </th>
-                  <th style={{ textAlign: 'left', padding: '0.5rem', color: 'var(--ctp-text)' }}>
+                  <th style={{ textAlign: 'left', padding: '0.5rem', color: 'var(--color-text)' }}>
                     {t('firmware.release_date', 'Release Date')}
                   </th>
-                  <th style={{ textAlign: 'center', padding: '0.5rem', color: 'var(--ctp-text)' }}>
+                  <th style={{ textAlign: 'center', padding: '0.5rem', color: 'var(--color-text)' }}>
                     {t('firmware.release_notes', 'Release Notes')}
                   </th>
-                  <th style={{ textAlign: 'right', padding: '0.5rem', color: 'var(--ctp-text)' }}></th>
+                  <th style={{ textAlign: 'right', padding: '0.5rem', color: 'var(--color-text)' }}></th>
                 </tr>
               </thead>
               <tbody>
                 {releases.map((release) => (
-                  <tr key={release.tagName} style={{ borderBottom: '1px solid var(--ctp-surface1)' }}>
-                    <td style={{ padding: '0.5rem', color: 'var(--ctp-text)' }}>
+                  <tr key={release.tagName} style={{ borderBottom: '1px solid var(--color-surface-hover)' }}>
+                    <td style={{ padding: '0.5rem', color: 'var(--color-text)' }}>
                       {release.version}
                       {release.prerelease && (
                         <span style={{
@@ -971,14 +971,14 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
                           padding: '0.1rem 0.4rem',
                           fontSize: '0.75rem',
                           borderRadius: '3px',
-                          backgroundColor: 'var(--ctp-peach)',
-                          color: 'var(--ctp-base)',
+                          backgroundColor: 'var(--color-caution)',
+                          color: 'var(--color-bg)',
                         }}>
                           alpha
                         </span>
                       )}
                     </td>
-                    <td style={{ padding: '0.5rem', color: 'var(--ctp-text)' }}>
+                    <td style={{ padding: '0.5rem', color: 'var(--color-text)' }}>
                       {new Date(release.publishedAt).toLocaleDateString()}
                     </td>
                     <td style={{ textAlign: 'center', padding: '0.5rem' }}>
@@ -1024,11 +1024,11 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
 
       {/* Configuration Backups */}
       <div style={{ marginTop: '2rem' }}>
-        <h4 style={{ color: 'var(--ctp-text)', marginBottom: '0.5rem' }}>
+        <h4 style={{ color: 'var(--color-text)', marginBottom: '0.5rem' }}>
           {t('firmware.backups_title', 'Configuration Backups')}
         </h4>
         {backups.length === 0 ? (
-          <p style={{ color: 'var(--ctp-text)', fontStyle: 'italic', fontSize: '0.9rem' }}>
+          <p style={{ color: 'var(--color-text)', fontStyle: 'italic', fontSize: '0.9rem' }}>
             {t('firmware.no_backups', 'No configuration backups found.')}
           </p>
         ) : (
@@ -1039,14 +1039,14 @@ const FirmwareUpdateSection: React.FC<FirmwareUpdateSectionProps> = ({ baseUrl }
           }}>
             <tbody>
               {backups.map((backup) => (
-                <tr key={backup.filename} style={{ borderBottom: '1px solid var(--ctp-surface1)' }}>
-                  <td style={{ padding: '0.5rem', color: 'var(--ctp-text)' }}>
+                <tr key={backup.filename} style={{ borderBottom: '1px solid var(--color-surface-hover)' }}>
+                  <td style={{ padding: '0.5rem', color: 'var(--color-text)' }}>
                     {backup.filename}
                   </td>
-                  <td style={{ padding: '0.5rem', color: 'var(--ctp-text)' }}>
+                  <td style={{ padding: '0.5rem', color: 'var(--color-text)' }}>
                     {new Date(backup.timestamp).toLocaleString()}
                   </td>
-                  <td style={{ padding: '0.5rem', color: 'var(--ctp-text)' }}>
+                  <td style={{ padding: '0.5rem', color: 'var(--color-text)' }}>
                     {formatBytes(backup.size)}
                   </td>
                   <td style={{ textAlign: 'right', padding: '0.5rem' }}>

--- a/src/components/configuration/GpioPinSummary.tsx
+++ b/src/components/configuration/GpioPinSummary.tsx
@@ -114,16 +114,16 @@ const GpioPinSummary: React.FC<GpioPinSummaryProps> = (props) => {
     return (
       <div style={{
         padding: '1rem',
-        backgroundColor: 'var(--ctp-surface0)',
+        backgroundColor: 'var(--color-surface)',
         borderRadius: '8px',
-        border: '1px solid var(--ctp-surface2)',
+        border: '1px solid var(--color-surface-active)',
         maxHeight: 'calc(100dvh - 2rem)',
         overflowY: 'auto'
       }}>
-        <h4 style={{ margin: '0 0 0.5rem 0', color: 'var(--ctp-text)' }}>
+        <h4 style={{ margin: '0 0 0.5rem 0', color: 'var(--color-text)' }}>
           {t('gpio_summary.title')}
         </h4>
-        <p style={{ margin: 0, color: 'var(--ctp-subtext0)', fontSize: '0.85rem' }}>
+        <p style={{ margin: 0, color: 'var(--color-text-subtle)', fontSize: '0.85rem' }}>
           {t('gpio_summary.no_pins')}
         </p>
       </div>
@@ -133,16 +133,16 @@ const GpioPinSummary: React.FC<GpioPinSummaryProps> = (props) => {
   return (
     <div style={{
       padding: '1rem',
-      backgroundColor: 'var(--ctp-surface0)',
+      backgroundColor: 'var(--color-surface)',
       borderRadius: '8px',
-      border: '1px solid var(--ctp-surface2)',
+      border: '1px solid var(--color-surface-active)',
       maxHeight: 'calc(100dvh - 2rem)',
       overflowY: 'auto'
     }}>
-      <h4 style={{ margin: '0 0 0.5rem 0', color: 'var(--ctp-text)' }}>
+      <h4 style={{ margin: '0 0 0.5rem 0', color: 'var(--color-text)' }}>
         {t('gpio_summary.title')}
       </h4>
-      <p style={{ margin: '0 0 1rem 0', color: 'var(--ctp-subtext0)', fontSize: '0.85rem' }}>
+      <p style={{ margin: '0 0 1rem 0', color: 'var(--color-text-subtle)', fontSize: '0.85rem' }}>
         {t('gpio_summary.description')}
       </p>
 
@@ -166,7 +166,7 @@ const GpioPinSummary: React.FC<GpioPinSummaryProps> = (props) => {
         fontSize: '0.8rem'
       }}>
         <thead>
-          <tr style={{ borderBottom: '2px solid var(--ctp-surface2)' }}>
+          <tr style={{ borderBottom: '2px solid var(--color-surface-active)' }}>
             <th style={{ textAlign: 'left', padding: '0.4rem', width: '55px' }}>
               {t('gpio_summary.pin')}
             </th>
@@ -179,7 +179,7 @@ const GpioPinSummary: React.FC<GpioPinSummaryProps> = (props) => {
           {pinGroups.map(([pin, usages]) => {
             const isConflict = conflictPins.has(pin);
             const rowStyle: React.CSSProperties = {
-              borderBottom: '1px solid var(--ctp-surface1)',
+              borderBottom: '1px solid var(--color-surface-hover)',
               backgroundColor: isConflict ? 'rgba(255, 68, 68, 0.1)' : 'transparent'
             };
             const cellStyle: React.CSSProperties = {
@@ -199,7 +199,7 @@ const GpioPinSummary: React.FC<GpioPinSummaryProps> = (props) => {
                     <div key={idx} style={{ marginBottom: idx < usages.length - 1 ? '0.25rem' : 0 }}>
                       <span style={{ fontWeight: 500 }}>{usage.field}</span>
                       <br />
-                      <span style={{ fontSize: '0.75rem', color: 'var(--ctp-subtext0)' }}>
+                      <span style={{ fontSize: '0.75rem', color: 'var(--color-text-subtle)' }}>
                         {usage.section}
                       </span>
                     </div>

--- a/src/components/configuration/ImportConfigModal.tsx
+++ b/src/components/configuration/ImportConfigModal.tsx
@@ -243,7 +243,7 @@ export const ImportConfigModal: React.FC<ImportConfigModalProps> = ({ isOpen, on
         onClick={(e) => e.stopPropagation()}
         style={{
           maxWidth: '600px',
-          background: 'var(--ctp-base)',
+          background: 'var(--color-bg)',
           borderRadius: '8px',
           padding: '1.5rem',
           maxHeight: '90vh',
@@ -269,8 +269,8 @@ export const ImportConfigModal: React.FC<ImportConfigModalProps> = ({ isOpen, on
             disabled={loading || !url.trim()}
             style={{
               marginTop: '0.5rem',
-              background: 'var(--ctp-blue)',
-              color: 'var(--ctp-base)',
+              background: 'var(--color-accent)',
+              color: 'var(--color-bg)',
               border: 'none',
               borderRadius: '4px',
               padding: '0.5rem 1rem',
@@ -296,7 +296,7 @@ export const ImportConfigModal: React.FC<ImportConfigModalProps> = ({ isOpen, on
         </div>
 
         {error && (
-          <div style={{ color: 'var(--ctp-red)', marginBottom: '1rem', padding: '0.5rem', background: 'var(--ctp-surface0)', borderRadius: '4px' }}>
+          <div style={{ color: 'var(--color-error)', marginBottom: '1rem', padding: '0.5rem', background: 'var(--color-surface)', borderRadius: '4px' }}>
             {error}
           </div>
         )}
@@ -313,10 +313,10 @@ export const ImportConfigModal: React.FC<ImportConfigModalProps> = ({ isOpen, on
                     key={idx}
                     style={{
                       padding: '0.75rem',
-                      background: 'var(--ctp-surface0)',
+                      background: 'var(--color-surface)',
                       borderRadius: '4px',
                       marginBottom: '0.5rem',
-                      border: selectedChannels.has(idx) ? '2px solid var(--ctp-blue)' : '2px solid transparent'
+                      border: selectedChannels.has(idx) ? '2px solid var(--color-accent)' : '2px solid transparent'
                     }}
                   >
                     <label style={{ display: 'flex', alignItems: 'flex-start', cursor: 'pointer' }}>
@@ -330,7 +330,7 @@ export const ImportConfigModal: React.FC<ImportConfigModalProps> = ({ isOpen, on
                         <div style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>
                           {t('import_config.channel_label', { idx, name: channel.name || t('import_config.channel_unnamed') })}
                         </div>
-                        <div style={{ fontSize: '0.875rem', color: 'var(--ctp-subtext0)' }}>
+                        <div style={{ fontSize: '0.875rem', color: 'var(--color-text-subtle)' }}>
                           {channel.psk ? t('import_config.psk_label', { psk: channel.psk }) : t('import_config.psk_none')}
                           {channel.positionPrecision !== undefined && ` | ${t('import_config.position_precision', { bits: channel.positionPrecision })}`}
                           {channel.uplinkEnabled !== undefined && ` | ${channel.uplinkEnabled ? t('import_config.uplink_enabled') : t('import_config.uplink_disabled')}`}
@@ -348,9 +348,9 @@ export const ImportConfigModal: React.FC<ImportConfigModalProps> = ({ isOpen, on
                 <div
                   style={{
                     padding: '0.75rem',
-                    background: 'var(--ctp-surface0)',
+                    background: 'var(--color-surface)',
                     borderRadius: '4px',
-                    border: includeLoraConfig ? '2px solid var(--ctp-blue)' : '2px solid transparent'
+                    border: includeLoraConfig ? '2px solid var(--color-accent)' : '2px solid transparent'
                   }}
                 >
                   <label style={{ display: 'flex', alignItems: 'flex-start', cursor: 'pointer' }}>
@@ -364,7 +364,7 @@ export const ImportConfigModal: React.FC<ImportConfigModalProps> = ({ isOpen, on
                       <div style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>
                         {t('import_config.lora_settings')}
                       </div>
-                      <div style={{ fontSize: '0.875rem', color: 'var(--ctp-subtext0)' }}>
+                      <div style={{ fontSize: '0.875rem', color: 'var(--color-text-subtle)' }}>
                         {t('import_config.preset', { preset: modemPresetNames[decoded.loraConfig.modemPreset ?? 0] || decoded.loraConfig.modemPreset })}
                         {decoded.loraConfig.region !== undefined && ` | ${t('import_config.region', { region: regionNames[decoded.loraConfig.region] || decoded.loraConfig.region })}`}
                         {decoded.loraConfig.hopLimit !== undefined && ` | ${t('import_config.hop_limit', { limit: decoded.loraConfig.hopLimit })}`}
@@ -381,23 +381,23 @@ export const ImportConfigModal: React.FC<ImportConfigModalProps> = ({ isOpen, on
                 style={{
                   marginTop: '1rem',
                   padding: '1rem',
-                  background: 'var(--ctp-surface0)',
+                  background: 'var(--color-surface)',
                   borderRadius: '8px',
-                  border: '2px solid var(--ctp-blue)',
+                  border: '2px solid var(--color-accent)',
                   textAlign: 'center'
                 }}
               >
-                <div style={{ fontSize: '1rem', fontWeight: 'bold', color: 'var(--ctp-blue)', marginBottom: '0.5rem' }}>
+                <div style={{ fontSize: '1rem', fontWeight: 'bold', color: 'var(--color-accent)', marginBottom: '0.5rem' }}>
                   {t('import_config.import_in_progress')}
                 </div>
-                <div style={{ fontSize: '0.875rem', color: 'var(--ctp-text)', marginBottom: '0.75rem' }}>
+                <div style={{ fontSize: '0.875rem', color: 'var(--color-text)', marginBottom: '0.75rem' }}>
                   {importStatus}
                 </div>
                 <div
                   style={{
                     width: '100%',
                     height: '4px',
-                    background: 'var(--ctp-surface1)',
+                    background: 'var(--color-surface-hover)',
                     borderRadius: '2px',
                     overflow: 'hidden'
                   }}
@@ -405,7 +405,7 @@ export const ImportConfigModal: React.FC<ImportConfigModalProps> = ({ isOpen, on
                   <div
                     style={{
                       height: '100%',
-                      background: 'var(--ctp-blue)',
+                      background: 'var(--color-accent)',
                       animation: 'progress-bar 2s ease-in-out infinite',
                       width: '30%'
                     }}
@@ -421,14 +421,14 @@ export const ImportConfigModal: React.FC<ImportConfigModalProps> = ({ isOpen, on
               </div>
             )}
 
-            <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end', marginTop: '1rem', paddingTop: '1rem', borderTop: '1px solid var(--ctp-surface0)' }}>
+            <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end', marginTop: '1rem', paddingTop: '1rem', borderTop: '1px solid var(--color-surface)' }}>
               <button
                 onClick={handleClose}
                 disabled={importing}
                 style={{
-                  background: 'var(--ctp-surface1)',
-                  color: 'var(--ctp-text)',
-                  border: '1px solid var(--ctp-surface2)',
+                  background: 'var(--color-surface-hover)',
+                  color: 'var(--color-text)',
+                  border: '1px solid var(--color-surface-active)',
                   borderRadius: '4px',
                   padding: '0.5rem 1rem',
                   cursor: importing ? 'not-allowed' : 'pointer',
@@ -439,12 +439,12 @@ export const ImportConfigModal: React.FC<ImportConfigModalProps> = ({ isOpen, on
                 }}
                 onMouseOver={(e) => {
                   if (!importing) {
-                    e.currentTarget.style.background = 'var(--ctp-surface2)';
+                    e.currentTarget.style.background = 'var(--color-surface-active)';
                   }
                 }}
                 onMouseOut={(e) => {
                   if (!importing) {
-                    e.currentTarget.style.background = 'var(--ctp-surface1)';
+                    e.currentTarget.style.background = 'var(--color-surface-hover)';
                   }
                 }}
               >
@@ -454,8 +454,8 @@ export const ImportConfigModal: React.FC<ImportConfigModalProps> = ({ isOpen, on
                 onClick={handleImport}
                 disabled={loading || importing || (selectedChannels.size === 0 && !includeLoraConfig)}
                 style={{
-                  background: 'var(--ctp-blue)',
-                  color: 'var(--ctp-base)',
+                  background: 'var(--color-accent)',
+                  color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',
                   padding: '0.5rem 1rem',

--- a/src/components/configuration/LoRaConfigSection.tsx
+++ b/src/components/configuration/LoRaConfigSection.tsx
@@ -420,10 +420,10 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
             style={{
               marginTop: '0.5rem',
               padding: '0.6rem 0.75rem',
-              border: '1px solid var(--ctp-yellow, #f9e2af)',
+              border: '1px solid var(--color-warning, #f9e2af)',
               borderRadius: '4px',
               backgroundColor: 'rgba(249, 226, 175, 0.12)',
-              color: 'var(--ctp-yellow, #f9e2af)',
+              color: 'var(--color-warning, #f9e2af)',
               lineHeight: '1.4'
             }}
           >

--- a/src/components/configuration/MQTTConfigSection.tsx
+++ b/src/components/configuration/MQTTConfigSection.tsx
@@ -306,13 +306,13 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
             padding: '10px 12px',
             borderRadius: 6,
             background: 'rgba(137, 180, 250, 0.10)', // ctp-blue @ low alpha
-            border: '1px solid var(--ctp-blue, #89b4fa)',
-            color: 'var(--ctp-text)',
+            border: '1px solid var(--color-accent, #89b4fa)',
+            color: 'var(--color-text)',
             fontSize: 13,
             lineHeight: 1.4,
           }}
         >
-          <strong style={{ color: 'var(--ctp-blue, #89b4fa)' }}>
+          <strong style={{ color: 'var(--color-accent, #89b4fa)' }}>
             <UiIcon name="network" /> {t('mqtt_config.bridged_recommend_title', 'This is a bridged node')}
           </strong>
           <div style={{ marginTop: 4 }}>
@@ -332,13 +332,13 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
             padding: '10px 12px',
             borderRadius: 6,
             background: 'rgba(243, 139, 168, 0.10)', // ctp-red @ low alpha
-            border: '1px solid var(--ctp-red, #f38ba8)',
-            color: 'var(--ctp-text)',
+            border: '1px solid var(--color-error, #f38ba8)',
+            color: 'var(--color-text)',
             fontSize: 13,
             lineHeight: 1.4,
           }}
         >
-          <strong style={{ color: 'var(--ctp-red, #f38ba8)' }}>
+          <strong style={{ color: 'var(--color-error, #f38ba8)' }}>
             <UiIcon name="encrypted" /> {t('mqtt_config.permission_denied', "You don't have permission to modify MQTT settings for this source.")}
           </strong>
         </div>
@@ -355,13 +355,13 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
             padding: '10px 12px',
             borderRadius: 6,
             background: 'rgba(249, 226, 175, 0.10)', // ctp-yellow @ low alpha
-            border: '1px solid var(--ctp-yellow, #f9e2af)',
-            color: 'var(--ctp-text)',
+            border: '1px solid var(--color-warning, #f9e2af)',
+            color: 'var(--color-text)',
             fontSize: 13,
             lineHeight: 1.4,
           }}
         >
-          <strong style={{ color: 'var(--ctp-yellow, #f9e2af)' }}>
+          <strong style={{ color: 'var(--color-warning, #f9e2af)' }}>
             <UiIcon name="alert" /> {t('mqtt_config.proxy_warning_title', 'Client proxy is enabled but no broker is linked')}
           </strong>
           <div style={{ marginTop: 6 }}>
@@ -580,7 +580,7 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
             <div style={{
               marginLeft: '1rem',
               paddingLeft: '1rem',
-              borderLeft: '2px solid var(--ctp-surface2)',
+              borderLeft: '2px solid var(--color-surface-active)',
               marginTop: '0.5rem',
               marginBottom: '1rem'
             }}>

--- a/src/components/configuration/NetworkConfigSection.tsx
+++ b/src/components/configuration/NetworkConfigSection.tsx
@@ -165,13 +165,13 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
             padding: '10px 12px',
             borderRadius: 6,
             background: 'rgba(137, 180, 250, 0.10)', // ctp-blue @ low alpha
-            border: '1px solid var(--ctp-blue, #89b4fa)',
-            color: 'var(--ctp-text)',
+            border: '1px solid var(--color-accent, #89b4fa)',
+            color: 'var(--color-text)',
             fontSize: 13,
             lineHeight: 1.4,
           }}
         >
-          <strong style={{ color: 'var(--ctp-blue, #89b4fa)' }}>
+          <strong style={{ color: 'var(--color-accent, #89b4fa)' }}>
             <UiIcon name="network" /> {t('network_config.bridged_inert_title', 'This is a bridged node')}
           </strong>
           <div style={{ marginTop: 4 }}>
@@ -241,8 +241,8 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
                 onClick={() => setShowPassword(!showPassword)}
                 style={{
                   background: 'transparent',
-                  border: '1px solid var(--ctp-surface2)',
-                  color: 'var(--ctp-subtext0)',
+                  border: '1px solid var(--color-surface-active)',
+                  color: 'var(--color-text-subtle)',
                   padding: '0.5rem',
                   borderRadius: '4px',
                   cursor: 'pointer'
@@ -278,10 +278,10 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
             <div style={{
               marginLeft: '1rem',
               paddingLeft: '1rem',
-              borderLeft: '2px solid var(--ctp-surface2)',
+              borderLeft: '2px solid var(--color-surface-active)',
               marginTop: '1rem'
             }}>
-              <h4 style={{ marginBottom: '1rem', color: 'var(--ctp-subtext0)' }}>
+              <h4 style={{ marginBottom: '1rem', color: 'var(--color-text-subtle)' }}>
                 {t('network_config.static_ip_settings')}
               </h4>
 

--- a/src/components/configuration/PositionConfigSection.tsx
+++ b/src/components/configuration/PositionConfigSection.tsx
@@ -348,7 +348,7 @@ const PositionConfigSection: React.FC<PositionConfigSectionProps> = ({
         <div style={{
           marginLeft: '1rem',
           paddingLeft: '1rem',
-          borderLeft: '2px solid var(--ctp-surface2)',
+          borderLeft: '2px solid var(--color-surface-active)',
           marginTop: '0.5rem',
           marginBottom: '1rem'
         }}>
@@ -422,8 +422,8 @@ const PositionConfigSection: React.FC<PositionConfigSectionProps> = ({
           className="advanced-toggle-btn"
           style={{
             background: 'transparent',
-            border: '1px solid var(--ctp-surface2)',
-            color: 'var(--ctp-subtext0)',
+            border: '1px solid var(--color-surface-active)',
+            color: 'var(--color-text-subtle)',
             padding: '0.5rem 1rem',
             borderRadius: '4px',
             cursor: 'pointer',
@@ -442,7 +442,7 @@ const PositionConfigSection: React.FC<PositionConfigSectionProps> = ({
         <div className="advanced-section" style={{
           marginLeft: '1rem',
           paddingLeft: '1rem',
-          borderLeft: '2px solid var(--ctp-surface2)'
+          borderLeft: '2px solid var(--color-surface-active)'
         }}>
           {/* RX GPIO */}
           <div className="setting-item">

--- a/src/components/configuration/PowerConfigSection.tsx
+++ b/src/components/configuration/PowerConfigSection.tsx
@@ -297,8 +297,8 @@ const PowerConfigSection: React.FC<PowerConfigSectionProps> = ({
           className="advanced-toggle-btn"
           style={{
             background: 'transparent',
-            border: '1px solid var(--ctp-surface2)',
-            color: 'var(--ctp-subtext0)',
+            border: '1px solid var(--color-surface-active)',
+            color: 'var(--color-text-subtle)',
             padding: '0.5rem 1rem',
             borderRadius: '4px',
             cursor: 'pointer',
@@ -317,7 +317,7 @@ const PowerConfigSection: React.FC<PowerConfigSectionProps> = ({
         <div className="advanced-section" style={{
           marginLeft: '1rem',
           paddingLeft: '1rem',
-          borderLeft: '2px solid var(--ctp-surface2)'
+          borderLeft: '2px solid var(--color-surface-active)'
         }}>
           {/* INA Battery Address */}
           <div className="setting-item">

--- a/src/components/configuration/RemoteHardwareConfigSection.tsx
+++ b/src/components/configuration/RemoteHardwareConfigSection.tsx
@@ -117,11 +117,11 @@ const RemoteHardwareConfigSection: React.FC<RemoteHardwareConfigSectionProps> = 
 
           <div className="setting-item" style={{
             padding: '0.75rem',
-            backgroundColor: 'var(--ctp-surface0)',
+            backgroundColor: 'var(--color-surface)',
             borderRadius: '4px',
             marginTop: '0.5rem'
           }}>
-            <span style={{ color: 'var(--ctp-yellow)' }}>
+            <span style={{ color: 'var(--color-warning)' }}>
               {t('remotehw_config.pins_note')}
             </span>
           </div>

--- a/src/components/configuration/SecurityConfigSection.tsx
+++ b/src/components/configuration/SecurityConfigSection.tsx
@@ -190,8 +190,8 @@ const SecurityConfigSection: React.FC<SecurityConfigSectionProps> = ({
             className="setting-input"
             style={{
               flex: 1,
-              backgroundColor: 'var(--ctp-surface0)',
-              color: 'var(--ctp-subtext0)',
+              backgroundColor: 'var(--color-surface)',
+              color: 'var(--color-text-subtle)',
               fontFamily: 'monospace',
               fontSize: '0.85rem'
             }}
@@ -202,11 +202,11 @@ const SecurityConfigSection: React.FC<SecurityConfigSectionProps> = ({
               onClick={() => navigator.clipboard.writeText(publicKey)}
               style={{
                 padding: '0.5rem',
-                backgroundColor: 'var(--ctp-surface1)',
+                backgroundColor: 'var(--color-surface-hover)',
                 border: 'none',
                 borderRadius: '4px',
                 cursor: 'pointer',
-                color: 'var(--ctp-text)'
+                color: 'var(--color-text)'
               }}
               title={t('common.copy_to_clipboard')}
             >
@@ -231,8 +231,8 @@ const SecurityConfigSection: React.FC<SecurityConfigSectionProps> = ({
             className="setting-input"
             style={{
               flex: 1,
-              backgroundColor: 'var(--ctp-surface0)',
-              color: 'var(--ctp-subtext0)',
+              backgroundColor: 'var(--color-surface)',
+              color: 'var(--color-text-subtle)',
               fontFamily: 'monospace',
               fontSize: '0.85rem'
             }}
@@ -243,11 +243,11 @@ const SecurityConfigSection: React.FC<SecurityConfigSectionProps> = ({
               onClick={handleCopyPrivateKey}
               style={{
                 padding: '0.5rem',
-                backgroundColor: 'var(--ctp-surface1)',
+                backgroundColor: 'var(--color-surface-hover)',
                 border: 'none',
                 borderRadius: '4px',
                 cursor: 'pointer',
-                color: 'var(--ctp-text)'
+                color: 'var(--color-text)'
               }}
               title={t('common.copy_to_clipboard')}
             >
@@ -255,13 +255,13 @@ const SecurityConfigSection: React.FC<SecurityConfigSectionProps> = ({
             </button>
           )}
         </div>
-        <span className="setting-description" style={{ display: 'block', marginTop: '0.25rem', color: 'var(--ctp-yellow)' }}>
+        <span className="setting-description" style={{ display: 'block', marginTop: '0.25rem', color: 'var(--color-warning)' }}>
           <UiIcon name="alert" /> {t('security_config.private_key_warning')}
         </span>
       </div>
 
       {/* Separator */}
-      <hr style={{ border: 'none', borderTop: '1px solid var(--ctp-surface2)', margin: '1.5rem 0' }} />
+      <hr style={{ border: 'none', borderTop: '1px solid var(--color-surface-active)', margin: '1.5rem 0' }} />
 
       {/* Admin Keys */}
       <div className="setting-item">
@@ -283,8 +283,8 @@ const SecurityConfigSection: React.FC<SecurityConfigSectionProps> = ({
                     flex: 1,
                     fontFamily: 'monospace',
                     fontSize: '0.85rem',
-                    borderColor: isInvalid ? 'var(--ctp-red)' : undefined,
-                    boxShadow: isInvalid ? '0 0 0 1px var(--ctp-red)' : undefined
+                    borderColor: isInvalid ? 'var(--color-error)' : undefined,
+                    boxShadow: isInvalid ? '0 0 0 1px var(--color-error)' : undefined
                   }}
                   placeholder={t('security_config.admin_key_placeholder')}
                 />
@@ -294,7 +294,7 @@ const SecurityConfigSection: React.FC<SecurityConfigSectionProps> = ({
                     onClick={() => handleRemoveAdminKey(index)}
                     style={{
                       padding: '0.5rem 0.75rem',
-                      backgroundColor: 'var(--ctp-red)',
+                      backgroundColor: 'var(--color-error)',
                       border: 'none',
                       borderRadius: '4px',
                       cursor: 'pointer',
@@ -306,7 +306,7 @@ const SecurityConfigSection: React.FC<SecurityConfigSectionProps> = ({
                 )}
               </div>
               {isInvalid && (
-                <span style={{ color: 'var(--ctp-red)', fontSize: '0.85rem' }}>
+                <span style={{ color: 'var(--color-error)', fontSize: '0.85rem' }}>
                   {t('security_config.invalid_base64')}
                 </span>
               )}
@@ -319,7 +319,7 @@ const SecurityConfigSection: React.FC<SecurityConfigSectionProps> = ({
             onClick={handleAddAdminKey}
             style={{
               padding: '0.5rem 1rem',
-              backgroundColor: 'var(--ctp-green)',
+              backgroundColor: 'var(--color-success)',
               border: 'none',
               borderRadius: '4px',
               cursor: 'pointer',

--- a/src/components/configuration/SerialConfigSection.tsx
+++ b/src/components/configuration/SerialConfigSection.tsx
@@ -234,8 +234,8 @@ const SerialConfigSection: React.FC<SerialConfigSectionProps> = ({
               className="advanced-toggle-btn"
               style={{
                 background: 'transparent',
-                border: '1px solid var(--ctp-surface2)',
-                color: 'var(--ctp-subtext0)',
+                border: '1px solid var(--color-surface-active)',
+                color: 'var(--color-text-subtle)',
                 padding: '0.5rem 1rem',
                 borderRadius: '4px',
                 cursor: 'pointer',
@@ -254,7 +254,7 @@ const SerialConfigSection: React.FC<SerialConfigSectionProps> = ({
             <div className="advanced-section" style={{
               marginLeft: '1rem',
               paddingLeft: '1rem',
-              borderLeft: '2px solid var(--ctp-surface2)'
+              borderLeft: '2px solid var(--color-surface-active)'
             }}>
               {/* RXD Pin */}
               <div className="setting-item">

--- a/src/components/configuration/StatusMessageConfigSection.tsx
+++ b/src/components/configuration/StatusMessageConfigSection.tsx
@@ -74,9 +74,9 @@ const StatusMessageConfigSection: React.FC<StatusMessageConfigSectionProps> = ({
       {isDisabled && (
         <div style={{
           padding: '1rem',
-          backgroundColor: 'var(--ctp-surface0)',
+          backgroundColor: 'var(--color-surface)',
           borderRadius: '0.5rem',
-          color: 'var(--ctp-subtext0)',
+          color: 'var(--color-text-subtle)',
           fontStyle: 'italic',
           marginBottom: '1rem'
         }}>
@@ -109,7 +109,7 @@ const StatusMessageConfigSection: React.FC<StatusMessageConfigSectionProps> = ({
               right: '0.5rem',
               bottom: '-1.2rem',
               fontSize: '0.75rem',
-              color: nodeStatus.length >= 70 ? 'var(--ctp-peach)' : 'var(--ctp-subtext0)'
+              color: nodeStatus.length >= 70 ? 'var(--color-caution)' : 'var(--color-text-subtle)'
             }}>
               {nodeStatus.length}/80
             </span>

--- a/src/components/configuration/SystemBackupSection.tsx
+++ b/src/components/configuration/SystemBackupSection.tsx
@@ -216,18 +216,18 @@ const SystemBackupSection: React.FC = () => {
       <h3>{t('system_backup.title')}</h3>
 
       <div style={{
-        backgroundColor: 'var(--ctp-surface0)',
+        backgroundColor: 'var(--color-surface)',
         padding: '1rem',
         borderRadius: '8px',
         marginBottom: '1.5rem'
       }}>
         <h4 style={{ marginTop: 0, marginBottom: '0.5rem' }}>{t('system_backup.about_title')}</h4>
-        <p style={{ color: 'var(--ctp-subtext0)', margin: 0, fontSize: '0.9rem', lineHeight: '1.6' }}>
+        <p style={{ color: 'var(--color-text-subtle)', margin: 0, fontSize: '0.9rem', lineHeight: '1.6' }}>
           {t('system_backup.about_description')}
         </p>
         <div style={{
-          backgroundColor: 'var(--ctp-yellow)',
-          color: 'var(--ctp-base)',
+          backgroundColor: 'var(--color-warning)',
+          color: 'var(--color-bg)',
           padding: '0.75rem',
           borderRadius: '6px',
           marginTop: '1rem',
@@ -240,7 +240,7 @@ const SystemBackupSection: React.FC = () => {
       {/* Manual Backup */}
       <div style={{ marginBottom: '1.5rem' }}>
         <h4 style={{ marginBottom: '0.5rem' }}>{t('system_backup.manual_title')}</h4>
-        <p style={{ color: 'var(--ctp-subtext0)', marginBottom: '1rem', fontSize: '0.9rem' }}>
+        <p style={{ color: 'var(--color-text-subtle)', marginBottom: '1rem', fontSize: '0.9rem' }}>
           {t('system_backup.manual_description')}
         </p>
         <div className="settings-buttons">
@@ -264,7 +264,7 @@ const SystemBackupSection: React.FC = () => {
       {/* Automated Backups */}
       <div style={{ marginBottom: '1.5rem' }}>
         <h4 style={{ marginBottom: '0.5rem' }}>{t('system_backup.auto_title')}</h4>
-        <p style={{ color: 'var(--ctp-subtext0)', marginBottom: '1rem', fontSize: '0.9rem' }}>
+        <p style={{ color: 'var(--color-text-subtle)', marginBottom: '1rem', fontSize: '0.9rem' }}>
           {t('system_backup.auto_description')}
         </p>
 
@@ -292,9 +292,9 @@ const SystemBackupSection: React.FC = () => {
                   style={{
                     padding: '0.5rem',
                     borderRadius: '4px',
-                    border: '1px solid var(--ctp-surface2)',
-                    backgroundColor: 'var(--ctp-surface0)',
-                    color: 'var(--ctp-text)',
+                    border: '1px solid var(--color-surface-active)',
+                    backgroundColor: 'var(--color-surface)',
+                    color: 'var(--color-text)',
                     fontSize: '1rem'
                   }}
                 />
@@ -313,14 +313,14 @@ const SystemBackupSection: React.FC = () => {
                   style={{
                     padding: '0.5rem',
                     borderRadius: '4px',
-                    border: '1px solid var(--ctp-surface2)',
-                    backgroundColor: 'var(--ctp-surface0)',
-                    color: 'var(--ctp-text)',
+                    border: '1px solid var(--color-surface-active)',
+                    backgroundColor: 'var(--color-surface)',
+                    color: 'var(--color-text)',
                     fontSize: '1rem',
                     width: '100px'
                   }}
                 />
-                <p style={{ color: 'var(--ctp-subtext0)', fontSize: '0.85rem', marginTop: '0.25rem' }}>
+                <p style={{ color: 'var(--color-text-subtle)', fontSize: '0.85rem', marginTop: '0.25rem' }}>
                   {t('system_backup.max_backups_hint')}
                 </p>
               </div>
@@ -346,7 +346,7 @@ const SystemBackupSection: React.FC = () => {
 
             <div className="backup-list">
               {backupList.length === 0 ? (
-                <p style={{ textAlign: 'center', color: 'var(--ctp-subtext0)', padding: '2rem' }}>
+                <p style={{ textAlign: 'center', color: 'var(--color-text-subtle)', padding: '2rem' }}>
                   {t('system_backup.no_backups')}
                 </p>
               ) : (

--- a/src/components/configuration/TelemetryConfigSection.tsx
+++ b/src/components/configuration/TelemetryConfigSection.tsx
@@ -192,7 +192,7 @@ const TelemetryConfigSection: React.FC<TelemetryConfigSectionProps> = ({
       </h3>
 
       {/* Device Telemetry Section */}
-      <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--ctp-subtext0)' }}>
+      <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--color-text-subtle)' }}>
         {t('telemetry_config.device_section')}
       </h4>
 
@@ -241,7 +241,7 @@ const TelemetryConfigSection: React.FC<TelemetryConfigSectionProps> = ({
       )}
 
       {/* Environment Telemetry Section */}
-      <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--ctp-subtext0)' }}>
+      <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--color-text-subtle)' }}>
         {t('telemetry_config.environment_section')}
       </h4>
 
@@ -329,8 +329,8 @@ const TelemetryConfigSection: React.FC<TelemetryConfigSectionProps> = ({
           className="advanced-toggle-btn"
           style={{
             background: 'transparent',
-            border: '1px solid var(--ctp-surface2)',
-            color: 'var(--ctp-subtext0)',
+            border: '1px solid var(--color-surface-active)',
+            color: 'var(--color-text-subtle)',
             padding: '0.5rem 1rem',
             borderRadius: '4px',
             cursor: 'pointer',
@@ -349,10 +349,10 @@ const TelemetryConfigSection: React.FC<TelemetryConfigSectionProps> = ({
         <div className="advanced-section" style={{
           marginLeft: '1rem',
           paddingLeft: '1rem',
-          borderLeft: '2px solid var(--ctp-surface2)'
+          borderLeft: '2px solid var(--color-surface-active)'
         }}>
           {/* Air Quality Section */}
-          <h4 style={{ marginTop: '1rem', marginBottom: '0.5rem', color: 'var(--ctp-subtext0)' }}>
+          <h4 style={{ marginTop: '1rem', marginBottom: '0.5rem', color: 'var(--color-text-subtle)' }}>
             {t('telemetry_config.air_quality_section')}
           </h4>
 
@@ -399,7 +399,7 @@ const TelemetryConfigSection: React.FC<TelemetryConfigSectionProps> = ({
           </div>
 
           {/* Power Metrics Section */}
-          <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--ctp-subtext0)' }}>
+          <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--color-text-subtle)' }}>
             {t('telemetry_config.power_section')}
           </h4>
 
@@ -463,7 +463,7 @@ const TelemetryConfigSection: React.FC<TelemetryConfigSectionProps> = ({
           </div>
 
           {/* Health Metrics Section */}
-          <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--ctp-subtext0)' }}>
+          <h4 style={{ marginTop: '1.5rem', marginBottom: '0.5rem', color: 'var(--color-text-subtle)' }}>
             {t('telemetry_config.health_section')}
           </h4>
 

--- a/src/components/configuration/TrafficManagementConfigSection.tsx
+++ b/src/components/configuration/TrafficManagementConfigSection.tsx
@@ -152,14 +152,14 @@ const TrafficManagementConfigSection: React.FC<TrafficManagementConfigSectionPro
   const subGroupStyle = {
     marginLeft: '1rem',
     paddingLeft: '1rem',
-    borderLeft: '2px solid var(--ctp-surface1)',
+    borderLeft: '2px solid var(--color-surface-hover)',
     marginBottom: '1rem'
   };
 
   const subGroupTitleStyle = {
     fontSize: '0.9rem',
     fontWeight: 600 as const,
-    color: 'var(--ctp-text)',
+    color: 'var(--color-text)',
     marginBottom: '0.5rem',
     marginTop: '0.75rem'
   };
@@ -173,9 +173,9 @@ const TrafficManagementConfigSection: React.FC<TrafficManagementConfigSectionPro
       {isDisabled && (
         <div style={{
           padding: '1rem',
-          backgroundColor: 'var(--ctp-surface0)',
+          backgroundColor: 'var(--color-surface)',
           borderRadius: '0.5rem',
-          color: 'var(--ctp-subtext0)',
+          color: 'var(--color-text-subtle)',
           fontStyle: 'italic',
           marginBottom: '1rem'
         }}>
@@ -243,7 +243,7 @@ const TrafficManagementConfigSection: React.FC<TrafficManagementConfigSectionPro
                       className="setting-input"
                       style={{ width: '100%' }}
                     />
-                    <div style={{ fontSize: '0.85rem', color: 'var(--ctp-subtext0)' }}>
+                    <div style={{ fontSize: '0.85rem', color: 'var(--color-text-subtle)' }}>
                       {t('trafficmanagement_config.position_precision_bits_value', '{{bits}} bits', { bits: positionPrecisionBits })}
                     </div>
                   </div>

--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -53,14 +53,14 @@ function SegmentSnrChart({ chartData }: {
       <div style={{ display: 'flex', gap: '4px', marginBottom: '6px' }}>
         <button
           className={`node-popup-tab ${mode === 'timeOfDay' ? 'active' : ''}`}
-          style={{ fontSize: '10px', padding: '2px 8px', border: '1px solid var(--ctp-surface2)', borderRadius: '4px', cursor: 'pointer', background: mode === 'timeOfDay' ? 'var(--ctp-blue)' : 'var(--ctp-surface0)', color: mode === 'timeOfDay' ? 'var(--ctp-base)' : 'var(--ctp-subtext1)' }}
+          style={{ fontSize: '10px', padding: '2px 8px', border: '1px solid var(--color-surface-active)', borderRadius: '4px', cursor: 'pointer', background: mode === 'timeOfDay' ? 'var(--color-accent)' : 'var(--color-surface)', color: mode === 'timeOfDay' ? 'var(--color-bg)' : 'var(--color-text-muted)' }}
           onClick={e => { e.stopPropagation(); setMode('timeOfDay'); }}
         >
           Time of Day
         </button>
         <button
           className={`node-popup-tab ${mode === 'chronological' ? 'active' : ''}`}
-          style={{ fontSize: '10px', padding: '2px 8px', border: '1px solid var(--ctp-surface2)', borderRadius: '4px', cursor: 'pointer', background: mode === 'chronological' ? 'var(--ctp-blue)' : 'var(--ctp-surface0)', color: mode === 'chronological' ? 'var(--ctp-base)' : 'var(--ctp-subtext1)' }}
+          style={{ fontSize: '10px', padding: '2px 8px', border: '1px solid var(--color-surface-active)', borderRadius: '4px', cursor: 'pointer', background: mode === 'chronological' ? 'var(--color-accent)' : 'var(--color-surface)', color: mode === 'chronological' ? 'var(--color-bg)' : 'var(--color-text-muted)' }}
           onClick={e => { e.stopPropagation(); setMode('chronological'); }}
         >
           Over Time
@@ -69,7 +69,7 @@ function SegmentSnrChart({ chartData }: {
       <ResponsiveContainer width="100%" height={150}>
         {mode === 'timeOfDay' ? (
           <LineChart data={chartData} margin={{ top: 10, right: 10, left: -20, bottom: 5 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="var(--ctp-surface2)" />
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--color-surface-active)" />
             <XAxis
               dataKey="timeDecimal"
               type="number"
@@ -80,27 +80,27 @@ function SegmentSnrChart({ chartData }: {
                 const minutes = Math.round((value - hours) * 60);
                 return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
               }}
-              tick={{ fill: 'var(--ctp-subtext1)', fontSize: 10 }}
-              stroke="var(--ctp-surface2)"
+              tick={{ fill: 'var(--color-text-muted)', fontSize: 10 }}
+              stroke="var(--color-surface-active)"
             />
             <YAxis
-              tick={{ fill: 'var(--ctp-subtext1)', fontSize: 10 }}
-              stroke="var(--ctp-surface2)"
-              label={{ value: 'SNR (dB)', angle: -90, position: 'insideLeft', style: { fill: 'var(--ctp-subtext1)', fontSize: 10 } }}
+              tick={{ fill: 'var(--color-text-muted)', fontSize: 10 }}
+              stroke="var(--color-surface-active)"
+              label={{ value: 'SNR (dB)', angle: -90, position: 'insideLeft', style: { fill: 'var(--color-text-muted)', fontSize: 10 } }}
             />
             <Tooltip
-              contentStyle={{ backgroundColor: 'var(--ctp-surface0)', border: '1px solid var(--ctp-surface2)', borderRadius: '4px', fontSize: '12px' }}
-              labelStyle={{ color: 'var(--ctp-text)' }}
+              contentStyle={{ backgroundColor: 'var(--color-surface)', border: '1px solid var(--color-surface-active)', borderRadius: '4px', fontSize: '12px' }}
+              labelStyle={{ color: 'var(--color-text)' }}
               labelFormatter={value => {
                 const item = chartData.find(d => d.timeDecimal === value);
                 return item ? item.timeLabel : String(value);
               }}
             />
-            <Line type="monotone" dataKey="snr" stroke="var(--ctp-mauve)" strokeWidth={2} dot={{ fill: 'var(--ctp-mauve)', r: 3 }} />
+            <Line type="monotone" dataKey="snr" stroke="var(--color-accent-alt)" strokeWidth={2} dot={{ fill: 'var(--color-accent-alt)', r: 3 }} />
           </LineChart>
         ) : (
           <LineChart data={chronoData} margin={{ top: 10, right: 10, left: -20, bottom: 5 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="var(--ctp-surface2)" />
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--color-surface-active)" />
             <XAxis
               dataKey="chronoTime"
               type="number"
@@ -109,23 +109,23 @@ function SegmentSnrChart({ chartData }: {
                 const date = new Date(value);
                 return `${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getDate().toString().padStart(2, '0')}`;
               }}
-              tick={{ fill: 'var(--ctp-subtext1)', fontSize: 10 }}
-              stroke="var(--ctp-surface2)"
+              tick={{ fill: 'var(--color-text-muted)', fontSize: 10 }}
+              stroke="var(--color-surface-active)"
             />
             <YAxis
-              tick={{ fill: 'var(--ctp-subtext1)', fontSize: 10 }}
-              stroke="var(--ctp-surface2)"
-              label={{ value: 'SNR (dB)', angle: -90, position: 'insideLeft', style: { fill: 'var(--ctp-subtext1)', fontSize: 10 } }}
+              tick={{ fill: 'var(--color-text-muted)', fontSize: 10 }}
+              stroke="var(--color-surface-active)"
+              label={{ value: 'SNR (dB)', angle: -90, position: 'insideLeft', style: { fill: 'var(--color-text-muted)', fontSize: 10 } }}
             />
             <Tooltip
-              contentStyle={{ backgroundColor: 'var(--ctp-surface0)', border: '1px solid var(--ctp-surface2)', borderRadius: '4px', fontSize: '12px' }}
-              labelStyle={{ color: 'var(--ctp-text)' }}
+              contentStyle={{ backgroundColor: 'var(--color-surface)', border: '1px solid var(--color-surface-active)', borderRadius: '4px', fontSize: '12px' }}
+              labelStyle={{ color: 'var(--color-text)' }}
               labelFormatter={value => {
                 const item = chronoData.find(d => d.chronoTime === value);
                 return item ? item.chronoLabel : String(value);
               }}
             />
-            <Line type="monotone" dataKey="snr" stroke="var(--ctp-mauve)" strokeWidth={2} dot={{ fill: 'var(--ctp-mauve)', r: 3 }} />
+            <Line type="monotone" dataKey="snr" stroke="var(--color-accent-alt)" strokeWidth={2} dot={{ fill: 'var(--color-accent-alt)', r: 3 }} />
           </LineChart>
         )}
       </ResponsiveContainer>
@@ -640,7 +640,7 @@ export function useTraceroutePaths({
                   e.stopPropagation();
                   callbacks.onSelectRouteSegment(nodeNum1, nodeNum2);
                 }}
-                style={{ cursor: 'pointer', color: 'var(--ctp-blue)', textDecoration: 'underline' }}
+                style={{ cursor: 'pointer', color: 'var(--color-accent)', textDecoration: 'underline' }}
                 title="Click to view all traceroutes using this segment"
               >
                 {usage}
@@ -832,7 +832,7 @@ export function useTraceroutePaths({
                 </div>
               )}
               {(seg.avgSnr !== null || seg.isMqtt) && (
-                <div className="route-usage" style={{ marginTop: '8px', borderTop: '1px solid var(--ctp-surface0)', paddingTop: '4px' }}>
+                <div className="route-usage" style={{ marginTop: '8px', borderTop: '1px solid var(--color-surface)', paddingTop: '4px' }}>
                   Segment SNR: <strong>{seg.avgSnr !== null ? `${seg.avgSnr.toFixed(1)} dB` : 'Unknown'}</strong>
                   {seg.isMqtt && ' (IP)'}
                 </div>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1087,7 +1087,7 @@ function DashboardInner() {
             <h3>{t('source.kebab.prune_outside_roi')}</h3>
             <p>{t('source.prune_outside_roi_confirm')}</p>
             {pruneError && (
-              <p style={{ color: 'var(--ctp-red)', fontSize: 13 }}>{pruneError}</p>
+              <p style={{ color: 'var(--color-error)', fontSize: 13 }}>{pruneError}</p>
             )}
             <div className="dashboard-confirm-actions">
               <button onClick={() => setPruneConfirm(null)} disabled={prunePending}>
@@ -1172,7 +1172,7 @@ function DashboardInner() {
                     onChange={(e) => setFormMqttListenPort(e.target.value)}
                     placeholder="1883"
                   />
-                  <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                  <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 0' }}>
                     {t('source.form.mqtt_listen_port_help', 'Devices configure their MQTT module to point at this port on the MeshMonitor host.')}
                   </p>
                 </label>
@@ -1216,7 +1216,7 @@ function DashboardInner() {
                     <span className="dashboard-form-label" style={{ display: 'block' }}>
                       {t('source.form.mqtt_hop_limit_override', 'Override hop limit on delivery')}
                     </span>
-                    <span style={{ fontSize: 11, color: 'var(--ctp-subtext0)' }}>
+                    <span style={{ fontSize: 11, color: 'var(--color-text-subtle)' }}>
                       {t(
                         'source.form.mqtt_hop_limit_override_help',
                         'Rewrite hop_limit on packets the broker delivers to connected devices. 0 is zero-hop injection, matching the public Meshtastic broker — it prevents MQTT-bridged packets from being rebroadcast over RF.',
@@ -1243,7 +1243,7 @@ function DashboardInner() {
                       ))}
                     </select>
                     {formMqttHopOverrideValue > 0 && (
-                      <span style={{ fontSize: 11, color: 'var(--ctp-peach)', marginTop: 4 }}>
+                      <span style={{ fontSize: 11, color: 'var(--color-caution)', marginTop: 4 }}>
                         {t(
                           'source.form.mqtt_hop_limit_warning',
                           'Warning: packets arriving over MQTT may have originated on a distant, unrelated mesh. With a nonzero hop limit, every node in RF range will rebroadcast them up to this many hops — a real airtime and flood risk on a busy mesh.',
@@ -1266,7 +1266,7 @@ function DashboardInner() {
                       <span className="dashboard-form-label">
                         {t('source.form.bridge_topic_rewrites', 'Bridge topic rewrites')}
                       </span>
-                      <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 8px' }}>
+                      <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 8px' }}>
                         {t(
                           'source.form.bridge_topic_rewrites_help',
                           'For each bridge attached to this broker, replace a literal topic prefix on inbound (downlink) or outbound (uplink) messages. Leave both From and To empty to disable that direction.',
@@ -1292,24 +1292,24 @@ function DashboardInner() {
                             key={bridge.id}
                             open={Boolean(hasAny)}
                             style={{
-                              border: '1px solid var(--ctp-surface1)',
+                              border: '1px solid var(--color-surface-hover)',
                               borderRadius: 4,
                               padding: '6px 10px',
                               marginBottom: 6,
-                              background: 'var(--ctp-surface0)',
+                              background: 'var(--color-surface)',
                             }}
                           >
                             <summary style={{ cursor: 'pointer', fontWeight: 500 }}>
                               {bridge.name}
                               {hasAny && (
-                                <span style={{ marginLeft: 8, fontSize: 10, color: 'var(--ctp-blue)' }}>
+                                <span style={{ marginLeft: 8, fontSize: 10, color: 'var(--color-accent)' }}>
                                   • {t('source.form.bridge_topic_rewrites_active', 'configured')}
                                 </span>
                               )}
                             </summary>
                             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginTop: 8 }}>
                               <div>
-                                <span style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--ctp-subtext0)' }}>
+                                <span style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--color-text-subtle)' }}>
                                   {t('source.form.bridge_topic_rewrites_downlink', 'Downlink (to local broker)')}
                                 </span>
                                 <input
@@ -1330,7 +1330,7 @@ function DashboardInner() {
                                 />
                               </div>
                               <div>
-                                <span style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--ctp-subtext0)' }}>
+                                <span style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--color-text-subtle)' }}>
                                   {t('source.form.bridge_topic_rewrites_uplink', 'Uplink (to upstream)')}
                                 </span>
                                 <input
@@ -1376,7 +1376,7 @@ function DashboardInner() {
                         </option>
                       ))}
                   </select>
-                  <span style={{ fontSize: 11, color: 'var(--ctp-subtext0)', marginTop: 4 }}>
+                  <span style={{ fontSize: 11, color: 'var(--color-text-subtle)', marginTop: 4 }}>
                     {t(
                       'source.form.mqtt_bridge_broker_help',
                       'With a parent broker, the bridge also republishes upstream traffic to local devices and forwards their packets upstream. Without one, it runs as a pure MQTT client — useful for monitoring or as a client-proxy target for a Meshtastic source.',
@@ -1427,7 +1427,7 @@ function DashboardInner() {
                     maintained in one place — not duplicated here. When editing
                     an existing source we can deep-link straight to it. */}
                 <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginTop: 4 }}>
-                  <span style={{ fontSize: 11, color: 'var(--ctp-subtext0)', flex: 1 }}>
+                  <span style={{ fontSize: 11, color: 'var(--color-text-subtle)', flex: 1 }}>
                     {t(
                       'source.form.mqtt_bridge_advanced_hint',
                       'Mode, forwarding, publish/subscribe filters, geofence, and topic rewrites are on the bridge’s Configuration page.',
@@ -1442,8 +1442,8 @@ function DashboardInner() {
                         fontSize: 11,
                         padding: '4px 8px',
                         background: 'transparent',
-                        color: 'var(--ctp-blue)',
-                        border: '1px solid var(--ctp-blue)',
+                        color: 'var(--color-accent)',
+                        border: '1px solid var(--color-accent)',
                         borderRadius: 4,
                         cursor: 'pointer',
                       }}
@@ -1483,7 +1483,7 @@ function DashboardInner() {
                         onChange={(e) => setFormMcTcpHost(e.target.value)}
                         placeholder={t('source.form.host_placeholder')}
                       />
-                      <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                      <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 0' }}>
                         {t('meshcore.form.tcp_host_help', 'Hostname or IP of the MeshCore companion reachable over TCP (e.g. esp-link, ser2net, or native TCP firmware).')}
                       </p>
                     </label>
@@ -1509,7 +1509,7 @@ function DashboardInner() {
                       onChange={(e) => setFormMcSerialPort(e.target.value)}
                       placeholder="/dev/ttyACM0"
                     />
-                    <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                    <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 0' }}>
                       {t('meshcore.form.serial_port_help', 'OS path of the USB-connected MeshCore companion (e.g. /dev/ttyACM0, COM3).')}
                     </p>
                   </label>
@@ -1538,7 +1538,7 @@ function DashboardInner() {
                     onChange={(e) => setFormHeartbeat(e.target.value)}
                     placeholder="0"
                   />
-                  <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                  <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 0' }}>
                     {t('meshcore.form.heartbeat_help', 'Seconds between companion keepalive probes (0 = disabled). On repeated failure the source reconnects automatically with backoff. Applies to Companion devices only.')}
                   </p>
                 </label>
@@ -1551,12 +1551,12 @@ function DashboardInner() {
                   />
                   {t('source.form.auto_connect')}
                 </label>
-                <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '0 0 8px 24px' }}>
+                <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '0 0 8px 24px' }}>
                   {t('source.form.auto_connect_help')}
                 </p>
 
-                <fieldset style={{ border: '1px solid var(--ctp-surface1)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
-                  <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--ctp-subtext0)' }}>{t('source.form.virtual_node')}</legend>
+                <fieldset style={{ border: '1px solid var(--color-surface-hover)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
+                  <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--color-text-subtle)' }}>{t('source.form.virtual_node')}</legend>
                   <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, marginTop: 4 }}>
                     <input
                       type="checkbox"
@@ -1578,7 +1578,7 @@ function DashboardInner() {
                           onChange={(e) => setFormVnPort(e.target.value)}
                           placeholder="5000"
                         />
-                        <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                        <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 0' }}>
                           {t('meshcore.form.virtual_node_help', 'TCP port the MeshCore mobile app connects to. Point the app at this host and port over WiFi.')}
                         </p>
                       </label>
@@ -1590,7 +1590,7 @@ function DashboardInner() {
                         />
                         {t('meshcore.form.allow_admin_commands', 'Allow admin commands')}
                       </label>
-                      <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                      <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 0' }}>
                         {t('meshcore.form.allow_admin_help', 'Third-party clients connected to the virtual node can send config/admin commands to your MeshCore node. Leave off unless you trust the clients.')}
                       </p>
                       <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, marginTop: 8 }}>
@@ -1601,37 +1601,37 @@ function DashboardInner() {
                         />
                         {t('meshcore.form.allow_pki_export', 'Allow PKI export')}
                       </label>
-                      <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                      <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 0' }}>
                         {t('meshcore.form.allow_pki_export_help', 'Let connected clients read your node\'s private key. Some tools (e.g. Remote-Terminal\'s community MQTT) require it to authenticate as your node. The virtual node port has no client authentication, so anyone who can reach it can copy your node identity. Leave off unless you need it. Requires node firmware built with ENABLE_PRIVATE_KEY_EXPORT.')}
                       </p>
                     </>
                   )}
                 </fieldset>
 
-                <fieldset style={{ border: '1px solid var(--ctp-surface1)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
-                  <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--ctp-subtext0)' }}>{t('meshcore.form.observer', 'Analyzer Observer')}</legend>
+                <fieldset style={{ border: '1px solid var(--color-surface-hover)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
+                  <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--color-text-subtle)' }}>{t('meshcore.form.observer', 'Analyzer Observer')}</legend>
                   <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, marginTop: 4 }}>
                     <input type="checkbox" checked={formObserver.enabled} disabled={formMcDeviceType === 'repeater'} onChange={(e) => setFormObserver({ ...formObserver, enabled: e.target.checked })} />
                     {t('meshcore.form.observer_enable', 'Publish heard packets to a MeshCore Analyzer broker')}
                   </label>
-                  <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>{t('meshcore.form.observer_help', 'Relays every packet this Companion hears to a MeshCore Analyzer MQTT broker so your node counts as an observer. MeshMonitor only publishes — it never receives from the broker or transmits on the mesh. Companion devices only.')}</p>
+                  <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 0' }}>{t('meshcore.form.observer_help', 'Relays every packet this Companion hears to a MeshCore Analyzer MQTT broker so your node counts as an observer. MeshMonitor only publishes — it never receives from the broker or transmits on the mesh. Companion devices only.')}</p>
                   {formMcDeviceType === 'repeater' ? (
-                    <p role="alert" style={{ fontSize: 11, color: 'var(--ctp-yellow)', margin: '4px 0 0' }}>{t('meshcore.form.observer_repeater_note', 'The Analyzer Observer requires a Companion device — a repeater cannot export the signing key it needs.')}</p>
+                    <p role="alert" style={{ fontSize: 11, color: 'var(--color-warning)', margin: '4px 0 0' }}>{t('meshcore.form.observer_repeater_note', 'The Analyzer Observer requires a Companion device — a repeater cannot export the signing key it needs.')}</p>
                   ) : formObserver.enabled && (
                     <>
                       {OBSERVER_FIELDS.map((f) => (
                         <label key={f.key} className="dashboard-form-field" style={{ marginTop: 8 }}>
                           <span className="dashboard-form-label">{t(f.labelKey, f.labelFallback)}</span>
                           <input className="dashboard-form-input" type="text" value={formObserver[f.key]} onChange={(e) => setFormObserver({ ...formObserver, [f.key]: e.target.value })} placeholder={f.placeholder} />
-                          <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>{t(f.helpKey, f.helpFallback)}</p>
+                          <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 0' }}>{t(f.helpKey, f.helpFallback)}</p>
                         </label>
                       ))}
                       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginTop: 8 }}>
-                        <span style={{ fontSize: 11, color: 'var(--ctp-subtext0)', flex: 1 }}>{t('meshcore.form.observer_key_hint', "The signing key and live publish status are on this source's MeshCore → Configuration page.")}</span>
+                        <span style={{ fontSize: 11, color: 'var(--color-text-subtle)', flex: 1 }}>{t('meshcore.form.observer_key_hint', "The signing key and live publish status are on this source's MeshCore → Configuration page.")}</span>
                         {editingSourceId && (
                           <button
                             type="button"
-                            style={{ flexShrink: 0, whiteSpace: 'nowrap', fontSize: 11, padding: '4px 8px', background: 'transparent', color: 'var(--ctp-blue)', border: '1px solid var(--ctp-blue)', borderRadius: 4, cursor: 'pointer' }}
+                            style={{ flexShrink: 0, whiteSpace: 'nowrap', fontSize: 11, padding: '4px 8px', background: 'transparent', color: 'var(--color-accent)', border: '1px solid var(--color-accent)', borderRadius: 4, cursor: 'pointer' }}
                             title={t('meshcore.form.observer_open_config', 'Open Configuration page')}
                             onClick={() => { setShowSourceModal(false); void navigate(`/source/${editingSourceId}`); }}
                           >
@@ -1678,7 +1678,7 @@ function DashboardInner() {
                 onChange={(e) => setFormHeartbeat(e.target.value)}
                 placeholder="0"
               />
-              <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+              <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 0' }}>
                 {t('source.form.heartbeat_help')}
               </p>
             </label>
@@ -1691,7 +1691,7 @@ function DashboardInner() {
               />
               {t('source.form.auto_connect')}
             </label>
-            <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '0 0 8px 24px' }}>
+            <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '0 0 8px 24px' }}>
               {t('source.form.auto_connect_help')}
             </p>
 
@@ -1703,7 +1703,7 @@ function DashboardInner() {
               />
               {t('source.form.passive_mode', 'Passive Mode')}
             </label>
-            <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '0 0 8px 24px' }}>
+            <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '0 0 8px 24px' }}>
               {t(
                 'source.form.passive_mode_help',
                 'Reduces outbound requests to large or fragile TCP nodes. Preserves cached config across reconnects and skips post-config device requests. Recommended for router-class nodes with large NodeDBs.'
@@ -1725,7 +1725,7 @@ function DashboardInner() {
                   onChange={(e) => setFormPassiveResyncStaleHours(e.target.value)}
                   placeholder={t('source.form.passive_resync_stale_default', '4 (default)')}
                 />
-                <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 0' }}>
                   {t(
                     'source.form.passive_resync_stale_help',
                     'How long the cached config stays valid after a disconnect before the next reconnect forces a full sync. Leave blank for 4 hours (default). Range: 1 minute – 7 days.'
@@ -1734,8 +1734,8 @@ function DashboardInner() {
               </label>
             )}
 
-            <fieldset style={{ border: '1px solid var(--ctp-surface1)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
-              <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--ctp-subtext0)' }}>{t('source.form.virtual_node')}</legend>
+            <fieldset style={{ border: '1px solid var(--color-surface-hover)', borderRadius: 6, padding: '8px 12px 12px', margin: '8px 0' }}>
+              <legend style={{ fontSize: 12, padding: '0 6px', color: 'var(--color-text-subtle)' }}>{t('source.form.virtual_node')}</legend>
               <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, marginTop: 4 }}>
                 <input
                   type="checkbox"
@@ -1764,7 +1764,7 @@ function DashboardInner() {
                     />
                     {t('source.form.allow_admin_commands')}
                   </label>
-                  <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                  <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 0' }}>
                     {t('source.form.allow_admin_help')}
                   </p>
                 </>
@@ -1790,7 +1790,7 @@ function DashboardInner() {
                       </option>
                     ))}
                 </select>
-                <p style={{ fontSize: 11, color: 'var(--ctp-subtext0)', margin: '4px 0 0' }}>
+                <p style={{ fontSize: 11, color: 'var(--color-text-subtle)', margin: '4px 0 0' }}>
                   {t(
                     'source.form.mqtt_proxy_link_help',
                     'When set, MeshMonitor relays the device’s mqttClientProxyMessage traffic to the selected embedded broker. Requires the device’s MQTT module to have proxy_to_client_enabled = true.',
@@ -1802,12 +1802,12 @@ function DashboardInner() {
             )}
 
             {formError && (
-              <p style={{ color: 'var(--ctp-red)', fontSize: 12, margin: '8px 0 0' }}>{formError}</p>
+              <p style={{ color: 'var(--color-error)', fontSize: 12, margin: '8px 0 0' }}>{formError}</p>
             )}
 
             <div className="dashboard-confirm-actions" style={{ marginTop: 16 }}>
               <button onClick={() => setShowSourceModal(false)}>{t('common.cancel')}</button>
-              <button onClick={onSaveSource} disabled={formSaving} style={{ background: 'var(--ctp-blue)', color: 'var(--ctp-base)' }}>
+              <button onClick={onSaveSource} disabled={formSaving} style={{ background: 'var(--color-accent)', color: 'var(--color-bg)' }}>
                 {formSaving ? t('common.saving') : t('common.save')}
               </button>
             </div>

--- a/src/pages/UnifiedMessagesPage.tsx
+++ b/src/pages/UnifiedMessagesPage.tsx
@@ -92,14 +92,14 @@ const PAGE_SIZE = 100;
 const POLL_INTERVAL_MS = 10_000;
 
 const SOURCE_COLORS = [
-  'var(--ctp-blue)',
-  'var(--ctp-mauve)',
-  'var(--ctp-green)',
-  'var(--ctp-peach)',
-  'var(--ctp-yellow)',
+  'var(--color-accent)',
+  'var(--color-accent-alt)',
+  'var(--color-success)',
+  'var(--color-caution)',
+  'var(--color-warning)',
   'var(--ctp-teal)',
   'var(--ctp-pink)',
-  'var(--ctp-sapphire)',
+  'var(--color-accent-hover)',
 ];
 
 // ── Helpers ──────────────────────────────────────────────────────────────

--- a/src/pages/UnifiedPacketMonitorPage.tsx
+++ b/src/pages/UnifiedPacketMonitorPage.tsx
@@ -372,7 +372,7 @@ export default function UnifiedPacketMonitorPage() {
                           onClick={() => loadMore()}
                           style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: `${virtualRow.size}px`, transform: `translateY(${virtualRow.start}px)`, display: 'table', tableLayout: 'fixed', cursor: 'pointer' }}
                         >
-                          <td colSpan={15} style={{ textAlign: 'center', color: 'var(--ctp-blue, var(--text-secondary))' }}>
+                          <td colSpan={15} style={{ textAlign: 'center', color: 'var(--color-accent, var(--text-secondary))' }}>
                             {loadingMore ? t('packet_monitor.loading_more') : t('packet_monitor.load_more_click', 'Click to load more packets...')}
                           </td>
                         </tr>

--- a/src/pages/UnifiedTelemetryPage.tsx
+++ b/src/pages/UnifiedTelemetryPage.tsx
@@ -29,8 +29,8 @@ interface TelemetryEntry {
 }
 
 const SOURCE_COLORS = [
-  'var(--ctp-blue)', 'var(--ctp-mauve)', 'var(--ctp-green)',
-  'var(--ctp-red)', 'var(--ctp-yellow)', 'var(--ctp-teal)',
+  'var(--color-accent)', 'var(--color-accent-alt)', 'var(--color-success)',
+  'var(--color-error)', 'var(--color-warning)', 'var(--ctp-teal)',
 ];
 
 function getSourceColor(sourceId: string, sourceIds: string[]): string {

--- a/src/styles/semanticTokens.test.ts
+++ b/src/styles/semanticTokens.test.ts
@@ -4,7 +4,7 @@
  * The app used to consume raw Catppuccin palette names (`--ctp-blue`) directly,
  * so a custom theme could only restyle a role if the role happened to share a
  * name with the swatch wired to it. `App.css` now defines a role layer
- * (`--color-error: var(--ctp-red)`) that components consume instead.
+ * (`--color-error: var(--color-error)`) that components consume instead.
  *
  * These tests pin the two properties that make the layer trustworthy:
  *  1. Every semantic token resolves to a palette var that actually exists in

--- a/src/utils/sourceColors.ts
+++ b/src/utils/sourceColors.ts
@@ -7,14 +7,14 @@
  * so a given source keeps the same color across filter/sort changes.
  */
 export const SOURCE_COLORS = [
-  'var(--ctp-blue)',
-  'var(--ctp-mauve)',
-  'var(--ctp-green)',
-  'var(--ctp-peach)',
-  'var(--ctp-yellow)',
+  'var(--color-accent)',
+  'var(--color-accent-alt)',
+  'var(--color-success)',
+  'var(--color-caution)',
+  'var(--color-warning)',
   'var(--ctp-teal)',
   'var(--ctp-pink)',
-  'var(--ctp-sapphire)',
+  'var(--color-accent-hover)',
 ];
 
 /**
@@ -30,7 +30,7 @@ export function getSourceColor(sourceId: string, sourceIds: string[]): string {
  * Resolve a color value to a literal (hex/rgb) string.
  *
  * The palette in {@link SOURCE_COLORS} is expressed as CSS custom properties
- * (`var(--ctp-blue)`). CSS variables resolve fine when set on an element's
+ * (`var(--color-accent)`). CSS variables resolve fine when set on an element's
  * `style` (backgrounds, borders, legend swatches), but Leaflet paints SVG
  * strokes via the presentation *attribute* (`setAttribute('stroke', color)`),
  * which does NOT evaluate `var()`. Leaflet overlays (e.g. the polar grid on the

--- a/src/utils/traceroute.tsx
+++ b/src/utils/traceroute.tsx
@@ -36,8 +36,8 @@ function formatSnrElement(snrValue: number | null, key: string): React.ReactNode
         style={{
           marginLeft: '0.25rem',
           padding: '0.1rem 0.3rem',
-          backgroundColor: 'var(--ctp-overlay0)',
-          color: 'var(--ctp-text)',
+          backgroundColor: 'var(--color-surface-inactive)',
+          color: 'var(--color-text)',
           borderRadius: '3px',
           fontSize: '0.85em',
           fontWeight: 500,
@@ -205,8 +205,8 @@ export function formatTracerouteRoute(
           <span
             key={`highlight-${idx}`}
             style={{
-              background: 'var(--ctp-yellow)',
-              color: 'var(--ctp-base)',
+              background: 'var(--color-warning)',
+              color: 'var(--color-bg)',
               padding: '0.1rem 0.3rem',
               borderRadius: '3px',
               fontWeight: 'bold'


### PR DESCRIPTION
Fourth batch of #4579. The largest slice: **110 files, 1,988 of 2,007 references**.

| Slice | Files | Refs | Status |
| --- | --- | --- | --- |
| CSS modules | 12 | 119 | #4581 ✅ |
| Non-module component CSS | 40 | 1,670 | #4582 ✅ |
| overlay0 role trio | 16 | 59 | #4583 ✅ |
| **Inline styles in `.tsx`/`.ts`** | **110** | **2,007** | **this PR** |
| Global sheets (`src/styles`) | 10 | 806 | last — frozen, `nodes.css` cascade trap |

## Batch 3 paying off

All 62 inline `overlay0` references classified automatically from their property key (camelCase in JSX style objects: `color`, `borderColor`, `backgroundColor`, …). **No new roles were needed for a 2,000-reference slice** — which is the argument for having designed the trio separately rather than improvising it mid-sweep.

## One judgement call

`AirtimeCutoffSection` builds a status colour by ternary:

```js
const bannerColor = disabled ? overlay0 : gated ? red : green;
```

The direct pass converted the red/green branches to `--color-error` / `--color-success`, which left the neutral branch raw and semantically odd **inside a single expression**. The value feeds `border`, `borderLeft` *and* `color`, so it takes `--color-text-faint` — it lands on `color:` directly — with a comment marking it the neutral sibling of the other two.

It renders identically whichever of the three overlay0 roles is chosen. The point was not shipping one branch of a ternary inconsistent with its siblings.

## Deliberately left raw

19 references, unchanged from earlier batches' reasoning: `teal` (12) and `pink` (5) still have no honest role, and `--ctp-yellow-soft` (1) is not part of the 26-key palette at all — it is a separate mechanism that needs its own decision, not a role.

## Verification

Same standard as the earlier batches, extended to TSX: expanding **both** the working tree and `origin/main` back to palette vars matches for **all 110 files**. A 1,988-reference sweep across inline styles is exactly where a silent restyle would hide.

- Full Vitest suite: `success: true`, **13,551 passed, 0 failed, 0 failed suites**
- `npx tsc --noEmit` clean, `npm run lint:ci` no in-repo failures

After this merges, only the global sheets remain — and `nodes.css` carries the #3532 cascade-order trap, so it gets its own PR rather than riding along with the other nine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX