### PR TITLE
fix(mqtt): fire message events and alerts for MQTT-sourced messages (#4593)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -18,6 +18,7 @@ import { logger } from '../utils/logger.js';
 import { transportColumnForPacket } from '../utils/nodeTransport.js';
 import { getEnvironmentConfig } from './config/environment.js';
 import { notificationService } from './services/notificationService.js';
+import { sendMessagePushNotification } from './services/messagePushNotifier.js';
 import { getMaxNodeAgeHours } from './services/nodeDisplaySettings.js';
 import { deadDropService, nodeIdHex } from './services/deadDropService.js';
 import { serverEventNotificationService } from './services/serverEventNotificationService.js';
@@ -10079,94 +10080,28 @@ class MeshtasticManager implements ISourceManager {
    * Send notifications for new message (Web Push + Apprise)
    */
   private async sendMessagePushNotification(message: any, messageText: string, isDirectMessage: boolean): Promise<void> {
-    try {
-      // Skip if no notification services are available
-      const serviceStatus = notificationService.getServiceStatus();
-      if (!serviceStatus.anyAvailable) {
-        return;
-      }
-
-      // Skip non-chat messages (telemetry, traceroutes, etc.). ATAK GeoChat
-      // (PortNum.ATAK_PLUGIN, and its V2 form on PortNum.ATAK_PLUGIN_V2) is a
-      // real chat message too — see processTakPacket / processTakV2Packet —
-      // and gets a push notification the same as a text message (spec §7.3).
-      if (message.portnum !== PortNum.TEXT_MESSAGE_APP && message.portnum !== PortNum.ATAK_PLUGIN && message.portnum !== PortNum.ATAK_PLUGIN_V2) {
-        return;
-      }
-
-      // Skip messages from our own locally connected node
-      const localNodeNum = this.localNodeInfo?.nodeNum?.toString() ?? await databaseService.settings.getSetting(this.localNodeSettingKey('localNodeNum'));
-      if (localNodeNum && parseInt(localNodeNum) === message.fromNodeNum) {
-        logger.debug('⏭️  Skipping push notification for message from local node');
-        return;
-      }
-
-      // Get sender info
-      const fromNode = await databaseService.nodes.getNode(message.fromNodeNum);
-      const senderName = fromNode?.longName || fromNode?.shortName || `Node ${message.fromNodeNum}`;
-
-      // Determine notification title and body
-      let title: string;
-      let body: string;
-
-      if (isDirectMessage) {
-        title = `Direct Message from ${senderName}`;
-        body = messageText.length > 100 ? messageText.substring(0, 97) + '...' : messageText;
-      } else {
-        // Get channel name
-        const channel = await databaseService.channels.getChannelById(message.channel, this.sourceId);
-        const channelName = channel?.name || `Channel ${message.channel}`;
-        title = `${senderName} in ${channelName}`;
-        body = messageText.length > 100 ? messageText.substring(0, 97) + '...' : messageText;
-      }
-
-      // Build navigation data for push notification click handling.
-      // `sourceId` is required for the cold-launch deep link: the service
-      // worker builds a `/source/<sourceId>/<tab>` route from it, because the
-      // app root renders DashboardPage and never reads navigation data (#4463).
-      const navigationData = isDirectMessage
-        ? {
-            type: 'dm' as const,
-            sourceId: this.sourceId,
-            messageId: message.id,
-            senderNodeId: fromNode?.nodeId || message.fromNodeId,
-          }
-        : {
-            type: 'channel' as const,
-            sourceId: this.sourceId,
-            channelId: message.channel,
-            messageId: message.id,
-          };
-
-      // Phase B: resolve source name for prefixing
-      const source = await databaseService.sources.getSource(this.sourceId);
-      const sourceName = source?.name || this.sourceId;
-
-      // Send notifications (Web Push + Apprise) with filtering to all subscribed users
-      const result = await notificationService.broadcast({
-        title,
-        body,
-        data: navigationData,
-        sourceId: this.sourceId,
-        sourceName,
-      }, {
-        messageText,
-        channelId: message.channel,
-        isDirectMessage,
-        viaMqtt: message.viaMqtt === true,
-        sourceId: this.sourceId,
-        sourceName,
-      });
-
-      logger.debug(
-        `📤 Sent notifications: ${result.total.sent} delivered, ${result.total.failed} failed, ${result.total.filtered} filtered ` +
-        `(Push: ${result.webPush.sent}/${result.webPush.failed}/${result.webPush.filtered}, ` +
-        `Apprise: ${result.apprise.sent}/${result.apprise.failed}/${result.apprise.filtered})`
-      );
-    } catch (error) {
-      logger.error('❌ Error sending message push notification:', error);
-      // Don't throw - push notification failures shouldn't break message processing
-    }
+    // Body extracted to services/messagePushNotifier.ts (#4593) so MQTT-sourced
+    // messages can raise the same alerts. This wrapper only resolves THIS
+    // source's local node number (live info first, persisted setting as the
+    // fallback for a not-yet-connected source).
+    //
+    // The "no notification service configured" bail is repeated here (the
+    // notifier checks it too) so the settings read below stays off the hot path
+    // for the common case, exactly as it did before the extraction.
+    // Optional-called: a partially-stubbed notificationService (several unit
+    // suites) must degrade to "no notification", never throw into the caller.
+    if (!notificationService.getServiceStatus?.()?.anyAvailable) return;
+    const localNodeNumRaw =
+      this.localNodeInfo?.nodeNum?.toString() ??
+      await databaseService.settings.getSetting(this.localNodeSettingKey('localNodeNum'));
+    const localNodeNum = localNodeNumRaw ? parseInt(localNodeNumRaw) : null;
+    await sendMessagePushNotification({
+      message,
+      messageText,
+      isDirectMessage,
+      sourceId: this.sourceId,
+      localNodeNum: Number.isFinite(localNodeNum as number) ? localNodeNum : null,
+    });
   }
 
   private async checkAutoAcknowledge(message: any, messageText: string, channelIndex: number, isDirectMessage: boolean, fromNum: number, packetId?: number, rxSnr?: number, rxRssi?: number): Promise<void> {

--- a/src/server/mqttIngestion.automationBus.test.ts
+++ b/src/server/mqttIngestion.automationBus.test.ts
@@ -1,0 +1,229 @@
+/**
+ * End-to-end guard for #4593: an MQTT-ingested text message must reach the
+ * Automation Engine — WITHOUT letting MeshMonitor answer its own traffic.
+ *
+ * The chain exercised here is the real one, minus the singleton bootstrap:
+ *   ingestServiceEnvelope → dataEventEmitter('data', message:new)
+ *     → engine.onMessage (the exact mapping automationEngineSingleton does)
+ *       → self-origin guard → action deps
+ *
+ * The engine runs against a real in-memory automations repo and the REAL
+ * `createMeshNodeDataProvider`, so the self-origin guard resolves identity the
+ * same way production does: through `sourceManagerRegistry`.
+ *
+ * Why the self-origin half matters (the #3914 hazard, re-opened by #4593):
+ * an `mqtt_bridge` has no local node of its own, so a message MeshMonitor sent
+ * on a Meshtastic source comes back down the bridge — uplinked by somebody
+ * else's gateway — as an ordinary inbound packet from our own nodeNum. If the
+ * engine fired on that, an auto-reply automation would answer its own reply
+ * forever.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    upsertNodeAsync: vi.fn(async () => undefined),
+    nodes: {
+      getNode: vi.fn(async () => null),
+      getNodesByNums: vi.fn(async () => new Map()),
+      upsertNode: vi.fn(async () => undefined),
+    },
+    ignoredNodes: {
+      isIgnoredCached: vi.fn(() => false),
+      addGeoIgnoreAsync: vi.fn(async () => true),
+      liftGeoIgnoreAsync: vi.fn(async () => false),
+    },
+    messages: {
+      getMessage: vi.fn(async () => null),
+      insertMessage: vi.fn(async (_msg: any, _sourceId?: string) => true),
+    },
+    channels: {
+      upsertChannel: vi.fn(async () => undefined),
+      getChannelById: vi.fn(async () => null),
+      getAllChannels: vi.fn(async () => []),
+    },
+    channelDatabase: {
+      findOrCreateByNameAndHashAsync: vi.fn(async () => undefined),
+      findOrCreatePassiveByNameAsync: vi.fn(async () => undefined),
+      getEnabledAsync: vi.fn(async () => []),
+    },
+    settings: {
+      getSettingForSource: vi.fn(async () => null),
+    },
+    sources: {
+      getSource: vi.fn(async () => null),
+    },
+  },
+}));
+
+vi.mock('./meshtasticProtobufService.js', () => ({
+  default: {
+    processPayload: vi.fn((portnum: number, payload: Uint8Array) =>
+      portnum === 1 ? new TextDecoder('utf-8').decode(payload) : null,
+    ),
+    getPortNumName: vi.fn((portnum: number) => `PORT_${portnum}`),
+  },
+}));
+
+vi.mock('./services/mqttPacketLogService.js', () => ({
+  default: { logEnvelope: vi.fn(async () => undefined) },
+}));
+
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { ingestServiceEnvelope, _resetMqttIngestCachesForTest } from './mqttIngestion.js';
+import { dataEventEmitter, type DataEvent } from './services/dataEventEmitter.js';
+import { AutomationEngineService } from './services/automation/automationEngineService.js';
+import { createMeshNodeDataProvider } from './services/automation/meshNodeData.js';
+import { VariableResolver } from './services/automation/variableResolver.js';
+import { automationTraceBus } from './services/automation/automationTraceBus.js';
+import type { ActionDeps } from './services/automation/actionExecutor.js';
+import { AutomationsRepository } from '../db/repositories/automations.js';
+import { AutomationVariablesRepository } from '../db/repositories/automationVariables.js';
+import { createTestDb } from './test-helpers/testDb.js';
+import { sourceManagerRegistry, type ISourceManager } from './sourceManagerRegistry.js';
+import type { DbMessage } from '../services/database.js';
+import * as schema from '../db/schema/index.js';
+import type { ServiceEnvelopeShape } from './mqttPacketFilter.js';
+
+const BRIDGE = 'bridge-1';
+const TCP_SOURCE = 'tcp-1';
+const OUR_NODE = 0x11223344;
+const FOREIGN_NODE = 0x0a0b0c0d;
+
+/** Minimal ISourceManager stand-in — only the identity accessors matter here. */
+function fakeManager(sourceId: string, sourceType: any, nodeNum: number | null): ISourceManager {
+  return {
+    sourceId,
+    sourceType,
+    start: async () => undefined,
+    stop: async () => undefined,
+    getStatus: () => ({ sourceId, sourceName: sourceId, sourceType, connected: true }),
+    getLocalNodeInfo: () =>
+      nodeNum == null
+        ? null
+        : { nodeNum, nodeId: `!${nodeNum.toString(16)}`, longName: 'Ours', shortName: 'US' },
+    startDistanceDeleteScheduler: async () => undefined,
+    stopDistanceDeleteScheduler: () => undefined,
+  } as ISourceManager;
+}
+
+function envFrom(from: number, text: string): ServiceEnvelopeShape {
+  return {
+    channelId: 'LongFast',
+    gatewayId: '!00000001',
+    packet: {
+      id: 0x4a4b4c4d,
+      from,
+      to: 0xffffffff,
+      channel: 0,
+      decoded: { portnum: 1, payload: new TextEncoder().encode(text) },
+    },
+  } as ServiceEnvelopeShape;
+}
+
+describe('MQTT ingestion → Automation Engine (#4593)', () => {
+  let db: ReturnType<typeof createTestDb>['sqlite'];
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let autos: AutomationsRepository;
+  let engine: AutomationEngineService;
+  let calls: Array<{ fn: string; args: any }>;
+  let pending: Promise<unknown>[];
+  let listener: (e: DataEvent) => void;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    _resetMqttIngestCachesForTest();
+
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    autos = new AutomationsRepository(drizzleDb, 'sqlite');
+    const resolver = new VariableResolver(new AutomationVariablesRepository(drizzleDb, 'sqlite'));
+
+    calls = [];
+    // Only the four action deps this suite's automation can reach are stubbed.
+    const deps = {
+      sendMessage: async (a: any) => { calls.push({ fn: 'sendMessage', args: a }); return 1; },
+      sendTapback: async (a: any) => { calls.push({ fn: 'sendTapback', args: a }); return 2; },
+      manageNode: async (a: any) => { calls.push({ fn: 'manageNode', args: a }); return 3; },
+      notify: async (a: any) => { calls.push({ fn: 'notify', args: a }); return 4; },
+    } as unknown as ActionDeps;
+
+    engine = new AutomationEngineService({
+      automationsRepo: autos,
+      varResolver: resolver,
+      deps,
+      // The REAL provider — its self-identity accessors read sourceManagerRegistry.
+      data: createMeshNodeDataProvider(),
+    });
+    await autos.createAutomation({
+      name: 'auto-reply',
+      enabled: true,
+      config: JSON.stringify({
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping' } },
+          { id: 's', type: 'action.sendMessage', params: { text: 'pong', sourceId: TCP_SOURCE } },
+        ],
+        edges: [{ from: 't', to: 's' }],
+      }),
+    });
+    await engine.load();
+
+    // Same event → trigger mapping automationEngineSingleton.handleEvent uses.
+    pending = [];
+    listener = (event: DataEvent) => {
+      if (event.type === 'message:new') {
+        pending.push(engine.onMessage(event.data as DbMessage, event.sourceId ?? null));
+      }
+    };
+    dataEventEmitter.on('data', listener);
+  });
+
+  afterEach(async () => {
+    dataEventEmitter.off('data', listener);
+    for (const id of ['bridge-1', TCP_SOURCE]) {
+      await sourceManagerRegistry.removeManager(id);
+    }
+    db.close();
+    automationTraceBus.reset();
+    automationTraceBus.setSink(null);
+  });
+
+  it('fires a message automation for a message ingested from an mqtt_bridge source', async () => {
+    await sourceManagerRegistry.addManager(fakeManager(BRIDGE, 'mqtt_bridge', null));
+
+    await ingestServiceEnvelope({ sourceId: BRIDGE, envelope: envFrom(FOREIGN_NODE, 'ping') });
+    const fired = await Promise.all(pending);
+
+    expect(fired).toEqual([1]);
+    expect(calls.map((c) => c.fn)).toEqual(['sendMessage']);
+    expect(calls[0].args.text).toBe('pong');
+  });
+
+  it('does NOT fire for our own message relayed back down the bridge (no self-response loop)', async () => {
+    // A bridge has no identity of its own…
+    await sourceManagerRegistry.addManager(fakeManager(BRIDGE, 'mqtt_bridge', null));
+    // …but the Meshtastic source that actually sent the message does.
+    await sourceManagerRegistry.addManager(fakeManager(TCP_SOURCE, 'meshtastic_tcp', OUR_NODE));
+
+    await ingestServiceEnvelope({ sourceId: BRIDGE, envelope: envFrom(OUR_NODE, 'ping') });
+    const fired = await Promise.all(pending);
+
+    // The row was still ingested and emitted (the UI wants it); only the
+    // automation trigger is suppressed.
+    expect(fired).toEqual([0]);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('still fires for a third party when one of our own nodes is registered', async () => {
+    await sourceManagerRegistry.addManager(fakeManager(BRIDGE, 'mqtt_bridge', null));
+    await sourceManagerRegistry.addManager(fakeManager(TCP_SOURCE, 'meshtastic_tcp', OUR_NODE));
+
+    await ingestServiceEnvelope({ sourceId: BRIDGE, envelope: envFrom(FOREIGN_NODE, 'ping') });
+    const fired = await Promise.all(pending);
+
+    expect(fired).toEqual([1]);
+    expect(calls.map((c) => c.fn)).toEqual(['sendMessage']);
+  });
+});

--- a/src/server/mqttIngestion.emit.test.ts
+++ b/src/server/mqttIngestion.emit.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression guard for #4593 — MQTT-sourced text messages must raise the same
+ * `dataEventEmitter` event every other ingestion path raises after an insert.
+ *
+ * Before the fix `mqttIngestion.ts` inserted the row fire-and-forget and
+ * stopped, so nothing downstream of the event bus ever saw an `mqtt_bridge`
+ * message: the Automation Engine (which only wakes on `dataEventEmitter`'s
+ * `data` event) never fired, and WebSocket clients got no live update.
+ *
+ * The companion self-loop guard is covered in mqttIngestion.automationBus.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    upsertNodeAsync: vi.fn(async () => undefined),
+    nodes: {
+      getNode: vi.fn(async () => null),
+      getNodesByNums: vi.fn(async () => new Map()),
+      upsertNode: vi.fn(async () => undefined),
+    },
+    ignoredNodes: {
+      isIgnoredCached: vi.fn(() => false),
+      addGeoIgnoreAsync: vi.fn(async () => true),
+      liftGeoIgnoreAsync: vi.fn(async () => false),
+    },
+    messages: {
+      getMessage: vi.fn(async () => null),
+      insertMessage: vi.fn(async (_msg: any, _sourceId?: string) => true),
+    },
+    channels: {
+      upsertChannel: vi.fn(async () => undefined),
+      getChannelById: vi.fn(async () => null),
+    },
+    channelDatabase: {
+      findOrCreateByNameAndHashAsync: vi.fn(async () => undefined),
+      findOrCreatePassiveByNameAsync: vi.fn(async () => undefined),
+      getEnabledAsync: vi.fn(async () => []),
+    },
+    settings: {
+      getSettingForSource: vi.fn(async () => null),
+    },
+    sources: {
+      getSource: vi.fn(async () => null),
+    },
+  },
+}));
+
+vi.mock('./meshtasticProtobufService.js', () => ({
+  default: {
+    processPayload: vi.fn((portnum: number, payload: Uint8Array) => {
+      if (portnum === 1 /* TEXT_MESSAGE_APP */) {
+        return new TextDecoder('utf-8').decode(payload);
+      }
+      if (portnum === 4 /* NODEINFO_APP */) {
+        return { longName: 'Test', shortName: 'TST', hwModel: 1 };
+      }
+      if (portnum === 65 /* STORE_FORWARD_APP */) {
+        return { rr: 9 /* ROUTER_TEXT_BROADCAST */, text: new TextEncoder().encode('replayed') };
+      }
+      return null;
+    }),
+    getPortNumName: vi.fn((portnum: number) => `PORT_${portnum}`),
+  },
+}));
+
+vi.mock('./services/mqttPacketLogService.js', () => ({
+  default: { logEnvelope: vi.fn(async () => undefined) },
+}));
+
+vi.mock('./services/messagePushNotifier.js', () => ({
+  sendMessagePushNotification: vi.fn(async () => undefined),
+}));
+
+import { ingestServiceEnvelope, _resetMqttIngestCachesForTest } from './mqttIngestion.js';
+import { dataEventEmitter, type DataEvent } from './services/dataEventEmitter.js';
+import { sendMessagePushNotification } from './services/messagePushNotifier.js';
+import databaseService from '../services/database.js';
+import type { ServiceEnvelopeShape } from './mqttPacketFilter.js';
+
+const SOURCE = 'bridge-1';
+const SENDER = 0x0a0b0c0d;
+
+function envFor(portnum: number, opts: { to?: number; text?: string; id?: number } = {}): ServiceEnvelopeShape {
+  return {
+    channelId: 'LongFast',
+    gatewayId: '!00000001',
+    packet: {
+      id: opts.id ?? 0x12345678,
+      from: SENDER,
+      to: opts.to ?? 0xffffffff,
+      channel: 0,
+      decoded: {
+        portnum,
+        payload: new TextEncoder().encode(opts.text ?? 'hello mesh'),
+      },
+    },
+  } as ServiceEnvelopeShape;
+}
+
+describe('mqttIngestion → dataEventEmitter (#4593)', () => {
+  let events: DataEvent[];
+  let listener: (e: DataEvent) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetMqttIngestCachesForTest();
+    (databaseService.messages.insertMessage as any).mockResolvedValue(true);
+    (databaseService.messages.getMessage as any).mockResolvedValue(null);
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(false);
+    events = [];
+    listener = (e: DataEvent) => events.push(e);
+    dataEventEmitter.on('data', listener);
+  });
+
+  afterEach(() => {
+    dataEventEmitter.off('data', listener);
+  });
+
+  it('emits message:new for a broadcast text message ingested from an mqtt_bridge source', async () => {
+    const result = await ingestServiceEnvelope({ sourceId: SOURCE, envelope: envFor(1, { text: 'ping' }) });
+
+    expect(result.ingested).toBe(true);
+    const msgEvents = events.filter((e) => e.type === 'message:new');
+    expect(msgEvents).toHaveLength(1);
+    expect(msgEvents[0].sourceId).toBe(SOURCE);
+    const emitted = msgEvents[0].data as any;
+    expect(emitted.text).toBe('ping');
+    expect(emitted.fromNodeNum).toBe(SENDER);
+    expect(emitted.channel).toBe(0);
+    // The emitted row is the same one that was inserted (row id convention intact).
+    expect(emitted.id).toBe((databaseService.messages.insertMessage as any).mock.calls[0][0].id);
+  });
+
+  it('emits with channel -1 for a directed (DM) text message', async () => {
+    const result = await ingestServiceEnvelope({
+      sourceId: SOURCE,
+      envelope: envFor(1, { to: 0x99887766, text: 'psst' }),
+    });
+
+    expect(result.ingested).toBe(true);
+    const emitted = events.find((e) => e.type === 'message:new')?.data as any;
+    expect(emitted).toBeDefined();
+    expect(emitted.channel).toBe(-1);
+    expect(emitted.toNodeNum).toBe(0x99887766);
+  });
+
+  it('does NOT emit when the insert was a duplicate (second gateway relaying the same packet)', async () => {
+    (databaseService.messages.insertMessage as any).mockResolvedValue(false);
+
+    const result = await ingestServiceEnvelope({ sourceId: SOURCE, envelope: envFor(1, { text: 'ping' }) });
+
+    // The packet was still processed (node lastHeard refresh etc.)…
+    expect(result.ingested).toBe(true);
+    // …but no row was created, so nothing may re-trigger downstream consumers.
+    expect(events.filter((e) => e.type === 'message:new')).toHaveLength(0);
+  });
+
+  it('does NOT emit message:new for a non-text portnum', async () => {
+    await ingestServiceEnvelope({ sourceId: SOURCE, envelope: envFor(4 /* NODEINFO_APP */) });
+    expect(events.filter((e) => e.type === 'message:new')).toHaveLength(0);
+  });
+
+  it('emits message:new for a Store & Forward replayed text message', async () => {
+    const result = await ingestServiceEnvelope({ sourceId: SOURCE, envelope: envFor(65 /* STORE_FORWARD_APP */) });
+
+    expect(result.ingested).toBe(true);
+    const msgEvents = events.filter((e) => e.type === 'message:new');
+    expect(msgEvents).toHaveLength(1);
+    expect((msgEvents[0].data as any).text).toBe('replayed');
+    expect((msgEvents[0].data as any).viaStoreForward).toBe(true);
+  });
+
+  // Bug 2 of #4593: message push/Apprise alerts were TCP-only because
+  // sendMessagePushNotification was called inline from meshtasticManager and
+  // nowhere else. New-NODE alerts were unaffected (they fire from
+  // upsertNodeAsync, which mqttIngestion already calls).
+  it('raises a message push notification for an ingested MQTT text message', async () => {
+    await ingestServiceEnvelope({ sourceId: SOURCE, envelope: envFor(1, { text: 'ping' }) });
+
+    expect(sendMessagePushNotification).toHaveBeenCalledTimes(1);
+    const arg = (sendMessagePushNotification as any).mock.calls[0][0];
+    expect(arg.sourceId).toBe(SOURCE);
+    expect(arg.messageText).toBe('ping');
+    expect(arg.isDirectMessage).toBe(false);
+  });
+
+  it('flags a directed message as a DM for the push notification', async () => {
+    await ingestServiceEnvelope({ sourceId: SOURCE, envelope: envFor(1, { to: 0x99887766, text: 'psst' }) });
+
+    expect((sendMessagePushNotification as any).mock.calls[0][0].isDirectMessage).toBe(true);
+  });
+
+  it('does not notify when the insert was a duplicate', async () => {
+    (databaseService.messages.insertMessage as any).mockResolvedValue(false);
+    await ingestServiceEnvelope({ sourceId: SOURCE, envelope: envFor(1, { text: 'ping' }) });
+    expect(sendMessagePushNotification).not.toHaveBeenCalled();
+  });
+
+  it('does NOT emit for a Store & Forward replay of a message we already hold', async () => {
+    (databaseService.messages.getMessage as any).mockResolvedValue({ id: 'already-here' });
+
+    await ingestServiceEnvelope({ sourceId: SOURCE, envelope: envFor(65 /* STORE_FORWARD_APP */) });
+
+    expect(events.filter((e) => e.type === 'message:new')).toHaveLength(0);
+    expect(databaseService.messages.insertMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -13,6 +13,8 @@
 
 import meshtasticProtobufService from './meshtasticProtobufService.js';
 import { channelDecryptionService } from './services/channelDecryptionService.js';
+import { dataEventEmitter } from './services/dataEventEmitter.js';
+import { sendMessagePushNotification } from './services/messagePushNotifier.js';
 import mqttPacketLogService from './services/mqttPacketLogService.js';
 import { autoDeleteByDistanceService } from './services/autoDeleteByDistanceService.js';
 import databaseService from '../services/database.js';
@@ -157,6 +159,60 @@ export interface MqttIngestionResult {
   ingested: boolean;
   reason?: 'no-packet' | 'no-decoded' | 'encrypted' | 'unsupported-portnum' | 'ignored' | 'geo-ignored' | 'distance' | 'decode-error';
   portnum?: number;
+}
+
+/**
+ * Insert an MQTT-sourced text message and run the same post-insert hooks every
+ * other ingestion path runs (#4593). Before this existed, `mqttIngestion`
+ * inserted the row fire-and-forget and stopped there, so for `mqtt_bridge` /
+ * `mqtt_broker` sources:
+ *   - the Automation Engine never woke up (it only listens on
+ *     `dataEventEmitter`'s `data` event), and
+ *   - no push/Apprise message alert was ever raised.
+ *
+ * Mirrors `meshtasticManager.processTextMessageProtobuf`: hooks fire ONLY when
+ * the insert actually created a row. `insertMessage` is INSERT-OR-IGNORE keyed
+ * on the `${sourceId}_${fromNum}_${packetId}` row id, so a packet redelivered
+ * by a second gateway (or a Store & Forward replay of a message we already
+ * hold) is a no-op — that dedup is what keeps a duplicate MQTT reception from
+ * re-triggering an automation.
+ *
+ * Self-origin: the emit is NOT suppressed for our own nodes, so the live UI
+ * still updates. The loop guard lives where #3914 put it — the Automation
+ * Engine drops events whose sender is one of our own nodes, which now also
+ * covers identity-less MQTT bridge sources (see utils/ownNodes.ts). The push
+ * notifier applies the same check itself.
+ */
+async function insertAndAnnounceMessage(
+  msg: DbMessage,
+  sourceId: string,
+  text: string,
+  isDirectMessage: boolean,
+): Promise<boolean> {
+  let inserted: boolean;
+  try {
+    inserted = await databaseService.messages.insertMessage(msg, sourceId);
+  } catch (err) {
+    logger.error('Failed to insert MQTT message:', err);
+    return false;
+  }
+  if (!inserted) return false;
+
+  try {
+    dataEventEmitter.emitNewMessage(msg, sourceId);
+  } catch (err) {
+    logger.error('Failed to emit MQTT message event:', err);
+  }
+  void sendMessagePushNotification({
+    message: msg,
+    messageText: text,
+    isDirectMessage,
+    sourceId,
+    // MQTT sources have no local node of their own; the notifier's
+    // cross-source `isOwnNodeNum` check covers self-origin instead.
+    localNodeNum: null,
+  });
+  return true;
 }
 
 /**
@@ -491,7 +547,9 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
       // Use the repo's per-source insert — the `databaseService.insertMessage`
       // facade drops the sourceId, leaving rows orphaned (`sourceId=NULL`)
       // and invisible to source-scoped queries like /api/unified/messages.
-      databaseService.messages.insertMessage(msg, sourceId).catch(err => logger.error('Failed to insert MQTT message:', err));
+      // Awaited (was fire-and-forget) so the post-insert hooks below only run
+      // for a row that was actually created — see insertAndAnnounceMessage.
+      await insertAndAnnounceMessage(msg, sourceId, text, isDirectMessage);
       // Refresh lastHeard for the sender.
       void databaseService.upsertNodeAsync({
         nodeNum: fromNum,
@@ -1043,8 +1101,18 @@ async function ingestStoreForward(
     (msg as any).sourceId = sourceId;
     (msg as any).viaStoreForward = true;
     // Same per-source insert path as the TEXT_MESSAGE_APP case above —
-    // the facade drops sourceId; the repo accepts it.
-    databaseService.messages.insertMessage(msg, sourceId).catch(err => logger.error('Failed to insert MQTT message:', err));
+    // the facade drops sourceId; the repo accepts it. Shares the same
+    // post-insert hooks (event bus + push alert), so a Store & Forward replay
+    // that IS new to us triggers automations exactly like a live message; a
+    // replay of a message we already hold is deduped by the row id and fires
+    // nothing (the explicit getMessage check above already covers most of it).
+    await insertAndAnnounceMessage(
+      msg,
+      sourceId,
+      text,
+      // ROUTER_TEXT_DIRECT replays a DM; ROUTER_TEXT_BROADCAST a channel message.
+      rr === StoreForwardRequestResponse.ROUTER_TEXT_DIRECT,
+    );
     return true;
   }
 

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -244,6 +244,32 @@ describe('AutomationEngineService', () => {
     expect(await engine.onMessage(message({ fromNodeNum: 222, text: 'ping' }), 'default')).toBe(1);
   });
 
+  it('self-origin (#4593): ignores our own node on a source with no local identity (MQTT bridge)', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('ping', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping' } },
+        { id: 's', type: 'action.sendMessage', params: { text: 'pong' } },
+      ],
+      edges: [{ from: 't', to: 's' }],
+    });
+    // A bridge has no local node → getLocalNodeNum resolves null; the
+    // cross-source owned-node set is the only thing that can recognise us.
+    const selfData = {
+      ...data,
+      getLocalNodeNum: async () => null,
+      isOwnNodeNum: async (n: number) => n === 111,
+    };
+    const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data: selfData, now: () => clock });
+    await engine.load();
+    // Our own message, relayed back to us by a third-party gateway → dropped.
+    expect(await engine.onMessage(message({ fromNodeNum: 111, text: 'ping' }), 'bridge-1')).toBe(0);
+    expect(calls).toHaveLength(0);
+    // Anyone else on the bridge still fires.
+    expect(await engine.onMessage(message({ fromNodeNum: 222, text: 'ping' }), 'bridge-1')).toBe(1);
+  });
+
   it('self-origin (#3914): ignores a MeshCore message from our own public key (case-insensitive)', async () => {
     const { calls, deps } = recorder();
     await createEnabled('mc-ping', {

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -507,11 +507,26 @@ export class AutomationEngineService {
   // source via optional data-provider accessors; when they're absent (e.g. a
   // unit test that doesn't wire them) nothing is dropped — existing behavior.
 
-  /** True if `fromNodeNum` is this Meshtastic source's own local node. */
+  /**
+   * True if `fromNodeNum` is one of MeshMonitor's own nodes.
+   *
+   * Checks the event's own source first (the #3914 behaviour), then falls back
+   * to the cross-source owned-node set. The fallback exists for sources that
+   * have no local node of their own — an `mqtt_bridge` re-delivers a message we
+   * sent on a Meshtastic source once some third-party gateway uplinks it to the
+   * broker, and without the fallback the guard never fires there, so an
+   * auto-reply automation re-triggers on its own reply (#4593).
+   */
   private async isSelfMeshtastic(sourceId: string | null, fromNodeNum: number | null | undefined): Promise<boolean> {
-    if (!this.data.getLocalNodeNum || fromNodeNum == null) return false;
-    const local = await this.data.getLocalNodeNum(sourceId);
-    return local != null && Number(local) === Number(fromNodeNum);
+    if (fromNodeNum == null) return false;
+    if (this.data.getLocalNodeNum) {
+      const local = await this.data.getLocalNodeNum(sourceId);
+      if (local != null && Number(local) === Number(fromNodeNum)) return true;
+    }
+    if (this.data.isOwnNodeNum) {
+      return await this.data.isOwnNodeNum(Number(fromNodeNum));
+    }
+    return false;
   }
 
   /** True if `fromPublicKey` is this MeshCore source's own local node key. */

--- a/src/server/services/automation/engineContext.ts
+++ b/src/server/services/automation/engineContext.ts
@@ -64,6 +64,15 @@ export interface NodeDataProvider {
    */
   getLocalNodeNum?(sourceId: string | null): Promise<number | null>;
   /**
+   * True when a node number belongs to ANY source MeshMonitor owns. The
+   * per-source `getLocalNodeNum` is null for a source with no local identity —
+   * an `mqtt_bridge` — yet our own messages still arrive there, relayed to the
+   * broker by third-party gateways. Without this the #3914 self-origin guard is
+   * a no-op on bridges and an automation can answer its own reply forever
+   * (#4593). Optional; absent → no extra drop.
+   */
+  isOwnNodeNum?(nodeNum: number): Promise<boolean>;
+  /**
    * Own/local node public key for a MeshCore source — the self signal for MeshCore
    * received messages (#3914). Optional; absent → no drop.
    */

--- a/src/server/services/automation/meshNodeData.ts
+++ b/src/server/services/automation/meshNodeData.ts
@@ -9,6 +9,7 @@ import type { NodeDataProvider, NodeFacts } from './engineContext.js';
 import { sourceProtocol } from './channelUnify.js';
 import { sourceManagerRegistry } from '../../sourceManagerRegistry.js';
 import { isMeshCoreManager } from '../../sourceManagerTypes.js';
+import { isOwnNodeNum as isOwnedByAnySource } from '../../utils/ownNodes.js';
 
 function nodeIdOf(nodeNum: number): string {
   return `!${(nodeNum >>> 0).toString(16).padStart(8, '0')}`;
@@ -73,6 +74,17 @@ export function createMeshNodeDataProvider(): NodeDataProvider {
         return nodeNum != null ? Number(nodeNum) : null;
       } catch {
         return null;
+      }
+    },
+
+    // Cross-source owned-node check (#4593) — the fallback the engine uses when
+    // the event's own source has no local identity (an MQTT bridge). Reads the
+    // registry live; an empty registry means "nothing is ours" → no drop.
+    async isOwnNodeNum(nodeNum) {
+      try {
+        return isOwnedByAnySource(nodeNum);
+      } catch {
+        return false;
       }
     },
 

--- a/src/server/services/messagePushNotifier.test.ts
+++ b/src/server/services/messagePushNotifier.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared message push/Apprise notifier (#4593) — extracted from
+ * meshtasticManager so MQTT-sourced messages raise alerts too.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const broadcast = vi.fn(async () => ({
+  webPush: { sent: 1, failed: 0, filtered: 0 },
+  apprise: { sent: 0, failed: 0, filtered: 0 },
+  total: { sent: 1, failed: 0, filtered: 0 },
+}));
+const getServiceStatus = vi.fn(() => ({ webPush: true, apprise: false, anyAvailable: true }));
+
+vi.mock('./notificationService.js', () => ({
+  notificationService: {
+    broadcast: (...a: any[]) => broadcast(...(a as [])),
+    getServiceStatus: () => getServiceStatus(),
+  },
+}));
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    nodes: { getNode: vi.fn(async () => ({ nodeNum: 0x0a0b0c0d, nodeId: '!0a0b0c0d', longName: 'Far Node', shortName: 'FAR' })) },
+    channels: { getChannelById: vi.fn(async () => null) },
+    channelDatabase: { getByIdAsync: vi.fn(async () => ({ id: 3, name: 'LongFast' })) },
+    sources: { getSource: vi.fn(async () => ({ id: 'bridge-1', name: 'Public Bridge' })) },
+  },
+}));
+
+const isOwnNodeNum = vi.fn((_nodeNum?: unknown) => false);
+vi.mock('../utils/ownNodes.js', () => ({
+  isOwnNodeNum: (n: any) => isOwnNodeNum(n),
+  getOwnNodeNums: () => [],
+}));
+
+import { sendMessagePushNotification } from './messagePushNotifier.js';
+import { CHANNEL_DB_OFFSET } from '../constants/meshtastic.js';
+
+function msg(over: Record<string, any> = {}) {
+  return {
+    id: 'bridge-1_168627213_42',
+    fromNodeNum: 0x0a0b0c0d,
+    fromNodeId: '!0a0b0c0d',
+    toNodeNum: 0xffffffff,
+    channel: 0,
+    portnum: 1, // TEXT_MESSAGE_APP
+    viaMqtt: true,
+    ...over,
+  };
+}
+
+describe('sendMessagePushNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getServiceStatus.mockReturnValue({ webPush: true, apprise: false, anyAvailable: true });
+    isOwnNodeNum.mockReturnValue(false);
+  });
+
+  it('broadcasts a channel message alert with the resolved source name', async () => {
+    await sendMessagePushNotification({
+      message: msg(),
+      messageText: 'hello mesh',
+      isDirectMessage: false,
+      sourceId: 'bridge-1',
+    });
+
+    expect(broadcast).toHaveBeenCalledTimes(1);
+    const [payload, filterCtx] = (broadcast as any).mock.calls[0];
+    expect(payload.title).toContain('Far Node');
+    expect(payload.body).toBe('hello mesh');
+    expect(payload.sourceId).toBe('bridge-1');
+    expect(payload.sourceName).toBe('Public Bridge');
+    expect(payload.data).toMatchObject({ type: 'channel', sourceId: 'bridge-1', channelId: 0 });
+    expect(filterCtx).toMatchObject({ messageText: 'hello mesh', isDirectMessage: false, viaMqtt: true });
+  });
+
+  it('names a virtual (channel_database) channel instead of showing its offset id', async () => {
+    await sendMessagePushNotification({
+      message: msg({ channel: CHANNEL_DB_OFFSET + 3 }),
+      messageText: 'hi',
+      isDirectMessage: false,
+      sourceId: 'bridge-1',
+    });
+
+    expect((broadcast as any).mock.calls[0][0].title).toBe('Far Node in LongFast');
+  });
+
+  it('titles a DM and carries the sender node id for deep linking', async () => {
+    await sendMessagePushNotification({
+      message: msg({ toNodeNum: 0x11223344, channel: -1 }),
+      messageText: 'psst',
+      isDirectMessage: true,
+      sourceId: 'bridge-1',
+    });
+
+    const payload = (broadcast as any).mock.calls[0][0];
+    expect(payload.title).toBe('Direct Message from Far Node');
+    expect(payload.data).toMatchObject({ type: 'dm', senderNodeId: '!0a0b0c0d' });
+  });
+
+  it('skips when no notification service is configured', async () => {
+    getServiceStatus.mockReturnValue({ webPush: false, apprise: false, anyAvailable: false });
+    await sendMessagePushNotification({ message: msg(), messageText: 'x', isDirectMessage: false, sourceId: 'bridge-1' });
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  it('skips non-chat portnums', async () => {
+    await sendMessagePushNotification({ message: msg({ portnum: 67 }), messageText: 'x', isDirectMessage: false, sourceId: 'bridge-1' });
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  it('skips a message from the source’s own local node', async () => {
+    await sendMessagePushNotification({
+      message: msg({ fromNodeNum: 0x11223344 }),
+      messageText: 'x',
+      isDirectMessage: false,
+      sourceId: 'tcp-1',
+      localNodeNum: 0x11223344,
+    });
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  it('skips a message from one of our own nodes seen through an identity-less source (#4593)', async () => {
+    isOwnNodeNum.mockReturnValue(true);
+    await sendMessagePushNotification({
+      message: msg({ fromNodeNum: 0x11223344 }),
+      messageText: 'x',
+      isDirectMessage: false,
+      sourceId: 'bridge-1',
+      localNodeNum: null,
+    });
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the notification service fails', async () => {
+    broadcast.mockRejectedValueOnce(new Error('apprise down') as never);
+    await expect(
+      sendMessagePushNotification({ message: msg(), messageText: 'x', isDirectMessage: false, sourceId: 'bridge-1' }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/server/services/messagePushNotifier.ts
+++ b/src/server/services/messagePushNotifier.ts
@@ -1,0 +1,161 @@
+/**
+ * New-message push/Apprise notification (shared across ingestion paths).
+ *
+ * Extracted from `MeshtasticManager.sendMessagePushNotification` (#4593) so
+ * MQTT-sourced messages get the same alerts. Before the extraction this logic
+ * lived inline in meshtasticManager and was called from three TCP-only sites,
+ * so a message ingested by `mqttIngestion.ts` (an `mqtt_bridge` or
+ * `mqtt_broker` source) never produced a notification — new-NODE alerts worked
+ * because those fire one layer down, in `databaseService.upsertNodeAsync`.
+ *
+ * Behaviour is unchanged for the Meshtastic path; the only additions are the
+ * cross-source self-check (see `isOwnNodeNum`) and a channel-name fallback for
+ * the `CHANNEL_DB_OFFSET`-encoded virtual channels MQTT messages carry.
+ */
+
+import { notificationService } from './notificationService.js';
+import databaseService from '../../services/database.js';
+import { PortNum, CHANNEL_DB_OFFSET } from '../constants/meshtastic.js';
+import { isOwnNodeNum } from '../utils/ownNodes.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * The subset of a message row this notifier reads. Structurally satisfied by
+ * both `DbMessage` (MQTT ingestion) and `TextMessage` (meshtasticManager).
+ */
+export interface NotifiableMessage {
+  id: string;
+  fromNodeNum: number;
+  fromNodeId?: string | null;
+  channel: number;
+  portnum?: number | null;
+  viaMqtt?: boolean | null;
+}
+
+export interface MessagePushInput {
+  /** The inserted message row. */
+  message: NotifiableMessage;
+  /** Plain text body used for the notification and for keyword filters. */
+  messageText: string;
+  isDirectMessage: boolean;
+  sourceId: string;
+  /**
+   * The source's own local node number, when it has one. Messages from it are
+   * skipped (we don't notify a user about their own outgoing message). MQTT
+   * bridges have no local node — pass null and rely on the cross-source
+   * `isOwnNodeNum` check below.
+   */
+  localNodeNum?: number | null;
+}
+
+/** Resolve a display name for the message's channel, including virtual (channel_database) ids. */
+async function resolveChannelName(channelId: number, sourceId: string): Promise<string> {
+  try {
+    const channel = await databaseService.channels.getChannelById(channelId, sourceId);
+    if (channel?.name) return channel.name;
+  } catch {
+    // fall through to the channel_database lookup / numeric label
+  }
+  if (channelId >= CHANNEL_DB_OFFSET) {
+    try {
+      const row = await databaseService.channelDatabase.getByIdAsync(channelId - CHANNEL_DB_OFFSET);
+      if (row?.name) return row.name;
+    } catch {
+      // fall through
+    }
+  }
+  return `Channel ${channelId}`;
+}
+
+/**
+ * Send notifications (Web Push + Apprise) for a newly ingested message.
+ * Never throws — notification failures must not break message processing.
+ */
+export async function sendMessagePushNotification(input: MessagePushInput): Promise<void> {
+  const { message, messageText, isDirectMessage, sourceId, localNodeNum } = input;
+  try {
+    // Skip if no notification services are available
+    const serviceStatus = notificationService.getServiceStatus();
+    if (!serviceStatus.anyAvailable) {
+      return;
+    }
+
+    // Skip non-chat messages (telemetry, traceroutes, etc.). ATAK GeoChat
+    // (PortNum.ATAK_PLUGIN, and its V2 form on PortNum.ATAK_PLUGIN_V2) is a
+    // real chat message too — see processTakPacket / processTakV2Packet —
+    // and gets a push notification the same as a text message (spec §7.3).
+    if (message.portnum !== PortNum.TEXT_MESSAGE_APP && message.portnum !== PortNum.ATAK_PLUGIN && message.portnum !== PortNum.ATAK_PLUGIN_V2) {
+      return;
+    }
+
+    // Skip messages from our own node. `localNodeNum` covers the source that
+    // owns the node; `isOwnNodeNum` additionally covers our own traffic seen
+    // through a source with no local identity — an MQTT bridge re-delivering
+    // a message we sent on a different source (#4593).
+    if (localNodeNum != null && Number(localNodeNum) === Number(message.fromNodeNum)) {
+      logger.debug('⏭️  Skipping push notification for message from local node');
+      return;
+    }
+    if (isOwnNodeNum(message.fromNodeNum)) {
+      logger.debug('⏭️  Skipping push notification for message from one of our own nodes');
+      return;
+    }
+
+    // Get sender info
+    const fromNode = await databaseService.nodes.getNode(message.fromNodeNum);
+    const senderName = fromNode?.longName || fromNode?.shortName || `Node ${message.fromNodeNum}`;
+
+    // Determine notification title and body
+    const body = messageText.length > 100 ? messageText.substring(0, 97) + '...' : messageText;
+    const title = isDirectMessage
+      ? `Direct Message from ${senderName}`
+      : `${senderName} in ${await resolveChannelName(message.channel, sourceId)}`;
+
+    // Build navigation data for push notification click handling.
+    // `sourceId` is required for the cold-launch deep link: the service
+    // worker builds a `/source/<sourceId>/<tab>` route from it, because the
+    // app root renders DashboardPage and never reads navigation data (#4463).
+    const navigationData = isDirectMessage
+      ? {
+          type: 'dm' as const,
+          sourceId,
+          messageId: message.id,
+          senderNodeId: fromNode?.nodeId || message.fromNodeId || undefined,
+        }
+      : {
+          type: 'channel' as const,
+          sourceId,
+          channelId: message.channel,
+          messageId: message.id,
+        };
+
+    // Phase B: resolve source name for prefixing
+    const source = await databaseService.sources.getSource(sourceId);
+    const sourceName = source?.name || sourceId;
+
+    // Send notifications (Web Push + Apprise) with filtering to all subscribed users
+    const result = await notificationService.broadcast({
+      title,
+      body,
+      data: navigationData,
+      sourceId,
+      sourceName,
+    }, {
+      messageText,
+      channelId: message.channel,
+      isDirectMessage,
+      viaMqtt: message.viaMqtt === true,
+      sourceId,
+      sourceName,
+    });
+
+    logger.debug(
+      `📤 Sent notifications: ${result.total.sent} delivered, ${result.total.failed} failed, ${result.total.filtered} filtered ` +
+      `(Push: ${result.webPush.sent}/${result.webPush.failed}/${result.webPush.filtered}, ` +
+      `Apprise: ${result.apprise.sent}/${result.apprise.failed}/${result.apprise.filtered})`
+    );
+  } catch (error) {
+    logger.error('❌ Error sending message push notification:', error);
+    // Don't throw - push notification failures shouldn't break message processing
+  }
+}

--- a/src/server/utils/ownNodes.test.ts
+++ b/src/server/utils/ownNodes.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Cross-source self-identity (#4593). See utils/ownNodes.ts for why an
+ * `mqtt_bridge` needs this: it has no local node of its own, so the per-source
+ * self-origin guard (#3914) cannot recognise our own traffic arriving there.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { getOwnNodeNums, isOwnNodeNum } from './ownNodes.js';
+import { sourceManagerRegistry, type ISourceManager } from '../sourceManagerRegistry.js';
+
+function fakeManager(sourceId: string, sourceType: any, nodeNum: number | null): ISourceManager {
+  return {
+    sourceId,
+    sourceType,
+    start: async () => undefined,
+    stop: async () => undefined,
+    getStatus: () => ({ sourceId, sourceName: sourceId, sourceType, connected: true }),
+    getLocalNodeInfo: () =>
+      nodeNum == null ? null : { nodeNum, nodeId: `!${nodeNum.toString(16)}`, longName: 'n', shortName: 'n' },
+    startDistanceDeleteScheduler: async () => undefined,
+    stopDistanceDeleteScheduler: () => undefined,
+  } as ISourceManager;
+}
+
+describe('ownNodes', () => {
+  const added: string[] = [];
+  const add = async (m: ISourceManager) => { added.push(m.sourceId); await sourceManagerRegistry.addManager(m); };
+
+  afterEach(async () => {
+    while (added.length) await sourceManagerRegistry.removeManager(added.pop()!);
+  });
+
+  it('is empty (and drops nothing) when no source is registered', () => {
+    expect(getOwnNodeNums()).toEqual([]);
+    expect(isOwnNodeNum(0x11223344)).toBe(false);
+  });
+
+  it('collects the local node of every source that has one', async () => {
+    await add(fakeManager('tcp-a', 'meshtastic_tcp', 0x11223344));
+    await add(fakeManager('tcp-b', 'meshtastic_tcp', 0x55667788));
+
+    expect(getOwnNodeNums().sort()).toEqual([0x11223344, 0x55667788].sort());
+    expect(isOwnNodeNum(0x11223344)).toBe(true);
+    expect(isOwnNodeNum(0x55667788)).toBe(true);
+    expect(isOwnNodeNum(0x0a0b0c0d)).toBe(false);
+  });
+
+  it('ignores identity-less sources (an mqtt_bridge contributes nothing)', async () => {
+    await add(fakeManager('bridge-1', 'mqtt_bridge', null));
+    expect(getOwnNodeNums()).toEqual([]);
+  });
+
+  it('recognises a node owned by ANY source, not just the one asking', async () => {
+    await add(fakeManager('bridge-1', 'mqtt_bridge', null));
+    await add(fakeManager('tcp-a', 'meshtastic_tcp', 0x11223344));
+
+    // The message arrived on bridge-1, but the node belongs to tcp-a → still ours.
+    expect(isOwnNodeNum(0x11223344)).toBe(true);
+  });
+
+  it('survives a manager that throws while reporting its local node', async () => {
+    const broken = fakeManager('broken', 'meshtastic_tcp', 1);
+    (broken as any).getLocalNodeInfo = () => { throw new Error('mid-connect'); };
+    await add(broken);
+    await add(fakeManager('tcp-a', 'meshtastic_tcp', 0x11223344));
+
+    expect(getOwnNodeNums()).toEqual([0x11223344]);
+  });
+
+  it('treats null/undefined/NaN node numbers as not ours', async () => {
+    await add(fakeManager('tcp-a', 'meshtastic_tcp', 0x11223344));
+    expect(isOwnNodeNum(null)).toBe(false);
+    expect(isOwnNodeNum(undefined)).toBe(false);
+    expect(isOwnNodeNum(Number.NaN)).toBe(false);
+  });
+});

--- a/src/server/utils/ownNodes.ts
+++ b/src/server/utils/ownNodes.ts
@@ -1,0 +1,52 @@
+/**
+ * "Is this one of MeshMonitor's own nodes?" — cross-source self-identity.
+ *
+ * The per-source self-origin guard (#3914) asks a single source's manager for
+ * its local node (`getLocalNodeInfo()`). That works for a Meshtastic TCP or
+ * MeshCore source, which owns a physical node, but an `mqtt_bridge` source has
+ * NO local identity at all — `MqttBridgeManager.getLocalNodeInfo()` returns
+ * null — so the guard silently degrades to a no-op there.
+ *
+ * That matters because our own traffic reaches a bridge anyway: a message we
+ * send through a Meshtastic source travels the mesh, some third-party gateway
+ * uplinks it to the broker, and the bridge downlinks it right back to us as an
+ * ordinary inbound packet from our own nodeNum. Without a cross-source check an
+ * automation would fire on MeshMonitor's own reply and answer itself forever
+ * (#4593).
+ *
+ * The set is read live from the registry — no caching — so a source that
+ * connects, reconnects with a new nodeNum, or is removed is reflected
+ * immediately. An empty registry (unit tests, boot) yields an empty set, i.e.
+ * nothing is treated as ours: fail-open, matching the #3914 convention that an
+ * unresolvable identity never drops an event.
+ */
+
+import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+
+/**
+ * Every local node number MeshMonitor currently owns, across all registered
+ * sources. Sources with no local identity (MQTT bridges) contribute nothing.
+ */
+export function getOwnNodeNums(): number[] {
+  const nums: number[] = [];
+  for (const manager of sourceManagerRegistry.getAllManagers()) {
+    let nodeNum: unknown;
+    try {
+      nodeNum = manager.getLocalNodeInfo()?.nodeNum;
+    } catch {
+      continue; // a manager mid-connect must never break the caller
+    }
+    if (nodeNum == null) continue;
+    const n = Number(nodeNum);
+    if (Number.isFinite(n) && !nums.includes(n)) nums.push(n);
+  }
+  return nums;
+}
+
+/** True when `nodeNum` is the local node of ANY registered source. */
+export function isOwnNodeNum(nodeNum: number | null | undefined): boolean {
+  if (nodeNum == null) return false;
+  const n = Number(nodeNum);
+  if (!Number.isFinite(n)) return false;
+  return getOwnNodeNums().includes(n);
+}


### PR DESCRIPTION
Closes #4593.

## Diagnosis confirmed empirically

`git show <base>:src/server/mqttIngestion.ts | grep -n "dataEventEmitter\|notificationService"` returned **nothing** — the file had zero references to either. Both insert sites the issue named were exactly right (lines 494 and 1047), both fire-and-forget `insertMessage(...).catch(...)` with the return value discarded.

Proved by test rather than inference: the regression tests were written first and run with only `mqttIngestion.ts` stashed — **3 of 6 failed**, and pass with the fix.

**One thing the issue missed:** only two things consume the bus — the Automation Engine *and* `webSocketService.ts:232`. So MQTT sources weren't just missing automations and alerts; **live WebSocket updates were dead too.**

**Both insert sites are distinct paths, but not the DM/broadcast split you'd assume.** Site 1 is `TEXT_MESSAGE_APP` handling *both* DM and broadcast (it computes `isDirectMessage` and forces `channel: -1`). Site 2 is inside `ingestStoreForward` — a Store & Forward replay with its own dedup. Both fixed.

## The self-loop hazard was real — and this fix would have re-opened it

The #3914 self-origin guard **does not protect MQTT bridges**:

- `MqttBridgeManager.getLocalNodeInfo()` returns `null` (`mqttBridgeManager.ts:489-491`). #3914 resolves identity via `registry.getManager(sourceId)?.getLocalNodeInfo()?.nodeNum`, so on a bridge it resolved `null` and **dropped nothing**.
- Neither MQTT manager has `sendTextMessage`, so an automation can't reply *on* the bridge — but `action.sendMessage` takes an arbitrary target `sourceId`, so the loop is **cross-source**: bridge trigger → reply sent on a Meshtastic source → a third-party gateway uplinks it → the bridge downlinks our own message back → trigger again, forever.
- The row-id dedup that protects the TCP path does **not** help here: ids are `${sourceId}_${fromNum}_${packetId}`, so the bridge's copy is a genuinely new row.

Three guards, matching how the existing paths do it:

1. **Insert-dedup** — mirrors meshtastic's `if (wasInserted)`; hooks fire only when `insertMessage` actually created a row, so a second gateway relaying the same packet triggers nothing.
2. **Cross-source self-origin** — new `src/server/utils/ownNodes.ts` reads every registered manager's local node live. `isSelfMeshtastic` checks the event's own source first (unchanged behaviour), then falls back to the owned-node set. Empty registry ⇒ empty set ⇒ nothing dropped, matching #3914's fail-open convention.
3. **The emit itself is deliberately not suppressed** — WebSocket clients still get live updates for our own traffic; only the automation trigger and push alert are suppressed.

Proof the guard is load-bearing: stashing only `automationEngineService.ts` makes the self-loop test fail while the others pass.

## Also in here

`sendMessagePushNotification` moves out of `meshtasticManager` into `src/server/services/messagePushNotifier.ts` so both ingestion paths share it, with a `CHANNEL_DB_OFFSET` channel-name fallback so MQTT virtual channels show a name instead of `Channel 100003`. The meshtastic method becomes a thin wrapper that keeps its existing "no notification service ⇒ bail before the settings read" hot path.

## Verification

- New/changed suites: `success: true`, **73 passed, 0 failed**
- `npm run lint:ci`: exit 0. It caught one genuine new violation (`no-useless-assignment`), which is fixed
- `npx tsc -p tsconfig.server.json --noEmit`: no errors

**Full-suite caveat, stated plainly.** In the agent's worktree the full run reports 13,483 passed / 0 failed but `success: false`, from **6 suite-level import errors** (`Failed to resolve import "ts-overlapping-marker-spiderfier-leaflet"` in frontend map hooks). Proven pre-existing worktree `node_modules` drift by stashing all changes and re-running to the identical failure — a known hazard in this repo's shared checkout. CI installs fresh, so **treat CI as the real verdict here, not that local number.**

Separately, `meshtasticManager.lastHeardReplayGuard.test.ts` fails 4 assertions standalone and passes in a full run — also proven pre-existing. It captures `nowSec` at describe-eval and asserts `toBeCloseTo(nowSec, -1)` after a slow dynamic import, so it breaks whenever that import takes ≥5s.

## Out of scope, worth its own issue

The S&F path writes `channel: effectiveChannel` (`mqttIngestion.ts:1088`) even for `ROUTER_TEXT_DIRECT`, so a **replayed DM lands in a channel instead of `-1`**, unlike the live path. Pre-existing; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX