### PR TITLE
refactor(themes): migrate global stylesheets to semantic tokens — batch 5 (#4579)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -570,8 +570,8 @@ body {
     'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  background: var(--color-bg);
+  color: var(--color-text);
   margin: 0;
   padding: 0;
   padding-bottom: env(safe-area-inset-bottom); /* Account for iPhone home indicator */
@@ -584,8 +584,8 @@ body {
   top: -100%;
   left: 50%;
   transform: translateX(-50%);
-  background: var(--ctp-blue);
-  color: var(--ctp-crust);
+  background: var(--color-accent);
+  color: var(--color-bg-sunken);
   padding: 0.5rem 1rem;
   border-radius: 0 0 8px 8px;
   z-index: 100000;
@@ -601,7 +601,7 @@ body {
 .app {
   min-height: 100vh;
   min-height: 100dvh; /* Use dynamic viewport height for mobile browsers */
-  background: var(--ctp-base);
+  background: var(--color-bg);
   display: flex;
   flex-direction: column;
 }
@@ -641,9 +641,9 @@ body {
 }
 
 .filter-input {
-  background: var(--ctp-surface1);
-  border: 2px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 2px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.75rem 1rem;
   border-radius: var(--radius-lg);
   font-size: 1rem;
@@ -653,24 +653,24 @@ body {
 
 .filter-input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .filter-input::placeholder {
-  color: var(--ctp-overlay1);
+  color: var(--color-text-disabled);
 }
 
 .filter-label {
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   font-weight: 500;
   font-size: 0.9rem;
 }
 
 .nodes-table {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
   overflow: hidden;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
 }
 
 .nodes-table table {
@@ -679,12 +679,12 @@ body {
 }
 
 .nodes-table th {
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  color: var(--color-text);
   padding: 1rem;
   text-align: left;
   font-weight: 600;
-  border-bottom: 2px solid var(--ctp-surface2);
+  border-bottom: 2px solid var(--color-surface-active);
   cursor: pointer;
   user-select: none;
   transition: all 0.2s ease;
@@ -692,8 +692,8 @@ body {
 }
 
 .nodes-table th:hover {
-  background: var(--ctp-surface2);
-  color: var(--ctp-lavender);
+  background: var(--color-surface-active);
+  color: var(--color-accent-muted);
 }
 
 .nodes-table th.sortable::after {
@@ -712,23 +712,23 @@ body {
 .nodes-table th.sorted-asc::after {
   content: '↑';
   opacity: 1;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
 }
 
 .nodes-table th.sorted-desc::after {
   content: '↓';
   opacity: 1;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
 }
 
 .nodes-table td {
   padding: 0.75rem 1rem;
-  color: var(--ctp-text);
-  border-bottom: 1px solid var(--ctp-surface1);
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-surface-hover);
 }
 
 .nodes-table tbody tr:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 /* Channel Tab */
@@ -740,9 +740,9 @@ body {
 }
 
 .channel-btn {
-  background: var(--ctp-surface1);
-  border: 2px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 2px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.5rem 1rem;
   border-radius: var(--radius-lg);
   cursor: pointer;
@@ -751,21 +751,21 @@ body {
 }
 
 .channel-btn:hover {
-  background: var(--ctp-surface2);
-  border-color: var(--ctp-blue);
+  background: var(--color-surface-active);
+  border-color: var(--color-accent);
 }
 
 .channel-btn.active {
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
-  border-color: var(--ctp-blue);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
+  border-color: var(--color-accent);
 }
 
 .channel-messages {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
   padding: 1.5rem;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
 }
 
 /* Messages Tab */
@@ -774,9 +774,9 @@ body {
 }
 
 .node-select {
-  background: var(--ctp-surface1);
-  border: 2px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 2px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.75rem 1rem;
   border-radius: var(--radius-lg);
   font-size: 1rem;
@@ -786,14 +786,14 @@ body {
 
 .node-select:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .dm-conversation {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
   padding: 1.5rem;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   /* Desktop: constrain to viewport height */
   min-height: 400px;
   max-height: calc(100vh - var(--header-height) - 12rem);
@@ -822,7 +822,7 @@ body {
 
 .dm-resize-handle:hover,
 .dm-resize-handle.resizing {
-  background: var(--ctp-blue);
+  background: var(--color-accent);
 }
 
 .dm-resize-handle::before {
@@ -833,14 +833,14 @@ body {
   transform: translate(-50%, -50%);
   width: 40px;
   height: 4px;
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   border-radius: var(--radius-xs);
   transition: background 0.2s ease;
 }
 
 .dm-resize-handle:hover::before,
 .dm-resize-handle.resizing::before {
-  background: var(--ctp-blue);
+  background: var(--color-accent);
 }
 
 /* DM Send Section - wrapper for send form and info below */
@@ -861,7 +861,7 @@ body {
   align-items: center;
   justify-content: center;
   height: 100%;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 1.1rem;
 }
 
@@ -874,13 +874,13 @@ body {
 }
 
 .message-item.sent .message-text {
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
   margin-left: auto;
 }
 
 .message-item.received .message-text {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 /* Info Tab */
@@ -891,26 +891,26 @@ body {
 }
 
 .info-section {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
   padding: 1.5rem;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
 }
 
 .info-section-full-width {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
   padding: 1.5rem;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   margin-top: 1.5rem;
   width: 100%;
 }
 
 .info-section-wide {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
   padding: 1.5rem;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   grid-column: span 2;
 }
 
@@ -935,18 +935,18 @@ body {
 .info-section h3,
 .info-section-full-width h3,
 .info-section-wide h3 {
-  color: var(--ctp-lavender);
+  color: var(--color-accent-muted);
   margin-bottom: 1rem;
   font-size: 1.25rem;
 }
 
 .info-section p {
   margin-bottom: 0.5rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .info-section strong {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
 }
 
 .status-text {
@@ -955,23 +955,23 @@ body {
 }
 
 .status-text.connected {
-  color: var(--ctp-green);
+  color: var(--color-success);
 }
 
 .status-text.disconnected {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .status-text.connecting {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .status-text.rebooting {
-  color: var(--ctp-peach);
+  color: var(--color-caution);
 }
 
 .status-text.node-offline {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .channel-config {
@@ -984,14 +984,14 @@ body {
 
 .channel-item hr {
   border: none;
-  border-top: 1px solid var(--ctp-surface2);
+  border-top: 1px solid var(--color-surface-active);
   margin: 0.5rem 0;
 }
 
 /* General Styling */
 .no-data {
   text-align: center;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   font-style: italic;
   padding: 2rem;
 }
@@ -999,11 +999,11 @@ body {
 .connection-panel,
 .nodes-panel,
 .messages-panel {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
   padding: 1.5rem;
   margin-bottom: 2rem;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
 }
 
 .connection-panel h2,
@@ -1011,7 +1011,7 @@ body {
 .messages-panel h2 {
   margin-top: 0;
   margin-bottom: 1rem;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   font-weight: 600;
 }
 
@@ -1023,27 +1023,27 @@ body {
 .connection-form input {
   flex: 1;
   padding: 0.75rem 1rem;
-  border: 2px solid var(--ctp-surface1);
+  border: 2px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   font-size: 1rem;
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  background: var(--color-bg);
+  color: var(--color-text);
   transition: border-color 0.2s;
 }
 
 .connection-form input:focus {
   outline: none;
-  border-color: var(--ctp-lavender);
+  border-color: var(--color-accent-muted);
 }
 
 .connection-form input::placeholder {
-  color: var(--ctp-overlay1);
+  color: var(--color-text-disabled);
 }
 
 .connection-form button {
   padding: 0.75rem 2rem;
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
   border: none;
   border-radius: var(--radius-lg);
   font-size: 1rem;
@@ -1053,7 +1053,7 @@ body {
 }
 
 .connection-form button:hover:not(:disabled) {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
   transform: translateY(-2px);
   box-shadow: 0 8px 25px -5px rgba(137, 180, 250, 0.3);
 }
@@ -1064,33 +1064,33 @@ body {
 }
 
 .connection-form button.disconnect-btn {
-  background: var(--ctp-red);
-  color: var(--ctp-accent-text);
+  background: var(--color-error);
+  color: var(--color-accent-text);
 }
 
 .connection-form button.disconnect-btn:hover:not(:disabled) {
-  background: var(--ctp-maroon);
+  background: var(--color-danger);
 }
 
 .error-panel {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-red);
+  background: var(--color-surface);
+  border: 1px solid var(--color-error);
   border-radius: var(--radius-lg);
   padding: 1.5rem;
   margin-bottom: 1rem;
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .error-panel h3 {
   margin: 0 0 0.75rem 0;
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-size: 1.1rem;
 }
 
 .error-panel p {
   margin: 0 0 1rem 0;
   line-height: 1.5;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .error-actions {
@@ -1100,8 +1100,8 @@ body {
 }
 
 .retry-btn {
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: var(--radius-md);
@@ -1111,13 +1111,13 @@ body {
 }
 
 .retry-btn:hover {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
 }
 
 .dismiss-error {
   background: none;
-  border: 1px solid var(--ctp-overlay0);
-  color: var(--ctp-text);
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text);
   padding: 0.5rem 1rem;
   border-radius: var(--radius-md);
   font-weight: 500;
@@ -1126,21 +1126,21 @@ body {
 }
 
 .dismiss-error:hover {
-  background: var(--ctp-surface1);
-  border-color: var(--ctp-overlay1);
+  background: var(--color-surface-hover);
+  border-color: var(--color-text-disabled);
 }
 
 .device-info {
   margin-top: 1.5rem;
   padding: 1rem;
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   border-radius: var(--radius-lg);
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
 }
 
 .device-info h3 {
   margin: 0 0 1rem 0;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   font-size: 1.1rem;
 }
 
@@ -1164,7 +1164,7 @@ body {
 
 .info-item .value {
   font-size: 0.95rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-family: var(--font-mono);
 }
 
@@ -1175,22 +1175,22 @@ body {
 }
 
 .node-card {
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   padding: 1.25rem;
   border-radius: var(--radius-lg);
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   transition: all 0.2s;
 }
 
 .node-card:hover {
-  border-color: var(--ctp-surface2);
+  border-color: var(--color-surface-active);
   transform: translateY(-2px);
   box-shadow: 0 8px 25px -5px rgba(0, 0, 0, 0.3);
 }
 
 .node-card h3 {
   margin: 0 0 0.75rem 0;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1198,24 +1198,24 @@ body {
 
 .node-card p {
   margin: 0.5rem 0;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.9rem;
 }
 
 .no-nodes,
 .no-messages {
   text-align: center;
-  color: var(--ctp-overlay1);
+  color: var(--color-text-disabled);
   padding: 2rem;
   font-style: italic;
 }
 
 .messages-container {
   overflow-y: auto;
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   padding: 1rem;
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   flex: 1;
   min-height: 0;
 }
@@ -1225,25 +1225,25 @@ body {
 }
 
 .messages-container::-webkit-scrollbar-track {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-sm);
 }
 
 .messages-container::-webkit-scrollbar-thumb {
-  background: var(--ctp-overlay0);
+  background: var(--color-surface-inactive);
   border-radius: var(--radius-sm);
 }
 
 .messages-container::-webkit-scrollbar-thumb:hover {
-  background: var(--ctp-overlay1);
+  background: var(--color-text-disabled);
 }
 
 .message-item {
   padding: 0.75rem;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
   border-radius: var(--radius-md);
   margin-bottom: 0.5rem;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
 }
 
 .message-header {
@@ -1256,11 +1256,11 @@ body {
 
 .message-from {
   font-weight: 600;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
 }
 
 .message-to {
-  color: var(--ctp-green);
+  color: var(--color-success);
   font-weight: 500;
 }
 
@@ -1272,7 +1272,7 @@ body {
 }
 
 .message-text {
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin-bottom: 0.5rem;
   line-height: 1.4;
   word-wrap: break-word;
@@ -1281,8 +1281,8 @@ body {
 
 /* Impersonation warning on a spoof-suspected message (#2584). */
 .message-bubble.spoofed {
-  border: 1px solid var(--ctp-red);
-  box-shadow: 0 0 0 1px var(--ctp-red) inset;
+  border: 1px solid var(--color-error);
+  box-shadow: 0 0 0 1px var(--color-error) inset;
 }
 
 .message-spoof-warning {
@@ -1292,8 +1292,8 @@ body {
   margin-bottom: 0.35rem;
   padding: 0.2rem 0.45rem;
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--ctp-red) 18%, transparent);
-  color: var(--ctp-red);
+  background: color-mix(in srgb, var(--color-error) 18%, transparent);
+  color: var(--color-error);
   font-size: 0.72rem;
   font-weight: 600;
   cursor: help;
@@ -1303,16 +1303,16 @@ body {
   display: flex;
   gap: 1rem;
   font-size: 0.75rem;
-  color: var(--ctp-overlay1);
+  color: var(--color-text-disabled);
   font-family: var(--font-mono);
 }
 
 .send-message {
   margin-bottom: 1rem;
   padding: 1rem;
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   border-radius: var(--radius-lg);
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
 }
 
 .message-input-container {
@@ -1323,21 +1323,21 @@ body {
 .message-input-container input {
   flex: 1;
   padding: 0.75rem;
-  border: 2px solid var(--ctp-surface1);
+  border: 2px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
   font-size: 0.95rem;
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  background: var(--color-bg);
+  color: var(--color-text);
   transition: border-color 0.2s;
 }
 
 .message-input-container input:focus {
   outline: none;
-  border-color: var(--ctp-lavender);
+  border-color: var(--color-accent-muted);
 }
 
 .message-input-container input::placeholder {
-  color: var(--ctp-overlay1);
+  color: var(--color-text-disabled);
 }
 
 /*
@@ -1362,8 +1362,8 @@ body {
   padding: 0.75rem 0.5rem;
   min-width: 40px;
   width: 40px;
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
   border: none;
   border-radius: var(--radius-lg);
   font-weight: 600;
@@ -1382,7 +1382,7 @@ body {
 }
 
 .send-btn:hover:not(:disabled) {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
   transform: translateY(-1px);
   box-shadow: 0 6px 20px -3px rgba(166, 227, 161, 0.4);
 }
@@ -1409,7 +1409,7 @@ body {
 .channels-table table {
   width: 100%;
   border-collapse: collapse;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
   overflow: hidden;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
@@ -1419,56 +1419,56 @@ body {
 .channels-table td {
   padding: 1rem;
   text-align: left;
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
 }
 
 .channels-table th {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   font-weight: 600;
-  color: var(--ctp-lavender);
+  color: var(--color-accent-muted);
 }
 
 .channels-table tr:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .channel-name {
   font-weight: 600;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
 }
 
 .status-indicator.enabled {
-  color: var(--ctp-green);
+  color: var(--color-success);
   font-weight: 600;
 }
 
 .status-indicator.disabled {
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-weight: 600;
 }
 
 .channel-info {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
   padding: 1.5rem;
   margin-top: 2rem;
-  border-left: 2px solid var(--ctp-blue);
+  border-left: 2px solid var(--color-accent);
 }
 
 .channel-info h3 {
-  color: var(--ctp-lavender);
+  color: var(--color-accent-muted);
   margin-bottom: 1rem;
 }
 
 .channel-info p {
   margin-bottom: 1rem;
   line-height: 1.6;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
 }
 
 .channel-info ul {
   list-style-position: inside;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
 }
 
 .channel-info li {
@@ -1477,7 +1477,7 @@ body {
 }
 
 .channel-info strong {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 @media (max-width: 768px) {
@@ -1709,7 +1709,7 @@ body {
     padding-bottom: env(safe-area-inset-bottom, 0);
     width: 100%;
     box-sizing: border-box;
-    background: var(--ctp-mantle);
+    background: var(--color-bg-raised);
   }
 
   /* Reduce padding on mobile for more space */
@@ -1904,7 +1904,7 @@ body {
 .channel-messages-section {
   margin-bottom: 3rem;
   padding-bottom: 2rem;
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .channels-header {
@@ -1957,8 +1957,8 @@ body {
   top: 100%;
   right: 0;
   margin-top: 4px;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-active);
   border-radius: 6px;
   z-index: 1000;
   min-width: 230px;
@@ -1974,7 +1974,7 @@ body {
   padding: 0.65rem 1rem;
   background: none;
   border: none;
-  color: var(--ctp-text);
+  color: var(--color-text);
   cursor: pointer;
   text-align: left;
   font-size: 0.9rem;
@@ -1982,12 +1982,12 @@ body {
 }
 
 .channel-overflow-item:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .channel-overflow-divider {
   height: 1px;
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   margin: 0.25rem 0;
 }
 
@@ -1995,24 +1995,24 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   padding: 0.5rem 0.75rem;
   border-radius: var(--radius-lg);
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   font-size: 0.85rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   transition: all 0.2s ease;
 }
 
 .mqtt-toggle:hover {
-  background: var(--ctp-surface2);
-  border-color: var(--ctp-blue);
+  background: var(--color-surface-active);
+  border-color: var(--color-accent);
 }
 
 .mqtt-toggle input[type='checkbox'] {
   width: 16px;
   height: 16px;
-  accent-color: var(--ctp-blue);
+  accent-color: var(--color-accent);
   cursor: pointer;
 }
 
@@ -2034,11 +2034,11 @@ body {
 .channel-select,
 .node-select {
   padding: 0.5rem 1rem;
-  border: 2px solid var(--ctp-surface1);
+  border: 2px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   font-size: 1rem;
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
+  background: var(--color-surface);
+  color: var(--color-text);
   cursor: pointer;
   min-width: 200px;
   transition: border-color 0.2s;
@@ -2047,14 +2047,14 @@ body {
 .channel-select:focus,
 .node-select:focus {
   outline: none;
-  border-color: var(--ctp-lavender);
+  border-color: var(--color-accent-muted);
 }
 
 .send-message-form {
   flex-shrink: 0;
   margin-top: 1rem;
   padding-top: 1rem;
-  border-top: 1px solid var(--ctp-surface2);
+  border-top: 1px solid var(--color-surface-active);
 }
 
 .message-input-container {
@@ -2067,11 +2067,11 @@ body {
   flex: 1;
   width: 100%;
   padding: 0.75rem 1rem;
-  border: 2px solid var(--ctp-surface1);
+  border: 2px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   font-size: 1rem;
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  background: var(--color-bg);
+  color: var(--color-text);
   transition: border-color 0.2s;
   resize: none;
   min-height: 2.75rem;
@@ -2082,11 +2082,11 @@ body {
 
 .message-input:focus {
   outline: none;
-  border-color: var(--ctp-lavender);
+  border-color: var(--color-accent-muted);
 }
 
 .message-input::placeholder {
-  color: var(--ctp-overlay1);
+  color: var(--color-text-disabled);
 }
 
 /* `.send-btn` is defined once, above — see the note there (#4478). */
@@ -2116,10 +2116,10 @@ body {
   width: 100%;
   max-width: min(400px, 90vw);
   padding: 0.75rem;
-  background: var(--ctp-surface0);
-  border: 2px solid var(--ctp-surface2);
+  background: var(--color-surface);
+  border: 2px solid var(--color-surface-active);
   border-radius: var(--radius-lg);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
   cursor: pointer;
   appearance: none;
@@ -2131,7 +2131,7 @@ body {
 
 .channel-dropdown-select:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 /* Mobile node dropdown - hidden on desktop */
@@ -2145,28 +2145,28 @@ body {
 }
 
 .channel-button {
-  background: var(--ctp-surface0);
-  border: 2px solid var(--ctp-surface2);
+  background: var(--color-surface);
+  border: 2px solid var(--color-surface-active);
   border-radius: var(--radius-xl);
   padding: 1rem;
   cursor: pointer;
   transition: all 0.3s ease;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-weight: 500;
   position: relative;
 }
 
 .channel-button:hover {
-  background: var(--ctp-surface1);
-  border-color: var(--ctp-blue);
+  background: var(--color-surface-hover);
+  border-color: var(--color-accent);
   transform: translateY(-2px);
   box-shadow: 0 8px 25px -5px rgba(137, 180, 250, 0.3);
 }
 
 .channel-button.selected {
-  background: var(--ctp-blue);
-  border-color: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-accent-text);
   transform: translateY(-2px);
   box-shadow: 0 8px 25px -5px rgba(137, 180, 250, 0.5);
 }
@@ -2222,15 +2222,15 @@ body {
 }
 
 .encryption-icon.secure {
-  color: var(--ctp-green);
+  color: var(--color-success);
 }
 
 .encryption-icon.default-key {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .encryption-icon.unencrypted {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .channel-button.selected .encryption-icon {
@@ -2239,7 +2239,7 @@ body {
 
 .channel-info-link {
   font-size: 0.75rem;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   text-decoration: none;
   padding: 2px 6px;
   border-radius: var(--radius-xs);
@@ -2247,19 +2247,19 @@ body {
 }
 
 .channel-info-link:hover {
-  background: var(--ctp-surface0);
-  color: var(--ctp-sky);
+  background: var(--color-surface);
+  color: var(--color-info);
 }
 
 .channel-button.selected .channel-info-link {
-  color: var(--ctp-accent-text);
+  color: var(--color-accent-text);
   background: rgba(17, 17, 27, 0.3);
   font-weight: 600;
 }
 
 .channel-button.selected .channel-info-link:hover {
   background: rgba(17, 17, 27, 0.5);
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .channel-button-status {
@@ -2281,41 +2281,41 @@ body {
 }
 
 .arrow-icon.uplink.enabled {
-  color: var(--ctp-green);
+  color: var(--color-success);
   background: rgba(166, 227, 161, 0.2);
 }
 
 .arrow-icon.uplink.disabled {
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
   background: rgba(108, 112, 134, 0.1);
   opacity: 0.5;
 }
 
 .arrow-icon.downlink.enabled {
-  color: var(--ctp-green);
+  color: var(--color-success);
   background: rgba(166, 227, 161, 0.2);
 }
 
 .arrow-icon.downlink.disabled {
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
   background: rgba(108, 112, 134, 0.1);
   opacity: 0.5;
 }
 
 .channel-button.selected .arrow-icon.enabled {
-  color: var(--ctp-accent-text);
+  color: var(--color-accent-text);
   background: rgba(17, 17, 27, 0.3);
 }
 
 .channel-button.selected .arrow-icon.disabled {
-  color: var(--ctp-accent-text);
+  color: var(--color-accent-text);
   background: rgba(17, 17, 27, 0.2);
   opacity: 0.4;
 }
 
 /* Channel Conversation Section */
 .channel-conversation-section {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
   padding: 0.75rem;
   border: none;
@@ -2327,7 +2327,7 @@ body {
 }
 
 .channel-conversation-section h3 {
-  color: var(--ctp-lavender);
+  color: var(--color-accent-muted);
   margin-bottom: 1rem;
   display: flex;
   align-items: center;
@@ -2336,8 +2336,8 @@ body {
 }
 
 .channel-id-label {
-  background: var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.25rem 0.5rem;
   border-radius: var(--radius-md);
   font-size: 0.9rem;
@@ -2346,10 +2346,10 @@ body {
 }
 
 .channel-conversation {
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   border-radius: var(--radius-lg);
   padding: 1rem;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -2410,8 +2410,8 @@ body {
 
 /* Footer Styles */
 .app-footer {
-  background: var(--ctp-crust);
-  border-top: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-sunken);
+  border-top: 1px solid var(--color-surface);
   padding: 0.75rem 1rem;
   margin-top: auto;
 }
@@ -2422,31 +2422,31 @@ body {
   justify-content: center;
   gap: 1rem;
   font-size: 0.85rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .footer-title {
   font-weight: 600;
-  color: var(--ctp-mauve);
+  color: var(--color-accent-alt);
 }
 
 .footer-version {
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   font-family: var(--font-mono);
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   padding: 0.15rem 0.5rem;
   border-radius: var(--radius-sm);
 }
 
 .footer-link {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   text-decoration: none;
   transition: color 0.2s ease;
   font-weight: 500;
 }
 
 .footer-link:hover {
-  color: var(--ctp-sapphire);
+  color: var(--color-accent-hover);
   text-decoration: underline;
 }
 
@@ -2460,14 +2460,14 @@ body {
   display: flex;
   align-items: center;
   margin: 24px 0;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .login-divider::before,
 .login-divider::after {
   content: '';
   flex: 1;
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .login-divider span {
@@ -2483,7 +2483,7 @@ body {
 .form-group label {
   display: block;
   margin-bottom: 8px;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   font-weight: 600;
   font-size: 0.95em;
 }
@@ -2491,17 +2491,17 @@ body {
 .form-group input {
   width: 100%;
   padding: 12px;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-lg);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1em;
   transition: all 0.2s ease;
 }
 
 .form-group input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
   box-shadow: 0 0 0 3px rgba(137, 180, 250, 0.1);
 }
 
@@ -2513,9 +2513,9 @@ body {
 .error-message {
   padding: 12px;
   background: rgba(243, 139, 168, 0.1);
-  border: 1px solid var(--ctp-red);
+  border: 1px solid var(--color-error);
   border-radius: var(--radius-lg);
-  color: var(--ctp-red);
+  color: var(--color-error);
   margin-bottom: 16px;
   font-size: 0.95em;
   white-space: pre-line; /* Preserve line breaks in error messages */
@@ -2525,9 +2525,9 @@ body {
 .success-message {
   padding: 12px;
   background: rgba(166, 227, 161, 0.1);
-  border: 1px solid var(--ctp-green);
+  border: 1px solid var(--color-success);
   border-radius: var(--radius-lg);
-  color: var(--ctp-green);
+  color: var(--color-success);
   margin-bottom: 16px;
   font-size: 0.95em;
 }
@@ -2536,7 +2536,7 @@ body {
   display: block;
   margin-top: 4px;
   font-size: 0.85em;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .modal-actions {
@@ -2566,24 +2566,24 @@ body {
 }
 
 .button-primary {
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
 }
 
 .button-primary:hover:not(:disabled) {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(137, 180, 250, 0.3);
 }
 
 .button-secondary {
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-active);
 }
 
 .button-secondary:hover:not(:disabled) {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   transform: translateY(-1px);
 }
 
@@ -2591,7 +2591,7 @@ body {
   background: none;
   border: none;
   font-size: 2em;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   cursor: pointer;
   padding: 0;
   width: 32px;
@@ -2605,8 +2605,8 @@ body {
 }
 
 .close-button:hover {
-  background: var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-active);
+  color: var(--color-text);
 }
 
 /* User Menu */
@@ -2620,10 +2620,10 @@ body {
   align-items: center;
   gap: 8px;
   padding: 8px 16px;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-lg);
-  color: var(--ctp-text);
+  color: var(--color-text);
   cursor: pointer;
   font-size: 0.95em;
   font-weight: 500;
@@ -2631,8 +2631,8 @@ body {
 }
 
 .user-menu-button:hover {
-  background: var(--ctp-surface1);
-  border-color: var(--ctp-blue);
+  background: var(--color-surface-hover);
+  border-color: var(--color-accent);
   transform: translateY(-1px);
 }
 
@@ -2666,8 +2666,8 @@ body {
   top: calc(100% + 8px);
   right: 0;
   min-width: 250px;
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-lg);
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
   z-index: 9999;
@@ -2676,25 +2676,25 @@ body {
 
 .user-menu-header {
   padding: 16px;
-  background: var(--ctp-surface0);
-  border-bottom: 1px solid var(--ctp-surface2);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .user-menu-name {
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.1em;
   margin-bottom: 4px;
 }
 
 .user-menu-username {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.9em;
   margin-bottom: 4px;
 }
 
 .user-menu-email {
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   font-size: 0.85em;
   margin-bottom: 8px;
 }
@@ -2702,10 +2702,10 @@ body {
 .user-menu-provider {
   display: inline-block;
   padding: 2px 8px;
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   border-radius: var(--radius-sm);
   font-size: 0.75em;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   text-transform: uppercase;
   font-weight: 600;
   letter-spacing: 0.5px;
@@ -2716,10 +2716,10 @@ body {
   margin-left: 8px;
   padding: 2px 8px;
   background: rgba(249, 226, 175, 0.2);
-  border: 1px solid var(--ctp-yellow);
+  border: 1px solid var(--color-warning);
   border-radius: var(--radius-sm);
   font-size: 0.75em;
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
   text-transform: uppercase;
   font-weight: 600;
   letter-spacing: 0.5px;
@@ -2727,7 +2727,7 @@ body {
 
 .user-menu-divider {
   height: 1px;
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
 }
 
 .user-menu-item {
@@ -2735,7 +2735,7 @@ body {
   padding: 12px 16px;
   background: none;
   border: none;
-  color: var(--ctp-text);
+  color: var(--color-text);
   text-align: left;
   cursor: pointer;
   font-size: 0.95em;
@@ -2743,8 +2743,8 @@ body {
 }
 
 .user-menu-item:hover:not(:disabled) {
-  background: var(--ctp-surface0);
-  color: var(--ctp-red);
+  background: var(--color-surface);
+  color: var(--color-error);
 }
 
 .user-menu-item:disabled {
@@ -2780,8 +2780,8 @@ body {
   width: 100%;
   /* height is now set dynamically via inline style */
   z-index: 2;
-  background: var(--ctp-base);
-  border-top: 2px solid var(--ctp-surface2);
+  background: var(--color-bg);
+  border-top: 2px solid var(--color-surface-active);
   display: flex;
   flex-direction: column;
 }
@@ -2801,7 +2801,7 @@ body {
 
 .packet-monitor-resize-handle:hover,
 .packet-monitor-container.resizing .packet-monitor-resize-handle {
-  background: var(--ctp-blue);
+  background: var(--color-accent);
 }
 
 .packet-monitor-resize-handle::before {
@@ -2812,14 +2812,14 @@ body {
   transform: translate(-50%, -50%);
   width: 40px;
   height: 4px;
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   border-radius: var(--radius-xs);
   transition: background 0.2s ease;
 }
 
 .packet-monitor-resize-handle:hover::before,
 .packet-monitor-container.resizing .packet-monitor-resize-handle::before {
-  background: var(--ctp-blue);
+  background: var(--color-accent);
 }
 
 /* During resize, prevent pointer events on content */
@@ -2866,24 +2866,24 @@ body {
   right: 8px;
   bottom: 8px;
   font-size: 0.75rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-family: var(--font-mono);
   white-space: nowrap;
   opacity: 0.6;
   pointer-events: none; /* Allow clicking through to the input */
-  background: var(--ctp-base);
+  background: var(--color-bg);
   padding: 2px 4px;
   border-radius: var(--radius-xs);
 }
 
 .byte-counter-warning {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
   font-weight: 600;
   opacity: 0.9;
 }
 
 .byte-counter-over {
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-weight: 700;
   opacity: 1;
 }
@@ -2895,8 +2895,8 @@ body {
   gap: 0.5rem;
   padding: 0.75rem 1rem;
   margin-bottom: 1rem;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   position: sticky;
   top: var(--header-height);
@@ -2904,9 +2904,9 @@ body {
 }
 
 .section-nav-item {
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-active);
   padding: 0.375rem 0.75rem;
   border-radius: var(--radius-md);
   font-size: 0.85rem;
@@ -2916,9 +2916,9 @@ body {
 }
 
 .section-nav-item:hover {
-  background: var(--ctp-surface2);
-  border-color: var(--ctp-blue);
-  color: var(--ctp-blue);
+  background: var(--color-surface-active);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 .section-nav-item:active {
@@ -2957,8 +2957,8 @@ body {
   top: calc(100% + 4px);
   right: 0;
   min-width: 220px;
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
   z-index: 10000;
@@ -2987,7 +2987,7 @@ body {
   padding: 0.625rem 1rem;
   background: transparent;
   border: none;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9rem;
   text-align: left;
   cursor: pointer;
@@ -2995,7 +2995,7 @@ body {
 }
 
 .actions-menu-item:hover:not(:disabled) {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
 }
 
 .actions-menu-item:disabled {
@@ -3004,7 +3004,7 @@ body {
 }
 
 .actions-menu-item-danger {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .actions-menu-item-danger:hover:not(:disabled) {
@@ -3013,7 +3013,7 @@ body {
 
 .actions-menu-divider {
   height: 1px;
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   margin: 0.5rem 0;
 }
 

--- a/src/styles/BackupManagement.css
+++ b/src/styles/BackupManagement.css
@@ -13,7 +13,7 @@
 }
 
 .backup-modal-content {
-  background-color: var(--ctp-crust);
+  background-color: var(--color-bg-sunken);
   padding: 2rem;
   border-radius: var(--radius-lg);
   max-width: 90vw;
@@ -37,15 +37,15 @@
 
 .modal-content.backup-modal .modal-footer {
   padding: 1rem 1.5rem;
-  border-top: 1px solid var(--ctp-surface0);
+  border-top: 1px solid var(--color-surface);
   display: flex;
   justify-content: flex-end;
 }
 
 /* Emoji action buttons — styled consistently */
 .backup-action-button {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-md);
   cursor: pointer;
   font-size: 1.1rem;
@@ -59,23 +59,23 @@
 }
 
 .backup-action-button:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   transform: translateY(-1px);
 }
 
 .backup-action-button.download:hover {
-  background: var(--ctp-green);
-  border-color: var(--ctp-green);
+  background: var(--color-success);
+  border-color: var(--color-success);
 }
 
 .backup-action-button.delete:hover {
-  background: var(--ctp-red);
-  border-color: var(--ctp-red);
+  background: var(--color-error);
+  border-color: var(--color-error);
 }
 
 .backup-version {
   font-size: 0.85rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .backup-dirname {
@@ -104,7 +104,7 @@
 }
 
 .backup-table thead tr {
-  border-bottom: 2px solid var(--ctp-surface2);
+  border-bottom: 2px solid var(--color-surface-active);
 }
 
 .backup-table th {
@@ -117,7 +117,7 @@
 }
 
 .backup-table tbody tr {
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
 }
 
 .backup-table td {
@@ -143,11 +143,11 @@
 }
 
 .backup-type-badge.automatic {
-  background-color: var(--ctp-blue);
+  background-color: var(--color-accent);
 }
 
 .backup-type-badge.manual {
-  background-color: var(--ctp-mauve);
+  background-color: var(--color-accent-alt);
 }
 
 .backup-size {
@@ -172,11 +172,11 @@
 }
 
 .backup-btn.download {
-  background-color: var(--ctp-green);
+  background-color: var(--color-success);
 }
 
 .backup-btn.delete {
-  background-color: var(--ctp-red);
+  background-color: var(--color-error);
 }
 
 .backup-modal-footer {
@@ -185,8 +185,8 @@
 }
 
 .backup-close-btn {
-  background-color: var(--ctp-surface2);
-  color: var(--ctp-text);
+  background-color: var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.75rem 1.5rem;
   border: none;
   border-radius: var(--radius-sm);
@@ -222,7 +222,7 @@
   .backup-table tbody tr {
     display: block;
     margin-bottom: 1rem;
-    border: 1px solid var(--ctp-surface2);
+    border: 1px solid var(--color-surface-active);
     border-radius: var(--radius-lg);
     padding: 1rem;
   }

--- a/src/styles/SecurityTab.css
+++ b/src/styles/SecurityTab.css
@@ -10,12 +10,12 @@
 
 .security-header h2 {
   margin: 0 0 10px 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .security-header p {
   margin: 0;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 14px;
 }
 
@@ -25,8 +25,8 @@
 }
 
 .status-card {
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   padding: 20px;
 }
@@ -34,7 +34,7 @@
 .status-card h3 {
   margin: 0 0 15px 0;
   font-size: 18px;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .status-details {
@@ -44,7 +44,7 @@
 .status-row {
   display: flex;
   padding: 8px 0;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 .status-row:last-child {
@@ -54,33 +54,33 @@
 .status-row .label {
   font-weight: 600;
   min-width: 140px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .status-row .value {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-weight: 500;
 }
 
 .status-row .value.running {
-  color: var(--ctp-green);
+  color: var(--color-success);
   font-weight: 600;
 }
 
 .status-row .value.stopped {
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-weight: 600;
 }
 
 .status-row .timestamp {
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
   font-size: 12px;
   margin-left: 5px;
 }
 
 .scan-button {
-  background: var(--ctp-blue);
-  color: var(--ctp-crust);
+  background: var(--color-accent);
+  color: var(--color-bg-sunken);
   border: none;
   padding: 10px 20px;
   border-radius: 5px;
@@ -91,11 +91,11 @@
 }
 
 .scan-button:hover:not(:disabled) {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
 }
 
 .scan-button:disabled {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
   cursor: not-allowed;
   opacity: 0.6;
 }
@@ -109,23 +109,23 @@
 }
 
 .stat-card {
-  background: var(--ctp-base);
+  background: var(--color-bg);
   border-radius: var(--radius-lg);
   padding: 20px;
   text-align: center;
-  border: 2px solid var(--ctp-surface1);
+  border: 2px solid var(--color-surface-hover);
 }
 
 .stat-card.total {
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .stat-card.low-entropy {
-  border-color: var(--ctp-yellow);
+  border-color: var(--color-warning);
 }
 
 .stat-card.duplicate {
-  border-color: var(--ctp-red);
+  border-color: var(--color-error);
 }
 
 .stat-value {
@@ -135,28 +135,28 @@
 }
 
 .stat-card.total .stat-value {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
 }
 
 .stat-card.low-entropy .stat-value {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .stat-card.duplicate .stat-value {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .stat-card.excessive-packets {
-  border-color: var(--ctp-peach);
+  border-color: var(--color-caution);
 }
 
 .stat-card.excessive-packets .stat-value {
-  color: var(--ctp-peach);
+  color: var(--color-caution);
 }
 
 .stat-label {
   font-size: 14px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: 500;
 }
 
@@ -171,14 +171,14 @@
 
 .issues-section h3 {
   margin-bottom: 20px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 20px;
 }
 
 .no-issues {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
-  border-left: 4px solid var(--ctp-green);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
+  border-left: 4px solid var(--color-success);
   border-radius: var(--radius-lg);
   padding: 30px;
   text-align: center;
@@ -186,13 +186,13 @@
 
 .no-issues p {
   margin: 10px 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 16px;
 }
 
 .no-issues .help-text {
   font-size: 14px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .issues-list {
@@ -202,8 +202,8 @@
 }
 
 .issue-card {
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   overflow: hidden;
   transition: box-shadow 0.2s;
@@ -223,7 +223,7 @@
 }
 
 .issue-header:hover {
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
 }
 
 .node-info {
@@ -236,27 +236,27 @@
 }
 
 .node-name strong {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .node-name .long-name {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 14px;
 }
 
 .node-id {
   font-size: 12px;
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
 }
 
 .node-id .hw-model {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: 500;
 }
 
 .node-last-seen {
   font-size: 12px;
-  color: var(--ctp-overlay1);
+  color: var(--color-text-disabled);
   font-style: italic;
   margin-top: 3px;
 }
@@ -275,29 +275,29 @@
 }
 
 .badge.low-entropy {
-  background: var(--ctp-yellow);
-  color: var(--ctp-accent-text);
-  border: 1px solid var(--ctp-yellow);
+  background: var(--color-warning);
+  color: var(--color-accent-text);
+  border: 1px solid var(--color-warning);
   opacity: 0.8;
 }
 
 .badge.duplicate {
-  background: var(--ctp-red);
-  color: var(--ctp-accent-text);
-  border: 1px solid var(--ctp-red);
+  background: var(--color-error);
+  color: var(--color-accent-text);
+  border: 1px solid var(--color-error);
   opacity: 0.8;
 }
 
 .badge.excessive-packets {
-  background: var(--ctp-peach);
-  color: var(--ctp-accent-text);
-  border: 1px solid var(--ctp-peach);
+  background: var(--color-caution);
+  color: var(--color-accent-text);
+  border: 1px solid var(--color-caution);
   opacity: 0.8;
 }
 
 .packet-rate {
   font-size: 12px;
-  color: var(--ctp-peach);
+  color: var(--color-caution);
   margin-left: 8px;
   font-weight: 500;
 }
@@ -308,7 +308,7 @@
 }
 
 .top-broadcasters-section .section-description {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 14px;
   margin-bottom: 15px;
 }
@@ -316,7 +316,7 @@
 .top-broadcasters-table {
   width: 100%;
   border-collapse: collapse;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
   overflow: hidden;
 }
@@ -325,19 +325,19 @@
 .top-broadcasters-table td {
   padding: 12px 15px;
   text-align: left;
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
 }
 
 .top-broadcasters-table th {
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  color: var(--color-text);
   font-weight: 600;
   font-size: 13px;
   text-transform: uppercase;
 }
 
 .top-broadcasters-table td {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 14px;
 }
 
@@ -346,13 +346,13 @@
 }
 
 .top-broadcasters-table tr:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .top-broadcasters-table .rank {
   width: 60px;
   font-weight: 600;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .top-broadcasters-table .node-name {
@@ -360,13 +360,13 @@
 }
 
 .top-broadcasters-table .node-name .short-name {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: 400;
 }
 
 .top-broadcasters-table .node-id {
   font-family: var(--font-mono);
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 13px;
 }
 
@@ -378,7 +378,7 @@
 
 .top-broadcasters-table .packet-count {
   font-weight: 600;
-  color: var(--ctp-peach);
+  color: var(--color-caution);
 }
 
 /* Security Digest Section */
@@ -391,7 +391,7 @@
   flex-direction: column;
   gap: 12px;
   padding: 12px;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
 }
 
@@ -404,7 +404,7 @@
 .digest-label {
   min-width: 140px;
   font-size: 14px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   display: flex;
   align-items: center;
   gap: 6px;
@@ -413,16 +413,16 @@
 .digest-input {
   flex: 1;
   padding: 6px 10px;
-  background: var(--ctp-surface1);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-sm);
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 14px;
 }
 
 .digest-input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .digest-time {
@@ -453,17 +453,17 @@
 }
 
 .digest-save-btn {
-  background: var(--ctp-blue);
-  color: var(--ctp-base);
+  background: var(--color-accent);
+  color: var(--color-bg);
 }
 
 .digest-save-btn:hover:not(:disabled) {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
 }
 
 .digest-send-btn {
-  background: var(--ctp-green);
-  color: var(--ctp-base);
+  background: var(--color-success);
+  color: var(--color-bg);
 }
 
 .digest-send-btn:hover:not(:disabled) {
@@ -483,24 +483,24 @@
 }
 
 .digest-message.success {
-  background: var(--ctp-green);
-  color: var(--ctp-base);
+  background: var(--color-success);
+  color: var(--color-bg);
 }
 
 .digest-message.error {
-  background: var(--ctp-red);
-  color: var(--ctp-base);
+  background: var(--color-error);
+  color: var(--color-bg);
 }
 
 .expand-icon {
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
   font-size: 12px;
   margin-left: 10px;
 }
 
 .send-notification-btn {
-  background: var(--ctp-blue);
-  color: var(--ctp-crust);
+  background: var(--color-accent);
+  color: var(--color-bg-sunken);
   border: none;
   padding: 6px 12px;
   border-radius: var(--radius-sm);
@@ -513,7 +513,7 @@
 }
 
 .send-notification-btn:hover {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
   transform: scale(1.05);
 }
 
@@ -530,8 +530,8 @@
 
 .issue-details {
   padding: 20px;
-  border-top: 1px solid var(--ctp-surface1);
-  background: var(--ctp-mantle);
+  border-top: 1px solid var(--color-surface-hover);
+  background: var(--color-bg-raised);
 }
 
 .detail-row {
@@ -547,18 +547,18 @@
 .detail-label {
   font-weight: 600;
   min-width: 120px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .detail-value {
-  color: var(--ctp-text);
+  color: var(--color-text);
   flex: 1;
 }
 
 .detail-value.key-hash {
   font-family: var(--font-mono);
   font-size: 12px;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   padding: 4px 8px;
   border-radius: var(--radius-sm);
   word-break: break-all;
@@ -576,7 +576,7 @@
 
 .detail-row.recommendations li {
   margin-bottom: 8px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   line-height: 1.5;
 }
 
@@ -586,21 +586,21 @@
 
 /* Clickable Node Links */
 .node-link {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   cursor: pointer;
   text-decoration: none;
   transition: color 0.2s;
 }
 
 .node-link:hover {
-  color: var(--ctp-sapphire);
+  color: var(--color-accent-hover);
   text-decoration: underline;
 }
 
 /* Duplicate Key Groups */
 .duplicate-group {
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   margin-bottom: 20px;
   overflow: hidden;
@@ -608,9 +608,9 @@
 
 .duplicate-group-header {
   padding: 15px 20px;
-  background: var(--ctp-surface2);
-  border-bottom: 1px solid var(--ctp-surface1);
-  border-left: 4px solid var(--ctp-red);
+  background: var(--color-surface-active);
+  border-bottom: 1px solid var(--color-surface-hover);
+  border-left: 4px solid var(--color-error);
 }
 
 .group-title {
@@ -623,8 +623,8 @@
 .group-title .key-hash {
   font-family: var(--font-mono);
   font-size: 12px;
-  color: var(--ctp-text);
-  background: var(--ctp-surface0);
+  color: var(--color-text);
+  background: var(--color-surface);
   padding: 4px 8px;
   border-radius: var(--radius-sm);
   flex: 1;
@@ -632,13 +632,13 @@
 
 .node-count {
   font-size: 14px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-weight: 500;
 }
 
 .duplicate-node-list {
   padding: 15px 20px;
-  background: var(--ctp-base);
+  background: var(--color-bg);
 }
 
 .duplicate-node-item {
@@ -647,8 +647,8 @@
   align-items: center;
   padding: 10px 15px;
   margin-bottom: 8px;
-  background: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg-raised);
+  border: 1px solid var(--color-surface-hover);
   border-radius: 5px;
   transition: background 0.2s;
 }
@@ -660,7 +660,7 @@
 }
 
 .duplicate-node-item:hover {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
 }
 
 .duplicate-node-item:last-child {
@@ -669,7 +669,7 @@
 
 .duplicate-node-item .node-id {
   font-size: 12px;
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
   font-family: var(--font-mono);
 }
 
@@ -681,16 +681,16 @@
 
 .group-recommendations {
   padding: 15px 20px;
-  background: var(--ctp-surface2);
-  border-top: 1px solid var(--ctp-surface1);
-  border-left: 4px solid var(--ctp-yellow);
-  color: var(--ctp-text);
+  background: var(--color-surface-active);
+  border-top: 1px solid var(--color-surface-hover);
+  border-left: 4px solid var(--color-warning);
+  color: var(--color-text);
   font-size: 14px;
   line-height: 1.6;
 }
 
 .group-recommendations strong {
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 /* Loading & Error States */
@@ -698,25 +698,25 @@
 .error {
   text-align: center;
   padding: 40px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .error {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .error button {
   margin-top: 10px;
   padding: 8px 16px;
-  background: var(--ctp-blue);
-  color: var(--ctp-crust);
+  background: var(--color-accent);
+  color: var(--color-bg-sunken);
   border: none;
   border-radius: 5px;
   cursor: pointer;
 }
 
 .error button:hover {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
 }
 
 /* Export Button */
@@ -737,8 +737,8 @@
 }
 
 .export-button {
-  background: var(--ctp-blue);
-  color: var(--ctp-crust);
+  background: var(--color-accent);
+  color: var(--color-bg-sunken);
   border: none;
   padding: 10px 20px;
   border-radius: 5px;
@@ -750,7 +750,7 @@
 }
 
 .export-button:hover {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
 }
 
 .export-menu {
@@ -758,8 +758,8 @@
   top: 100%;
   right: 0;
   margin-top: 5px;
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface-hover);
   border-radius: 5px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   min-width: 160px;
@@ -773,7 +773,7 @@
   padding: 10px 15px;
   background: transparent;
   border: none;
-  color: var(--ctp-text);
+  color: var(--color-text);
   cursor: pointer;
   font-size: 14px;
   text-align: left;
@@ -781,11 +781,11 @@
 }
 
 .export-menu-item:hover {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
 }
 
 .export-menu-item:not(:last-child) {
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
 }
 
 /* Mobile responsiveness */

--- a/src/styles/analysis-reports.css
+++ b/src/styles/analysis-reports.css
@@ -8,16 +8,16 @@
 .reports-page {
   min-height: 100vh;
   min-height: 100dvh;
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  background: var(--color-bg);
+  color: var(--color-text);
   font-family: var(--font-family, sans-serif);
   display: flex;
   flex-direction: column;
 }
 
 .reports-header {
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface);
   padding: 14px 24px;
   display: flex;
   align-items: center;
@@ -27,8 +27,8 @@
 }
 
 .reports-header__back {
-  background: var(--ctp-surface1);
-  color: var(--ctp-subtext0);
+  background: var(--color-surface-hover);
+  color: var(--color-text-subtle);
   border: none;
   border-radius: 8px;
   padding: 7px 14px;
@@ -39,15 +39,15 @@
 }
 
 .reports-header__back:hover {
-  background: var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-active);
+  color: var(--color-text);
 }
 
 .reports-header h1 {
   margin: 0;
   font-size: 18px;
   font-weight: 700;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .reports-body {
@@ -70,15 +70,15 @@
 
 .reports-grid__intro {
   margin: 0 0 8px;
-  color: var(--ctp-subtext1, var(--ctp-subtext0));
+  color: var(--color-text-muted);
   font-size: 14px;
   line-height: 1.5;
   max-width: 720px;
 }
 
 .reports-card {
-  background: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-raised);
+  border: 1px solid var(--color-surface);
   border-radius: 12px;
   padding: 22px;
   cursor: pointer;
@@ -86,7 +86,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   transition:
     border-color 0.15s,
     transform 0.15s,
@@ -97,8 +97,8 @@
 }
 
 .reports-card:hover {
-  border-color: var(--ctp-blue);
-  background: var(--ctp-surface0);
+  border-color: var(--color-accent);
+  background: var(--color-surface);
   transform: translateY(-2px);
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
 }
@@ -112,14 +112,14 @@
   margin: 0;
   font-size: 16px;
   font-weight: 700;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .reports-card__desc {
   margin: 0;
   font-size: 13px;
   line-height: 1.5;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 /* ── Report shell (when a report is selected) ──────────────────────────── */
@@ -132,9 +132,9 @@
 
 .reports-section__back {
   align-self: flex-start;
-  background: var(--ctp-surface0);
-  color: var(--ctp-subtext0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  color: var(--color-text-subtle);
+  border: 1px solid var(--color-surface-hover);
   padding: 7px 14px;
   border-radius: 8px;
   font-size: 13px;
@@ -143,15 +143,15 @@
 }
 
 .reports-section__back:hover {
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  color: var(--color-text);
 }
 
 .reports-section__title {
   margin: 0;
   font-size: 22px;
   font-weight: 700;
-  color: var(--ctp-text);
+  color: var(--color-text);
   display: flex;
   gap: 10px;
   align-items: baseline;
@@ -161,13 +161,13 @@
   margin: 0;
   font-size: 13px;
   line-height: 1.5;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   max-width: 760px;
 }
 
 .reports-panel {
-  background: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-raised);
+  border: 1px solid var(--color-surface);
   border-radius: 12px;
   padding: 18px;
 }
@@ -186,28 +186,28 @@
   align-items: center;
   gap: 8px;
   font-size: 13px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .reports-controls__field input[type='number'] {
   width: 5.5rem;
   padding: 6px 8px;
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface1);
-  color: var(--ctp-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface-hover);
+  color: var(--color-text);
   border-radius: 6px;
   font: inherit;
 }
 
 .reports-controls__field input[type='number']:focus {
   outline: none;
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .reports-btn {
   padding: 7px 16px;
-  background: var(--ctp-blue);
-  color: var(--ctp-base);
+  background: var(--color-accent);
+  color: var(--color-bg);
   border: none;
   border-radius: 8px;
   cursor: pointer;
@@ -227,13 +227,13 @@
 }
 
 .reports-btn--ghost {
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-hover);
 }
 
 .reports-btn--ghost:hover:not(:disabled) {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   filter: none;
 }
 
@@ -247,15 +247,15 @@
 }
 
 .reports-banner--error {
-  background: color-mix(in srgb, var(--ctp-red) 18%, var(--ctp-mantle));
-  border: 1px solid var(--ctp-red);
-  color: var(--ctp-red);
+  background: color-mix(in srgb, var(--color-error) 18%, var(--color-bg-raised));
+  border: 1px solid var(--color-error);
+  color: var(--color-error);
 }
 
 .reports-banner--empty {
-  background: var(--ctp-mantle);
-  border: 1px dashed var(--ctp-surface1);
-  color: var(--ctp-subtext0);
+  background: var(--color-bg-raised);
+  border: 1px dashed var(--color-surface-hover);
+  color: var(--color-text-subtle);
   text-align: center;
   padding: 36px 16px;
 }
@@ -263,7 +263,7 @@
 .reports-banner__hint {
   margin-top: 8px;
   font-size: 11px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   opacity: 0.85;
 }
 
@@ -276,8 +276,8 @@
 }
 
 .reports-stat {
-  background: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-raised);
+  border: 1px solid var(--color-surface);
   border-radius: 10px;
   padding: 12px 14px;
 }
@@ -287,14 +287,14 @@
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin-bottom: 4px;
 }
 
 .reports-stat__value {
   font-size: 22px;
   font-weight: 700;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 /* ── Node cards (per detected solar node) ──────────────────────────────── */
@@ -306,15 +306,15 @@
 }
 
 .reports-node {
-  background: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-raised);
+  border: 1px solid var(--color-surface);
   border-radius: 12px;
   overflow: hidden;
   transition: border-color 0.15s;
 }
 
 .reports-node--insufficient {
-  border-color: var(--ctp-yellow);
+  border-color: var(--color-warning);
 }
 
 .reports-node__header {
@@ -322,7 +322,7 @@
   padding: 14px 18px;
   background: transparent;
   border: none;
-  color: var(--ctp-text);
+  color: var(--color-text);
   cursor: pointer;
   text-align: left;
   display: flex;
@@ -333,13 +333,13 @@
 }
 
 .reports-node__header:hover {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
 }
 
 .reports-node__name {
   font-size: 15px;
   font-weight: 700;
-  color: var(--ctp-text);
+  color: var(--color-text);
   display: flex;
   align-items: center;
   gap: 10px;
@@ -350,30 +350,30 @@
   font-weight: 600;
   letter-spacing: 0.03em;
   padding: 2px 9px;
-  background: var(--ctp-yellow);
-  color: var(--ctp-base);
+  background: var(--color-warning);
+  color: var(--color-bg);
   border-radius: 999px;
 }
 
 .reports-node__meta {
   font-size: 12px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin-top: 3px;
 }
 
 .reports-node__chevron {
   font-size: 12px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   flex-shrink: 0;
 }
 
 .reports-node__body {
   padding: 16px 18px 18px;
-  border-top: 1px solid var(--ctp-surface0);
+  border-top: 1px solid var(--color-surface);
   display: flex;
   flex-direction: column;
   gap: 16px;
-  background: var(--ctp-base);
+  background: var(--color-bg);
 }
 
 .reports-node__fields {
@@ -384,7 +384,7 @@
 }
 
 .reports-node__field-label {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: 600;
   letter-spacing: 0.03em;
   text-transform: uppercase;
@@ -393,7 +393,7 @@
 }
 
 .reports-node__field-value {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-weight: 600;
   font-size: 13px;
 }
@@ -401,8 +401,8 @@
 .reports-node__chart {
   width: 100%;
   height: 220px;
-  background: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-raised);
+  border: 1px solid var(--color-surface);
   border-radius: 8px;
   padding: 8px 8px 8px 0;
 }
@@ -412,7 +412,7 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin: 0 0 6px;
 }
 
@@ -420,7 +420,7 @@
 
 .reports-table-wrap {
   overflow-x: auto;
-  border: 1px solid var(--ctp-surface0);
+  border: 1px solid var(--color-surface);
   border-radius: 8px;
 }
 
@@ -428,24 +428,24 @@
   width: 100%;
   border-collapse: collapse;
   font-size: 12px;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .reports-table th {
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   padding: 8px 12px;
   text-align: left;
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--ctp-subtext0);
-  border-bottom: 1px solid var(--ctp-surface0);
+  color: var(--color-text-subtle);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 .reports-table td {
   padding: 8px 12px;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
   white-space: nowrap;
 }
 
@@ -454,7 +454,7 @@
 }
 
 .reports-table tbody tr:hover {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
 }
 
 /* Rows that open a preview modal on click (e.g. NodeInfo enrichment). */
@@ -484,14 +484,14 @@
 
 .reports-forecast__sub {
   font-size: 12px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   line-height: 1.5;
 }
 
 .reports-banner--warning {
-  background: color-mix(in srgb, var(--ctp-yellow) 15%, var(--ctp-mantle));
-  border: 1px solid var(--ctp-yellow);
-  color: var(--ctp-yellow);
+  background: color-mix(in srgb, var(--color-warning) 15%, var(--color-bg-raised));
+  border: 1px solid var(--color-warning);
+  color: var(--color-warning);
 }
 
 .reports-pill {
@@ -504,13 +504,13 @@
 }
 
 .reports-pill--ok {
-  background: color-mix(in srgb, var(--ctp-green) 18%, transparent);
-  color: var(--ctp-green);
+  background: color-mix(in srgb, var(--color-success) 18%, transparent);
+  color: var(--color-success);
 }
 
 .reports-pill--warn {
-  background: color-mix(in srgb, var(--ctp-yellow) 22%, transparent);
-  color: var(--ctp-yellow);
+  background: color-mix(in srgb, var(--color-warning) 22%, transparent);
+  color: var(--color-warning);
 }
 
 .reports-at-risk {
@@ -521,13 +521,13 @@
   flex-direction: column;
   gap: 6px;
   font-size: 13px;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .reports-at-risk li {
   padding: 8px 12px;
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface0);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface);
   border-radius: 8px;
   display: flex;
   justify-content: space-between;
@@ -549,13 +549,13 @@
   align-items: center;
   gap: 8px;
   font-size: 13px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   cursor: pointer;
 }
 
 .reports-enrichment__push .reports-enrichment__push-help {
   font-size: 11px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin-left: 24px;
 }
 
@@ -566,6 +566,6 @@
   border-radius: 6px;
   font-size: 11px;
   font-weight: 600;
-  background: var(--ctp-surface0);
-  color: var(--ctp-subtext1);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
 }

--- a/src/styles/audit.css
+++ b/src/styles/audit.css
@@ -18,7 +18,7 @@
 .audit-log-header h2 {
   font-size: 1.5rem;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0;
 }
 
@@ -31,8 +31,8 @@
 }
 
 .stat-card {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   padding: 16px;
 }
@@ -40,28 +40,28 @@
 .stat-card h3 {
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   margin: 0 0 8px 0;
 }
 
 .stat-value {
   font-size: 1.875rem;
   font-weight: 700;
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0;
 }
 
 .stat-label {
   font-size: 1.125rem;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0;
 }
 
 /* Filters Section */
 .audit-filters {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   padding: 20px;
   margin-bottom: 24px;
@@ -70,7 +70,7 @@
 .audit-filters h3 {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin: 0 0 16px 0;
 }
 
@@ -109,8 +109,8 @@
 
 /* Table Styles */
 .audit-table-container {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   overflow: hidden;
   margin-bottom: 24px;
@@ -122,7 +122,7 @@
 }
 
 .audit-table thead {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .audit-table thead th {
@@ -130,34 +130,34 @@
   text-align: left;
   font-size: 0.75rem;
   font-weight: 600;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 
 .audit-table tbody tr.audit-row {
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
   cursor: pointer;
   transition: background-color 0.15s ease;
 }
 
 .audit-table tbody tr.audit-row:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .audit-table tbody td {
   padding: 12px 16px;
   font-size: 0.875rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .timestamp-cell {
   white-space: nowrap;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .system-label {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-style: italic;
 }
 
@@ -166,15 +166,15 @@
 }
 
 .action-error {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 .action-warning {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .action-success {
-  color: var(--ctp-green);
+  color: var(--color-success);
 }
 
 .details-cell {
@@ -187,7 +187,7 @@
 /* Expanded Row Details */
 .audit-detail-row td {
   padding: 0 !important;
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
 }
 
 .audit-details {
@@ -206,20 +206,20 @@
   display: block;
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin-bottom: 8px;
 }
 
 .detail-pre {
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-sm);
   padding: 12px;
   font-size: 0.75rem;
   font-family: var(--font-mono);
   overflow-x: auto;
   margin: 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .detail-comparison {
@@ -230,12 +230,12 @@
 
 .detail-section.before .detail-pre {
   background: rgba(243, 139, 168, 0.1);
-  border-color: var(--ctp-red);
+  border-color: var(--color-error);
 }
 
 .detail-section.after .detail-pre {
   background: rgba(166, 227, 161, 0.1);
-  border-color: var(--ctp-green);
+  border-color: var(--color-success);
 }
 
 /* Pagination */
@@ -249,7 +249,7 @@
 
 .pagination-info {
   font-size: 0.875rem;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
 }
 
 .pagination-controls {
@@ -261,7 +261,7 @@
 .page-indicator {
   padding: 8px 12px;
   font-size: 0.875rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 /* Loading and Empty States */
@@ -269,13 +269,13 @@
 .audit-empty {
   text-align: center;
   padding: 48px 24px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 1rem;
 }
 
 .audit-empty {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
 }
 

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -9,8 +9,8 @@
   height: 100dvh;
   display: flex;
   flex-direction: column;
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  background: var(--color-bg);
+  color: var(--color-text);
   font-family: var(--font-family, sans-serif);
   overflow: hidden;
 }
@@ -23,8 +23,8 @@
   padding: 0 24px;
   height: var(--header-height, 64px);
   flex-shrink: 0;
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 .dashboard-topbar-logo {
@@ -41,7 +41,7 @@
 }
 
 .dashboard-topbar-title {
-  color: var(--ctp-lavender);
+  color: var(--color-accent-muted);
   font-size: 1.6rem;
   font-weight: 700;
   letter-spacing: -0.01em;
@@ -71,7 +71,7 @@
   display: none; /* Hidden on desktop — shown via media query below */
   background: none;
   border: none;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 22px;
   line-height: 1;
   padding: 6px 10px;
@@ -81,7 +81,7 @@
 }
 
 .dashboard-topbar-hamburger:hover {
-  background-color: var(--ctp-surface0);
+  background-color: var(--color-surface);
 }
 
 /* ── Sidebar backdrop (mobile overlay) ──────────────────────────────────── */
@@ -104,11 +104,11 @@
      persisted value, falling back to the default when unset. */
   width: var(--dashboard-sidebar-width, 240px);
   flex-shrink: 0;
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   display: flex;
   flex-direction: column;
   overflow-y: auto;
-  border-right: 1px solid var(--ctp-surface0);
+  border-right: 1px solid var(--color-surface);
 }
 
 /* Drag-to-resize handle — sits in the flex row between the sidebar and the
@@ -125,7 +125,7 @@
 
 .dashboard-sidebar-resize-handle:hover,
 .dashboard-sidebar-resize-handle:focus-visible {
-  background: var(--ctp-blue);
+  background: var(--color-accent);
   outline: none;
 }
 
@@ -135,7 +135,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 /* ── Source cards ────────────────────────────────────────────────────────── */
@@ -144,7 +144,7 @@
   position: relative;
   margin: 4px 8px;
   padding: 10px;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: 6px;
   border: 1px solid transparent;
   cursor: pointer;
@@ -232,11 +232,11 @@
 }
 
 .dashboard-source-card:hover {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
 }
 
 .dashboard-source-card.selected {
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .dashboard-source-card-header {
@@ -249,7 +249,7 @@
 .dashboard-source-card-name {
   font-size: 13px;
   font-weight: 700;
-  color: var(--ctp-text);
+  color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -258,8 +258,8 @@
 }
 
 .dashboard-source-card-badge {
-  background: var(--ctp-surface1);
-  color: var(--ctp-subtext1);
+  background: var(--color-surface-hover);
+  color: var(--color-text-muted);
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
@@ -274,7 +274,7 @@
   width: 16px;
   height: 16px;
   flex-shrink: 0;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   opacity: 0.75;
 }
 
@@ -283,7 +283,7 @@
   align-items: center;
   gap: 5px;
   font-size: 11px;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   margin-top: 5px;
 }
 
@@ -292,23 +292,23 @@
   height: 6px;
   border-radius: 50%;
   flex-shrink: 0;
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
 }
 
 .dashboard-status-dot.connected {
-  background: var(--ctp-green);
+  background: var(--color-success);
 }
 
 .dashboard-status-dot.connecting {
-  background: var(--ctp-yellow);
+  background: var(--color-warning);
 }
 
 .dashboard-status-dot.disconnected {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
 }
 
 .dashboard-status-dot.disabled {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
 }
 
 .dashboard-activity-badge {
@@ -318,24 +318,24 @@
   font-size: 10px;
   font-weight: 600;
   line-height: 1.4;
-  background: var(--ctp-surface1);
-  color: var(--ctp-subtext0);
+  background: var(--color-surface-hover);
+  color: var(--color-text-subtle);
   white-space: nowrap;
 }
 
 .dashboard-activity-badge.dashboard-activity-live {
-  background: color-mix(in srgb, var(--ctp-green) 20%, transparent);
-  color: var(--ctp-green);
+  background: color-mix(in srgb, var(--color-success) 20%, transparent);
+  color: var(--color-success);
 }
 
 .dashboard-activity-badge.dashboard-activity-partial {
-  background: color-mix(in srgb, var(--ctp-yellow) 22%, transparent);
-  color: var(--ctp-yellow);
+  background: color-mix(in srgb, var(--color-warning) 22%, transparent);
+  color: var(--color-warning);
 }
 
 .dashboard-activity-badge.dashboard-activity-idle {
-  background: color-mix(in srgb, var(--ctp-red) 18%, transparent);
-  color: var(--ctp-red);
+  background: color-mix(in srgb, var(--color-error) 18%, transparent);
+  color: var(--color-error);
 }
 
 .dashboard-permission-badge {
@@ -345,8 +345,8 @@
   font-size: 10px;
   font-weight: 600;
   line-height: 1.4;
-  background: color-mix(in srgb, var(--ctp-yellow) 22%, transparent);
-  color: var(--ctp-yellow);
+  background: color-mix(in srgb, var(--color-warning) 22%, transparent);
+  color: var(--color-warning);
   cursor: help;
   white-space: nowrap;
 }
@@ -362,15 +362,15 @@
   font-size: 10px;
   font-weight: 600;
   line-height: 1.4;
-  background: color-mix(in srgb, var(--ctp-blue) 20%, transparent);
-  color: var(--ctp-blue);
+  background: color-mix(in srgb, var(--color-accent) 20%, transparent);
+  color: var(--color-accent);
   cursor: help;
   white-space: nowrap;
 }
 
 .dashboard-publisher-badge.dashboard-publisher-partial {
-  background: color-mix(in srgb, var(--ctp-yellow) 22%, transparent);
-  color: var(--ctp-yellow);
+  background: color-mix(in srgb, var(--color-warning) 22%, transparent);
+  color: var(--color-warning);
 }
 
 .dashboard-source-card-actions {
@@ -387,8 +387,8 @@
 .dashboard-open-btn {
   flex: 0 0 auto;
   width: 80px;
-  background: var(--ctp-blue);
-  color: var(--ctp-base);
+  background: var(--color-accent);
+  color: var(--color-bg);
   border: none;
   border-radius: 4px;
   padding: 5px 0;
@@ -403,20 +403,20 @@
 }
 
 .dashboard-open-btn:disabled {
-  background: var(--ctp-surface1);
-  color: var(--ctp-overlay0);
+  background: var(--color-surface-hover);
+  color: var(--color-text-faint);
   opacity: 0.6;
   cursor: not-allowed;
 }
 
 .dashboard-node-count {
   font-size: 11px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .dashboard-lock-icon {
   font-size: 11px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 /* ── Kebab menu ──────────────────────────────────────────────────────────── */
@@ -424,7 +424,7 @@
 .dashboard-kebab-btn {
   background: transparent;
   border: none;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 16px;
   cursor: pointer;
   padding: 2px 4px;
@@ -435,16 +435,16 @@
 }
 
 .dashboard-kebab-btn:hover {
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  color: var(--color-text);
 }
 
 .dashboard-kebab-menu {
   position: absolute;
   right: 0;
   top: 100%;
-  background: var(--ctp-crust);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg-sunken);
+  border: 1px solid var(--color-surface-hover);
   border-radius: 6px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
   min-width: 120px;
@@ -460,17 +460,17 @@
   border: none;
   text-align: left;
   font-size: 12px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   cursor: pointer;
   transition: background 0.12s;
 }
 
 .dashboard-kebab-item:hover {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
 }
 
 .dashboard-kebab-item.danger {
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 /* ── Sidebar links ───────────────────────────────────────────────────────── */
@@ -478,7 +478,7 @@
 .dashboard-sidebar-links {
   margin-top: auto;
   padding: 10px 12px;
-  border-top: 1px solid var(--ctp-surface0);
+  border-top: 1px solid var(--color-surface);
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -486,7 +486,7 @@
 
 .dashboard-sidebar-link {
   font-size: 12px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   opacity: 0.5;
   cursor: default;
   text-decoration: none;
@@ -498,13 +498,13 @@
 
 .dashboard-sidebar-link--active {
   opacity: 1;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   cursor: pointer;
   transition: color 0.15s;
 }
 
 .dashboard-sidebar-link--active:hover {
-  color: var(--ctp-sapphire);
+  color: var(--color-accent-hover);
 }
 
 /* Sidebar footer styles moved to src/components/SidebarFooter.module.css
@@ -536,11 +536,11 @@
 }
 
 .dashboard-map-empty-content {
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   border-radius: 10px;
   padding: 32px 40px;
   text-align: center;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   pointer-events: auto;
 }
 
@@ -561,12 +561,12 @@
   bottom: 12px;
   left: 12px;
   z-index: 1000;
-  background: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-raised);
+  border: 1px solid var(--color-surface);
   border-radius: 8px;
   padding: 8px 10px;
   font-size: 12px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   pointer-events: none;
   max-width: 220px;
@@ -575,7 +575,7 @@
 .dashboard-polar-grid-legend__title {
   font-weight: 600;
   margin-bottom: 4px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .dashboard-polar-grid-legend__row {
@@ -605,8 +605,8 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  background: var(--ctp-blue);
-  color: var(--ctp-base);
+  background: var(--color-accent);
+  color: var(--color-bg);
   border: none;
   border-radius: var(--radius-lg, 8px);
   padding: 8px 16px;
@@ -617,14 +617,14 @@
 }
 
 .dashboard-signin-btn:hover {
-  background: var(--ctp-sapphire);
+  background: var(--color-accent-hover);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(137, 180, 250, 0.3);
 }
 
 .dashboard-add-source-btn {
-  background: var(--ctp-blue);
-  color: var(--ctp-base);
+  background: var(--color-accent);
+  color: var(--color-bg);
   border: none;
   border-radius: 4px;
   padding: 6px 14px;
@@ -651,13 +651,13 @@
 }
 
 .dashboard-confirm-dialog {
-  background: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg-raised);
+  border: 1px solid var(--color-surface-hover);
   border-radius: 8px;
   padding: 24px;
   max-width: 360px;
   width: calc(100vw - 48px);
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .dashboard-confirm-dialog h3 {
@@ -669,7 +669,7 @@
 .dashboard-confirm-dialog p {
   margin: 0 0 20px;
   font-size: 13px;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   line-height: 1.5;
 }
 
@@ -691,17 +691,17 @@
 
 .dashboard-confirm-actions button:first-child {
   background: transparent;
-  border: 1px solid var(--ctp-surface1);
-  color: var(--ctp-subtext0);
+  border: 1px solid var(--color-surface-hover);
+  color: var(--color-text-subtle);
 }
 
 .dashboard-confirm-actions button:first-child:hover {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
 }
 
 .dashboard-confirm-actions button:last-child {
-  background: var(--ctp-red);
-  color: var(--ctp-base);
+  background: var(--color-error);
+  color: var(--color-bg);
 }
 
 .dashboard-confirm-actions button:last-child:hover {
@@ -719,7 +719,7 @@
   display: block;
   font-size: 12px;
   font-weight: 600;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin-bottom: 4px;
 }
 
@@ -728,20 +728,20 @@
   box-sizing: border-box;
   padding: 8px 10px;
   font-size: 13px;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: 4px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   outline: none;
   transition: border-color 0.15s;
 }
 
 .dashboard-form-input:focus {
-  border-color: var(--ctp-blue);
+  border-color: var(--color-accent);
 }
 
 .dashboard-form-input::placeholder {
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
 }
 
 /* ── Mobile: collapsible sidebar ─────────────────────────────────────────── */

--- a/src/styles/messages.css
+++ b/src/styles/messages.css
@@ -29,14 +29,14 @@
 .date-separator::after {
   content: '';
   flex: 1;
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .date-separator-text {
   padding: 0 1rem;
   font-size: 0.75rem;
   font-weight: 600;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -45,8 +45,8 @@
   width: 32px;
   height: 32px;
   border-radius: var(--radius-full);
-  background: var(--ctp-blue);
-  color: var(--ctp-accent-text);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -76,24 +76,24 @@
 }
 
 .message-bubble.mine {
-  background: var(--ctp-chatBubbleSentBg, var(--ctp-blue));
-  color: var(--ctp-chatBubbleSentText, var(--ctp-accent-text));
+  background: var(--ctp-chatBubbleSentBg, var(--color-accent));
+  color: var(--ctp-chatBubbleSentText, var(--color-accent-text));
   border-bottom-right-radius: 6px;
 }
 
 .message-bubble.mine,
 .message-bubble.mine * {
-  color: var(--ctp-chatBubbleSentText, var(--ctp-accent-text));
+  color: var(--ctp-chatBubbleSentText, var(--color-accent-text));
 }
 
 .message-bubble.mine a.message-link {
-  color: var(--ctp-chatBubbleSentText, var(--ctp-accent-text));
+  color: var(--ctp-chatBubbleSentText, var(--color-accent-text));
   text-decoration: underline;
 }
 
 .message-bubble.theirs {
-  background: var(--ctp-chatBubbleReceivedBg, var(--ctp-surface1));
-  color: var(--ctp-chatBubbleReceivedText, var(--ctp-text));
+  background: var(--ctp-chatBubbleReceivedBg, var(--color-surface-hover));
+  color: var(--ctp-chatBubbleReceivedText, var(--color-text));
   border-bottom-left-radius: 6px;
 }
 
@@ -126,14 +126,14 @@
 
 /* Clickable links in messages */
 .message-bubble .message-text a.message-link {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   text-decoration: underline;
   cursor: pointer;
   word-break: break-all;
 }
 
 .message-bubble .message-text a.message-link:hover {
-  color: var(--ctp-sky);
+  color: var(--color-info);
   text-decoration: none;
 }
 
@@ -145,19 +145,19 @@
 
 .link-preview {
   display: flex;
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-lg);
   overflow: hidden;
   text-decoration: none;
   color: inherit;
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   transition: background 0.2s ease, border-color 0.2s ease;
   max-width: 400px;
 }
 
 .link-preview:hover {
-  background: var(--ctp-surface0);
-  border-color: var(--ctp-surface1);
+  background: var(--color-surface);
+  border-color: var(--color-surface-hover);
 }
 
 .link-preview-image {
@@ -165,7 +165,7 @@
   width: 120px;
   height: 120px;
   overflow: hidden;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -189,7 +189,7 @@
 .link-preview-title {
   font-weight: 600;
   font-size: 0.9rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -200,7 +200,7 @@
 
 .link-preview-description {
   font-size: 0.85rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -211,7 +211,7 @@
 
 .link-preview-url {
   font-size: 0.75rem;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   opacity: 0.8;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -222,9 +222,9 @@
 .link-preview.loading {
   padding: 12px;
   text-align: center;
-  color: var(--ctp-subtext0);
-  background: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface2);
+  color: var(--color-text-subtle);
+  background: var(--color-bg-raised);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-lg);
 }
 
@@ -251,11 +251,11 @@
 }
 
 .message-bubble.theirs .message-time {
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
 }
 
 .message-bubble.mine .message-time {
-  color: var(--ctp-chatBubbleSentText, var(--ctp-accent-text));
+  color: var(--ctp-chatBubbleSentText, var(--color-accent-text));
   opacity: 0.85;
 }
 
@@ -288,7 +288,7 @@
 
 /* Highlight the message bubble on hover to show action relationship */
 .message-bubble-container:hover .message-bubble {
-  outline: 1px solid var(--ctp-overlay1);
+  outline: 1px solid var(--color-text-disabled);
   outline-offset: 2px;
 }
 
@@ -314,9 +314,9 @@
 .emoji-button,
 .emoji-picker-button,
 .delete-button {
-  background: var(--ctp-surface2);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-overlay0);
+  background: var(--color-surface-active);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-xl);
   padding: 0.25rem 0.5rem;
   font-size: 0.75rem;
@@ -343,15 +343,15 @@
 .emoji-button:hover,
 .emoji-picker-button:hover,
 .delete-button:hover {
-  background: var(--ctp-surface1);
-  border-color: var(--ctp-overlay1);
+  background: var(--color-surface-hover);
+  border-color: var(--color-text-disabled);
   transform: scale(1.1);
 }
 
 .delete-button:hover {
-  background: var(--ctp-red);
-  border-color: var(--ctp-red);
-  color: var(--ctp-accent-text);
+  background: var(--color-error);
+  border-color: var(--color-error);
+  color: var(--color-accent-text);
 }
 
 .emoji-button:active,
@@ -361,8 +361,8 @@
 
 /* Reply indicator in send box */
 .reply-indicator {
-  background: var(--ctp-surface1);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-surface-active);
   border-radius: var(--radius-lg);
   padding: 0.5rem 0.75rem;
   margin-bottom: 0.5rem;
@@ -379,14 +379,14 @@
 
 .reply-indicator-label {
   font-size: 0.75rem;
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   font-weight: 600;
   margin-bottom: 0.25rem;
 }
 
 .reply-indicator-text {
   font-size: 0.85rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -395,7 +395,7 @@
 .reply-indicator-close {
   background: transparent;
   border: none;
-  color: var(--ctp-overlay1);
+  color: var(--color-text-disabled);
   cursor: pointer;
   font-size: 1.2rem;
   padding: 0;
@@ -410,8 +410,8 @@
 }
 
 .reply-indicator-close:hover {
-  background: var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-active);
+  color: var(--color-text);
 }
 
 .message-status {
@@ -425,18 +425,18 @@
 }
 
 .status-pending {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
   font-size: 0.8rem;
 }
 
 .status-delivered {
-  color: var(--ctp-green);
+  color: var(--color-success);
   font-size: 0.8rem;
   font-weight: bold;
 }
 
 .status-failed {
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-size: 0.8rem;
   font-weight: bold;
 }
@@ -447,19 +447,19 @@
 }
 
 .status-received-target {
-  color: var(--ctp-green);
+  color: var(--color-success);
   font-size: 0.8rem;
   font-weight: bold;
 }
 
 .status-confirmed {
-  color: var(--ctp-blue);
+  color: var(--color-accent);
   font-size: 0.8rem;
   font-weight: bold;
 }
 
 .status-timeout {
-  color: var(--ctp-peach);
+  color: var(--color-caution);
   font-size: 0.8rem;
 }
 
@@ -474,12 +474,12 @@
 }
 
 .messages-container::-webkit-scrollbar-thumb {
-  background: var(--ctp-overlay0);
+  background: var(--color-surface-inactive);
   border-radius: var(--radius-xs);
 }
 
 .messages-container::-webkit-scrollbar-thumb:hover {
-  background: var(--ctp-overlay1);
+  background: var(--color-text-disabled);
 }
 
 /* Loading indicator for infinite scroll */
@@ -489,17 +489,17 @@
   justify-content: center;
   gap: 0.5rem;
   padding: 0.75rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.875rem;
-  border-bottom: 1px solid var(--ctp-surface1);
+  border-bottom: 1px solid var(--color-surface-hover);
   margin-bottom: 0.5rem;
 }
 
 .loading-spinner {
   width: 16px;
   height: 16px;
-  border: 2px solid var(--ctp-surface2);
-  border-top-color: var(--ctp-mauve);
+  border: 2px solid var(--color-surface-active);
+  border-top-color: var(--color-accent-alt);
   border-radius: var(--radius-full);
   animation: spin 0.8s linear infinite;
 }

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -1,7 +1,7 @@
 /* Settings Page Styles */
 .settings-header-card {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-xl);
   padding: 2rem;
   margin-bottom: 2rem;
@@ -31,21 +31,21 @@
 
 .settings-app-name {
   margin: 0;
-  color: var(--ctp-lavender);
+  color: var(--color-accent-muted);
   font-size: 2rem;
   font-weight: 700;
 }
 
 .settings-version {
   margin: 0;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   font-size: 1rem;
   font-family: var(--font-mono);
 }
 
 .settings-content {
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-xl);
   padding: 2rem;
   min-height: 200px;
@@ -60,8 +60,8 @@
   .settings-content.settings-multi-column .settings-section {
     margin-bottom: 1.5rem;
     break-inside: avoid;
-    background: var(--ctp-base);
-    border: 1px solid var(--ctp-surface1);
+    background: var(--color-bg);
+    border: 1px solid var(--color-surface-hover);
     border-radius: var(--radius-lg);
     padding: 1.25rem;
   }
@@ -76,11 +76,11 @@
 }
 
 .settings-section h3 {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.2rem;
   margin: 0 0 1.5rem 0;
   padding-bottom: 0.75rem;
-  border-bottom: 2px solid var(--ctp-surface2);
+  border-bottom: 2px solid var(--color-surface-active);
 }
 
 .automation-section-header {
@@ -103,7 +103,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1rem;
   font-weight: 500;
   margin-bottom: 0.75rem;
@@ -111,14 +111,14 @@
 
 .setting-description {
   font-size: 0.85rem;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: normal;
 }
 
 .setting-input {
-  background: var(--ctp-surface1);
-  border: 2px solid var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-hover);
+  border: 2px solid var(--color-surface-active);
+  color: var(--color-text);
   padding: 0.75rem 1rem;
   border-radius: var(--radius-lg);
   font-size: 1rem;
@@ -128,19 +128,19 @@
 
 .setting-input:focus {
   outline: none;
-  border-color: var(--ctp-blue);
-  background: var(--ctp-base);
+  border-color: var(--color-accent);
+  background: var(--color-bg);
 }
 
 .setting-input:hover {
-  border-color: var(--ctp-overlay0);
+  border-color: var(--color-border-subtle);
 }
 
 /* Channel Checkbox List Styles */
 .channel-checkbox-list {
   margin-top: 0.5rem;
   padding: 0.75rem;
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   border-radius: var(--radius-sm);
 }
 
@@ -175,11 +175,11 @@
 }
 
 .channel-checkbox-row label.primary-channel {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
 }
 
 .channel-checkbox-row label.dm-channel {
-  color: var(--ctp-sky);
+  color: var(--color-info);
 }
 
 .channel-checkbox-row input[type="checkbox"]:disabled + label {
@@ -189,7 +189,7 @@
 
 /* Danger Zone Styles */
 .danger-zone {
-  border: 2px solid var(--ctp-red);
+  border: 2px solid var(--color-error);
   border-radius: var(--radius-lg);
   padding: 1.5rem;
   background: rgba(243, 139, 168, 0.05);
@@ -199,12 +199,12 @@
 }
 
 .danger-zone h3 {
-  color: var(--ctp-red);
-  border-bottom-color: var(--ctp-red);
+  color: var(--color-error);
+  border-bottom-color: var(--color-error);
 }
 
 .danger-zone-description {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.95rem;
   margin-bottom: 1.5rem;
   font-style: italic;
@@ -215,9 +215,9 @@
   flex-direction: column;
   padding: 1rem;
   margin-bottom: 1rem;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
-  border: 1px solid var(--ctp-surface2);
+  border: 1px solid var(--color-surface-active);
 }
 
 .danger-action:last-child {
@@ -229,14 +229,14 @@
 }
 
 .danger-action-info h4 {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1rem;
   margin: 0 0 0.5rem 0;
   font-weight: 600;
 }
 
 .danger-action-info p {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 0.875rem;
   margin: 0;
   line-height: 1.6;
@@ -247,8 +247,8 @@
 }
 
 .danger-button {
-  background: var(--ctp-red);
-  color: var(--ctp-accent-text);
+  background: var(--color-error);
+  color: var(--color-accent-text);
   border: none;
   padding: 0.75rem 1.5rem;
   border-radius: var(--radius-md);
@@ -261,7 +261,7 @@
 }
 
 .danger-button:hover {
-  background: var(--ctp-maroon);
+  background: var(--color-danger);
   transform: translateY(-1px);
 }
 
@@ -277,8 +277,8 @@
 }
 
 .settings-button {
-  background: var(--ctp-surface2);
-  color: var(--ctp-text);
+  background: var(--color-surface-active);
+  color: var(--color-text);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: var(--radius-md);
@@ -290,7 +290,7 @@
 }
 
 .settings-button:hover:not(:disabled) {
-  background: var(--ctp-surface1);
+  background: var(--color-surface-hover);
   transform: translateY(-1px);
 }
 
@@ -304,8 +304,8 @@
 }
 
 .settings-button-primary {
-  background: var(--ctp-green);
-  color: var(--ctp-accent-text);
+  background: var(--color-success);
+  color: var(--color-accent-text);
 }
 
 .settings-button-primary:hover:not(:disabled) {
@@ -313,8 +313,8 @@
 }
 
 .save-button {
-  background: var(--ctp-green);
-  color: var(--ctp-accent-text);
+  background: var(--color-success);
+  color: var(--color-accent-text);
   border: none;
   padding: 0.75rem 1.5rem;
   border-radius: var(--radius-md);
@@ -344,8 +344,8 @@
 }
 
 .reset-button {
-  background: var(--ctp-yellow);
-  color: var(--ctp-accent-text);
+  background: var(--color-warning);
+  color: var(--color-accent-text);
   border: none;
   padding: 0.75rem 1.5rem;
   border-radius: var(--radius-md);
@@ -361,7 +361,7 @@
 }
 
 .reset-button:hover:not(:disabled) {
-  background: var(--ctp-peach);
+  background: var(--color-caution);
   transform: translateY(-1px);
 }
 
@@ -392,19 +392,19 @@
   justify-content: space-between;
   align-items: center;
   padding: 10px 12px;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-md);
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
 }
 
 .info-label {
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   font-weight: 600;
   font-size: 0.9rem;
 }
 
 .info-value {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-family: var(--font-mono);
   font-size: 0.9rem;
   text-align: right;
@@ -413,27 +413,27 @@
 }
 
 .status-secure {
-  color: var(--ctp-green);
+  color: var(--color-success);
   font-weight: 600;
 }
 
 .status-default-key {
-  color: var(--ctp-yellow);
+  color: var(--color-warning);
   font-weight: 600;
 }
 
 .status-unencrypted {
-  color: var(--ctp-red);
+  color: var(--color-error);
   font-weight: 600;
 }
 
 .status-enabled {
-  color: var(--ctp-green);
+  color: var(--color-success);
   font-weight: 600;
 }
 
 .status-disabled {
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
   font-weight: 600;
 }
 

--- a/src/styles/unified.css
+++ b/src/styles/unified.css
@@ -8,8 +8,8 @@
 .unified-page {
   min-height: 100vh;
   min-height: 100dvh;
-  background: var(--ctp-base);
-  color: var(--ctp-text);
+  background: var(--color-bg);
+  color: var(--color-text);
   font-family: var(--font-family, sans-serif);
 }
 
@@ -39,8 +39,8 @@
 /* ── Header bar ─────────────────────────────────────────────────────────── */
 
 .unified-header {
-  background: var(--ctp-mantle);
-  border-bottom: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-raised);
+  border-bottom: 1px solid var(--color-surface);
   padding: 14px 24px;
   display: flex;
   align-items: center;
@@ -58,8 +58,8 @@
 }
 
 .unified-header__back {
-  background: var(--ctp-surface1);
-  color: var(--ctp-subtext0);
+  background: var(--color-surface-hover);
+  color: var(--color-text-subtle);
   border: none;
   border-radius: 8px;
   padding: 7px 14px;
@@ -70,7 +70,7 @@
 }
 
 .unified-header__back:hover {
-  background: var(--ctp-surface2);
+  background: var(--color-surface-active);
 }
 
 .unified-header__title {
@@ -82,13 +82,13 @@
   margin: 0;
   font-size: 18px;
   font-weight: 700;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .unified-header__title p {
   margin: 2px 0 0;
   font-size: 12px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 /* Source legend pills */
@@ -151,19 +151,19 @@ button.unified-source-pill.is-active {
 }
 
 .unified-btn-group button.active {
-  background: var(--ctp-blue);
-  color: var(--ctp-base);
+  background: var(--color-accent);
+  color: var(--color-bg);
 }
 
 .unified-btn-group button:not(.active) {
-  background: var(--ctp-surface1);
-  color: var(--ctp-subtext0);
+  background: var(--color-surface-hover);
+  color: var(--color-text-subtle);
 }
 
 .unified-select {
-  background: var(--ctp-surface1);
-  color: var(--ctp-text);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+  border: 1px solid var(--color-surface-active);
   border-radius: 6px;
   padding: 5px 10px;
   font-size: 12px;
@@ -177,7 +177,7 @@ button.unified-source-pill.is-active {
 }
 
 .unified-search::placeholder {
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
 }
 
 /* ── Body ────────────────────────────────────────────────────────────────── */
@@ -195,13 +195,13 @@ button.unified-source-pill.is-active {
 .unified-empty {
   text-align: center;
   padding: 64px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .unified-error {
   text-align: center;
   padding: 32px;
-  color: var(--ctp-red);
+  color: var(--color-error);
 }
 
 /* Channel overshadow / key-collision notice (#3644) */
@@ -209,9 +209,9 @@ button.unified-source-pill.is-active {
   margin: 8px 12px;
   padding: 10px 14px;
   border-radius: 8px;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-yellow);
-  color: var(--ctp-yellow);
+  background: var(--color-surface);
+  border: 1px solid var(--color-warning);
+  color: var(--color-warning);
   font-size: 0.85rem;
   line-height: 1.4;
 }
@@ -222,12 +222,12 @@ button.unified-source-pill.is-active {
   text-align: center;
   margin: 20px 0 10px;
   font-size: 12px;
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
   position: relative;
 }
 
 .unified-date-divider span {
-  background: var(--ctp-base);
+  background: var(--color-bg);
   padding: 0 12px;
   position: relative;
   z-index: 1;
@@ -240,14 +240,14 @@ button.unified-source-pill.is-active {
   left: 0;
   right: 0;
   height: 1px;
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
 }
 
 /* ── Message card ────────────────────────────────────────────────────────── */
 
 .unified-msg-card {
-  background: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface0);
+  background: var(--color-bg-raised);
+  border: 1px solid var(--color-surface);
   border-left-width: 3px;
   border-radius: 8px;
   padding: 12px 16px;
@@ -283,23 +283,23 @@ button.unified-source-pill.is-active {
 }
 
 .unified-msg-card__channel {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 12px;
 }
 
 .unified-msg-card__sender {
-  color: var(--ctp-overlay1);
+  color: var(--color-text-disabled);
   font-size: 12px;
 }
 
 .unified-msg-card__time {
   margin-left: auto;
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
   font-size: 11px;
 }
 
 .unified-msg-card__text {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 14px;
   line-height: 1.5;
   word-break: break-word;
@@ -313,16 +313,16 @@ button.unified-source-pill.is-active {
 }
 
 .unified-msg-card--clickable:hover {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
 }
 
 .unified-msg-card--clickable:focus-visible {
-  outline: 2px solid var(--ctp-blue);
+  outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 
 .unified-msg-card__reception-count {
-  color: var(--ctp-green);
+  color: var(--color-success);
   font-size: 11px;
   font-weight: 600;
 }
@@ -334,23 +334,23 @@ button.unified-source-pill.is-active {
   gap: 6px;
   padding: 4px 8px;
   margin: 4px 0 6px;
-  background: var(--ctp-surface0);
-  border-left: 2px solid var(--ctp-overlay0);
+  background: var(--color-surface);
+  border-left: 2px solid var(--color-border-subtle);
   border-radius: 0 6px 6px 0;
   font-size: 12px;
 }
 
 .unified-reply-preview__arrow {
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
 }
 
 .unified-reply-preview__from {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: 600;
 }
 
 .unified-reply-preview__text {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   opacity: 0.8;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -374,22 +374,22 @@ button.unified-source-pill.is-active {
   gap: 6px;
   margin-top: 8px;
   padding-top: 6px;
-  border-top: 1px dashed var(--ctp-surface1);
+  border-top: 1px dashed var(--color-surface-hover);
 }
 
 .unified-reaction {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
   border-radius: 99px;
   padding: 2px 8px;
   font-size: 13px;
 }
 
 .unified-reaction__from {
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 10px;
   font-weight: 600;
 }
@@ -398,7 +398,7 @@ button.unified-source-pill.is-active {
 .unified-scroll-sentinel {
   text-align: center;
   padding: 16px 0 32px;
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
   font-size: 12px;
   min-height: 32px;
 }
@@ -408,7 +408,7 @@ button.unified-source-pill.is-active {
 .unified-modal-overlay {
   position: fixed;
   inset: 0;
-  background: color-mix(in srgb, var(--ctp-crust) 70%, transparent);
+  background: color-mix(in srgb, var(--color-bg-sunken) 70%, transparent);
   backdrop-filter: blur(2px);
   display: flex;
   align-items: center;
@@ -418,8 +418,8 @@ button.unified-source-pill.is-active {
 }
 
 .unified-modal {
-  background: var(--ctp-mantle);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg-raised);
+  border: 1px solid var(--color-surface-hover);
   border-radius: 12px;
   max-width: 640px;
   width: 100%;
@@ -434,20 +434,20 @@ button.unified-source-pill.is-active {
   align-items: center;
   justify-content: space-between;
   padding: 14px 20px;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 .unified-modal__header h3 {
   margin: 0;
   font-size: 16px;
   font-weight: 700;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .unified-modal__close {
   background: none;
   border: none;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-size: 24px;
   line-height: 1;
   cursor: pointer;
@@ -457,8 +457,8 @@ button.unified-source-pill.is-active {
 }
 
 .unified-modal__close:hover {
-  background: var(--ctp-surface0);
-  color: var(--ctp-text);
+  background: var(--color-surface);
+  color: var(--color-text);
 }
 
 .unified-modal__body {
@@ -467,8 +467,8 @@ button.unified-source-pill.is-active {
 }
 
 .unified-modal__summary {
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface0);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface);
   border-radius: 8px;
   padding: 12px 14px;
   margin-bottom: 16px;
@@ -476,13 +476,13 @@ button.unified-source-pill.is-active {
 
 .unified-modal__sender {
   font-weight: 700;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 14px;
   margin-bottom: 4px;
 }
 
 .unified-modal__text {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 14px;
   line-height: 1.5;
   word-break: break-word;
@@ -491,15 +491,15 @@ button.unified-source-pill.is-active {
 
 .unified-modal__meta {
   font-size: 11px;
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
 }
 
 .unified-modal__meta code {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   padding: 1px 6px;
   border-radius: 4px;
   font-size: 11px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .unified-modal__table {
@@ -511,18 +511,18 @@ button.unified-source-pill.is-active {
 .unified-modal__table thead th {
   text-align: left;
   padding: 6px 10px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   font-weight: 600;
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  border-bottom: 1px solid var(--ctp-surface0);
+  border-bottom: 1px solid var(--color-surface);
 }
 
 .unified-modal__table tbody td {
   padding: 8px 10px;
-  border-bottom: 1px solid var(--ctp-surface0);
-  color: var(--ctp-text);
+  border-bottom: 1px solid var(--color-surface);
+  color: var(--color-text);
 }
 
 .unified-modal__table tbody tr:last-child td {
@@ -565,7 +565,7 @@ button.unified-source-pill.is-active {
 
 .unified-telem-source__count {
   font-size: 12px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .unified-telem-grid {
@@ -577,9 +577,9 @@ button.unified-source-pill.is-active {
 /* ── Telemetry node card ─────────────────────────────────────────────────── */
 
 .unified-node-card {
-  background: var(--ctp-mantle);
+  background: var(--color-bg-raised);
   border-radius: 8px;
-  border: 1px solid var(--ctp-surface0);
+  border: 1px solid var(--color-surface);
   border-top-width: 2px;
   padding: 14px;
 }
@@ -594,7 +594,7 @@ button.unified-source-pill.is-active {
 .unified-node-card__name {
   font-weight: 600;
   font-size: 14px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -604,7 +604,7 @@ button.unified-source-pill.is-active {
 
 .unified-node-card__age {
   font-size: 11px;
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
   flex-shrink: 0;
 }
 
@@ -620,18 +620,18 @@ button.unified-source-pill.is-active {
 
 .unified-reading__label {
   font-size: 10px;
-  color: var(--ctp-overlay0);
+  color: var(--color-text-faint);
   margin-bottom: 1px;
 }
 
 .unified-reading__value {
   font-size: 14px;
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .unified-reading__unit {
   font-size: 10px;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin-left: 2px;
 }

--- a/src/styles/users.css
+++ b/src/styles/users.css
@@ -20,7 +20,7 @@
 }
 
 .users-list {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
   padding: 16px;
   overflow-y: auto;
@@ -33,12 +33,12 @@
   gap: 16px;
   margin-bottom: 16px;
   padding-bottom: 12px;
-  border-bottom: 1px solid var(--ctp-surface2);
+  border-bottom: 1px solid var(--color-surface-active);
 }
 
 .users-list-header h2 {
   margin: 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.2em;
   flex-shrink: 0;
 }
@@ -52,8 +52,8 @@
 
 .user-item {
   padding: 12px;
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   margin-bottom: 8px;
   cursor: pointer;
@@ -64,13 +64,13 @@
 }
 
 .user-item:hover {
-  background: var(--ctp-surface1);
-  border-color: var(--ctp-blue);
+  background: var(--color-surface-hover);
+  border-color: var(--color-accent);
 }
 
 .user-item.selected {
-  background: var(--ctp-surface1);
-  border-color: var(--ctp-blue);
+  background: var(--color-surface-hover);
+  border-color: var(--color-accent);
   box-shadow: 0 0 0 2px rgba(137, 180, 250, 0.2);
 }
 
@@ -80,7 +80,7 @@
 
 .user-item-name {
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
   margin-bottom: 4px;
   display: flex;
   align-items: center;
@@ -89,22 +89,22 @@
 
 .user-item-meta {
   font-size: 0.85em;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
 }
 
 .inactive-badge {
   padding: 2px 8px;
   background: rgba(243, 139, 168, 0.2);
-  border: 1px solid var(--ctp-red);
+  border: 1px solid var(--color-error);
   border-radius: var(--radius-sm);
   font-size: 0.75em;
-  color: var(--ctp-red);
+  color: var(--color-error);
   text-transform: uppercase;
   font-weight: 600;
 }
 
 .user-details {
-  background: var(--ctp-surface0);
+  background: var(--color-surface);
   border-radius: var(--radius-xl);
   padding: 24px;
   overflow-y: auto;
@@ -112,12 +112,12 @@
 
 .user-details h2 {
   margin: 0 0 20px 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .user-details h3 {
   margin: 24px 0 16px 0;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1.1em;
 }
 
@@ -130,21 +130,21 @@
 
 .info-item {
   padding: 12px;
-  background: var(--ctp-base);
+  background: var(--color-bg);
   border-radius: var(--radius-lg);
-  border: 1px solid var(--ctp-surface1);
+  border: 1px solid var(--color-surface-hover);
 }
 
 .info-item label {
   display: block;
   font-size: 0.85em;
-  color: var(--ctp-subtext0);
+  color: var(--color-text-subtle);
   margin-bottom: 4px;
   font-weight: 600;
 }
 
 .info-item div {
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 1em;
 }
 
@@ -176,10 +176,10 @@
 
 .permission-scope-select {
   padding: 4px 8px;
-  background: var(--ctp-surface0);
-  border: 1px solid var(--ctp-surface2);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-active);
   border-radius: 4px;
-  color: var(--ctp-text);
+  color: var(--color-text);
   font-size: 0.9em;
 }
 
@@ -188,14 +188,14 @@
   justify-content: space-between;
   align-items: center;
   padding: 12px;
-  background: var(--ctp-base);
-  border: 1px solid var(--ctp-surface1);
+  background: var(--color-bg);
+  border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
 }
 
 .permission-label {
   font-weight: 600;
-  color: var(--ctp-text);
+  color: var(--color-text);
 }
 
 .permission-actions {
@@ -207,7 +207,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--ctp-subtext1);
+  color: var(--color-text-muted);
   cursor: pointer;
   user-select: none;
 }


### PR DESCRIPTION
Fifth batch of #4579. Ten global sheets plus `App.css`: **810 references** (787 direct + 23 `overlay0`).

`src/styles/nodes.css` is **deliberately held back** for its own PR — 247 references in the file carrying the [#3532](https://github.com/Yeraze/meshmonitor/issues/3532) cascade-order trap, where a mobile `@media` override must sit *after* the base rule. Substitution reorders nothing, but that file has bitten this project twice and shouldn't ride along with nine others.

## App.css needed a guard the other sheets didn't

It both **defines** the semantic tokens and **uses** them. A blind substitution would have rewritten:

```css
--color-error: var(--ctp-red);   →   --color-error: var(--color-error);
```

A self-referential custom property resolves to nothing — every error surface in the app loses its colour, on every theme, silently. The migration skips any line defining a `--color-*` token (**26 protected**), and I verified afterwards that all 26 still resolve to palette vars with zero self-references. The colour-identity check needed the same exemption, since a definition legitimately keeps `var(--ctp-*)` on its right-hand side.

## The #4585 guard earned itself one batch later

`analysis-reports.css` had:

```css
color: var(--ctp-subtext1, var(--ctp-subtext0));
```

The migration preserved the fallback while converting the variable, producing `var(--color-text-muted, var(--color-text-subtle))` — **reintroducing exactly the antipattern #4585 had just eliminated repo-wide.** The suite failed on it:

```
FAIL  semantic color tokens (#4567) › has no fallback value on a semantic token
```

Fixed by stripping the fallback (dead either way — the primary is always defined). Without that test one PR earlier, this would have crept back with no signal at all. Worth knowing: the migration script preserves fallbacks by design, so the `nodes.css` batch can hit the same thing, and the guard will catch it there too.

## Verification

- Colour-identical: **10/10 files**, with token definitions exempted from the re-expansion
- Full Vitest suite: `success: true`, **13,552 passed, 0 failed, 0 failed suites**
- `npx tsc --noEmit` clean, `npm run lint:ci` no in-repo failures

## Remaining on #4579

| Slice | Refs | Status |
| --- | --- | --- |
| CSS modules / component CSS / overlay0 / inline styles / dead fallbacks | ~3,850 | ✅ #4581–#4585 |
| **Global sheets** | **810** | **this PR** |
| `nodes.css` | 247 | next, on its own |
| Deliberate holdouts (`teal`, `pink`, `--ctp-*-rgb`, `yellow-soft`) | ~55 | staying raw — no honest role |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX