### PR TITLE
feat(positions): expose the anchors behind an estimated position (#4609)

### DIFF
--- a/src/cli/migrationTables.ts
+++ b/src/cli/migrationTables.ts
@@ -78,6 +78,9 @@ export const TABLE_ORDER = [
   'system_backup_history',
   // 3271: global estimated positions (no sourceId, no FK — one row per nodeNum)
   'estimated_positions',
+  // 4609: the anchors behind each estimate. Global like its parent, and copied
+  // after it so the rationale never lands without the estimate it explains.
+  'estimated_position_anchors',
   // 2608: per-source automated remote favorites management config + ledger
   'auto_favorite_targets',
   'auto_favorite_assignments',

--- a/src/db/activeSchema.ts
+++ b/src/db/activeSchema.ts
@@ -144,6 +144,11 @@ import {
   estimatedPositionsSqlite, estimatedPositionsPostgres, estimatedPositionsMysql,
 } from './schema/estimatedPositions.js';
 
+// Per-estimate anchor rationale (global — no sourceId, issue #4609)
+import {
+  estimatedPositionAnchorsSqlite, estimatedPositionAnchorsPostgres, estimatedPositionAnchorsMysql,
+} from './schema/estimatedPositionAnchors.js';
+
 // Automated Remote Favorites Management (issue #2608)
 import {
   autoFavoriteTargetsSqlite, autoFavoriteTargetsPostgres, autoFavoriteTargetsMysql,
@@ -260,6 +265,10 @@ export interface ActiveSchema {
   // Estimated positions (global — no sourceId)
   estimatedPositions: any;
 
+  // Per-estimate anchor rationale (global — no sourceId, issue #4609)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4609 every entry in this map is `any` by design (see the interface doc: the three dialect table types are incompatible at compile time, identical at runtime)
+  estimatedPositionAnchors: any;
+
   // Automated Remote Favorites Management (issue #2608)
   autoFavoriteTargets: any;
   autoFavoriteAssignments: any;
@@ -343,6 +352,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     waypoints: waypointsSqlite,
     sources: sourcesSqlite,
     estimatedPositions: estimatedPositionsSqlite,
+    estimatedPositionAnchors: estimatedPositionAnchorsSqlite,
     autoFavoriteTargets: autoFavoriteTargetsSqlite,
     autoFavoriteAssignments: autoFavoriteAssignmentsSqlite,
     sourcePkiKeys: sourcePkiKeysSqlite,
@@ -404,6 +414,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     waypoints: waypointsPostgres,
     sources: sourcesPostgres,
     estimatedPositions: estimatedPositionsPostgres,
+    estimatedPositionAnchors: estimatedPositionAnchorsPostgres,
     autoFavoriteTargets: autoFavoriteTargetsPostgres,
     autoFavoriteAssignments: autoFavoriteAssignmentsPostgres,
     sourcePkiKeys: sourcePkiKeysPostgres,
@@ -465,6 +476,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     waypoints: waypointsMysql,
     sources: sourcesMysql,
     estimatedPositions: estimatedPositionsMysql,
+    estimatedPositionAnchors: estimatedPositionAnchorsMysql,
     autoFavoriteTargets: autoFavoriteTargetsMysql,
     autoFavoriteAssignments: autoFavoriteAssignmentsMysql,
     sourcePkiKeys: sourcePkiKeysMysql,

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -151,6 +151,7 @@ import { migration as addMeshCoreObserverKeysMigration, runMigration133Postgres,
 import { migration as clearNullIslandEstimatesMigration, runMigration134Postgres, runMigration134Mysql } from '../server/migrations/134_clear_null_island_estimates.js';
 import { migration as backfillMeshcoreNodesViewOnMapMigration, runMigration135Postgres, runMigration135Mysql } from '../server/migrations/135_backfill_meshcore_nodes_viewonmap.js';
 import { migration as addMeshCoreObserverCredentialsMigration, runMigration136Postgres, runMigration136Mysql } from '../server/migrations/136_add_meshcore_observer_credentials.js';
+import { migration as estimatedPositionAnchorsMigration, runMigration137Postgres, runMigration137Mysql } from '../server/migrations/137_estimated_position_anchors.js';
 
 // ============================================================================
 // Registry
@@ -2163,4 +2164,22 @@ registry.register({
   sqlite: (db) => addMeshCoreObserverCredentialsMigration.up(db),
   postgres: (client) => runMigration136Postgres(client),
   mysql: (pool) => runMigration136Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 137: create `estimated_position_anchors` + estimate rationale
+// columns (issue #4609). The position estimator discarded its observation set
+// after solving, so there was no way to explain why an estimated pin sits where
+// it does. Anchors are now recorded at solve time (capped per node), and the
+// parent estimate records how its radius was derived. GLOBAL — no sourceId,
+// matching estimated_positions (#3271).
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 137,
+  name: 'estimated_position_anchors',
+  settingsKey: 'migration_137_estimated_position_anchors',
+  sqlite: (db) => estimatedPositionAnchorsMigration.up(db),
+  postgres: (client) => runMigration137Postgres(client),
+  mysql: (pool) => runMigration137Mysql(pool),
 });

--- a/src/db/repositories/estimatedPositions.ts
+++ b/src/db/repositories/estimatedPositions.ts
@@ -8,9 +8,20 @@
  *
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, inArray } from 'drizzle-orm';
+import { eq, inArray, desc } from 'drizzle-orm';
 import { BaseRepository, DrizzleDatabase } from './base.js';
 import { DatabaseType } from '../types.js';
+
+/**
+ * How an estimate's uncertainty radius was derived (issue #4609). Mirrors the
+ * branch taken in `solveNodePosition`:
+ *  - `single_anchor`  — one anchor (or weights so lopsided they behave as one):
+ *                       the flat radio-range default, no triangulation.
+ *  - `blended`        — partial convergence; the default blended toward the
+ *                       statistical radius.
+ *  - `convergence`    — a balanced multi-anchor solve; purely statistical.
+ */
+export type RadiusMethod = 'single_anchor' | 'blended' | 'convergence';
 
 /** A single estimated position row. */
 export interface EstimatedPosition {
@@ -21,6 +32,10 @@ export interface EstimatedPosition {
   uncertaintyKm: number | null;
   observationCount: number;
   updatedAt: number;
+  /** Kish effective sample size of the solve. Null on pre-#4609 rows. */
+  nEff: number | null;
+  /** How `uncertaintyKm` was derived. Null on pre-#4609 rows. */
+  radiusMethod: RadiusMethod | null;
 }
 
 /** Input for upserting an estimate (updatedAt is stamped by the caller). */
@@ -32,7 +47,34 @@ export interface EstimatedPositionInput {
   uncertaintyKm?: number | null;
   observationCount?: number;
   updatedAt: number;
+  nEff?: number | null;
+  radiusMethod?: RadiusMethod | null;
 }
+
+/** A stored anchor that contributed to one node's estimate (issue #4609). */
+export interface EstimatedPositionAnchor {
+  id: number;
+  nodeNum: number;
+  anchorNodeNum: number;
+  anchorNodeId: string;
+  anchorLat: number;
+  anchorLon: number;
+  kind: 'traceroute' | 'neighbor';
+  snrDb: number | null;
+  observedAt: number;
+  weight: number;
+  createdAt: number;
+}
+
+/** Input for recording one contributing anchor. */
+export type EstimatedPositionAnchorInput = Omit<EstimatedPositionAnchor, 'id'>;
+
+/**
+ * Rows written per `insert()` round trip when replacing anchors. Keeps the
+ * statement well under SQLite's default 999-variable bind limit (11 columns per
+ * row => 1,100 variables at 100 rows would exceed it, so 50 is the safe step).
+ */
+const ANCHOR_INSERT_BATCH = 50;
 
 export class EstimatedPositionsRepository extends BaseRepository {
   constructor(db: DrizzleDatabase, dbType: DatabaseType) {
@@ -50,6 +92,8 @@ export class EstimatedPositionsRepository extends BaseRepository {
       uncertaintyKm: input.uncertaintyKm ?? null,
       observationCount: input.observationCount ?? 0,
       updatedAt: input.updatedAt,
+      nEff: input.nEff ?? null,
+      radiusMethod: input.radiusMethod ?? null,
     };
     await this.upsert(estimatedPositions, values, estimatedPositions.nodeNum, {
       nodeId: values.nodeId,
@@ -58,6 +102,8 @@ export class EstimatedPositionsRepository extends BaseRepository {
       uncertaintyKm: values.uncertaintyKm,
       observationCount: values.observationCount,
       updatedAt: values.updatedAt,
+      nEff: values.nEff,
+      radiusMethod: values.radiusMethod,
     });
   }
 
@@ -87,20 +133,87 @@ export class EstimatedPositionsRepository extends BaseRepository {
     return this.normalizeBigInts(rows) as EstimatedPosition[];
   }
 
-  /** Delete estimates for the given node numbers. No-op on empty input. */
+  /**
+   * Delete estimates for the given node numbers. No-op on empty input.
+   *
+   * Also drops those nodes' anchor rows: there is no database-level FK (the
+   * table is intentionally FK-free, like its parent), so the cascade is done
+   * here. Leaving anchors behind would let a node that regained a real GPS fix
+   * still serve rationale for an estimate that no longer exists.
+   */
   async deleteByNodeNums(nodeNums: number[]): Promise<number> {
     if (nodeNums.length === 0) return 0;
     const { estimatedPositions } = this.tables;
+    await this.deleteAnchorsByNodeNums(nodeNums);
     const result = await this.db
       .delete(estimatedPositions)
       .where(inArray(estimatedPositions.nodeNum, nodeNums));
     return this.getAffectedRows(result);
   }
 
-  /** Delete every estimate. Returns the number of rows removed. */
+  /** Delete every estimate (and every anchor). Returns estimates removed. */
   async deleteAll(): Promise<number> {
-    const { estimatedPositions } = this.tables;
+    const { estimatedPositions, estimatedPositionAnchors } = this.tables;
+    await this.db.delete(estimatedPositionAnchors);
     const result = await this.db.delete(estimatedPositions);
+    return this.getAffectedRows(result);
+  }
+
+  // ------------------------------------------------------------------
+  // Anchor rationale (issue #4609)
+  // ------------------------------------------------------------------
+
+  /**
+   * Replace the stored anchors for the given nodes.
+   *
+   * Delete-then-insert, scoped to `nodeNums` — the estimator recomputes a
+   * node's whole observation set each run, so partial updates would leave
+   * anchors from a previous run mixed with the current one and misrepresent the
+   * estimate. Nodes absent from `nodeNums` are untouched.
+   *
+   * `nodeNums` is passed separately from `anchors` on purpose: a node can solve
+   * with zero retained anchors, and its stale rows must still be cleared.
+   */
+  async replaceAnchors(nodeNums: number[], anchors: EstimatedPositionAnchorInput[]): Promise<void> {
+    if (nodeNums.length === 0 && anchors.length === 0) return;
+
+    const targets = nodeNums.length > 0
+      ? nodeNums
+      : [...new Set(anchors.map((a) => a.nodeNum))];
+    await this.deleteAnchorsByNodeNums(targets);
+
+    if (anchors.length === 0) return;
+
+    const { estimatedPositionAnchors } = this.tables;
+    for (let i = 0; i < anchors.length; i += ANCHOR_INSERT_BATCH) {
+      const batch = anchors.slice(i, i + ANCHOR_INSERT_BATCH);
+      await this.db.insert(estimatedPositionAnchors).values(batch);
+    }
+  }
+
+  /**
+   * Anchors for one node, strongest contribution first. `limit` caps the reply
+   * independently of what is stored.
+   */
+  async getAnchorsByNodeNum(nodeNum: number, limit?: number): Promise<EstimatedPositionAnchor[]> {
+    const { estimatedPositionAnchors } = this.tables;
+    let query = this.db
+      .select()
+      .from(estimatedPositionAnchors)
+      .where(eq(estimatedPositionAnchors.nodeNum, nodeNum))
+      .orderBy(desc(estimatedPositionAnchors.weight));
+    if (limit != null && limit > 0) query = query.limit(limit);
+    const rows = await query;
+    return this.normalizeBigInts(rows) as EstimatedPositionAnchor[];
+  }
+
+  /** Delete anchors for the given node numbers. No-op on empty input. */
+  async deleteAnchorsByNodeNums(nodeNums: number[]): Promise<number> {
+    if (nodeNums.length === 0) return 0;
+    const { estimatedPositionAnchors } = this.tables;
+    const result = await this.db
+      .delete(estimatedPositionAnchors)
+      .where(inArray(estimatedPositionAnchors.nodeNum, nodeNums));
     return this.getAffectedRows(result);
   }
 }

--- a/src/db/repositories/index.ts
+++ b/src/db/repositories/index.ts
@@ -76,7 +76,13 @@ export type { PositionRow, PaginatedPositions, GetPositionsArgs } from './analys
 export { WaypointsRepository } from './waypoints.js';
 export type { Waypoint, WaypointUpsertInput, WaypointListOptions } from './waypoints.js';
 export { EstimatedPositionsRepository } from './estimatedPositions.js';
-export type { EstimatedPosition, EstimatedPositionInput } from './estimatedPositions.js';
+export type {
+  EstimatedPosition,
+  EstimatedPositionInput,
+  EstimatedPositionAnchor,
+  EstimatedPositionAnchorInput,
+  RadiusMethod,
+} from './estimatedPositions.js';
 export { AutoFavoriteTargetsRepository } from './autoFavoriteTargets.js';
 export type { AutoFavoriteTargetInput } from './autoFavoriteTargets.js';
 export { SourcePkiKeysRepository } from './sourcePkiKeys.js';

--- a/src/db/schema/estimatedPositionAnchors.ts
+++ b/src/db/schema/estimatedPositionAnchors.ts
@@ -1,0 +1,113 @@
+/**
+ * Drizzle schema for the `estimated_position_anchors` table (issue #4609).
+ *
+ * WHY THIS TABLE EXISTS
+ * ---------------------
+ * `positionEstimationService` builds a per-node set of geometric observations
+ * ("anchors") in memory, solves a weighted centroid, writes the solved point to
+ * `estimated_positions`, and then throws the anchors away. That made it
+ * impossible to answer the only question users actually ask about an estimated
+ * pin — *why is it there?*
+ *
+ * The anchors cannot be reconstructed after the fact. The raw traceroute and
+ * neighbor rows survive, but re-deriving observations would run the weight model
+ * against a different `now`, producing different time-decay weights and possibly
+ * a different anchor set than the one that produced the stored estimate. That
+ * would be a plausible story, not the actual rationale. So the anchors that fed
+ * each estimate are recorded at solve time.
+ *
+ * GLOBAL by design — there is intentionally NO `sourceId` column, matching the
+ * parent `estimated_positions` table (issue #3271) and the CLAUDE.md
+ * global-by-design carve-out. Observations are pooled from ALL Meshtastic
+ * sources (incl. MQTT) into one estimate per physical `nodeNum`; the same
+ * physical traceroute can be observed by several sources, so no single
+ * `sourceId` would be correct for an anchor. Attaching one would re-fragment
+ * exactly what #3271 unified. Estimation is Meshtastic-only (MeshCore excluded).
+ *
+ * VOLUME: rows are capped per node by the writer (see
+ * MAX_STORED_ANCHORS_PER_NODE in positionEstimationService) — the top-weighted
+ * anchors are kept, since those are the ones that actually moved the centroid.
+ * The true total stays on `estimated_positions.observationCount`, so a consumer
+ * can always say "showing N of M". Rows are replaced wholesale on each
+ * estimator run and deleted alongside their parent estimate.
+ */
+import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
+import {
+  pgTable,
+  text as pgText,
+  doublePrecision as pgDoublePrecision,
+  bigint as pgBigint,
+  serial as pgSerial,
+} from 'drizzle-orm/pg-core';
+import {
+  mysqlTable,
+  varchar as myVarchar,
+  double as myDouble,
+  bigint as myBigint,
+  int as myInt,
+} from 'drizzle-orm/mysql-core';
+
+// ============ SQLite Schema ============
+
+export const estimatedPositionAnchorsSqlite = sqliteTable('estimated_position_anchors', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  /** The node whose position was estimated from this anchor. */
+  nodeNum: integer('nodeNum').notNull(),
+  /** The positioned node that acted as the anchor. */
+  anchorNodeNum: integer('anchorNodeNum').notNull(),
+  anchorNodeId: text('anchorNodeId').notNull(),
+  /** The anchor's position at solve time (it may move or vanish later). */
+  anchorLat: real('anchorLat').notNull(),
+  anchorLon: real('anchorLon').notNull(),
+  /** 'traceroute' (hop segment) or 'neighbor' (NeighborInfo RF-range pair). */
+  kind: text('kind').notNull(),
+  /** Link SNR in dB, when the observation carried one. */
+  snrDb: real('snrDb'),
+  /** When the underlying observation was recorded (Unix ms). */
+  observedAt: integer('observedAt').notNull(),
+  /** Weight this anchor received in the solve (time-decay x SNR linear power). */
+  weight: real('weight').notNull(),
+  /** The estimator run's clock (Unix ms) — lets a consumer show estimate age. */
+  createdAt: integer('createdAt').notNull(),
+});
+
+// ============ PostgreSQL Schema ============
+
+export const estimatedPositionAnchorsPostgres = pgTable('estimated_position_anchors', {
+  id: pgSerial('id').primaryKey(),
+  nodeNum: pgBigint('nodeNum', { mode: 'number' }).notNull(),
+  anchorNodeNum: pgBigint('anchorNodeNum', { mode: 'number' }).notNull(),
+  anchorNodeId: pgText('anchorNodeId').notNull(),
+  // doublePrecision, not REAL — REAL's ~7 significant digits round positions.
+  anchorLat: pgDoublePrecision('anchorLat').notNull(),
+  anchorLon: pgDoublePrecision('anchorLon').notNull(),
+  kind: pgText('kind').notNull(),
+  snrDb: pgDoublePrecision('snrDb'),
+  observedAt: pgBigint('observedAt', { mode: 'number' }).notNull(),
+  weight: pgDoublePrecision('weight').notNull(),
+  createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
+});
+
+// ============ MySQL Schema ============
+
+export const estimatedPositionAnchorsMysql = mysqlTable('estimated_position_anchors', {
+  id: myInt('id').autoincrement().primaryKey(),
+  nodeNum: myBigint('nodeNum', { mode: 'number' }).notNull(),
+  anchorNodeNum: myBigint('anchorNodeNum', { mode: 'number' }).notNull(),
+  anchorNodeId: myVarchar('anchorNodeId', { length: 16 }).notNull(),
+  anchorLat: myDouble('anchorLat').notNull(),
+  anchorLon: myDouble('anchorLon').notNull(),
+  kind: myVarchar('kind', { length: 16 }).notNull(),
+  snrDb: myDouble('snrDb'),
+  observedAt: myBigint('observedAt', { mode: 'number' }).notNull(),
+  weight: myDouble('weight').notNull(),
+  createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
+});
+
+// Type inference
+export type EstimatedPositionAnchorSqlite = typeof estimatedPositionAnchorsSqlite.$inferSelect;
+export type NewEstimatedPositionAnchorSqlite = typeof estimatedPositionAnchorsSqlite.$inferInsert;
+export type EstimatedPositionAnchorPostgres = typeof estimatedPositionAnchorsPostgres.$inferSelect;
+export type NewEstimatedPositionAnchorPostgres = typeof estimatedPositionAnchorsPostgres.$inferInsert;
+export type EstimatedPositionAnchorMysql = typeof estimatedPositionAnchorsMysql.$inferSelect;
+export type NewEstimatedPositionAnchorMysql = typeof estimatedPositionAnchorsMysql.$inferInsert;

--- a/src/db/schema/estimatedPositions.ts
+++ b/src/db/schema/estimatedPositions.ts
@@ -29,6 +29,12 @@ export const estimatedPositionsSqlite = sqliteTable('estimated_positions', {
   // Number of observations that fed this estimate.
   observationCount: integer('observationCount').notNull().default(0),
   updatedAt: integer('updatedAt').notNull(),
+  // Kish effective sample size of the weighted solve (issue #4609). 1.0 means
+  // one anchor — or several so lopsided in weight that they behave as one.
+  nEff: real('nEff'),
+  // How uncertaintyKm was derived: 'single_anchor' | 'blended' | 'convergence'.
+  // Null on rows written before #4609 / by an older build.
+  radiusMethod: text('radiusMethod'),
 });
 
 // PostgreSQL schema
@@ -41,6 +47,8 @@ export const estimatedPositionsPostgres = pgTable('estimated_positions', {
   uncertaintyKm: pgDoublePrecision('uncertaintyKm'),
   observationCount: pgBigint('observationCount', { mode: 'number' }).notNull().default(0),
   updatedAt: pgBigint('updatedAt', { mode: 'number' }).notNull(),
+  nEff: pgDoublePrecision('nEff'),
+  radiusMethod: pgText('radiusMethod'),
 });
 
 // MySQL schema
@@ -52,6 +60,8 @@ export const estimatedPositionsMysql = mysqlTable('estimated_positions', {
   uncertaintyKm: myDouble('uncertaintyKm'),
   observationCount: myInt('observationCount').notNull().default(0),
   updatedAt: myBigint('updatedAt', { mode: 'number' }).notNull(),
+  nEff: myDouble('nEff'),
+  radiusMethod: myVarchar('radiusMethod', { length: 24 }),
 });
 
 // Type inference

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -56,6 +56,9 @@ export * from './waypoints.js';
 // Estimated positions table (global — no sourceId)
 export * from './estimatedPositions.js';
 
+// Per-estimate anchor rationale (global — no sourceId, issue #4609)
+export * from './estimatedPositionAnchors.js';
+
 // Automated Remote Favorites Management (issue #2608)
 export * from './autoFavoriteTargets.js';
 

--- a/src/server/migrations/137_estimated_position_anchors.test.ts
+++ b/src/server/migrations/137_estimated_position_anchors.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for migration 137 — estimated_position_anchors + estimate rationale
+ * columns (issue #4609).
+ */
+import Database from 'better-sqlite3';
+import { describe, expect, it, vi } from 'vitest';
+import { migration, runMigration137Postgres, runMigration137Mysql } from './137_estimated_position_anchors.js';
+
+/** The parent table as migration 082/091 leave it — no nEff/radiusMethod. */
+function createParentTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS estimated_positions (
+      nodeNum INTEGER PRIMARY KEY,
+      nodeId TEXT NOT NULL,
+      latitude REAL NOT NULL,
+      longitude REAL NOT NULL,
+      uncertaintyKm REAL,
+      observationCount INTEGER NOT NULL DEFAULT 0,
+      updatedAt INTEGER NOT NULL
+    )
+  `);
+}
+
+function columnNames(db: Database.Database, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((c) => c.name);
+}
+
+describe('Migration 137 — estimated_position_anchors', () => {
+  describe('SQLite', () => {
+    it('creates the table and is idempotent (second up() does not throw)', () => {
+      const db = new Database(':memory:');
+      createParentTable(db);
+
+      migration.up(db);
+      expect(() => migration.up(db)).not.toThrow();
+
+      const table = db.prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name = 'estimated_position_anchors'`
+      ).get();
+      expect(table).toBeTruthy();
+
+      db.close();
+    });
+
+    it('adds nEff and radiusMethod to estimated_positions without disturbing existing rows', () => {
+      const db = new Database(':memory:');
+      createParentTable(db);
+      db.prepare(`
+        INSERT INTO estimated_positions (nodeNum, nodeId, latitude, longitude, uncertaintyKm, observationCount, updatedAt)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `).run(305419896, '!12345678', 10.5, 20.5, 5.0, 3, 1_700_000_000_000);
+
+      migration.up(db);
+
+      const cols = columnNames(db, 'estimated_positions');
+      expect(cols).toContain('nEff');
+      expect(cols).toContain('radiusMethod');
+
+      // Pre-existing rows survive and read NULL for the new columns — the API
+      // must report "unknown", never a guessed derivation.
+      const row = db.prepare(`SELECT * FROM estimated_positions WHERE nodeNum = ?`).get(305419896) as any;
+      expect(row.latitude).toBe(10.5);
+      expect(row.nEff).toBeNull();
+      expect(row.radiusMethod).toBeNull();
+
+      db.close();
+    });
+
+    it('creates the nodeNum lookup indexes', () => {
+      const db = new Database(':memory:');
+      createParentTable(db);
+      migration.up(db);
+
+      const indexes = (db.prepare(
+        `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='estimated_position_anchors'`
+      ).all() as Array<{ name: string }>).map((r) => r.name);
+      expect(indexes).toContain('epa_node_idx');
+      expect(indexes).toContain('epa_node_weight_idx');
+
+      db.close();
+    });
+
+    it('round-trips a full anchor row, including a null SNR', () => {
+      const db = new Database(':memory:');
+      createParentTable(db);
+      migration.up(db);
+
+      const insert = db.prepare(`
+        INSERT INTO estimated_position_anchors (
+          nodeNum, anchorNodeNum, anchorNodeId, anchorLat, anchorLon,
+          kind, snrDb, observedAt, weight, createdAt
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      insert.run(1, 2, '!00000002', 10.25, -20.75, 'traceroute', 3.25, 1_700_000_000_000, 0.5, 1_700_000_100_000);
+      insert.run(1, 3, '!00000003', 11.0, -21.0, 'neighbor', null, 1_700_000_000_000, 0.25, 1_700_000_100_000);
+
+      const rows = db.prepare(
+        `SELECT * FROM estimated_position_anchors WHERE nodeNum = ? ORDER BY weight DESC`
+      ).all(1) as any[];
+
+      expect(rows).toHaveLength(2);
+      expect(rows[0].anchorNodeId).toBe('!00000002');
+      expect(rows[0].kind).toBe('traceroute');
+      expect(rows[0].snrDb).toBe(3.25);
+      expect(rows[0].anchorLat).toBe(10.25);
+      // A NeighborInfo pair with no reported SNR is legitimate — it must store
+      // as NULL rather than being coerced to 0, which would read as a real
+      // measurement.
+      expect(rows[1].snrDb).toBeNull();
+      expect(rows[1].kind).toBe('neighbor');
+
+      db.close();
+    });
+
+    it('is GLOBAL — there is deliberately no sourceId column', () => {
+      const db = new Database(':memory:');
+      createParentTable(db);
+      migration.up(db);
+
+      // Anchors pool observations from every Meshtastic source into one
+      // estimate per physical nodeNum (#3271), so no single sourceId is
+      // correct. Guard against a well-meaning "add sourceId out of habit".
+      expect(columnNames(db, 'estimated_position_anchors')).not.toContain('sourceId');
+
+      db.close();
+    });
+
+    it('down() drops the table', () => {
+      const db = new Database(':memory:');
+      createParentTable(db);
+      migration.up(db);
+      migration.down(db);
+
+      const table = db.prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name = 'estimated_position_anchors'`
+      ).get();
+      expect(table).toBeUndefined();
+
+      db.close();
+    });
+  });
+
+  describe('PostgreSQL', () => {
+    it('creates the table and indexes with IF NOT EXISTS and adds both columns', async () => {
+      const client = { query: vi.fn().mockResolvedValue({ rows: [] }) } as any;
+
+      await runMigration137Postgres(client);
+
+      const sql = client.query.mock.calls.map((c: any[]) => String(c[0])).join('\n');
+      expect(sql).toContain('CREATE TABLE IF NOT EXISTS estimated_position_anchors');
+      expect(sql).toContain('CREATE INDEX IF NOT EXISTS epa_node_idx');
+      expect(sql).toContain('CREATE INDEX IF NOT EXISTS epa_node_weight_idx');
+      // BIGINT for node numbers: nodeNum is unsigned 32-bit and overflows PG INTEGER.
+      expect(sql).toContain('"nodeNum" BIGINT NOT NULL');
+      expect(sql).toContain('"anchorNodeNum" BIGINT NOT NULL');
+      // doublePrecision, not REAL — REAL rounds coordinates.
+      expect(sql).toContain('"anchorLat" DOUBLE PRECISION NOT NULL');
+      expect(sql).toContain('"nEff"');
+      expect(sql).toContain('"radiusMethod"');
+      expect(sql).not.toContain('sourceId');
+    });
+  });
+
+  describe('MySQL', () => {
+    it('pre-checks information_schema before creating the table', async () => {
+      const conn = {
+        query: vi.fn().mockResolvedValue([[]]),
+        release: vi.fn(),
+      };
+      const pool = {
+        getConnection: vi.fn().mockResolvedValue(conn),
+        query: vi.fn().mockResolvedValue([[]]),
+      } as any;
+
+      await runMigration137Mysql(pool);
+
+      const sql = [
+        ...conn.query.mock.calls.map((c: any[]) => String(c[0])),
+        ...pool.query.mock.calls.map((c: any[]) => String(c[0])),
+      ].join('\n');
+
+      // MySQL has no CREATE TABLE/INDEX IF NOT EXISTS for our purposes, so the
+      // helpers must consult information_schema first.
+      expect(sql).toContain('information_schema');
+      expect(sql).toContain('estimated_position_anchors');
+      expect(conn.release).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/migrations/137_estimated_position_anchors.ts
+++ b/src/server/migrations/137_estimated_position_anchors.ts
@@ -1,0 +1,132 @@
+/**
+ * Migration 137: record the rationale behind an estimated position (#4609).
+ *
+ * Two changes, both GLOBAL (no `sourceId`) to match `estimated_positions`
+ * (#3271) — position estimation pools observations from ALL Meshtastic sources
+ * into one estimate per physical `nodeNum`, so an anchor has no single owning
+ * source.
+ *
+ *   1. Creates `estimated_position_anchors`: one row per retained contributing
+ *      anchor. The estimator previously discarded its observation set after
+ *      solving, which left no way to explain a pin. Rows are capped per node by
+ *      the writer and replaced wholesale on each estimator run.
+ *
+ *   2. Adds `nEff` and `radiusMethod` to `estimated_positions`, recording how
+ *      the uncertainty radius was derived (lone-anchor 5 km heuristic vs
+ *      multi-anchor convergence, and the blend between them).
+ *
+ * Existing rows keep NULL for both new columns until the next estimator run —
+ * the API reports that honestly rather than guessing a method.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+import {
+  addColumnIfMissing,
+  addColumnIfMissingPostgres,
+  addColumnIfMissingMysql,
+  createTableIfMissingMysql,
+  createIndexIfMissingMysql,
+} from './helpers.js';
+
+const LABEL = 'Migration 137';
+const TABLE = 'estimated_position_anchors';
+const PARENT = 'estimated_positions';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): creating ${TABLE} and estimate rationale columns...`);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS ${TABLE} (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        nodeNum INTEGER NOT NULL,
+        anchorNodeNum INTEGER NOT NULL,
+        anchorNodeId TEXT NOT NULL,
+        anchorLat REAL NOT NULL,
+        anchorLon REAL NOT NULL,
+        kind TEXT NOT NULL,
+        snrDb REAL,
+        observedAt INTEGER NOT NULL,
+        weight REAL NOT NULL,
+        createdAt INTEGER NOT NULL
+      )
+    `);
+    db.exec(`CREATE INDEX IF NOT EXISTS epa_node_idx ON ${TABLE}(nodeNum)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS epa_node_weight_idx ON ${TABLE}(nodeNum, weight)`);
+
+    addColumnIfMissing(db, PARENT, 'nEff', 'nEff REAL');
+    addColumnIfMissing(db, PARENT, 'radiusMethod', 'radiusMethod TEXT');
+
+    logger.info(`${LABEL} complete (SQLite)`);
+  },
+
+  down: (db: Database): void => {
+    logger.info(`${LABEL} down (SQLite): dropping ${TABLE}`);
+    db.exec(`DROP TABLE IF EXISTS ${TABLE}`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration137Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): creating ${TABLE} and estimate rationale columns...`);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS ${TABLE} (
+      id SERIAL PRIMARY KEY,
+      "nodeNum" BIGINT NOT NULL,
+      "anchorNodeNum" BIGINT NOT NULL,
+      "anchorNodeId" TEXT NOT NULL,
+      "anchorLat" DOUBLE PRECISION NOT NULL,
+      "anchorLon" DOUBLE PRECISION NOT NULL,
+      kind TEXT NOT NULL,
+      "snrDb" DOUBLE PRECISION,
+      "observedAt" BIGINT NOT NULL,
+      weight DOUBLE PRECISION NOT NULL,
+      "createdAt" BIGINT NOT NULL
+    )
+  `);
+  await client.query(`CREATE INDEX IF NOT EXISTS epa_node_idx ON ${TABLE}("nodeNum")`);
+  await client.query(`CREATE INDEX IF NOT EXISTS epa_node_weight_idx ON ${TABLE}("nodeNum", weight)`);
+
+  await addColumnIfMissingPostgres(client, PARENT, 'nEff', '"nEff" DOUBLE PRECISION');
+  await addColumnIfMissingPostgres(client, PARENT, 'radiusMethod', '"radiusMethod" TEXT');
+
+  logger.info(`${LABEL} complete (PostgreSQL)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration137Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): creating ${TABLE} and estimate rationale columns...`);
+
+  await createTableIfMissingMysql(pool, TABLE, `
+    CREATE TABLE ${TABLE} (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      nodeNum BIGINT NOT NULL,
+      anchorNodeNum BIGINT NOT NULL,
+      anchorNodeId VARCHAR(16) NOT NULL,
+      anchorLat DOUBLE NOT NULL,
+      anchorLon DOUBLE NOT NULL,
+      kind VARCHAR(16) NOT NULL,
+      snrDb DOUBLE,
+      observedAt BIGINT NOT NULL,
+      weight DOUBLE NOT NULL,
+      createdAt BIGINT NOT NULL,
+      KEY epa_node_idx (nodeNum),
+      KEY epa_node_weight_idx (nodeNum, weight)
+    )
+  `);
+  // Covers a database where the table pre-existed without the indexes.
+  await createIndexIfMissingMysql(pool, TABLE, 'epa_node_idx', `CREATE INDEX epa_node_idx ON ${TABLE}(nodeNum)`);
+  await createIndexIfMissingMysql(pool, TABLE, 'epa_node_weight_idx', `CREATE INDEX epa_node_weight_idx ON ${TABLE}(nodeNum, weight)`);
+
+  await addColumnIfMissingMysql(pool, PARENT, 'nEff', 'nEff DOUBLE');
+  await addColumnIfMissingMysql(pool, PARENT, 'radiusMethod', 'radiusMethod VARCHAR(24)');
+
+  logger.info(`${LABEL} complete (MySQL)`);
+}

--- a/src/server/routes/nodesRoutes.positionEstimate.test.ts
+++ b/src/server/routes/nodesRoutes.positionEstimate.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Route tests for GET /api/nodes/:nodeNum/position-estimate (issue #4609).
+ *
+ * Uses the real route-test harness: real express-session, real auth middleware,
+ * and the real singleton :memory: SQLite DB with all migrations applied — so
+ * migration 137, the repository, and the permission gate are all genuinely
+ * exercised rather than mocked.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+// The router pulls in the source manager registry transitively. Nothing in this
+// endpoint talks to a node, so a bare stub keeps the import graph quiet.
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    getManager: vi.fn(() => null),
+    getAllManagers: vi.fn(() => []),
+    getPrimarySourceId: vi.fn(() => null),
+  },
+}));
+
+const { default: nodesRouter } = await import('./nodesRoutes.js');
+const { default: databaseService } = await import('../../services/database.js');
+
+const NODE_NUM = 0x11223344;
+const NODE_ID = '!11223344';
+const NOW = 1_700_000_000_000;
+
+async function seedEstimate(overrides: Record<string, unknown> = {}) {
+  await databaseService.upsertEstimatedPositionsAsync([{
+    nodeNum: NODE_NUM,
+    nodeId: NODE_ID,
+    latitude: 10,
+    longitude: 20,
+    uncertaintyKm: 1.25,
+    observationCount: 4,
+    updatedAt: NOW,
+    nEff: 2.4,
+    radiusMethod: 'convergence',
+    ...overrides,
+  }]);
+}
+
+async function seedAnchors() {
+  await databaseService.replaceEstimatedPositionAnchorsAsync([NODE_NUM], [
+    {
+      nodeNum: NODE_NUM,
+      anchorNodeNum: 0xaaaa0001,
+      anchorNodeId: '!aaaa0001',
+      anchorLat: 10.05,
+      anchorLon: 20,
+      kind: 'traceroute',
+      snrDb: 6.25,
+      observedAt: NOW - 3600_000,
+      weight: 0.9,
+      createdAt: NOW,
+    },
+    {
+      nodeNum: NODE_NUM,
+      anchorNodeNum: 0xbbbb0002,
+      anchorNodeId: '!bbbb0002',
+      anchorLat: 9.95,
+      anchorLon: 20,
+      kind: 'neighbor',
+      snrDb: null,
+      observedAt: NOW - 7200_000,
+      weight: 0.4,
+      createdAt: NOW,
+    },
+  ]);
+}
+
+describe('GET /nodes/:nodeNum/position-estimate', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({ mount: (app) => app.use('/', nodesRouter) });
+    await databaseService.estimatedPositions.deleteAll();
+  });
+
+  afterEach(async () => {
+    await databaseService.estimatedPositions.deleteAll();
+    await harness.cleanup();
+  });
+
+  it('returns the estimate, its derivation, and its anchors', async () => {
+    await seedEstimate();
+    await seedAnchors();
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/nodes/${NODE_NUM}/position-estimate`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const d = res.body.data;
+    expect(d.nodeNum).toBe(NODE_NUM);
+    expect(d.nodeId).toBe(NODE_ID);
+    expect(d.uncertaintyKm).toBeCloseTo(1.25, 6);
+    expect(d.observationCount).toBe(4);
+    expect(d.nEff).toBeCloseTo(2.4, 6);
+    expect(d.radiusMethod).toBe('convergence');
+    // The 5 km lone-anchor heuristic is reported, not hardcoded twice.
+    expect(d.singleAnchorDefaultKm).toBe(5);
+    expect(d.maxStoredAnchors).toBeGreaterThan(0);
+
+    expect(d.anchors).toHaveLength(2);
+    // Strongest contribution first — the anchor that most moved the pin.
+    expect(d.anchors[0].anchorNodeId).toBe('!aaaa0001');
+    expect(d.anchors[0].kind).toBe('traceroute');
+    expect(d.anchors[0].snrDb).toBeCloseTo(6.25, 6);
+    expect(d.anchors[0].observedAt).toBe(NOW - 3600_000);
+    // distanceKm is derived at request time from the solved point.
+    expect(d.anchors[0].distanceKm).toBeGreaterThan(0);
+
+    expect(d.anchors[1].anchorNodeId).toBe('!bbbb0002');
+    expect(d.anchors[1].kind).toBe('neighbor');
+    // A NeighborInfo pair without SNR must read as absent, not as 0 dB.
+    expect(d.anchors[1].snrDb).toBeNull();
+  });
+
+  it('accepts a !hex node id as well as a decimal node number', async () => {
+    await seedEstimate();
+    await seedAnchors();
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/nodes/${NODE_ID}/position-estimate`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.nodeNum).toBe(NODE_NUM);
+  });
+
+  it('404s for a node with no estimated position (the GPS case)', async () => {
+    // A node reporting real GPS has no estimated_positions row — the estimator
+    // deletes it. So "no rationale for real fixes" falls out of the data model.
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/nodes/${NODE_NUM}/position-estimate`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+    expect(res.body.code).toBe('NO_ESTIMATED_POSITION');
+  });
+
+  it('flags truncation when more observations fed the estimate than were stored', async () => {
+    await seedEstimate({ observationCount: 137 });
+    await seedAnchors();
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/nodes/${NODE_NUM}/position-estimate`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.anchorsStored).toBe(2);
+    expect(res.body.data.observationCount).toBe(137);
+    expect(res.body.data.anchorsTruncated).toBe(true);
+  });
+
+  it('does not flag truncation when every observation was stored', async () => {
+    await seedEstimate({ observationCount: 2 });
+    await seedAnchors();
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/nodes/${NODE_NUM}/position-estimate`);
+
+    expect(res.body.data.anchorsTruncated).toBe(false);
+  });
+
+  it('reports a null derivation for estimates written before #4609', async () => {
+    await seedEstimate({ nEff: null, radiusMethod: null });
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/nodes/${NODE_NUM}/position-estimate`);
+
+    expect(res.status).toBe(200);
+    // Must stay null so the UI says "unknown" rather than inventing a method.
+    expect(res.body.data.nEff).toBeNull();
+    expect(res.body.data.radiusMethod).toBeNull();
+    expect(res.body.data.anchors).toEqual([]);
+  });
+
+  it('rejects a malformed node number', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/nodes/not-a-node/position-estimate');
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_NODE_NUM');
+  });
+
+  it('requires nodes:read', async () => {
+    await seedEstimate();
+
+    const agent = await harness.loginAs(harness.limited);
+    const denied = await agent.get(`/nodes/${NODE_NUM}/position-estimate`);
+    expect(denied.status).toBe(403);
+
+    // `nodes` is a per-source resource, so the union-across-sources check in
+    // checkPermissionAsync is what admits this global endpoint: read on any
+    // source is enough to see an estimate pooled from all of them.
+    await harness.grant(harness.limited.id, 'nodes', 'read', harness.sourceA);
+    const allowed = await agent.get(`/nodes/${NODE_NUM}/position-estimate`);
+    expect(allowed.status).toBe(200);
+  });
+});

--- a/src/server/routes/nodesRoutes.ts
+++ b/src/server/routes/nodesRoutes.ts
@@ -33,12 +33,32 @@ import { optionalAuth, requirePermission, hasPermission } from '../auth/authMidd
 import { logger } from '../../utils/logger.js';
 import { isValidNodeNum, MAX_NODE_NUM } from '../constants/meshtastic.js';
 import { fail, ok } from '../utils/apiResponse.js';
+import { calculateDistance } from '../../utils/distance.js';
+import {
+  DEFAULT_SINGLE_ANCHOR_KM,
+  MAX_STORED_ANCHORS_PER_NODE,
+} from '../services/positionEstimationService.js';
 import {
   encodeSharedContactUrl,
   SharedContactValidationError,
 } from '../services/sharedContactService.js';
 
 const router = express.Router();
+
+/**
+ * Parse a `:nodeNum` path param as either a decimal node number or a `!hex`
+ * node id. Callers hold one or the other depending on which list they came
+ * from, and getting it wrong should not be a silent NaN lookup.
+ *
+ * @returns the node number, or null when the value is not a valid one.
+ */
+function parseNodeNumParam(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const parsed = raw.startsWith('!')
+    ? parseInt(raw.slice(1), 16)
+    : (/^\d+$/.test(raw) ? Number(raw) : NaN);
+  return isValidNodeNum(parsed) ? parsed : null;
+}
 
 // API Routes
 /**
@@ -234,6 +254,77 @@ router.get('/nodes/:nodeNum/copy-candidates', requirePermission('nodes', 'read')
   } catch (error) {
     logger.error('Error getting copy candidates:', error);
     res.status(500).json({ error: 'Failed to retrieve copy candidates' });
+  }
+});
+
+/**
+ * GET /api/nodes/:nodeNum/position-estimate
+ *
+ * The rationale behind an ESTIMATED position (issue #4609): which anchors fed
+ * it, of what type, from which nodes, with what SNR and timestamps, and how the
+ * uncertainty radius was derived.
+ *
+ * Estimated positions only, by construction: the reply is built from the global
+ * `estimated_positions` row, and the estimator deletes that row the moment a
+ * node reports a real fix. A node with GPS therefore 404s rather than being
+ * handed a rationale for a position it did not infer.
+ *
+ * GLOBAL — no `sourceId`. Estimates pool observations from every Meshtastic
+ * source into one row per physical nodeNum (#3271), so there is nothing to
+ * scope. The `nodes:read` gate still applies.
+ *
+ * Anchors are capped at storage time (MAX_STORED_ANCHORS_PER_NODE); `anchors`
+ * carries what was kept and `observationCount` the true total, so a consumer
+ * can say "showing N of M" instead of implying the list is complete.
+ */
+router.get('/nodes/:nodeNum/position-estimate', requirePermission('nodes', 'read'), async (req, res) => {
+  try {
+    const nodeNum = parseNodeNumParam(req.params.nodeNum);
+    if (nodeNum === null) {
+      return fail(res, 400, 'INVALID_NODE_NUM', 'nodeNum must be a decimal node number or a !hex node id');
+    }
+
+    const estimate = await databaseService.getEstimatedPositionByNodeNumAsync(nodeNum);
+    if (!estimate) {
+      return fail(res, 404, 'NO_ESTIMATED_POSITION', 'This node has no estimated position');
+    }
+
+    const stored = await databaseService.getEstimatedPositionAnchorsAsync(nodeNum);
+    const anchors = stored.map((a) => ({
+      anchorNodeNum: a.anchorNodeNum,
+      anchorNodeId: a.anchorNodeId,
+      anchorLat: a.anchorLat,
+      anchorLon: a.anchorLon,
+      kind: a.kind,
+      snrDb: a.snrDb,
+      observedAt: a.observedAt,
+      weight: a.weight,
+      // Derived, not stored: how far this anchor sits from the solved point.
+      distanceKm: calculateDistance(estimate.latitude, estimate.longitude, a.anchorLat, a.anchorLon),
+    }));
+
+    return ok(res, {
+      nodeNum: estimate.nodeNum,
+      nodeId: estimate.nodeId,
+      latitude: estimate.latitude,
+      longitude: estimate.longitude,
+      uncertaintyKm: estimate.uncertaintyKm,
+      // True total observations behind the estimate — may exceed anchors.length.
+      observationCount: estimate.observationCount,
+      updatedAt: estimate.updatedAt,
+      // Null on estimates written before #4609; the UI must say "unknown"
+      // rather than guess a method.
+      nEff: estimate.nEff,
+      radiusMethod: estimate.radiusMethod,
+      singleAnchorDefaultKm: DEFAULT_SINGLE_ANCHOR_KM,
+      anchors,
+      anchorsStored: anchors.length,
+      anchorsTruncated: estimate.observationCount > anchors.length,
+      maxStoredAnchors: MAX_STORED_ANCHORS_PER_NODE,
+    });
+  } catch (error) {
+    logger.error('Error getting position estimate rationale:', error);
+    return fail(res, 500, 'POSITION_ESTIMATE_FAILED', 'Failed to retrieve position estimate rationale');
   }
 });
 

--- a/src/server/services/positionEstimationService.test.ts
+++ b/src/server/services/positionEstimationService.test.ts
@@ -13,6 +13,7 @@ const mockDb = vi.hoisted(() => ({
   neighbors: { getAllNeighborInfo: vi.fn() },
   upsertEstimatedPositionsAsync: vi.fn(),
   deleteEstimatedPositionsByNodeNumsAsync: vi.fn(),
+  replaceEstimatedPositionAnchorsAsync: vi.fn(),
 }));
 vi.mock('../../services/database.js', () => ({ default: mockDb }));
 
@@ -21,6 +22,8 @@ import {
   buildObservations,
   observationWeight,
   positionEstimationService,
+  DEFAULT_SINGLE_ANCHOR_KM,
+  MAX_STORED_ANCHORS_PER_NODE,
   type PositionObservation,
   type TracerouteForEstimation,
   type NeighborForEstimation,
@@ -32,6 +35,7 @@ const NOW = 1_700_000_000_000;
 function obs(partial: Partial<PositionObservation>): PositionObservation {
   return {
     nodeNum: 1,
+    anchorNodeNum: 999,
     anchorLat: 0,
     anchorLon: 0,
     timestamp: NOW,
@@ -304,6 +308,7 @@ describe('positionEstimationService.recomputeAll', () => {
     mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([]);
     mockDb.upsertEstimatedPositionsAsync.mockResolvedValue(undefined);
     mockDb.deleteEstimatedPositionsByNodeNumsAsync.mockResolvedValue(0);
+    mockDb.replaceEstimatedPositionAnchorsAsync.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -450,6 +455,222 @@ describe('positionEstimationService.recomputeAll', () => {
       });
       expect(result.estimatedNodeCount).toBe(1);
       expect(result.rejectedNodeCount).toBe(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #4609 — the rationale behind an estimated position.
+//
+// Before this, the estimator solved a position and discarded every observation
+// that produced it, leaving no way to explain a pin. These tests pin down the
+// three things that make an explanation possible: observations carry the
+// identity of the node that anchored them, the solve reports which branch of
+// the uncertainty math produced its radius, and the writer persists a capped,
+// strongest-first anchor set.
+// ---------------------------------------------------------------------------
+describe('estimate rationale (#4609)', () => {
+  describe('anchor identity', () => {
+    it('records which node anchored each traceroute hop, on both sides', () => {
+      const anchors = new Map<number, { lat: number; lon: number }>([
+        [100, { lat: 10, lon: 20 }],
+        [200, { lat: 12, lon: 20 }],
+      ]);
+      const traceroutes: TracerouteForEstimation[] = [{
+        fromNodeNum: 100, toNodeNum: 200, route: JSON.stringify([5]),
+        routeBack: null, snrTowards: JSON.stringify([20, 20]), snrBack: null, timestamp: NOW,
+      }];
+
+      const observations = buildObservations(traceroutes, [], anchors).get(5)!;
+
+      expect(observations).toHaveLength(2);
+      // Without anchorNodeNum the API could only say "some node at 10,20".
+      expect(observations.map((o) => o.anchorNodeNum).sort()).toEqual([100, 200]);
+      expect(observations.every((o) => o.kind === 'traceroute')).toBe(true);
+    });
+
+    it('records the anchoring node for a NeighborInfo pair, whichever side is positioned', () => {
+      const anchors = new Map<number, { lat: number; lon: number }>([
+        [100, { lat: 35.1, lon: -80.6 }],
+      ]);
+      const neighbors: NeighborForEstimation[] = [
+        // Unpositioned node 1 reports positioned 100 as a neighbour.
+        { nodeNum: 1, neighborNodeNum: 100, snr: 5, timestamp: NOW },
+        // Positioned 100 reports unpositioned 2 as a neighbour — reverse direction.
+        { nodeNum: 100, neighborNodeNum: 2, snr: -3, timestamp: NOW },
+      ];
+
+      const out = buildObservations([], neighbors, anchors);
+
+      expect(out.get(1)![0].anchorNodeNum).toBe(100);
+      expect(out.get(1)![0].kind).toBe('neighbor');
+      expect(out.get(2)![0].anchorNodeNum).toBe(100);
+      expect(out.get(2)![0].kind).toBe('neighbor');
+    });
+  });
+
+  describe('radius derivation', () => {
+    it('reports single_anchor for a lone observation (the flat 5 km heuristic)', () => {
+      const solved = solveNodePosition([obs({ anchorLat: 35, anchorLon: -80 })], NOW)!;
+      expect(solved.radiusMethod).toBe('single_anchor');
+      expect(solved.nEff).toBeCloseTo(1, 6);
+      expect(solved.uncertaintyKm).toBeCloseTo(DEFAULT_SINGLE_ANCHOR_KM, 6);
+    });
+
+    it('does not claim convergence when one strong anchor dominates the weights (#3616)', () => {
+      // Two observations, but nEff barely exceeds 1 — the weak anchor
+      // contributes almost nothing. The blend must stay pinned near the
+      // radio-range default, so the reported radius does not imply a solve that
+      // did not happen.
+      const solved = solveNodePosition([
+        obs({ anchorLat: 35.0, anchorLon: -80.0, snrDb: 20 }),
+        obs({ anchorLat: 35.2, anchorLon: -80.0, snrDb: -20 }),
+      ], NOW)!;
+      expect(solved.nEff).toBeLessThan(1.1);
+      expect(solved.radiusMethod).not.toBe('convergence');
+      expect(solved.uncertaintyKm).toBeCloseTo(DEFAULT_SINGLE_ANCHOR_KM, 1);
+    });
+
+    it('reports convergence for a balanced multi-anchor solve', () => {
+      // A tight, evenly weighted ring: nEff = 4 and the statistical radius is
+      // well inside the lone-anchor default.
+      const solved = solveNodePosition([
+        obs({ anchorLat: 35.01, anchorLon: -80.0, snrDb: 0 }),
+        obs({ anchorLat: 34.99, anchorLon: -80.0, snrDb: 0 }),
+        obs({ anchorLat: 35.0, anchorLon: -80.01, snrDb: 0 }),
+        obs({ anchorLat: 35.0, anchorLon: -79.99, snrDb: 0 }),
+      ], NOW)!;
+      expect(solved.nEff).toBeGreaterThanOrEqual(2);
+      expect(solved.radiusMethod).toBe('convergence');
+      expect(solved.uncertaintyKm).toBeLessThan(DEFAULT_SINGLE_ANCHOR_KM);
+    });
+
+    it('reports blended when confidence sits strictly between the two branches', () => {
+      // Two equal-weight anchors give nEff = 2 exactly; unequal SNR lands nEff
+      // in (1, 2) — the partial-convergence region.
+      const solved = solveNodePosition([
+        obs({ anchorLat: 35.0, anchorLon: -80.0, snrDb: 6 }),
+        obs({ anchorLat: 35.1, anchorLon: -80.0, snrDb: 0 }),
+      ], NOW)!;
+      expect(solved.nEff).toBeGreaterThan(1);
+      expect(solved.nEff).toBeLessThan(2);
+      expect(solved.radiusMethod).toBe('blended');
+      expect(solved.uncertaintyKm).toBeLessThan(DEFAULT_SINGLE_ANCHOR_KM);
+    });
+
+    it('returns used observations sorted strongest-contribution first', () => {
+      const solved = solveNodePosition([
+        obs({ anchorNodeNum: 1, anchorLat: 35.0, anchorLon: -80.0, snrDb: -10 }),
+        obs({ anchorNodeNum: 2, anchorLat: 35.1, anchorLon: -80.0, snrDb: 10 }),
+        obs({ anchorNodeNum: 3, anchorLat: 35.05, anchorLon: -80.0, snrDb: 0 }),
+      ], NOW)!;
+
+      expect(solved.usedObservations.map((u) => u.observation.anchorNodeNum)).toEqual([2, 3, 1]);
+      expect(solved.usedObservations[0].weight).toBeGreaterThan(solved.usedObservations[2].weight);
+    });
+  });
+
+  describe('persistence', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+      mockDb.traceroutes.getAllTraceroutes.mockResolvedValue([]);
+      mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([]);
+      mockDb.upsertEstimatedPositionsAsync.mockResolvedValue(undefined);
+      mockDb.deleteEstimatedPositionsByNodeNumsAsync.mockResolvedValue(0);
+      mockDb.replaceEstimatedPositionAnchorsAsync.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('persists the anchors behind each estimate, with the derivation on the estimate row', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([{ id: 'src-a', type: 'meshtastic_tcp' }]);
+      mockDb.nodes.getAllNodes.mockResolvedValue([
+        { nodeNum: 100, latitude: 10, longitude: 20 },
+        { nodeNum: 200, latitude: 12, longitude: 20 },
+      ]);
+      mockDb.traceroutes.getAllTraceroutes.mockResolvedValue([{
+        fromNodeNum: 100, toNodeNum: 200, route: JSON.stringify([5]),
+        routeBack: null, snrTowards: JSON.stringify([20, 20]), snrBack: null, timestamp: NOW,
+      }]);
+
+      await positionEstimationService.recomputeAll({ lookbackMs: 7 * 24 * 60 * 60 * 1000 });
+
+      const estimate = mockDb.upsertEstimatedPositionsAsync.mock.calls[0][0][0];
+      expect(estimate.nodeNum).toBe(5);
+      expect(estimate.nEff).toBeGreaterThan(0);
+      expect(estimate.radiusMethod).toBeTruthy();
+
+      const [nodeNums, anchorRows] = mockDb.replaceEstimatedPositionAnchorsAsync.mock.calls[0];
+      expect(nodeNums).toEqual([5]);
+      expect(anchorRows).toHaveLength(2);
+      expect(anchorRows.map((a: any) => a.anchorNodeNum).sort()).toEqual([100, 200]);
+      // nodeId is derived for display; the raw number stays authoritative.
+      expect(anchorRows.map((a: any) => a.anchorNodeId).sort()).toEqual(['!00000064', '!000000c8']);
+      expect(anchorRows.every((a: any) => a.kind === 'traceroute')).toBe(true);
+      expect(anchorRows.every((a: any) => a.snrDb === 5)).toBe(true); // raw 20 / 4
+      expect(anchorRows.every((a: any) => a.createdAt === NOW)).toBe(true);
+    });
+
+    it('caps stored anchors per node while leaving the true total on the estimate', async () => {
+      const anchorCount = MAX_STORED_ANCHORS_PER_NODE + 7;
+      mockDb.sources.getAllSources.mockResolvedValue([{ id: 'src-a', type: 'meshtastic_tcp' }]);
+      mockDb.nodes.getAllNodes.mockResolvedValue(
+        Array.from({ length: anchorCount }, (_, i) => ({
+          nodeNum: 1000 + i,
+          latitude: 35 + i * 0.001,
+          longitude: -80,
+        })),
+      );
+      // Every positioned node reports unpositioned node 7 as a neighbour, with
+      // ascending SNR so the strongest anchors are identifiable.
+      mockDb.neighbors.getAllNeighborInfo.mockResolvedValue(
+        Array.from({ length: anchorCount }, (_, i) => ({
+          nodeNum: 1000 + i, neighborNodeNum: 7, snr: i, timestamp: NOW,
+        })),
+      );
+
+      await positionEstimationService.recomputeAll({ lookbackMs: 7 * 24 * 60 * 60 * 1000 });
+
+      const estimate = mockDb.upsertEstimatedPositionsAsync.mock.calls[0][0][0];
+      const [, anchorRows] = mockDb.replaceEstimatedPositionAnchorsAsync.mock.calls[0];
+
+      expect(anchorRows).toHaveLength(MAX_STORED_ANCHORS_PER_NODE);
+      // The count on the estimate stays the honest total, so a consumer can say
+      // "showing 20 of 27" rather than implying the list is complete.
+      expect(estimate.observationCount).toBe(anchorCount);
+      // The kept anchors are the strongest, not an arbitrary prefix: SNR ascends
+      // with the index, so the weakest survivor is the cap-th from the top.
+      const keptSnrs = anchorRows.map((a: any) => a.snrDb).sort((x: number, y: number) => x - y);
+      expect(keptSnrs[0]).toBe(anchorCount - MAX_STORED_ANCHORS_PER_NODE);
+    });
+
+    it('clears anchors for a node whose estimate is rejected as too uncertain', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([{ id: 'src-a', type: 'meshtastic_tcp' }]);
+      mockDb.nodes.getAllNodes.mockResolvedValue([{ nodeNum: 100, latitude: 10, longitude: 20 }]);
+      mockDb.neighbors.getAllNeighborInfo.mockResolvedValue([
+        { nodeNum: 100, neighborNodeNum: 9, snr: 5, timestamp: NOW },
+      ]);
+
+      // A lone anchor always resolves to the 5 km default, so a 1 km ceiling
+      // rejects it.
+      const result = await positionEstimationService.recomputeAll({
+        lookbackMs: 7 * 24 * 60 * 60 * 1000,
+        maxUncertaintyKm: 1,
+      });
+
+      expect(result.rejectedNodeCount).toBe(1);
+      // Nothing is written for node 9...
+      const [nodeNums, anchorRows] = mockDb.replaceEstimatedPositionAnchorsAsync.mock.calls[0];
+      expect(nodeNums).toEqual([]);
+      expect(anchorRows).toEqual([]);
+      // ...and the delete (which cascades anchors in the repository) covers it.
+      expect(mockDb.deleteEstimatedPositionsByNodeNumsAsync).toHaveBeenCalledWith(
+        expect.arrayContaining([9]),
+      );
     });
   });
 });

--- a/src/server/services/positionEstimationService.ts
+++ b/src/server/services/positionEstimationService.ts
@@ -22,11 +22,20 @@ import { logger } from '../../utils/logger.js';
 import { calculateDistance } from '../../utils/distance.js';
 import { isBogusPosition } from '../../utils/nullIsland.js';
 import { getEffectiveDbNodePosition } from '../utils/nodeEnhancer.js';
-import type { EstimatedPositionInput } from '../../db/repositories/index.js';
+import type {
+  EstimatedPositionInput,
+  EstimatedPositionAnchorInput,
+  RadiusMethod,
+} from '../../db/repositories/index.js';
 
 /** A single geometric constraint: node `nodeNum` is near positioned `anchor`. */
 export interface PositionObservation {
   nodeNum: number;
+  /**
+   * The positioned node acting as the anchor. Carried so the estimate's
+   * rationale can name it (#4609) — the solve itself only needs the lat/lon.
+   */
+  anchorNodeNum: number;
   anchorLat: number;
   anchorLon: number;
   /** Link SNR in dB (already converted). Higher → closer → higher weight. */
@@ -36,11 +45,30 @@ export interface PositionObservation {
   kind: 'traceroute' | 'neighbor';
 }
 
+/** An observation plus the weight it received in the solve (#4609). */
+export interface WeightedObservation {
+  observation: PositionObservation;
+  weight: number;
+}
+
 export interface SolvedPosition {
   latitude: number;
   longitude: number;
   uncertaintyKm: number;
   observationCount: number;
+  /**
+   * Kish effective sample size. 1 means a lone anchor — or several so lopsided
+   * in weight that they behave as one. Recorded so the UI can explain the
+   * radius instead of just showing it (#4609).
+   */
+  nEff: number;
+  /** Which branch of the uncertainty math produced `uncertaintyKm` (#4609). */
+  radiusMethod: RadiusMethod;
+  /**
+   * Positive-weight observations with the weight each received, strongest
+   * first. These are the anchors that actually moved the centroid.
+   */
+  usedObservations: WeightedObservation[];
 }
 
 export interface RecomputeResult {
@@ -58,12 +86,26 @@ const HALF_LIFE_MS = 24 * 60 * 60 * 1000;
 const DECAY_CONSTANT = Math.LN2 / HALF_LIFE_MS;
 
 // A single anchor can't triangulate — only tells us "within radio range".
-const DEFAULT_SINGLE_ANCHOR_KM = 5;
+// Exported so the rationale API can state the heuristic it came from (#4609)
+// rather than hardcoding "5 km" a second time.
+export const DEFAULT_SINGLE_ANCHOR_KM = 5;
 // Floor so multi-anchor estimates never report absurd over-confidence.
 const MIN_UNCERTAINTY_KM = 0.05;
 
 // Upper bound on traceroutes pulled per source (defensive — lookback also caps).
 const MAX_TRACEROUTES_PER_SOURCE = 100000;
+
+/**
+ * Cap on anchors persisted per node for the rationale view (#4609).
+ *
+ * A well-connected node in a busy mesh can accumulate thousands of observations
+ * over the 7-day lookback; storing them all would grow the anchor table far
+ * beyond the value it provides. We keep the highest-weighted anchors — the ones
+ * that actually determined where the pin landed — and leave the true total on
+ * `estimated_positions.observationCount`, so a consumer can always say
+ * "showing N of M".
+ */
+export const MAX_STORED_ANCHORS_PER_NODE = 20;
 
 function nodeNumToId(nodeNum: number): string {
   return `!${nodeNum.toString(16).padStart(8, '0')}`;
@@ -161,12 +203,35 @@ export function solveNodePosition(observations: PositionObservation[], now: numb
   // strong anchor that dominates the weights (nEff barely above 1) no longer
   // skips the radio-range default and report a spuriously tight radius.
   const confidence = Math.min(1, Math.max(0, nEff - 1));
+  // Both terms are already >= MIN_UNCERTAINTY_KM (statisticalKm is floored and
+  // DEFAULT_SINGLE_ANCHOR_KM is far above it), so the outer Math.max is a
+  // belt-and-braces guard rather than a branch the radius can actually take.
   const uncertaintyKm = Math.max(
     MIN_UNCERTAINTY_KM,
     DEFAULT_SINGLE_ANCHOR_KM * (1 - confidence) + statisticalKm * confidence,
   );
 
-  return { latitude, longitude, uncertaintyKm, observationCount: observations.length };
+  // Name the branch that produced the radius (#4609), so the UI can say
+  // "lone anchor, 5 km default" rather than presenting a guess and a solve as
+  // if they were the same kind of answer.
+  const radiusMethod: RadiusMethod =
+    confidence <= 0 ? 'single_anchor'
+      : confidence >= 1 ? 'convergence'
+        : 'blended';
+
+  const usedObservations: WeightedObservation[] = used
+    .map(({ obs, w }) => ({ observation: obs, weight: w }))
+    .sort((a, b) => b.weight - a.weight);
+
+  return {
+    latitude,
+    longitude,
+    uncertaintyKm,
+    observationCount: observations.length,
+    nEff,
+    radiusMethod,
+    usedObservations,
+  };
 }
 
 /** Safely JSON-parse an array of numbers; returns [] on any problem. */
@@ -225,6 +290,7 @@ function addPathObservations(
     if (prev) {
       list.push({
         nodeNum,
+        anchorNodeNum: path[i - 1],
         anchorLat: prev.lat,
         anchorLon: prev.lon,
         snrDb: typeof snrPrevRaw === 'number' ? snrPrevRaw / 4 : undefined,
@@ -235,6 +301,7 @@ function addPathObservations(
     if (next) {
       list.push({
         nodeNum,
+        anchorNodeNum: path[i + 1],
         anchorLat: next.lat,
         anchorLon: next.lon,
         snrDb: typeof snrNextRaw === 'number' ? snrNextRaw / 4 : undefined,
@@ -290,6 +357,7 @@ export function buildObservations(
       const list = out.get(nb.nodeNum) ?? [];
       list.push({
         nodeNum: nb.nodeNum,
+        anchorNodeNum: nb.neighborNodeNum,
         anchorLat: neighborAnchor.lat,
         anchorLon: neighborAnchor.lon,
         snrDb,
@@ -302,6 +370,7 @@ export function buildObservations(
       const list = out.get(nb.neighborNodeNum) ?? [];
       list.push({
         nodeNum: nb.neighborNodeNum,
+        anchorNodeNum: nb.nodeNum,
         anchorLat: nodeAnchor.lat,
         anchorLon: nodeAnchor.lon,
         snrDb,
@@ -383,6 +452,8 @@ class PositionEstimationService {
 
     let observationCount = 0;
     const inputs: EstimatedPositionInput[] = [];
+    // Anchors backing the estimates written this run (#4609), capped per node.
+    const anchorInputs: EstimatedPositionAnchorInput[] = [];
     // Nodes solved but rejected for exceeding maxUncertaintyKm. Their existing
     // estimates (if any) are deleted below so a now-too-uncertain node doesn't
     // keep a stale, oversized circle on the map.
@@ -403,14 +474,40 @@ class PositionEstimationService {
         uncertaintyKm: solved.uncertaintyKm,
         observationCount: solved.observationCount,
         updatedAt: now,
+        nEff: solved.nEff,
+        radiusMethod: solved.radiusMethod,
       });
+
+      // usedObservations is already sorted strongest-first, so slicing keeps the
+      // anchors that actually determined the pin.
+      for (const { observation, weight } of solved.usedObservations.slice(0, MAX_STORED_ANCHORS_PER_NODE)) {
+        anchorInputs.push({
+          nodeNum,
+          anchorNodeNum: observation.anchorNodeNum,
+          anchorNodeId: nodeNumToId(observation.anchorNodeNum),
+          anchorLat: observation.anchorLat,
+          anchorLon: observation.anchorLon,
+          kind: observation.kind,
+          snrDb: observation.snrDb ?? null,
+          observedAt: observation.timestamp,
+          weight,
+          createdAt: now,
+        });
+      }
     }
 
     await databaseService.upsertEstimatedPositionsAsync(inputs);
+    // Replace anchors for exactly the nodes we just wrote. Passing the node list
+    // separately clears stale rows for a node that solved with no usable anchor.
+    await databaseService.replaceEstimatedPositionAnchorsAsync(
+      inputs.map((i) => i.nodeNum),
+      anchorInputs,
+    );
 
     // Clear estimates that are no longer valid: a node that gained a real
     // position (now an anchor), or one whose fresh estimate is too uncertain
-    // to keep under the configured maximum.
+    // to keep under the configured maximum. The repository cascades the
+    // matching anchor rows.
     const anchorNodeNums = [...anchors.keys()];
     await databaseService.deleteEstimatedPositionsByNodeNumsAsync([...anchorNodeNums, ...rejectedNodeNums]);
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -69,7 +69,13 @@ import {
   ThemesRepository,
   ALL_SOURCES,
 } from '../db/repositories/index.js';
-import type { EstimatedPosition, EstimatedPositionInput, SourceScope } from '../db/repositories/index.js';
+import type {
+  EstimatedPosition,
+  EstimatedPositionInput,
+  EstimatedPositionAnchor,
+  EstimatedPositionAnchorInput,
+  SourceScope,
+} from '../db/repositories/index.js';
 import type { DatabaseType, DbPacketLog as DbTypesPacketLog, DbPacketCountByNode, DbPacketCountByPortnum, DbDistinctRelayNode } from '../db/types.js';
 import { updateNodeMobility } from '../server/services/nodeMobilityService.js';
 import { selectNodeNeedingTraceroute } from '../server/services/autoTracerouteSelectionService.js';
@@ -1898,9 +1904,31 @@ class DatabaseService {
     return this.estimatedPositions.upsertManyEstimates(inputs);
   }
 
-  /** Delete global estimates for the given node numbers. */
+  /** Delete global estimates (and their anchors) for the given node numbers. */
   async deleteEstimatedPositionsByNodeNumsAsync(nodeNums: number[]): Promise<number> {
     return this.estimatedPositions.deleteByNodeNums(nodeNums);
+  }
+
+  /** Get one node's global estimated position, or null (issue #4609). */
+  async getEstimatedPositionByNodeNumAsync(nodeNum: number): Promise<EstimatedPosition | null> {
+    return this.estimatedPositions.getByNodeNum(nodeNum);
+  }
+
+  /**
+   * Replace the recorded anchors for the given nodes (issue #4609).
+   * `nodeNums` is separate from `anchors` so nodes that solved with no retained
+   * anchor still get their stale rows cleared.
+   */
+  async replaceEstimatedPositionAnchorsAsync(
+    nodeNums: number[],
+    anchors: EstimatedPositionAnchorInput[],
+  ): Promise<void> {
+    return this.estimatedPositions.replaceAnchors(nodeNums, anchors);
+  }
+
+  /** Get one node's recorded anchors, strongest contribution first (#4609). */
+  async getEstimatedPositionAnchorsAsync(nodeNum: number, limit?: number): Promise<EstimatedPositionAnchor[]> {
+    return this.estimatedPositions.getAnchorsByNodeNum(nodeNum, limit);
   }
 
 


### PR DESCRIPTION
Closes #4609 (#4610 was closed as a duplicate; its per-field list and use-case framing were folded into #4609 first).

## The crux: anchors were thrown away, and couldn't be reconstructed

`positionEstimationService.recomputeAll` built `Map<nodeNum, PositionObservation[]>` in memory, solved a weighted centroid, wrote `{nodeNum, nodeId, lat, lon, uncertaintyKm, observationCount, updatedAt}`, and dropped the observation set.

It's worse than "not stored": **`PositionObservation` never held the anchoring node's identity at all** — only `anchorLat`/`anchorLon`. The `anchors` map was keyed by nodeNum, but `buildObservations` read the coordinates and discarded the key. "Which node contributed this anchor" was lost *before* the solve ran.

**Reconstruction would not have been honest.** The raw traceroute/neighbor rows survive, so you could re-derive something — but re-running the time-decay model against a different `now` yields different weights and possibly a different anchor set than the one that produced the stored pin. That's a plausible story, not the rationale. A schema change was unavoidable.

## Schema

Migration **137**, all three backends, idempotent, registered.

- **`estimated_position_anchors`** — anchoring node and its position at solve time, kind (`traceroute` / `neighbor`), SNR, observation timestamp, solve weight, run clock.
- **`estimated_positions` gains `nEff` and `radiusMethod`** — 1:1 with the estimate, so no second table. Pre-existing rows read NULL and the API reports *unknown* rather than guessing.

**Deliberately global — no `sourceId`.** Estimates pool observations across every Meshtastic source (#3271), and the *same physical traceroute can be observed by several sources*, so there is no correct single owner. Adding one would re-fragment exactly what #3271 unified. **A test asserts the column's absence** so it doesn't get added out of habit later.

**Volume cap: 20 anchors per node, kept by descending weight** — the ones that actually moved the centroid. `observationCount` still carries the true total, so the UI can say "showing 20 of 137" rather than implying completeness. Replaced wholesale per run, cascade-deleted with the parent (hand-rolled, since the parent table is FK-free).

## Estimated-only falls out of the data model

No special-casing needed: a node with real GPS has no `estimated_positions` row — the estimator deletes it — so the endpoint 404s naturally.

## Scope

Backend complete: schema, migration, repository, `DatabaseService` facade, service rewiring (`anchorNodeNum` threaded through both traceroute sides and both NeighborInfo directions; `solveNodePosition` now reports `nEff`, `radiusMethod` and weighted observations), and `GET /api/nodes/:nodeNum/position-estimate` (`nodes:read`, accepts decimal or `!hex`).

**UI deferred deliberately** — the endpoint returns everything the issue asked for; what remains is a NodeDetails/popup component, i18n strings and a CSS module. Better as its own reviewable change than rushed onto the end of a migration PR.

## Verification

- Full suite: `success: true`, **14,331 passed, 0 failed**, 4,217/4,217 suites
- **PostgreSQL and MySQL containers were up** (5433/3307): **358 PG + 361 MySQL tests passed, 0 skipped** — so this was not a silent-skip run, which matters for a schema change
- New tests: migration (8), route (8, via the real `createRouteTestApp` harness — real session, real auth middleware, real migrated DB), service rationale (11)
- `tsc --noEmit` clean on both configs; `lint:ci` clean, with one targeted issue-referenced `no-explicit-any` disable rather than growing the baseline

Two small things worth noting: a `min_floor` radius-derivation value was written and then removed — `statisticalKm` is already floored, so the branch was unreachable, and a phantom enum value is worse than none. And the repo's own `cli/migrationTables.test.ts` caught the new table missing from the migrate-db table order.

## ⚠️ Migration number

#4607 is being worked in parallel and also picked **137** (`137_add_conversation_read_state`). This PR is finished first and keeps 137; **that branch will be renumbered to 138** before it opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX