### PR TITLE
fix(desktop): bundle dist/components into desktop app packaging

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -71,6 +71,7 @@ jobs:
           mkdir desktop\resources\dist
           mkdir desktop\resources\binaries
           xcopy /E /I /Y dist\server desktop\resources\dist\server
+          xcopy /E /I /Y dist\components desktop\resources\dist\components
           xcopy /E /I /Y dist\services desktop\resources\dist\services
           xcopy /E /I /Y dist\utils desktop\resources\dist\utils
           xcopy /E /I /Y dist\types desktop\resources\dist\types
@@ -186,6 +187,7 @@ jobs:
           mkdir -p desktop/resources/binaries
           # Copy server-side compiled code
           cp -r dist/server desktop/resources/dist/
+          cp -r dist/components desktop/resources/dist/
           cp -r dist/services desktop/resources/dist/
           cp -r dist/utils desktop/resources/dist/
           cp -r dist/types desktop/resources/dist/
@@ -302,6 +304,7 @@ jobs:
           mkdir -p desktop/resources/binaries
           # Copy server-side compiled code
           cp -r dist/server desktop/resources/dist/
+          cp -r dist/components desktop/resources/dist/
           cp -r dist/services desktop/resources/dist/
           cp -r dist/utils desktop/resources/dist/
           cp -r dist/types desktop/resources/dist/

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -70,26 +70,8 @@ jobs:
           mkdir desktop\resources
           mkdir desktop\resources\dist
           mkdir desktop\resources\binaries
-          xcopy /E /I /Y dist\server desktop\resources\dist\server
-          xcopy /E /I /Y dist\components desktop\resources\dist\components
-          xcopy /E /I /Y dist\services desktop\resources\dist\services
-          xcopy /E /I /Y dist\utils desktop\resources\dist\utils
-          xcopy /E /I /Y dist\types desktop\resources\dist\types
-          xcopy /E /I /Y dist\config desktop\resources\dist\config
-          xcopy /E /I /Y dist\constants desktop\resources\dist\constants
-          xcopy /E /I /Y dist\contexts desktop\resources\dist\contexts
-          xcopy /E /I /Y dist\assets desktop\resources\dist\assets
-          xcopy /E /I /Y dist\locales desktop\resources\dist\locales
-          xcopy /E /I /Y dist\pmtiles desktop\resources\dist\pmtiles
+          xcopy /E /I /Y dist desktop\resources\dist
           xcopy /E /I /Y protobufs desktop\resources\dist\protobufs
-          copy dist\index.html desktop\resources\dist\index.html
-          copy dist\logo.png desktop\resources\dist\logo.png
-          copy dist\logo-original.png desktop\resources\dist\logo-original.png
-          copy dist\favicon.ico desktop\resources\dist\favicon.ico
-          copy dist\favicon-16x16.png desktop\resources\dist\favicon-16x16.png
-          copy dist\favicon-32x32.png desktop\resources\dist\favicon-32x32.png
-          copy dist\cors-detection.js desktop\resources\dist\cors-detection.js
-          copy dist\cors-error.html desktop\resources\dist\cors-error.html
           copy package.json desktop\resources\package.json
           copy package.json desktop\resources\dist\package.json
           copy package-lock.json desktop\resources\dist\package-lock.json
@@ -185,32 +167,14 @@ jobs:
         run: |
           mkdir -p desktop/resources/dist
           mkdir -p desktop/resources/binaries
-          # Copy server-side compiled code
-          cp -r dist/server desktop/resources/dist/
-          cp -r dist/components desktop/resources/dist/
-          cp -r dist/services desktop/resources/dist/
-          cp -r dist/utils desktop/resources/dist/
-          cp -r dist/types desktop/resources/dist/
-          cp -r dist/config desktop/resources/dist/
-          cp -r dist/constants desktop/resources/dist/
-          cp -r dist/contexts desktop/resources/dist/
-          # Copy frontend assets
-          cp -r dist/assets desktop/resources/dist/
-          cp -r dist/locales desktop/resources/dist/
-          # Copy pmtiles if it exists (may be in public or dist)
-          [ -d dist/pmtiles ] && cp -r dist/pmtiles desktop/resources/dist/ || true
+          # Copy the full compiled/bundled output (server + frontend) wholesale,
+          # matching the Docker image, so a new top-level dist/ dir never needs
+          # an allowlist update here (see #4591).
+          cp -r dist/. desktop/resources/dist/
+          # Copy pmtiles if it exists in public but wasn't already part of dist/
           [ -d public/pmtiles ] && cp -r public/pmtiles desktop/resources/dist/ || true
           # Copy protobufs
           cp -r protobufs desktop/resources/dist/
-          # Copy individual files
-          cp dist/index.html desktop/resources/dist/
-          cp dist/logo.png desktop/resources/dist/
-          cp dist/logo-original.png desktop/resources/dist/
-          cp dist/favicon.ico desktop/resources/dist/
-          cp dist/favicon-16x16.png desktop/resources/dist/
-          cp dist/favicon-32x32.png desktop/resources/dist/
-          cp dist/cors-detection.js desktop/resources/dist/
-          cp dist/cors-error.html desktop/resources/dist/
           cp package.json desktop/resources/
           cp package.json desktop/resources/dist/
           cp package-lock.json desktop/resources/dist/
@@ -302,32 +266,14 @@ jobs:
         run: |
           mkdir -p desktop/resources/dist
           mkdir -p desktop/resources/binaries
-          # Copy server-side compiled code
-          cp -r dist/server desktop/resources/dist/
-          cp -r dist/components desktop/resources/dist/
-          cp -r dist/services desktop/resources/dist/
-          cp -r dist/utils desktop/resources/dist/
-          cp -r dist/types desktop/resources/dist/
-          cp -r dist/config desktop/resources/dist/
-          cp -r dist/constants desktop/resources/dist/
-          cp -r dist/contexts desktop/resources/dist/
-          # Copy frontend assets
-          cp -r dist/assets desktop/resources/dist/
-          cp -r dist/locales desktop/resources/dist/
-          # Copy pmtiles if it exists (may be in public or dist)
-          [ -d dist/pmtiles ] && cp -r dist/pmtiles desktop/resources/dist/ || true
+          # Copy the full compiled/bundled output (server + frontend) wholesale,
+          # matching the Docker image, so a new top-level dist/ dir never needs
+          # an allowlist update here (see #4591).
+          cp -r dist/. desktop/resources/dist/
+          # Copy pmtiles if it exists in public but wasn't already part of dist/
           [ -d public/pmtiles ] && cp -r public/pmtiles desktop/resources/dist/ || true
           # Copy protobufs
           cp -r protobufs desktop/resources/dist/
-          # Copy individual files
-          cp dist/index.html desktop/resources/dist/
-          cp dist/logo.png desktop/resources/dist/
-          cp dist/logo-original.png desktop/resources/dist/
-          cp dist/favicon.ico desktop/resources/dist/
-          cp dist/favicon-16x16.png desktop/resources/dist/
-          cp dist/favicon-32x32.png desktop/resources/dist/
-          cp dist/cors-detection.js desktop/resources/dist/
-          cp dist/cors-error.html desktop/resources/dist/
           cp package.json desktop/resources/
           cp package.json desktop/resources/dist/
           cp package-lock.json desktop/resources/dist/

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -74,6 +74,7 @@ jobs:
         run: |
           if not exist desktop\resources\dist mkdir desktop\resources\dist
           xcopy /E /I /Y dist\server desktop\resources\dist\server
+          xcopy /E /I /Y dist\components desktop\resources\dist\components
           xcopy /E /I /Y dist\services desktop\resources\dist\services
           xcopy /E /I /Y dist\db desktop\resources\dist\db
           xcopy /E /I /Y dist\utils desktop\resources\dist\utils
@@ -311,6 +312,7 @@ jobs:
           mkdir -p desktop/resources/dist
           # Copy server-side compiled code
           cp -r dist/server desktop/resources/dist/
+          cp -r dist/components desktop/resources/dist/
           cp -r dist/services desktop/resources/dist/
           cp -r dist/db desktop/resources/dist/
           cp -r dist/utils desktop/resources/dist/
@@ -691,6 +693,7 @@ jobs:
           mkdir -p desktop/resources/dist
           # Copy server-side compiled code
           cp -r dist/server desktop/resources/dist/
+          cp -r dist/components desktop/resources/dist/
           cp -r dist/services desktop/resources/dist/
           cp -r dist/db desktop/resources/dist/
           cp -r dist/utils desktop/resources/dist/

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -73,27 +73,8 @@ jobs:
         shell: cmd
         run: |
           if not exist desktop\resources\dist mkdir desktop\resources\dist
-          xcopy /E /I /Y dist\server desktop\resources\dist\server
-          xcopy /E /I /Y dist\components desktop\resources\dist\components
-          xcopy /E /I /Y dist\services desktop\resources\dist\services
-          xcopy /E /I /Y dist\db desktop\resources\dist\db
-          xcopy /E /I /Y dist\utils desktop\resources\dist\utils
-          xcopy /E /I /Y dist\types desktop\resources\dist\types
-          xcopy /E /I /Y dist\config desktop\resources\dist\config
-          xcopy /E /I /Y dist\constants desktop\resources\dist\constants
-          xcopy /E /I /Y dist\contexts desktop\resources\dist\contexts
-          xcopy /E /I /Y dist\assets desktop\resources\dist\assets
-          xcopy /E /I /Y dist\locales desktop\resources\dist\locales
-          xcopy /E /I /Y dist\pmtiles desktop\resources\dist\pmtiles
+          xcopy /E /I /Y dist desktop\resources\dist
           xcopy /E /I /Y protobufs desktop\resources\dist\protobufs
-          copy dist\index.html desktop\resources\dist\index.html
-          copy dist\logo.png desktop\resources\dist\logo.png
-          copy dist\logo-original.png desktop\resources\dist\logo-original.png
-          copy dist\favicon.ico desktop\resources\dist\favicon.ico
-          copy dist\favicon-16x16.png desktop\resources\dist\favicon-16x16.png
-          copy dist\favicon-32x32.png desktop\resources\dist\favicon-32x32.png
-          copy dist\cors-detection.js desktop\resources\dist\cors-detection.js
-          copy dist\cors-error.html desktop\resources\dist\cors-error.html
           copy package.json desktop\resources\package.json
           copy package.json desktop\resources\dist\package.json
           copy package-lock.json desktop\resources\dist\package-lock.json
@@ -310,33 +291,14 @@ jobs:
       - name: Copy server files to Tauri resources
         run: |
           mkdir -p desktop/resources/dist
-          # Copy server-side compiled code
-          cp -r dist/server desktop/resources/dist/
-          cp -r dist/components desktop/resources/dist/
-          cp -r dist/services desktop/resources/dist/
-          cp -r dist/db desktop/resources/dist/
-          cp -r dist/utils desktop/resources/dist/
-          cp -r dist/types desktop/resources/dist/
-          cp -r dist/config desktop/resources/dist/
-          cp -r dist/constants desktop/resources/dist/
-          cp -r dist/contexts desktop/resources/dist/
-          # Copy frontend assets
-          cp -r dist/assets desktop/resources/dist/
-          cp -r dist/locales desktop/resources/dist/
-          # Copy pmtiles if it exists (may be in public or dist)
-          [ -d dist/pmtiles ] && cp -r dist/pmtiles desktop/resources/dist/ || true
+          # Copy the full compiled/bundled output (server + frontend) wholesale,
+          # matching the Docker image, so a new top-level dist/ dir never needs
+          # an allowlist update here (see #4591).
+          cp -r dist/. desktop/resources/dist/
+          # Copy pmtiles if it exists in public but wasn't already part of dist/
           [ -d public/pmtiles ] && cp -r public/pmtiles desktop/resources/dist/ || true
           # Copy protobufs
           cp -r protobufs desktop/resources/dist/
-          # Copy individual files
-          cp dist/index.html desktop/resources/dist/
-          cp dist/logo.png desktop/resources/dist/
-          cp dist/logo-original.png desktop/resources/dist/
-          cp dist/favicon.ico desktop/resources/dist/
-          cp dist/favicon-16x16.png desktop/resources/dist/
-          cp dist/favicon-32x32.png desktop/resources/dist/
-          cp dist/cors-detection.js desktop/resources/dist/
-          cp dist/cors-error.html desktop/resources/dist/
           cp package.json desktop/resources/
           cp package.json desktop/resources/dist/
           cp package-lock.json desktop/resources/dist/
@@ -691,33 +653,14 @@ jobs:
       - name: Copy server files to Tauri resources
         run: |
           mkdir -p desktop/resources/dist
-          # Copy server-side compiled code
-          cp -r dist/server desktop/resources/dist/
-          cp -r dist/components desktop/resources/dist/
-          cp -r dist/services desktop/resources/dist/
-          cp -r dist/db desktop/resources/dist/
-          cp -r dist/utils desktop/resources/dist/
-          cp -r dist/types desktop/resources/dist/
-          cp -r dist/config desktop/resources/dist/
-          cp -r dist/constants desktop/resources/dist/
-          cp -r dist/contexts desktop/resources/dist/
-          # Copy frontend assets
-          cp -r dist/assets desktop/resources/dist/
-          cp -r dist/locales desktop/resources/dist/
-          # Copy pmtiles if it exists (may be in public or dist)
-          [ -d dist/pmtiles ] && cp -r dist/pmtiles desktop/resources/dist/ || true
+          # Copy the full compiled/bundled output (server + frontend) wholesale,
+          # matching the Docker image, so a new top-level dist/ dir never needs
+          # an allowlist update here (see #4591).
+          cp -r dist/. desktop/resources/dist/
+          # Copy pmtiles if it exists in public but wasn't already part of dist/
           [ -d public/pmtiles ] && cp -r public/pmtiles desktop/resources/dist/ || true
           # Copy protobufs
           cp -r protobufs desktop/resources/dist/
-          # Copy individual files
-          cp dist/index.html desktop/resources/dist/
-          cp dist/logo.png desktop/resources/dist/
-          cp dist/logo-original.png desktop/resources/dist/
-          cp dist/favicon.ico desktop/resources/dist/
-          cp dist/favicon-16x16.png desktop/resources/dist/
-          cp dist/favicon-32x32.png desktop/resources/dist/
-          cp dist/cors-detection.js desktop/resources/dist/
-          cp dist/cors-error.html desktop/resources/dist/
           cp package.json desktop/resources/
           cp package.json desktop/resources/dist/
           cp package-lock.json desktop/resources/dist/


### PR DESCRIPTION
## Summary

- v4.14.0's desktop app (Windows/macOS) fails to start with `ERR_MODULE_NOT_FOUND: Cannot find module '.../dist/components/automations/compile.js'`.
- Root cause: `src/server/services/automation/autoAckConverter.ts` (added for #4340 Phase 4 WP2) imports `../../../components/automations/compile.js` — a *frontend* module — from backend code. `server.ts` statically imports the route module that pulls this in (`autoAckConverterRoutes.js` → `autoAckConverterService.js` → `autoAckConverter.js`), so Node's ESM loader resolves the whole chain eagerly at server startup, not lazily on request.
- `tsc --project tsconfig.server.json` correctly emits `dist/components/automations/compile.js` (TypeScript follows the import even though `src/components/**` isn't in the backend `include` list), so the compiled file does exist in the full build output.
- The desktop packaging steps (`.github/workflows/desktop-release.yml` and `desktop-ci.yml`, both the Windows `xcopy` and macOS/Linux `cp -r` steps) copy an explicit allowlist of `dist/` subdirectories into `desktop/resources/dist/` (`server`, `services`, `db`, `utils`, `types`, `config`, `constants`, `contexts`, `assets`, `locales`, `pmtiles`) — `components` was never on that list, so the packaged desktop app is missing the file and crashes immediately on launch.
- Docker is unaffected: its Dockerfile copies the entire `dist/` tree (`COPY --from=builder /app/dist ./dist`), so `dist/components` is included there already.

## Fix

Add `dist/components` to the resource-copy allowlist in both workflow files, for every job (Windows + both macOS/Linux jobs), matching the existing `dist/server` copy step.

## Test plan

- [ ] Confirmed `dist/components/automations/compile.js` is produced by `npx tsc --project tsconfig.server.json` locally.
- [ ] CI (`desktop-ci.yml`) builds a debug desktop bundle on Windows/macOS with these changes and the packaged `resources/dist/components` directory is present.
- [ ] On the next tagged release, verify the packaged Windows installer starts without `ERR_MODULE_NOT_FOUND`.

Fixes #4591.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1FbfTPVARr2Mss7bbNVbH)_