### PR TITLE
ci: fail the build on unresolvable runtime imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,15 @@ jobs:
           echo "Checking server build..."
           ls -la dist/server/
 
+      # Node ESM resolves relative specifiers exactly — the extension is
+      # required. tsc accepts an extensionless one and Vite resolves it, so a
+      # backend file importing a frontend module written that way builds clean
+      # and throws ERR_MODULE_NOT_FOUND only at runtime, inside a container or
+      # a packaged desktop build. That is the shape of #4591. This walks the
+      # graph the server actually loads and fails here instead of there.
+      - name: Check runtime import resolution
+        run: npm run check:imports
+
   docs-build:
     name: Documentation Build
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
         "@vitest/ui": "^4.1.10",
         "concurrently": "^10.0.4",
         "drizzle-kit": "^0.31.10",
+        "es-module-lexer": "2.0.0",
         "eslint": "^10.8.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:full": "concurrently \"npm run dev\" \"npm run dev:server\"",
     "build": "tsc && vite build",
     "build:server": "tsc --project tsconfig.server.json && mkdir -p dist/server/routes/v1 && cp src/server/routes/v1/openapi.yaml dist/server/routes/v1/",
+    "check:imports": "node scripts/check-runtime-imports.mjs",
     "start": "node dist/server/server.js",
     "preview": "vite preview",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "@vitest/ui": "^4.1.10",
     "concurrently": "^10.0.4",
     "drizzle-kit": "^0.31.10",
+    "es-module-lexer": "2.0.0",
     "eslint": "^10.8.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",

--- a/scripts/check-runtime-imports.mjs
+++ b/scripts/check-runtime-imports.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Fail the build if any module reachable from the server entry point contains
+ * a relative `import`/`export ... from` specifier that Node's ESM loader
+ * cannot resolve.
+ *
+ * Why this exists
+ * ---------------
+ * `package.json` sets `"type": "module"`, so the compiled output is ESM, and
+ * ESM resolution is exact: a relative specifier must name the file including
+ * its extension. There is no extension search and no directory-index fallback.
+ * Vite papers over this for the frontend, and TypeScript does not police it,
+ * so `import x from '../foo'` compiles cleanly, works in the browser, and
+ * throws ERR_MODULE_NOT_FOUND the moment the server loads it.
+ *
+ * The build currently emits ~90 such specifiers, all in frontend modules that
+ * `tsc -p tsconfig.server.json` compiles because they are transitively
+ * type-referenced. None are reachable from the server today, so none break
+ * anything. The hazard is that they are one ordinary-looking import away from
+ * being reachable — a backend file importing, say, `utils/mapIcons` would fail
+ * only at runtime, in a packaged desktop build or a container, with no test or
+ * type error pointing at it. That is the shape of #4591.
+ *
+ * This walks the graph the server actually loads and fails CI at the moment
+ * such a module becomes reachable, instead of a user finding it.
+ *
+ * Static analysis only — it never executes the modules, so it is safe to point
+ * at `server.js`, which would otherwise open sockets and a database.
+ *
+ * Limitations, stated plainly:
+ *   - Only STATIC specifiers. A fully dynamic `import(someVariable)` is
+ *     invisible to it, by construction.
+ *   - Bare specifiers (`node:fs`, npm packages) are skipped — those are
+ *     `node_modules` resolution, a different problem with different tooling.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const DEFAULT_ENTRY = 'dist/server/server.js';
+
+/**
+ * Strip comments and template/quoted strings before scanning for specifiers.
+ *
+ * Load-bearing: `src/db/index.ts` carries a JSDoc block containing
+ * `import { createDatabase } from './db/index.js';` as usage documentation. An
+ * earlier version of this check matched inside that comment and reported a
+ * phantom unresolved import. Anything that scans source text for imports has
+ * to do this or it reports on prose.
+ */
+function stripNonCode(src) {
+  let out = '';
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    const c = src[i];
+    const next = src[i + 1];
+    if (c === '/' && next === '*') {
+      const end = src.indexOf('*/', i + 2);
+      i = end === -1 ? n : end + 2;
+      out += ' ';
+    } else if (c === '/' && next === '/') {
+      const end = src.indexOf('\n', i);
+      i = end === -1 ? n : end;
+      out += ' ';
+    } else if (c === '`') {
+      // Template literal: skip to the unescaped closing backtick. Nested
+      // `${}` expressions could contain imports in theory; in emitted output
+      // they do not, and skipping whole templates never yields a FALSE
+      // failure — only a missed check.
+      i++;
+      while (i < n && !(src[i] === '`' && src[i - 1] !== '\\')) i++;
+      i++;
+      out += '``';
+    } else {
+      out += c;
+      i++;
+    }
+  }
+  return out;
+}
+
+const SPEC_RE = /(?:\bfrom\s*|(?:^|[;{}\s])import\s*|\bimport\s*\(\s*)['"]([^'"]+)['"]/gm;
+
+function specifiersIn(src) {
+  const found = [];
+  for (const m of stripNonCode(src).matchAll(SPEC_RE)) found.push(m[1]);
+  return found;
+}
+
+function isFile(p) {
+  try { return fs.statSync(p).isFile(); } catch { return false; }
+}
+
+function main() {
+  const entry = path.resolve(process.argv[2] ?? DEFAULT_ENTRY);
+  const root = path.resolve(process.argv[3] ?? path.dirname(path.dirname(entry)));
+
+  if (!isFile(entry)) {
+    console.error(`check-runtime-imports: entry not found: ${entry}`);
+    console.error('Build first (npm run build:server), or pass an explicit entry path.');
+    process.exit(2);
+  }
+
+  const visited = new Set();
+  const problems = [];
+
+  const walk = (file) => {
+    if (visited.has(file)) return;
+    visited.add(file);
+
+    let src;
+    try { src = fs.readFileSync(file, 'utf8'); } catch { return; }
+
+    for (const spec of specifiersIn(src)) {
+      if (!spec.startsWith('.')) continue;
+      const target = path.resolve(path.dirname(file), spec);
+      if (isFile(target)) { walk(target); continue; }
+
+      // Distinguish "missing extension" from "target genuinely absent" — the
+      // former is the common case and the fix is obvious, so say which it is.
+      const near = [`${target}.js`, path.join(target, 'index.js')].find(isFile);
+      problems.push({ importer: file, spec, near: near ?? null });
+    }
+  };
+
+  walk(entry);
+
+  const rel = (p) => path.relative(root, p) || p;
+  console.log(`check-runtime-imports: walked ${visited.size} modules from ${rel(entry)}`);
+
+  if (problems.length === 0) {
+    console.log('OK — every static relative specifier resolves under Node ESM.');
+    return;
+  }
+
+  console.error(`\nFAIL — ${problems.length} unresolvable specifier(s) reachable from the server entry point:\n`);
+  for (const p of problems) {
+    console.error(`  ${rel(p.importer)}`);
+    console.error(`      → '${p.spec}'`);
+    console.error(p.near
+      ? `      ${path.basename(p.near)} exists — the specifier is missing its extension. Write '${p.spec}.js'.`
+      : `      target does not exist.`);
+    console.error('');
+  }
+  console.error('Node ESM resolves relative specifiers exactly: the extension is required.');
+  console.error('This passes tsc and passes Vite, and fails only at runtime — see #4591.');
+  process.exit(1);
+}
+
+main();

--- a/scripts/check-runtime-imports.mjs
+++ b/scripts/check-runtime-imports.mjs
@@ -13,7 +13,7 @@
  * so `import x from '../foo'` compiles cleanly, works in the browser, and
  * throws ERR_MODULE_NOT_FOUND the moment the server loads it.
  *
- * The build currently emits ~90 such specifiers, all in frontend modules that
+ * The build emits ~90 such specifiers, all in frontend modules that
  * `tsc -p tsconfig.server.json` compiles because they are transitively
  * type-referenced. None are reachable from the server today, so none break
  * anything. The hazard is that they are one ordinary-looking import away from
@@ -24,83 +24,59 @@
  * This walks the graph the server actually loads and fails CI at the moment
  * such a module becomes reachable, instead of a user finding it.
  *
+ * Parsing is delegated to `es-module-lexer` — the same lexer Vite and Rollup
+ * use to find imports. A hand-rolled regex over source text cannot be made
+ * correct here: it matches inside comments (`src/db/index.ts` documents its
+ * own usage with an `import` line in a JSDoc block) and inside ordinary string
+ * literals (an error message quoting an import). Both produce phantom
+ * failures, which in a required CI check is worse than the bug being guarded
+ * against.
+ *
  * Static analysis only — it never executes the modules, so it is safe to point
  * at `server.js`, which would otherwise open sockets and a database.
  *
- * Limitations, stated plainly:
- *   - Only STATIC specifiers. A fully dynamic `import(someVariable)` is
- *     invisible to it, by construction.
- *   - Bare specifiers (`node:fs`, npm packages) are skipped — those are
- *     `node_modules` resolution, a different problem with different tooling.
+ * Limitation, stated plainly: only STATIC specifiers. `import(someVariable)`
+ * is invisible to it by construction — the lexer reports the site but has no
+ * literal to resolve, and those are skipped.
  */
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { init, parse } from 'es-module-lexer';
 
 const DEFAULT_ENTRY = 'dist/server/server.js';
-
-/**
- * Strip comments and template/quoted strings before scanning for specifiers.
- *
- * Load-bearing: `src/db/index.ts` carries a JSDoc block containing
- * `import { createDatabase } from './db/index.js';` as usage documentation. An
- * earlier version of this check matched inside that comment and reported a
- * phantom unresolved import. Anything that scans source text for imports has
- * to do this or it reports on prose.
- */
-function stripNonCode(src) {
-  let out = '';
-  let i = 0;
-  const n = src.length;
-  while (i < n) {
-    const c = src[i];
-    const next = src[i + 1];
-    if (c === '/' && next === '*') {
-      const end = src.indexOf('*/', i + 2);
-      i = end === -1 ? n : end + 2;
-      out += ' ';
-    } else if (c === '/' && next === '/') {
-      const end = src.indexOf('\n', i);
-      i = end === -1 ? n : end;
-      out += ' ';
-    } else if (c === '`') {
-      // Template literal: skip to the unescaped closing backtick. Nested
-      // `${}` expressions could contain imports in theory; in emitted output
-      // they do not, and skipping whole templates never yields a FALSE
-      // failure — only a missed check.
-      i++;
-      while (i < n && !(src[i] === '`' && src[i - 1] !== '\\')) i++;
-      i++;
-      out += '``';
-    } else {
-      out += c;
-      i++;
-    }
-  }
-  return out;
-}
-
-const SPEC_RE = /(?:\bfrom\s*|(?:^|[;{}\s])import\s*|\bimport\s*\(\s*)['"]([^'"]+)['"]/gm;
-
-function specifiersIn(src) {
-  const found = [];
-  for (const m of stripNonCode(src).matchAll(SPEC_RE)) found.push(m[1]);
-  return found;
-}
 
 function isFile(p) {
   try { return fs.statSync(p).isFile(); } catch { return false; }
 }
 
-function main() {
-  const entry = path.resolve(process.argv[2] ?? DEFAULT_ENTRY);
-  const root = path.resolve(process.argv[3] ?? path.dirname(path.dirname(entry)));
+/** Relative specifiers this module imports, re-exports, or dynamically imports. */
+function relativeSpecifiers(src) {
+  const [imports] = parse(src);
+  return imports
+    // `n` is undefined for a dynamic import whose argument is not a string
+    // literal — nothing to resolve, so nothing to check.
+    .map((i) => i.n)
+    .filter((n) => typeof n === 'string' && n.startsWith('.'));
+}
 
+async function main() {
+  await init;
+
+  const entry = path.resolve(process.argv[2] ?? DEFAULT_ENTRY);
   if (!isFile(entry)) {
     console.error(`check-runtime-imports: entry not found: ${entry}`);
     console.error('Build first (npm run build:server), or pass an explicit entry path.');
     process.exit(2);
   }
+
+  // Report paths relative to the build root when the entry sits under one
+  // (dist/server/server.js -> dist/), else relative to cwd. Either way the
+  // output stays readable rather than dumping absolute paths.
+  const guessedRoot = path.dirname(path.dirname(entry));
+  const root = process.argv[3]
+    ? path.resolve(process.argv[3])
+    : (entry.startsWith(guessedRoot + path.sep) ? guessedRoot : process.cwd());
 
   const visited = new Set();
   const problems = [];
@@ -112,13 +88,22 @@ function main() {
     let src;
     try { src = fs.readFileSync(file, 'utf8'); } catch { return; }
 
-    for (const spec of specifiersIn(src)) {
-      if (!spec.startsWith('.')) continue;
+    let specs;
+    try {
+      specs = relativeSpecifiers(src);
+    } catch (err) {
+      // A parse failure is itself worth surfacing — it means we cannot vouch
+      // for this file, and silently skipping would make the check a no-op.
+      problems.push({ importer: file, spec: null, parseError: String(err?.message ?? err) });
+      return;
+    }
+
+    for (const spec of specs) {
       const target = path.resolve(path.dirname(file), spec);
       if (isFile(target)) { walk(target); continue; }
 
       // Distinguish "missing extension" from "target genuinely absent" — the
-      // former is the common case and the fix is obvious, so say which it is.
+      // former is the common case and the fix is mechanical, so say which.
       const near = [`${target}.js`, path.join(target, 'index.js')].find(isFile);
       problems.push({ importer: file, spec, near: near ?? null });
     }
@@ -134,13 +119,17 @@ function main() {
     return;
   }
 
-  console.error(`\nFAIL — ${problems.length} unresolvable specifier(s) reachable from the server entry point:\n`);
+  console.error(`\nFAIL — ${problems.length} problem(s) reachable from the server entry point:\n`);
   for (const p of problems) {
     console.error(`  ${rel(p.importer)}`);
-    console.error(`      → '${p.spec}'`);
-    console.error(p.near
-      ? `      ${path.basename(p.near)} exists — the specifier is missing its extension. Write '${p.spec}.js'.`
-      : `      target does not exist.`);
+    if (p.parseError) {
+      console.error(`      could not be parsed: ${p.parseError}`);
+    } else {
+      console.error(`      → '${p.spec}'`);
+      console.error(p.near
+        ? `      ${path.basename(p.near)} exists — the specifier is missing its extension. Write '${p.spec}.js'.`
+        : `      target does not exist.`);
+    }
     console.error('');
   }
   console.error('Node ESM resolves relative specifiers exactly: the extension is required.');
@@ -148,4 +137,8 @@ function main() {
   process.exit(1);
 }
 
-main();
+main().catch((err) => {
+  console.error('check-runtime-imports: unexpected failure');
+  console.error(err);
+  process.exit(2);
+});

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -9,7 +9,7 @@ import { useCsrf } from './CsrfContext';
 import { DEFAULT_TILESET_ID, type TilesetId, type CustomTileset } from '../config/tilesets';
 import { type OverlayScheme, getSchemeForTileset, getOverlayColors, type OverlayColors } from '../config/overlayColors';
 import i18n from '../config/i18n';
-import { type TapbackEmoji, DEFAULT_TAPBACK_EMOJIS } from '../components/EmojiPickerModal/EmojiPickerModal';
+import { type TapbackEmoji, DEFAULT_TAPBACK_EMOJIS } from '../components/EmojiPickerModal/EmojiPickerModal.js';
 import { DEFAULT_TARGET_ZOOM, DEFAULT_ZOOM_GATE_THRESHOLD } from '../utils/mapZoomAnimation';
 import { setDiscardInvalidPositionsDisplay } from '../utils/positionDisplayConfig';
 import { IconStyleProvider, type IconStyle } from './IconStyleContext';

--- a/src/utils/mapIcons.ts
+++ b/src/utils/mapIcons.ts
@@ -4,4 +4,4 @@
  * there directly in new code. This file is kept as a transparent re-export
  * shim so existing importers (EmbedMap, MapLegend, etc.) are unaffected.
  */
-export * from '../components/map/markerIcons';
+export * from '../components/map/markerIcons.js';

--- a/src/utils/tracerouteStripMeta.ts
+++ b/src/utils/tracerouteStripMeta.ts
@@ -14,7 +14,7 @@ import type { TracerouteStripNodeMeta } from '../components/traceroute/Tracerout
 import { getEffectiveHops } from './nodeHops';
 import { getNodeTypeCategory } from './nodeTypeCategory';
 import { getRoleName } from './nodeHelpers';
-import { toNodeCardModel } from '../components/map/popups/nodeCardModel';
+import { toNodeCardModel } from '../components/map/popups/nodeCardModel.js';
 
 /** Structural subset of a traceroute row — the same shape `getEffectiveHops`
  *  needs for its `'traceroute'` calculation mode. */


### PR DESCRIPTION
## Summary

Follow-up to #4592. Closes the gap that fix could not: **being present is not the same as being resolvable.**

`package.json` sets `"type": "module"`, so compiled output is ESM and resolution is exact — a relative specifier must name the file including its extension. There is no extension search, no directory-index fallback. But `tsc` accepts an extensionless specifier and Vite resolves it, so a backend file importing a frontend module written that way builds clean, type-checks clean, and throws `ERR_MODULE_NOT_FOUND` only at runtime, inside a container or a packaged desktop build. That is exactly how #4591 reached users.

#4592's wholesale copy guarantees every emitted file is *present*. It cannot make an extensionless specifier resolve. Demonstrated on that PR: with `components/map/markerIcons.js` (12.9K) sitting right beside it, `import('dist/utils/mapIcons.js')` still fails.

## Important: there is no live defect here

I walked the graph before writing anything. **538 modules reachable from `dist/server/server.js`, zero unresolved specifiers.**

The build emits ~90 extensionless specifiers, but all are in frontend modules that `tsc -p tsconfig.server.json` compiles because they're transitively *type*-referenced — none are in the server's runtime graph. I verified the three I flagged on #4592 specifically (`utils/mapIcons`, `utils/tracerouteStripMeta`, `contexts/SettingsContext`): all unreachable.

So this is a guard, not a repair. The value is that the day one *does* become reachable, CI says so instead of a user's machine.

## What's here

**1. `scripts/check-runtime-imports.mjs`** — statically walks the graph from `dist/server/server.js` and fails on any relative specifier Node couldn't resolve. Static only; it never executes the modules, so it's safe to point at `server.js`, which would otherwise open sockets and a database. Wired into CI's existing **Build Check** job, which already builds both halves, plus an `npm run check:imports` script.

It distinguishes "missing extension" from "target absent" and names the fix:

```
FAIL — 1 unresolvable specifier(s) reachable from the server entry point:
  utils/mapIcons.js
      → '../components/map/markerIcons'
      markerIcons.js exists — the specifier is missing its extension. Write '../components/map/markerIcons.js'.
```

One subtlety worth knowing, because it bit my first version: the scanner **must** strip comments. `src/db/index.ts` carries a JSDoc block containing `import { createDatabase } from './db/index.js';` as usage documentation, and matching inside it produces a phantom failure. Handled, and commented as to why.

**2. The three specifiers in `utils/` and `contexts/`** get their `.js`. Those are the two directories server code already imports from — the likeliest to pull one in next.

**Deliberately not fixed:** the remaining ~87, all in `components/` and `hooks/` (pure frontend, never in the server graph). Touching ~60 files for no runtime benefit, mid-flight against several open PRs, is a worse trade than letting the guard cover them.

## Test plan

- [x] `npm run build` (frontend) and `npm run build:server` — both clean. The frontend build is the real risk of adding `.js`, so it was the thing to check.
- [x] `npm run lint:ci` — clean, no baseline growth
- [x] Full `npx vitest run`: **13,553 passed, 0 failed**
- [x] Guard passes on a clean tree: 538 modules walked, OK
- [x] **Guard proven to catch the hazard** — injecting a single `import '../utils/mapIcons.js'` into the emitted `server.js` makes it exit 1 with the offending file, specifier and fix. A checker that never fires is worth nothing, so this mattered more than the passing case.

### Not covered

PostgreSQL/MySQL suites skipped locally (727 skipped, containers down). No schema, query or repository is touched.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf