### PR TITLE
fix(nodes): remove the dead hopsAway write in processNodeInfoMessageProtobuf (#4604)

### DIFF
--- a/src/server/meshtasticManager.hopsAwayField.test.ts
+++ b/src/server/meshtasticManager.hopsAwayField.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression guard for #4604.
+ *
+ * `processNodeInfoMessageProtobuf` used to write `hopsAway: meshPacket.hopsAway`.
+ * That looked reasonable and typechecked, but `MeshPacket` has no `hops_away`
+ * field at all — it exists only on `NodeInfo` — so the expression was always
+ * `undefined`. It wasn't destructive (`upsertNode` uses `?? existingNode`, so
+ * undefined preserves the old value), which is exactly why it survived: it
+ * failed silently and looked like working code.
+ *
+ * These tests pin the schema fact the removal rests on. If a future protobuf
+ * bump ever adds `hops_away` to `MeshPacket`, the first test fails and whoever
+ * is doing the bump gets to make a deliberate decision instead of rediscovering
+ * this by hand.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { loadProtobufDefinitions, getProtobufRoot } from './protobufLoader.js';
+
+describe('hopsAway is not a MeshPacket field (#4604)', () => {
+  beforeAll(async () => {
+    await loadProtobufDefinitions();
+  });
+
+  it('MeshPacket does not declare hops_away', () => {
+    const root = getProtobufRoot();
+    expect(root).toBeTruthy();
+    const meshPacket = root!.lookupType('meshtastic.MeshPacket');
+    const fieldNames = Object.keys(meshPacket.fields);
+
+    // Guard against both the wire name and protobufjs's camelCase alias.
+    expect(fieldNames).not.toContain('hops_away');
+    expect(fieldNames).not.toContain('hopsAway');
+  });
+
+  it('NodeInfo does declare hops_away — it is the only carrier', () => {
+    const root = getProtobufRoot();
+    const nodeInfo = root!.lookupType('meshtastic.NodeInfo');
+    const fieldNames = Object.keys(nodeInfo.fields);
+    // protobufjs exposes snake_case field names as declared in the .proto.
+    expect(fieldNames.some((f) => f === 'hops_away' || f === 'hopsAway')).toBe(true);
+  });
+
+  it('a decoded MeshPacket yields undefined for hopsAway', () => {
+    // The behavioural half: even constructing one directly, the property is
+    // absent — so nothing can read a hop count off a packet by accident.
+    const root = getProtobufRoot();
+    const MeshPacket = root!.lookupType('meshtastic.MeshPacket');
+    const decoded = MeshPacket.decode(
+      MeshPacket.encode(MeshPacket.create({ from: 0x1234abcd, to: 0xffffffff })).finish(),
+    ) as unknown as Record<string, unknown>;
+    expect(decoded.hopsAway).toBeUndefined();
+    expect(decoded.hops_away).toBeUndefined();
+  });
+
+  it('meshtasticManager no longer reads hopsAway off a MeshPacket', () => {
+    // Source-level backstop. The schema tests above prove the read is
+    // meaningless; this one proves it is gone, including from log statements
+    // (the debug line printed the same always-undefined value).
+    const src = readFileSync(resolve('src/server/meshtasticManager.ts'), 'utf8');
+    expect(src).not.toMatch(/meshPacket\.hopsAway/);
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7170,7 +7170,12 @@ class MeshtasticManager implements ISourceManager {
         shortName: user.shortName,
         hwModel: user.hwModel,
         role: user.role,
-        hopsAway: meshPacket.hopsAway,
+        // NOTE (#4604): deliberately NO hopsAway here. `MeshPacket` has no
+        // `hops_away` field — it exists only on `NodeInfo` (mesh.proto) — so
+        // reading it off the packet was always `undefined` and wrote nothing.
+        // hopsAway stays what the docs describe: a snapshot of the radio's own
+        // NodeDB, refreshed by processNodeInfoProtobuf on connect/resync.
+        // The per-packet measurement lives in lastMessageHops.
         // Use server time for lastHeard — rxTime from the device clock is unreliable.
         // Replay guard (see replayGuard.ts): omit lastHeard for replayed/retained
         // frames so a stale NodeInfo can't resurrect an offline node.
@@ -7357,7 +7362,7 @@ class MeshtasticManager implements ISourceManager {
         }
       }
 
-      logger.debug(`🔍 Saving node with role=${user.role}, hopsAway=${meshPacket.hopsAway}`);
+      logger.debug(`🔍 Saving node with role=${user.role}`);
       await databaseService.upsertNodeAsync(nodeData, this.sourceId);
       logger.debug(`👤 Updated user info: ${user.longName || nodeId}`);
 


### PR DESCRIPTION
Closes #4604. Follow-up to #4590 / #4603.

## The change

```diff
         role: user.role,
-        hopsAway: meshPacket.hopsAway,
```

`hopsAway: meshPacket.hopsAway` typechecked and read as reasonable code, but **`MeshPacket` has no `hops_away` field** — it exists only on `NodeInfo` in `mesh.proto`. The expression was always `undefined`.

It was never destructive: `upsertNode` uses `hopsAway ?? existingNode.hopsAway`, so `undefined` preserved the previous value. **That's precisely why it survived** — it failed silently and looked like it worked. The real cost was the false impression that an over-the-air NodeInfo refreshes `hopsAway`, which `link-quality.md` claimed until #4603 corrected it.

The debug log that printed the same always-`undefined` value goes too.

## Why delete rather than derive

The issue offered both. Deriving `hopsAway` from the packet's own `hopStart - hopLimit` would make NodeInfo broadcasts genuinely refresh it — fresher, and arguably what a reader expects.

But it would converge `hopsAway` with `lastMessageHops`, and those two feed a **user-facing setting**: Node Hops Calculation offers "NodeInfo packet" vs "All messages" as distinct options. If both start tracking per-packet hop counts, those options return nearly the same number and the choice stops meaning anything.

Keeping them distinct matches what the docs now describe, and what the UI's fallback chain (`lastMessageHops ?? hopsAway`) assumes: **`hopsAway` = the radio's NodeDB snapshot; `lastMessageHops` = the per-packet measurement.**

## Regression guard

The test pins the **schema fact** rather than grepping source:

- `MeshPacket` declares no `hops_away` (checked for both the wire name and protobufjs's camelCase alias)
- `NodeInfo` does — it's the only carrier
- A round-tripped `MeshPacket` yields `undefined` for the property
- Plus a source-level backstop that `meshPacket.hopsAway` is gone, including from log statements

If a future protobuf bump ever adds `hops_away` to `MeshPacket`, the first test fails and whoever does the bump makes a deliberate decision instead of rediscovering this by hand.

## Not addressed here

The issue also notes a **fourth** `hopsAway` write path the original #4590 analysis missed — an identical `senderHopsAway + 1` neighbour-stub heuristic at `src/server/mqttIngestion.ts:876,903`. That's a real heuristic rather than dead code, so changing it is a behaviour decision, not a cleanup. Left for its own discussion.

## Verification

- Full Vitest suite: `success: true`, **14,309 passed, 0 failed, 0 failed suites**
- `npx tsc --noEmit` and `tsc -p tsconfig.server.json --noEmit` clean
- `npm run lint:ci` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX