### PR TITLE
docs(link-quality): correct where hopsAway comes from (#4590)

### DIFF
--- a/docs/features/link-quality.md
+++ b/docs/features/link-quality.md
@@ -99,9 +99,11 @@ Controls how much historical data is displayed in the graphs.
 
 Controls how the hop count is determined for the node list display, map marker colors, and Messages node details (separate from Smart Hops):
 
-- **NodeInfo packet (default)**: Uses the `hopsAway` value from the node's most recent NodeInfo broadcast. This is the standard Meshtastic behavior and provides a stable, consistent hop count.
+- **NodeInfo packet (default)**: Uses the `hopsAway` value the radio reports for the node in its own node database. MeshMonitor reads this when it syncs the NodeDB — on connect, on reconnect, and on a manual refresh — **not** on every NodeInfo broadcast it overhears. It is therefore a snapshot rather than a live value: stable and consistent, but it can be arbitrarily out of date for a node that has since moved or gone quiet, and it is never cleared.
 - **Traceroute length**: Uses the shortest path found in traceroute results between your node and the target. Falls back to NodeInfo if no traceroute data is available.
 - **All messages**: Uses the hop count from the most recent packet received from the node — **any packet type**, not just text messages. This includes telemetry, position, NodeInfo, text messages, traceroute responses, and all other packet types. The hop count is derived from the packet's `hopStart - hopLimit` fields, which indicate how many relay hops the packet actually traversed. Falls back to NodeInfo if no message hop data is available.
+
+  Note that `hopStart` is a proto3 scalar, so an unset value decodes as `0` and is indistinguishable from a genuine zero. MeshMonitor therefore only records a hop count when `hopStart > 0`. Packets from older firmware, and some bridged transports that strip the LoRa header, produce no value at all — so this field can be absent for a node you are actively hearing. Like `hopsAway`, it is never cleared, so pair it with `lastHeard` if you need to know whether it is still current.
 
 ::: tip
 Smart Hops always uses actual message hop counts regardless of this setting. The Node Hops Calculation setting only affects the hop count shown in the node list, map markers, and message node details.


### PR DESCRIPTION
Follow-up to #4590, where a user asked which of `hopsAway` / `lastMessageHops` gives a node's current hop state — and cited this page as evidence that `hopsAway` tracks NodeInfo broadcasts.

**It doesn't. That write path is dead code.**

`meshtasticManager.ts:7172` reads `hopsAway` off a `MeshPacket`, and `MeshPacket` has **no `hops_away` field in `mesh.proto` at all** — it exists only on `NodeInfo` (line 2031). Verified at the schema level rather than from the TypeScript types, and the object reaching that code is a genuine protobufjs `MeshPacket`, so no stray field can ride along. The value is always `undefined`, and an over-the-air NodeInfo broadcast never refreshes `hopsAway`.

The only live source is the radio's own NodeDB, read when MeshMonitor syncs it — connect, reconnect, or manual refresh. **There is no periodic timer.**

The irony worth noting: this doc line was the one piece of evidence the user's analysis leaned on, and it's the one place the docs actively mislead — overstating exactly the field that's least fresh.

## Also corrected

Two omissions on the **All messages** option that sent the same user down the wrong path:

- **`lastMessageHops` is only recorded when `hopStart > 0`.** `hop_start` is a proto3 scalar, so unset decodes as `0` and is indistinguishable from a genuine zero — the guard is deliberate. Older firmware and some bridged transports therefore produce no value at all, so the field can be **absent for a node you are actively hearing**. The page previously implied it was recorded for every packet.
- **Neither field is ever cleared.** The page implied `hopsAway` goes stale while `lastMessageHops` stays fresh. In truth `lastMessageHops` is refreshed far more often but has no TTL either — both need pairing with `lastHeard` to mean "current".

## Scope

Docs only — no code change. The dead write path is filed separately as #4604, since fixing it (deriving `hopsAway` from the packet's own `hopStart - hopLimit`) is a behaviour change that deserves its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX