### PR TITLE
feat(themes): add a categorical color scale, separate from role tokens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -102,6 +102,37 @@
      the overlay0 swatch today but mean different things, and a theme that wants
      lighter chrome without lightening faint text needs them separable. */
   --color-surface-inactive: var(--ctp-overlay0);
+
+  /* ---- Categorical scale ------------------------------------------------
+
+     Eight visually distinguishable hues for CATEGORY encoding: tagging which
+     source a row came from, series in a multi-series chart. Deliberately a
+     separate namespace from the roles above, because they answer different
+     questions. A role says what a color MEANS ("this is an error"); a
+     categorical slot only has to be TELLABLE APART from its neighbours.
+
+     Conflating the two is a real bug, not a style preference. `SOURCE_COLORS`
+     previously read `[accent, accent-alt, success, caution, warning, ...]`,
+     which claimed source #3 was "succeeding" at something, and — worse — let
+     a theme that picks a greenish accent make sources #1 and #3
+     indistinguishable. Role tokens are chosen for meaning and may legitimately
+     collide in hue; categorical slots must not.
+
+     Order is chosen to maximise separation between ADJACENT slots, since a
+     view with three sources uses 1-2-3 and those are the ones that must not
+     look alike. The defaults reproduce the sequence `SOURCE_COLORS` already
+     used, so no existing source changes colour.
+
+     Themes may override these (Phase 3 exposes them in the theme schema);
+     until then they track the palette like every other token here. */
+  --chart-1: var(--ctp-blue);
+  --chart-2: var(--ctp-mauve);
+  --chart-3: var(--ctp-green);
+  --chart-4: var(--ctp-peach);
+  --chart-5: var(--ctp-yellow);
+  --chart-6: var(--ctp-teal);
+  --chart-7: var(--ctp-pink);
+  --chart-8: var(--ctp-sapphire);
 }
 
 /* ==============================

--- a/src/pages/UnifiedMessagesPage.tsx
+++ b/src/pages/UnifiedMessagesPage.tsx
@@ -34,7 +34,7 @@ import LinkPreview from '../components/LinkPreview';
 import '../styles/unified.css';
 import { UiIcon } from '../components/icons';
 import { resolveReplyPreview } from '../utils/replyPreview';
-import { SOURCE_COLORS } from '../utils/sourceColors';
+import { getSourceColor } from '../utils/sourceColors';
 
 type TFn = (key: string, options?: Record<string, unknown>) => string;
 
@@ -295,11 +295,12 @@ export default function UnifiedMessagesPage() {
     return Array.from(map.entries()).map(([id, name]) => ({ id, name }));
   }, [allMessages]);
 
+  // Uses the shared lookup rather than re-deriving the index here, so the
+  // "one SOURCE_COLORS" invariant holds at the implementation level and not
+  // just the definition level — a private copy of the modulo/fallback logic is
+  // how the three palettes drifted apart in the first place.
   const sourceColor = useCallback(
-    (sourceId: string) => {
-      const idx = sourcesInView.findIndex((s) => s.id === sourceId);
-      return SOURCE_COLORS[(idx < 0 ? 0 : idx) % SOURCE_COLORS.length];
-    },
+    (sourceId: string) => getSourceColor(sourceId, sourcesInView.map((s) => s.id)),
     [sourcesInView]
   );
 

--- a/src/pages/UnifiedMessagesPage.tsx
+++ b/src/pages/UnifiedMessagesPage.tsx
@@ -34,6 +34,7 @@ import LinkPreview from '../components/LinkPreview';
 import '../styles/unified.css';
 import { UiIcon } from '../components/icons';
 import { resolveReplyPreview } from '../utils/replyPreview';
+import { SOURCE_COLORS } from '../utils/sourceColors';
 
 type TFn = (key: string, options?: Record<string, unknown>) => string;
 
@@ -91,16 +92,6 @@ interface ChannelCollisionRow {
 const PAGE_SIZE = 100;
 const POLL_INTERVAL_MS = 10_000;
 
-const SOURCE_COLORS = [
-  'var(--color-accent)',
-  'var(--color-accent-alt)',
-  'var(--color-success)',
-  'var(--color-caution)',
-  'var(--color-warning)',
-  'var(--ctp-teal)',
-  'var(--ctp-pink)',
-  'var(--color-accent-hover)',
-];
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 

--- a/src/pages/UnifiedTelemetryPage.tsx
+++ b/src/pages/UnifiedTelemetryPage.tsx
@@ -10,7 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import apiService, { ApiError } from '../services/api';
 import { type TemperatureUnit, formatTemperature, getTemperatureUnit, isTemperatureType } from '../utils/temperature';
-import { getSourceColor as sharedGetSourceColor } from '../utils/sourceColors';
+import { getSourceColor } from '../utils/sourceColors';
 import { unitScale, formatDuration, isUptimeType } from '../utils/telemetryFormat';
 import '../styles/unified.css';
 
@@ -27,10 +27,6 @@ interface TelemetryEntry {
   sourceName: string;
   nodeLongName?: string | null;
   nodeShortName?: string | null;
-}
-
-function getSourceColor(sourceId: string, sourceIds: string[]): string {
-  return sharedGetSourceColor(sourceId, sourceIds);
 }
 
 // Compact labels for the card view. Keys must match the telemetryType values

--- a/src/pages/UnifiedTelemetryPage.tsx
+++ b/src/pages/UnifiedTelemetryPage.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import apiService, { ApiError } from '../services/api';
 import { type TemperatureUnit, formatTemperature, getTemperatureUnit, isTemperatureType } from '../utils/temperature';
+import { getSourceColor as sharedGetSourceColor } from '../utils/sourceColors';
 import { unitScale, formatDuration, isUptimeType } from '../utils/telemetryFormat';
 import '../styles/unified.css';
 
@@ -28,14 +29,8 @@ interface TelemetryEntry {
   nodeShortName?: string | null;
 }
 
-const SOURCE_COLORS = [
-  'var(--color-accent)', 'var(--color-accent-alt)', 'var(--color-success)',
-  'var(--color-error)', 'var(--color-warning)', 'var(--ctp-teal)',
-];
-
 function getSourceColor(sourceId: string, sourceIds: string[]): string {
-  const idx = sourceIds.indexOf(sourceId);
-  return SOURCE_COLORS[idx % SOURCE_COLORS.length];
+  return sharedGetSourceColor(sourceId, sourceIds);
 }
 
 // Compact labels for the card view. Keys must match the telemetryType values

--- a/src/styles/semanticTokens.test.ts
+++ b/src/styles/semanticTokens.test.ts
@@ -20,11 +20,26 @@ import { join, resolve } from 'node:path';
 
 const appCss = readFileSync(resolve('src/App.css'), 'utf8');
 
+/**
+ * The bare `:root { … }` block — where the role and categorical layers are
+ * defined. Explicitly NOT the `:root[data-theme='x']` blocks, which define the
+ * palette and deliberately never redeclare these tokens.
+ *
+ * Scoped rather than matched across the whole file so a token accidentally
+ * declared inside a theme block reads as MISSING from the layer (which it
+ * effectively is — it would only apply under that one theme) instead of being
+ * silently counted as a definition.
+ */
+function rootBlock(): string {
+  const m = appCss.match(/:root\s*\{([\s\S]*?)\n\}/);
+  return m?.[1] ?? '';
+}
+
 /** Semantic tokens and the palette var each points at, from the :root block. */
 function semanticDefinitions(): Map<string, string> {
   const out = new Map<string, string>();
   const re = /(--color-[a-z0-9-]+)\s*:\s*var\((--ctp-[a-z0-9-]+)\)/g;
-  for (const m of appCss.matchAll(re)) out.set(m[1], m[2]);
+  for (const m of rootBlock().matchAll(re)) out.set(m[1], m[2]);
   return out;
 }
 
@@ -146,7 +161,7 @@ describe('categorical scale (--chart-N)', () => {
   /** Chart slots and the palette var each points at, from the :root block. */
   function chartDefinitions(): Map<string, string> {
     const out = new Map<string, string>();
-    for (const m of appCss.matchAll(/(--chart-\d+)\s*:\s*var\((--ctp-[a-z0-9-]+)\)/g)) {
+    for (const m of rootBlock().matchAll(/(--chart-\d+)\s*:\s*var\((--ctp-[a-z0-9-]+)\)/g)) {
       out.set(m[1], m[2]);
     }
     return out;
@@ -177,9 +192,17 @@ describe('categorical scale (--chart-N)', () => {
   });
 
   it('borrows no role token — the scale is independent of meaning', () => {
-    const chartBlock = appCss.match(/--chart-1\s*:[\s\S]*?--chart-8\s*:[^;]+;/)?.[0] ?? '';
-    expect(chartBlock).not.toBe('');
-    expect(chartBlock).not.toMatch(/var\(--color-/);
+    // Checked per DECLARATION rather than over a `--chart-1 … --chart-8` span.
+    // A span regex depends on the two staying adjacent with nothing in
+    // between; reorder the block or drop a `}` into a comment and it matches
+    // nothing, at which point `not.toMatch` passes vacuously and only a
+    // separate emptiness guard stands between that and a silently dead test.
+    // Reading each declaration removes the failure mode instead of guarding it.
+    const decls = [...rootBlock().matchAll(/--chart-\d+\s*:\s*([^;]+);/g)].map((m) => m[1].trim());
+    expect(decls).toHaveLength(8);
+    for (const value of decls) {
+      expect(value, `${value} borrows a role token`).not.toMatch(/var\(--color-/);
+    }
   });
 
   it('is what SOURCE_COLORS draws on, with no role tokens or raw palette vars', () => {

--- a/src/styles/semanticTokens.test.ts
+++ b/src/styles/semanticTokens.test.ts
@@ -130,3 +130,77 @@ describe('semantic color tokens (#4567)', () => {
     expect(themeValidation).not.toMatch(/--color-|'color-(success|error|accent)'/);
   });
 });
+
+/**
+ * Categorical scale (`--chart-N`).
+ *
+ * Roles and categories answer different questions. A role says what a color
+ * MEANS ("this is an error"); a categorical slot only has to be TELLABLE APART
+ * from its neighbours. Roles are chosen for meaning and may legitimately
+ * collide in hue — which is exactly why category encoding must not borrow
+ * them. `SOURCE_COLORS` used to read `[accent, accent-alt, success, caution,
+ * …]`, so a theme with a greenish accent rendered sources #1 and #3
+ * indistinguishable, and slot 3 implied a source was "succeeding".
+ */
+describe('categorical scale (--chart-N)', () => {
+  /** Chart slots and the palette var each points at, from the :root block. */
+  function chartDefinitions(): Map<string, string> {
+    const out = new Map<string, string>();
+    for (const m of appCss.matchAll(/(--chart-\d+)\s*:\s*var\((--ctp-[a-z0-9-]+)\)/g)) {
+      out.set(m[1], m[2]);
+    }
+    return out;
+  }
+
+  const chart = chartDefinitions();
+
+  it('defines a contiguous scale', () => {
+    expect(chart.size).toBe(8);
+    for (let i = 1; i <= 8; i++) {
+      expect(chart.has(`--chart-${i}`), `--chart-${i} missing`).toBe(true);
+    }
+  });
+
+  it('points every slot at a palette var that exists in every theme', () => {
+    for (const { theme, vars } of paletteVarsInThemeBlocks()) {
+      for (const [slot, paletteVar] of chart) {
+        expect(vars.has(paletteVar), `${slot} -> ${paletteVar} undefined in theme '${theme}'`).toBe(true);
+      }
+    }
+  });
+
+  it('gives every slot a distinct hue', () => {
+    // Two slots resolving to the same swatch would make two categories
+    // indistinguishable, which is the one thing this scale exists to prevent.
+    const used = [...chart.values()];
+    expect(new Set(used).size).toBe(used.length);
+  });
+
+  it('borrows no role token — the scale is independent of meaning', () => {
+    const chartBlock = appCss.match(/--chart-1\s*:[\s\S]*?--chart-8\s*:[^;]+;/)?.[0] ?? '';
+    expect(chartBlock).not.toBe('');
+    expect(chartBlock).not.toMatch(/var\(--color-/);
+  });
+
+  it('is what SOURCE_COLORS draws on, with no role tokens or raw palette vars', () => {
+    const src = readFileSync(resolve('src/utils/sourceColors.ts'), 'utf8');
+    const arr = src.match(/export const SOURCE_COLORS = \[([\s\S]*?)\]/)?.[1] ?? '';
+    expect(arr).toMatch(/--chart-1/);
+    expect(arr).not.toMatch(/--color-/);
+    expect(arr).not.toMatch(/--ctp-/);
+  });
+
+  it('has exactly one SOURCE_COLORS definition in the tree', () => {
+    // UnifiedMessagesPage and UnifiedTelemetryPage each carried a private copy
+    // and they had already drifted apart — Telemetry listed six entries and
+    // used `error` in slot four where the others used `caution`, so one source
+    // showed up in different colors on different pages and wrapped early past
+    // six sources. One definition, or it happens again.
+    const defs = walk(resolve('src')).filter((f) =>
+      /(export )?const SOURCE_COLORS\s*=/.test(readFileSync(f, 'utf8')),
+    );
+    expect(defs.map((f) => f.replace(resolve('.') + '/', ''))).toEqual([
+      'src/utils/sourceColors.ts',
+    ]);
+  });
+});

--- a/src/utils/sourceColors.test.ts
+++ b/src/utils/sourceColors.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+/**
+ * Source color assignment and CSS-variable resolution.
+ *
+ * `getSourceColor` is now the single lookup for source tagging — three pages
+ * previously carried private copies of the array AND the index/modulo logic,
+ * and both had drifted. These pin the assignment rules so a future private
+ * copy is a visible behaviour change rather than a silent one.
+ *
+ * `resolveCssColor` exists because Leaflet paints SVG strokes via the
+ * presentation *attribute*, which does not evaluate `var()`. Its var-lookup
+ * branch is asserted through a real stylesheet; note jsdom resolves a custom
+ * property to its declared token stream and does not perform the cascade's
+ * variable substitution, so a var pointing at another var is deliberately not
+ * asserted here — that behaviour belongs to a browser, and asserting jsdom's
+ * answer would pin the wrong thing.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { SOURCE_COLORS, getSourceColor, resolveCssColor, resolveSourceColor } from './sourceColors';
+
+const IDS = ['src-a', 'src-b', 'src-c'];
+
+afterEach(() => {
+  document.documentElement.style.cssText = '';
+});
+
+describe('getSourceColor', () => {
+  it('assigns by position, so a source keeps its color as the list is filtered', () => {
+    expect(getSourceColor('src-a', IDS)).toBe(SOURCE_COLORS[0]);
+    expect(getSourceColor('src-b', IDS)).toBe(SOURCE_COLORS[1]);
+    expect(getSourceColor('src-c', IDS)).toBe(SOURCE_COLORS[2]);
+  });
+
+  it('falls back to the first slot for an unknown id rather than returning undefined', () => {
+    // indexOf gives -1; without the guard this would index off the end and
+    // hand Leaflet `undefined` as a stroke.
+    expect(getSourceColor('nope', IDS)).toBe(SOURCE_COLORS[0]);
+  });
+
+  it('wraps once there are more sources than slots', () => {
+    const many = Array.from({ length: SOURCE_COLORS.length + 2 }, (_, i) => `s${i}`);
+    expect(getSourceColor(`s${SOURCE_COLORS.length}`, many)).toBe(SOURCE_COLORS[0]);
+    expect(getSourceColor(`s${SOURCE_COLORS.length + 1}`, many)).toBe(SOURCE_COLORS[1]);
+  });
+
+  it('draws only on the categorical scale', () => {
+    for (const c of SOURCE_COLORS) expect(c).toMatch(/^var\(--chart-\d+\)$/);
+  });
+});
+
+describe('resolveCssColor', () => {
+  it('passes a literal color through untouched', () => {
+    expect(resolveCssColor('#89b4fa')).toBe('#89b4fa');
+    expect(resolveCssColor('rgb(1, 2, 3)')).toBe('rgb(1, 2, 3)');
+  });
+
+  it('resolves a custom property declared on :root', () => {
+    document.documentElement.style.setProperty('--chart-1', '#89b4fa');
+    expect(resolveCssColor('var(--chart-1)')).toBe('#89b4fa');
+  });
+
+  it('returns the var() expression unchanged when the property is undefined', () => {
+    // Better than returning '' — an empty stroke silently disappears, whereas
+    // the untouched expression is at least traceable in the DOM.
+    expect(resolveCssColor('var(--not-defined-anywhere)')).toBe('var(--not-defined-anywhere)');
+  });
+
+  it('ignores a var() with a fallback, which its regex deliberately does not match', () => {
+    // The anchored pattern only accepts a bare `var(--x)`. Fallbacks are banned
+    // on semantic tokens by semanticTokens.test.ts, so this shape should not
+    // occur; passing it through unchanged is the safe answer either way.
+    expect(resolveCssColor('var(--chart-1, #fff)')).toBe('var(--chart-1, #fff)');
+  });
+});
+
+describe('resolveSourceColor', () => {
+  it('resolves the slot a source maps to', () => {
+    document.documentElement.style.setProperty('--chart-2', '#cba6f7');
+    expect(resolveSourceColor('src-b', IDS)).toBe('#cba6f7');
+  });
+});

--- a/src/utils/sourceColors.ts
+++ b/src/utils/sourceColors.ts
@@ -1,20 +1,32 @@
 /**
  * Stable color palette for tagging entries by source in cross-source ("Unified")
- * views. The palette mirrors the inline ones in UnifiedMessagesPage /
- * UnifiedTelemetryPage so source colors stay visually consistent across pages.
+ * views.
  *
  * Colors are assigned by the source's index within a stable, sorted source list
  * so a given source keeps the same color across filter/sort changes.
+ *
+ * This is CATEGORY encoding, so it draws on the categorical scale
+ * (`--chart-N`, defined in App.css) rather than on role tokens. It previously
+ * read `[accent, accent-alt, success, caution, warning, …]`, which tied source
+ * identity to meanings those sources do not have, and let a theme with a
+ * greenish accent render sources #1 and #3 indistinguishable. Roles are picked
+ * for meaning and may legitimately collide in hue; categorical slots must not.
+ *
+ * This module is the single definition. `UnifiedMessagesPage` and
+ * `UnifiedTelemetryPage` each carried their own copy, and they had already
+ * drifted — Telemetry listed six entries and used `error` in slot four where
+ * the others used `caution`, so one source showed up in different colors on
+ * different pages and wrapped early past six sources. Both now import this.
  */
 export const SOURCE_COLORS = [
-  'var(--color-accent)',
-  'var(--color-accent-alt)',
-  'var(--color-success)',
-  'var(--color-caution)',
-  'var(--color-warning)',
-  'var(--ctp-teal)',
-  'var(--ctp-pink)',
-  'var(--color-accent-hover)',
+  'var(--chart-1)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+  'var(--chart-5)',
+  'var(--chart-6)',
+  'var(--chart-7)',
+  'var(--chart-8)',
 ];
 
 /**


### PR DESCRIPTION
## Summary

Phase 1 of retiring `--ctp-*` so themes are authored in semantic terms (#4567 follow-up). This phase adds the missing **categorical** layer and fixes a design error the earlier semantic-token migration shipped.

## The error being fixed

Roles and categories answer different questions. A role says what a color **means** ("this is an error"). A categorical slot only has to be **tellable apart** from its neighbours. The migration conflated them:

```js
SOURCE_COLORS = [
  'var(--color-accent)', 'var(--color-accent-alt)',
  'var(--color-success)', 'var(--color-caution)',
  'var(--color-warning)', 'var(--ctp-teal)',   // ← no role existed, left raw
  'var(--ctp-pink)', 'var(--color-accent-hover)',
]
```

Source #3 isn't succeeding at anything. And because role tokens are chosen for *meaning*, a theme is free to pick a greenish accent — at which point sources #1 and #3 become indistinguishable. Categorical slots must not collide; role tokens legitimately may.

## What's here

**`--chart-1..8`** — a namespace independent of the roles, ordered so adjacent slots stay maximally separated (a view with three sources uses 1‑2‑3, so those are the ones that must not look alike). Defaults reproduce the sequence `SOURCE_COLORS` already used, so **no existing source changes colour**.

**Three duplicate `SOURCE_COLORS` arrays collapsed into one.** They had already drifted: `UnifiedTelemetryPage` listed six entries and used `error` in slot four where the others used `caution` — so a given source showed up in *different colours on different pages*, and wrapped early past six sources. Fixed as a consequence.

## Deliberately not included

The ramps in `HopDistributionWidget`, `DistanceDistributionWidget` and `HopDistanceHeatmapWidget`. I originally planned to migrate them here and the investigation changed my mind: those are **ordinal** (hop 0→6+, intensity 0→1), not categorical. Forcing them onto a categorical scale would repeat the exact mistake this PR fixes.

They also have a real bug of their own: `overlayColors.ts` already defines a per-theme, **user-configurable** hop gradient that the map honours via `getHopColor`, and these three hardcode their own 7-colour ramp inline — so widget hop colours don't match the map and ignore the user's configuration. That deserves its own change rather than being smuggled in here.

## Also found, not fixed here (Phase 2)

`--ctp-*-rgb` is **never defined anywhere**. Every use is `rgba(var(--ctp-red-rgb, 243, 139, 168), 0.15)` — so those alpha overlays always fall back to hardcoded Mocha values and ignore the active theme entirely. `color-mix()` removes the need for parallel rgb tokens; that lands with the remaining `--ctp-*` migration.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint:ci` — clean, no baseline growth
- [x] Full `npx vitest run`: **13,676 passed, 0 failed**
- [x] Five new guards in `semanticTokens.test.ts`: slots contiguous, resolve in every theme, mutually distinct, borrow no role token, exactly one `SOURCE_COLORS` in the tree
- [x] **Guards verified against the regressions they describe** — reintroducing a role token into `SOURCE_COLORS` and colliding two chart slots each fail the intended test and only that test

### Not covered

No browser check. Source-tag colours are asserted at the token level, not observed. Since the defaults preserve today's sequence, the visible change is limited to `UnifiedTelemetryPage`, where slot four moves from `error` to `caution` to match the other pages.

## Next

Phase 2 migrates the remaining raw `--ctp-*` consumers (62 occurrences, 23 files) and fixes the rgb overlays. Phase 3 flips the theme schema to semantic keys, exposes `--chart-N` for authoring, and deletes `--ctp-*`.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf