### PR TITLE
fix(auto-ack): key the tapback guard on the emoji flag, not its presence

### DIFF
--- a/src/server/meshtasticManager.autoAckTapbackSkip.test.ts
+++ b/src/server/meshtasticManager.autoAckTapbackSkip.test.ts
@@ -141,6 +141,17 @@ describe('MeshtasticManager — Auto-Ack skips tapbacks (#4569)', () => {
     expect(enqueue).toHaveBeenCalledTimes(1);
   });
 
+  it('does not skip a message whose emoji flag is 0', async () => {
+    // `emoji` is a flag: 0 means "not a reaction". The decode upstream happens
+    // to normalize 0 to undefined today, so this cannot arrive on the live TCP
+    // path — but the guard must not depend on that. An earlier `!= null`
+    // version treated 0 as a tapback, which would have silently stopped acking
+    // ordinary messages had the normalization moved or a new ingestion path
+    // skipped it. Ported from #4571.
+    const enqueue = await run({ emoji: 0 }, 'hello');
+    expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+
   it('does not burn a dedup slot: a tapback does not suppress a later packet reusing its id', async () => {
     // The guard runs BEFORE the per-packet dedup guard, so a skipped tapback
     // never lands in `autoAckProcessedPackets`. Were the order reversed, the

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -10185,11 +10185,19 @@ class MeshtasticManager implements ISourceManager {
       // (e.g. `.` or `.*`) to ack everything, where every reaction on the
       // channel drew a reply.
       //
-      // `emoji` is normalized upstream to `undefined` when absent or zero (see
-      // the TEXT_MESSAGE_APP decode), so presence alone is the tapback marker.
+      // Deliberately a truthiness test, not `!= null`. Meshtastic's `emoji` is
+      // a flag whose ZERO value means "not a reaction" — the decode upstream
+      // happens to normalize `0` to `undefined` today
+      // (`decodedEmoji > 0 ? decodedEmoji : undefined`), so both spellings
+      // behave identically on the live path. But `!= null` would treat a
+      // literal `emoji: 0` as a tapback and silently stop acking ordinary
+      // messages if that normalization ever moved or a new ingestion path
+      // skipped it. Keying on the flag's own semantics removes that coupling.
+      // (Ported from #4571, which had this right; see its discussion.)
+      //
       // Checked before the dedup guard below so a tapback's packetId never
       // consumes a slot in the bounded `autoAckProcessedPackets` set.
-      if (message?.emoji != null) {
+      if (message?.emoji) {
         logger.debug(`⏭️ Skipping auto-acknowledge for packet ${packetId}: message is a tapback/reaction`);
         return;
       }


### PR DESCRIPTION
## Summary

Ports the one substantive improvement from #4571, which fixed #4569 independently, arrived ~20 minutes before #4574, and got closed as superseded. Credit to it for having this detail right.

The guard that merged reads:

```js
if (message?.emoji != null)   // merged in #4574
if (message.emoji)            // #4571
```

Meshtastic's `emoji` is a **flag whose zero value means "not a reaction"**. `!= null` classifies a literal `emoji: 0` as a tapback, so auto-ack would skip an ordinary message.

**Unreachable today**, which is why it wasn't caught: the `TEXT_MESSAGE_APP` decode normalizes `0` to `undefined` (`decodedEmoji > 0 ? decodedEmoji : undefined`), so both spellings behave identically on the live path. But it left the guard silently dependent on a normalization several thousand lines away — move that, or add an ingestion path that skips it, and auto-ack quietly stops responding to real messages with no test catching it. Keying on the flag's own semantics removes the coupling.

Also worth recording: the automated review on #4574 asserted the `!= null` form "correctly passes through emoji=0". It does not — `0 != null` is `true`. I relayed that claim without checking it.

## Test plan

- [x] New `does not skip a message whose emoji flag is 0` case
- [x] **Red/green verified**: that one case fails against `!= null` and passes with the truthiness test; the other five assertions — including the explicit-`null` control — are unchanged either way, confirming the fix is narrow
- [x] Sibling `autoAckTapbackEmoji.test.ts` still green
- [x] `npx tsc -p tsconfig.server.json --noEmit` — clean
- [x] `npm run lint:ci` — clean, no baseline growth
- [x] Full `npx vitest run`: **13,553 passed, 0 failed**

### Not covered

PostgreSQL/MySQL suites skipped locally (727 skipped, containers down). This touches no schema, query or repository — it's one boolean expression in the Meshtastic manager — so the backends are not implicated. CI runs them regardless.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf