### PR TITLE
feat(themes): add a sequential scale; fix the magnitude ramps (Phase 2a)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -146,6 +146,35 @@
   --chart-6: var(--ctp-sapphire);
   --chart-7: var(--ctp-maroon);
   --chart-8: var(--ctp-rosewater);
+
+  /* ---- Sequential scale --------------------------------------------------
+
+     Five ordered steps for MAGNITUDE encoding: how far, how many, how dense.
+     The third kind of color in this file, and the distinction is the same one
+     that separates roles from categories. A role says what a color MEANS; a
+     categorical slot only has to differ from its neighbours; a sequential step
+     has to READ AS ORDERED — step 4 must look like "more" than step 2.
+
+     Categorical hues cannot do that job. `DistanceDistributionWidget` indexed
+     a 7-hue list by histogram position, and `HopDistanceHeatmapWidget` walked
+     surface -> blue -> sapphire -> teal for rising density, so neither ramp
+     read as ordered — and both reached past the role layer into raw `--ctp-*`
+     for hues no role provided. Pointing them at `--chart-N` would have been
+     the same category error in a new place.
+
+     Built with color-mix from the accent rather than picked from the palette,
+     which buys three things the palette cannot: the steps are monotonic BY
+     CONSTRUCTION; they can never collide (the failure that made --chart-6 and
+     --chart-8 render identically in Nord); and they track whatever accent a
+     theme sets without adding five more entries to every theme block.
+
+     Mixed toward `--color-surface` rather than `transparent` so the low steps
+     stay legible on any background instead of dissolving into it. */
+  --seq-1: color-mix(in srgb, var(--color-accent) 20%, var(--color-surface));
+  --seq-2: color-mix(in srgb, var(--color-accent) 40%, var(--color-surface));
+  --seq-3: color-mix(in srgb, var(--color-accent) 60%, var(--color-surface));
+  --seq-4: color-mix(in srgb, var(--color-accent) 80%, var(--color-surface));
+  --seq-5: var(--color-accent);
 }
 
 /* ==============================

--- a/src/components/DistanceDistributionWidget.tsx
+++ b/src/components/DistanceDistributionWidget.tsx
@@ -124,20 +124,15 @@ const DistanceDistributionWidget: React.FC<DistanceDistributionWidgetProps> = ({
     setShowSettings(false);
   }, [onBucketSizeChange]);
 
-  // Color gradient based on distance
+  // Bucket position is a MAGNITUDE (nearer -> further), so it uses the ordered
+  // sequential scale. The previous list walked green -> teal -> blue -> lavender
+  // -> mauve -> pink -> red: seven distinguishable hues, but nothing about them
+  // says "further", and two reached past the role layer into raw --ctp-*.
+  const SEQ_STEPS = 5;
   const getBarColor = (index: number, total: number): string => {
-    const colors = [
-      'var(--color-success)',
-      'var(--ctp-teal)',
-      'var(--color-accent)',
-      'var(--color-accent-muted)',
-      'var(--color-accent-alt)',
-      'var(--ctp-pink)',
-      'var(--color-error)',
-    ];
-    if (total <= 1) return colors[0];
-    const colorIndex = Math.round((index / (total - 1)) * (colors.length - 1));
-    return colors[colorIndex];
+    if (total <= 1) return 'var(--seq-1)';
+    const step = Math.round((index / (total - 1)) * (SEQ_STEPS - 1)) + 1;
+    return `var(--seq-${step})`;
   };
 
   const hasHomePosition = homeNode?.position?.latitude != null && homeNode?.position?.longitude != null;

--- a/src/components/HopDistanceHeatmapWidget.tsx
+++ b/src/components/HopDistanceHeatmapWidget.tsx
@@ -152,10 +152,17 @@ const HopDistanceHeatmapWidget: React.FC<HopDistanceHeatmapWidgetProps> = ({
   const getCellStyle = (count: number): { backgroundColor: string; color: string; opacity: number } => {
     if (count === 0) return { backgroundColor: 'transparent', color: 'var(--color-text)', opacity: 0 };
     const intensity = count / maxCount;
-    if (intensity <= 0.25) return { backgroundColor: 'var(--color-surface-hover)', color: 'var(--color-text)', opacity: 1 };
-    if (intensity <= 0.5) return { backgroundColor: 'var(--color-accent)', color: 'var(--color-bg-sunken)', opacity: 1 };
-    if (intensity <= 0.75) return { backgroundColor: 'var(--color-accent-hover)', color: 'var(--color-bg-sunken)', opacity: 1 };
-    return { backgroundColor: 'var(--ctp-teal)', color: 'var(--color-bg-sunken)', opacity: 1 };
+    // Density is a MAGNITUDE, so the cells walk the ordered sequential scale.
+    // The previous steps were surface-hover -> accent -> accent-hover -> teal:
+    // the last two are near-neighbours in some themes and identical in others
+    // (Nord has no separate sapphire and teal), so the top two density bands
+    // were not reliably tellable apart — and teal reached past the role layer.
+    // Text flips to the sunken background from --seq-3 up, where the fill is
+    // saturated enough that light-on-color stops reading.
+    if (intensity <= 0.25) return { backgroundColor: 'var(--seq-1)', color: 'var(--color-text)', opacity: 1 };
+    if (intensity <= 0.5) return { backgroundColor: 'var(--seq-2)', color: 'var(--color-text)', opacity: 1 };
+    if (intensity <= 0.75) return { backgroundColor: 'var(--seq-3)', color: 'var(--color-bg-sunken)', opacity: 1 };
+    return { backgroundColor: 'var(--seq-5)', color: 'var(--color-bg-sunken)', opacity: 1 };
   };
 
   const hasHomePosition = homeNode?.position?.latitude != null && homeNode?.position?.longitude != null;
@@ -266,10 +273,12 @@ const HopDistanceHeatmapWidget: React.FC<HopDistanceHeatmapWidgetProps> = ({
             <div className="heatmap-legend">
               <span className="heatmap-legend-label">{t('dashboard.widget.hop_distance_heatmap.fewer')}</span>
               <div className="heatmap-legend-bar">
-                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--color-surface-hover)' }} />
-                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--color-accent)' }} />
-                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--color-accent-hover)' }} />
-                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--ctp-teal)' }} />
+                {/* Must match getCellStyle's bands exactly, or the legend
+                    describes a scale the cells do not use. */}
+                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--seq-1)' }} />
+                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--seq-2)' }} />
+                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--seq-3)' }} />
+                <span className="heatmap-legend-cell" style={{ backgroundColor: 'var(--seq-5)' }} />
               </div>
               <span className="heatmap-legend-label">{t('dashboard.widget.hop_distance_heatmap.more')}</span>
             </div>

--- a/src/components/HopDistributionWidget.test.tsx
+++ b/src/components/HopDistributionWidget.test.tsx
@@ -37,6 +37,24 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+// The widget now reads `overlayColors.hopColors` so its bars use the same hop
+// scale as the map. Mock the hook rather than widening the react-i18next mock:
+// loading the real SettingsContext drags in `initReactI18next`, which this
+// file's partial i18n mock does not provide, and this test has no interest in
+// settings beyond the gradient.
+vi.mock('../contexts/SettingsContext', () => ({
+  useSettings: () => ({
+    overlayColors: {
+      hopColors: {
+        local: '#22c55e',
+        noData: '#9ca3af',
+        max: '#FF0000',
+        gradient: ['#0000FF', '#3300CC', '#660099', '#990066', '#CC0033', '#FF0000'],
+      },
+    },
+  }),
+}));
+
 import HopDistributionWidget from './HopDistributionWidget';
 
 type NodeInfo = {

--- a/src/components/HopDistributionWidget.tsx
+++ b/src/components/HopDistributionWidget.tsx
@@ -10,6 +10,8 @@ import { useTranslation } from 'react-i18next';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { type NodeInfo } from './TelemetryChart';
+import { getHopColor } from '../utils/mapIcons';
+import { useSettings } from '../contexts/SettingsContext';
 
 interface HopDistributionWidgetProps {
   id: string;
@@ -33,6 +35,7 @@ const HopDistributionWidget: React.FC<HopDistributionWidgetProps> = ({
   canEdit = true,
 }) => {
   const { t } = useTranslation();
+  const { overlayColors } = useSettings();
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
 
@@ -82,20 +85,15 @@ const HopDistributionWidget: React.FC<HopDistributionWidgetProps> = ({
 
   const maxCount = Math.max(...buckets.map(b => b.count), 1);
 
-  // Color gradient from green (close) to yellow to red (far)
-  const getBarColor = (hop: number | string): string => {
-    if (typeof hop === 'string') return 'var(--color-text-disabled)';
-    const colors = [
-      'var(--color-success)',
-      'var(--ctp-teal)',
-      'var(--color-accent)',
-      'var(--color-accent-muted)',
-      'var(--color-accent-alt)',
-      'var(--ctp-pink)',
-      'var(--color-error)',
-    ];
-    return colors[Math.min(hop, colors.length - 1)];
-  };
+  // These bars ARE hop counts, so they use the same hop scale the map does
+  // (`getHopColor` + `overlayColors.hopColors`) rather than a private list.
+  // The private list disagreed with the map — 2 hops was blue there and teal
+  // here — and silently ignored the user's configured gradient, which is the
+  // whole point of `hopColors` being configurable.
+  const getBarColor = (hop: number | string): string =>
+    typeof hop === 'string'
+      ? 'var(--color-text-disabled)'
+      : getHopColor(hop, overlayColors.hopColors);
 
   return (
     <div ref={setNodeRef} style={style} className="dashboard-chart-container hop-distribution-widget">

--- a/src/styles/semanticTokens.test.ts
+++ b/src/styles/semanticTokens.test.ts
@@ -294,3 +294,72 @@ describe('categorical scale (--chart-N)', () => {
     ]);
   });
 });
+
+/**
+ * Sequential scale (`--seq-N`).
+ *
+ * Magnitude encoding — how far, how many, how dense. Distinct from both roles
+ * (what a color MEANS) and categories (merely tellable apart): a sequential
+ * step has to READ AS ORDERED. Built with color-mix from the accent so the
+ * steps are monotonic by construction and cannot collide the way two palette
+ * picks can.
+ */
+describe('sequential scale (--seq-N)', () => {
+  const decls = new Map<string, string>();
+  for (const m of rootBlock().matchAll(/(--seq-\d+)\s*:\s*([^;]+);/g)) {
+    decls.set(m[1], m[2].trim());
+  }
+
+  it('defines a contiguous scale', () => {
+    expect(decls.size).toBe(5);
+    for (let i = 1; i <= 5; i++) expect(decls.has(`--seq-${i}`), `--seq-${i} missing`).toBe(true);
+  });
+
+  it('derives every step from the accent, so a theme change carries through', () => {
+    for (const [name, value] of decls) {
+      expect(value, `${name} does not reference the accent`).toMatch(/var\(--color-accent\)/);
+    }
+  });
+
+  it('increases monotonically, which is the whole point of a sequential scale', () => {
+    // Steps 1-4 are color-mix percentages; step 5 is the undiluted accent.
+    // Reading the percentages proves ordering without needing to render.
+    const pct: number[] = [];
+    for (let i = 1; i <= 4; i++) {
+      const m = decls.get(`--seq-${i}`)!.match(/var\(--color-accent\)\s+(\d+)%/);
+      expect(m, `--seq-${i} is not a color-mix percentage`).not.toBeNull();
+      pct.push(Number(m![1]));
+    }
+    expect(pct).toEqual([...pct].sort((a, b) => a - b));
+    expect(new Set(pct).size).toBe(pct.length);
+    expect(Math.max(...pct)).toBeLessThan(100);
+    expect(decls.get('--seq-5')).toBe('var(--color-accent)');
+  });
+
+  it('borrows no categorical slot — magnitude and category stay separate', () => {
+    for (const [name, value] of decls) {
+      expect(value, `${name} borrows a --chart-N slot`).not.toMatch(/var\(--chart-/);
+    }
+  });
+
+  it('is what the magnitude widgets draw on, with no raw palette vars', () => {
+    // These three encoded magnitude with categorical hues and reached past the
+    // role layer for the ones no role provided. Pin that they don't again.
+    for (const f of [
+      'src/components/DistanceDistributionWidget.tsx',
+      'src/components/HopDistanceHeatmapWidget.tsx',
+    ]) {
+      const text = readFileSync(resolve(f), 'utf8');
+      expect(text, `${f} still reads a raw palette var`).not.toMatch(/var\(--ctp-/);
+      expect(text, `${f} does not use the sequential scale`).toMatch(/var\(--seq-/);
+    }
+  });
+
+  it('routes the hop histogram through the shared hop scale, not a private list', () => {
+    // It IS hops, so it must agree with the map and honour the user's
+    // configured gradient rather than hardcoding its own.
+    const text = readFileSync(resolve('src/components/HopDistributionWidget.tsx'), 'utf8');
+    expect(text).toMatch(/getHopColor\(hop, overlayColors\.hopColors\)/);
+    expect(text).not.toMatch(/var\(--ctp-/);
+  });
+});

--- a/src/styles/semanticTokens.test.ts
+++ b/src/styles/semanticTokens.test.ts
@@ -31,8 +31,32 @@ const appCss = readFileSync(resolve('src/App.css'), 'utf8');
  * silently counted as a definition.
  */
 function rootBlock(): string {
-  const m = appCss.match(/:root\s*\{([\s\S]*?)\n\}/);
-  return m?.[1] ?? '';
+  // Brace-balanced rather than a lazy `[\s\S]*?` up to the first `\n}`.
+  // The lazy form stops at the first line that is just `}`, so a nested rule
+  // or a comment containing one would truncate the block and hide every token
+  // after it. The count assertions below would catch a big truncation, but a
+  // small one could pass while quietly narrowing what the other tests see —
+  // and this block has grown twice already (chart, then seq).
+  // Comments are blanked first: this block is heavily commented, and a `}`
+  // inside prose counts as a closing brace to any scanner that does not strip
+  // them. Verified by dropping a lone `}` into a comment above --chart-1 —
+  // brace-counting alone still truncated there.
+  const css = appCss.replace(/\/\*[\s\S]*?\*\//g, (m) => ' '.repeat(m.length));
+  const start = css.search(/:root\s*\{/);
+  if (start === -1) return '';
+  const open = css.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < css.length; i++) {
+    if (css[i] === '{') depth++;
+    else if (css[i] === '}') {
+      depth--;
+      // Slice from the ORIGINAL text so declarations are returned verbatim;
+      // only the brace scan runs on the blanked copy. Lengths match because
+      // comments are replaced with equal-length spaces, so offsets are stable.
+      if (depth === 0) return appCss.slice(open + 1, i);
+    }
+  }
+  return '';
 }
 
 /** Semantic tokens and the palette var each points at, from the :root block. */


### PR DESCRIPTION
## Summary

Folds in the widget-ramp bug, as asked. Investigating it **corrected my own framing** of it: only *one* of the three widgets is a hop ramp.

| widget | encodes | was | now |
|---|---|---|---|
| `HopDistributionWidget` | hop count | private 7-hue list | shared `getHopColor(hop, overlayColors.hopColors)` |
| `DistanceDistributionWidget` | histogram position | same private list | `--seq-N` |
| `HopDistanceHeatmapWidget` | cell density | surface→blue→sapphire→teal | `--seq-N` |

**The hop one was a genuine bug:** its private list disagreed with the map — 2 hops rendered blue there and teal here — and silently ignored `overlayColors.hopColors`, the gradient the user can configure and the map honours.

**The other two are magnitude, not hops.** Pointing them at `hopColors` would have mislabelled distance buckets as hop counts. Pointing them at `--chart-N` would have repeated the exact category error Phase 1 fixed.

## The third kind of colour

A role says what a colour **means**. A categorical slot only has to **differ** from its neighbours. A sequential step has to **read as ordered** — step 4 must look like "more" than step 2. Categorical hues cannot do that job, which is why both ramps reached past the role layer into raw `--ctp-*` for hues no role provided.

`--seq-1..5` are built with `color-mix` from the accent rather than picked from the palette, which buys three things the palette can't:

- **monotonic by construction** — 20/40/60/80/100%
- **cannot collide** — the failure that made `--chart-6` and `--chart-8` render identically in Nord is structurally impossible here
- **theme-responsive** without five more entries in every theme block

Mixed toward `--color-surface` rather than `transparent`, so low steps stay legible instead of dissolving into the background.

## Browser-verified, not assumed

Across mocha / latte / nord / gruvbox-dark / high-contrast-light:

```
mocha                monotonic=true  distinct=5/5  minStep=0.098
latte                monotonic=true  distinct=5/5  minStep=0.087
nord                 monotonic=true  distinct=5/5  minStep=0.082
gruvbox-dark         monotonic=true  distinct=5/5  minStep=0.085
high-contrast-light  monotonic=true  distinct=5/5  minStep=0.124
```

Luminance direction inverts between dark and light themes, which is correct — the ramp runs surface → accent.

Also fixed: the heatmap **legend** drew a fourth swatch (teal) that no cell used in themes where teal and sapphire coincide. It now mirrors `getCellStyle`'s bands exactly.

## A collection-time break worth naming

Importing `SettingsContext` into `HopDistributionWidget` broke that widget's test suite — the real context pulls in `initReactI18next`, which the file's partial `react-i18next` mock doesn't provide. Mocked `useSettings` there instead of widening the i18n mock, since the test has no interest in settings beyond the gradient.

**It only surfaced because the JSON reporter reported `success: false` with `failed: 0`** — a suite-level collection failure with zero failing assertions. The pass/fail test count alone would have looked clean.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint:ci` — clean
- [x] Full `npx vitest run`: **success=true, 13,693 passed, 0 failed, 0 failed suites**
- [x] Six new guards: contiguous scale, every step derives from the accent, monotonic percentages, borrows no `--chart-N`, magnitude widgets use `--seq-` and no raw palette, hop widget routes through the shared scale
- [x] **Each guard verified to fail against its own regression** (broke monotonicity and reintroduced raw `--ctp-teal`; exactly the two intended tests failed)
- [x] Deployed and confirmed `--seq-*` present in the served bundle before browser-measuring
- [x] Data volumes unchanged (3 before, 3 after)

## Scope

Phase 2**a**. The bulk `--ctp-*` migration (62 occurrences, 20 files) and the never-defined `--ctp-*-rgb` overlays follow in 2b — kept separate because this one is behavioural and that one is mechanical.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf