### PR TITLE
feat(messages): unread divider + jump-to-first-unread for Meshtastic and MeshCore (#4607)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -5197,5 +5197,6 @@
   "meshcore.receive_only.saved_on": "Receive-only mode enabled — this node will not transmit",
   "meshcore.receive_only.saved_off": "Receive-only mode disabled — this node can transmit again",
   "meshcore.receive_only.save_failed": "Failed to change receive-only mode",
-  "meshcore.receive_only.console_placeholder": "Local serial commands still work; commands that transmit are blocked."
+  "meshcore.receive_only.console_placeholder": "Local serial commands still work; commands that transmit are blocked.",
+  "messages.unread_divider": "New messages"
 }

--- a/src/cli/migrationTables.ts
+++ b/src/cli/migrationTables.ts
@@ -52,6 +52,9 @@ export const TABLE_ORDER = [
   'user_notification_preferences',
   // Misc tables
   'read_messages',
+  // 4607: per-user MeshCore last-read watermarks. No FKs (userId is a plain
+  // int with 0 for anonymous), so ordering here is only for readability.
+  'conversation_read_state',
   'news_cache',
   // user_news_status FKs to users (already migrated above)
   'user_news_status',

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -29,6 +29,9 @@ import { logger } from '../utils/logger';
 import { MessageStatusIndicator } from './MessageStatusIndicator';
 import { useNodes } from '../hooks/useServerData';
 import { UiIcon } from './icons';
+import UnreadDivider from './messages/UnreadDivider';
+import { resolveUnreadAnchorId, shouldSuppressDivider } from '../utils/unreadAnchor';
+import { useUnreadDividerAnchors } from '../contexts/MessagingContext';
 
 // Default PSK value (publicly known key - not truly secure)
 const DEFAULT_PUBLIC_PSK = 'AQ==';
@@ -224,6 +227,9 @@ export default function ChannelsTab({
   const { nodes } = useNodes();
   const { distanceUnit } = useSettings();
   const { isChannelMuted, muteChannel, unmuteChannel } = useNotificationMuteSettings();
+  // Oldest-unread timestamp for the open channel, pinned at entry (#4607).
+  // Drives the red "New messages" divider below.
+  const { channel: pinnedFirstUnreadChannel } = useUnreadDividerAnchors();
 
   const [showMuteMenu, setShowMuteMenu] = useState<number | null>(null);
   // Mobile overflow ("⋯") menu — collapses info / notifications / mark-all-read
@@ -1013,6 +1019,33 @@ export default function ChannelsTab({
                         (a, b) => getMessageSortTime(a) - getMessageSortTime(b)
                       );
 
+                      // Unread divider anchor (#4607). `pinnedFirstUnreadChannel`
+                      // is the oldest-unread timestamp captured when this channel
+                      // was opened — the read-marking effect clears the unread set
+                      // a tick later, so it has to come from the pin, not a live
+                      // lookup. Resolved against the SAME filtered+sorted list the
+                      // rows are rendered from, so the line can never point at a
+                      // row this view hides (MQTT off, traceroutes on Primary).
+                      const unreadAnchorId = (() => {
+                        const rows = messagesForChannel.map(m => ({ id: m.id, sortTime: getMessageSortTime(m) }));
+                        const ownIds = new Set(messagesForChannel.filter(isMyMessage).map(m => m.id));
+                        const anchor = resolveUnreadAnchorId({
+                          messages: rows,
+                          watermarkMs: pinnedFirstUnreadChannel,
+                          mode: 'firstUnread',
+                          ownMessageIds: ownIds,
+                        });
+                        // `hasMoreOlder: true` because this view renders a WINDOW
+                        // (latest ~100 rows) and pages older history in on scroll
+                        // — an anchor at the top of the window does not mean the
+                        // start of the conversation, so the line stays.
+                        return shouldSuppressDivider({
+                          anchorId: anchor,
+                          messages: rows,
+                          hasMoreOlder: true,
+                        }) ? null : anchor;
+                      })();
+
                       return messagesForChannel && messagesForChannel.length > 0 ? (
                         messagesForChannel.map((msg, index) => {
                           const isMine = isMyMessage(msg);
@@ -1045,7 +1078,10 @@ export default function ChannelsTab({
                                   </span>
                                 </div>
                               )}
-                              <div 
+                              {/* Red "New messages" line, directly above the
+                                  oldest message unseen at entry (#4607). */}
+                              {unreadAnchorId === msg.id && <UnreadDivider />}
+                              <div
                                 className={`message-bubble-container ${isMine ? 'mine' : 'theirs'}`}
                                 data-message-id={msg.id}
                               >

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -500,6 +500,22 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
     return Array.from(byId.values()).sort(compareMeshCoreMessages);
   }, [history, messages, activeFilter]);
 
+  // Unread-divider anchor (#4607): the last-read marker frozen at the moment
+  // this channel was opened. The effect below marks the channel read within a
+  // tick of entry, so reading `lastRead[active.id]` live would always say
+  // "nothing unread" by the time the stream rendered. Pinned per channel, and
+  // re-pinned when the channel or source changes.
+  //
+  // `undefined` means "not pinned yet"; the stream treats null/undefined as
+  // "no divider", which is also the correct answer for a channel opened before
+  // its backlog arrives.
+  const [entryLastRead, setEntryLastRead] = useState<number | null>(null);
+  useEffect(() => {
+    // Read through the ref, not `lastRead`: depending on the state value would
+    // re-pin on every mark-read and erase the line while you are reading it.
+    setEntryLastRead(lastReadRef.current[active.id] ?? 0);
+  }, [active.id, sourceId]);
+
   // Mark the active channel read up to its newest visible message. Runs whenever
   // the active channel's content changes (channel switch, backlog load, or a
   // live message arriving while it's open), so an open channel never shows as
@@ -770,6 +786,7 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
           onNodeNameClick={onNodeNameClick}
           onReply={handleReply}
           conversationKey={`channel-${active.id}`}
+          unreadAnchorMs={entryLastRead}
           onLoadOlder={loadOlderHistory}
           hasMoreOlder={hasMoreHistory}
           loadingOlder={loadingOlderHistory}

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -281,6 +281,24 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
   const [unreadTick, setUnreadTick] = useState(0);
   useEffect(() => subscribeUnreadChanged(() => setUnreadTick((n) => n + 1)), []);
 
+  // Unread-divider anchor (#4607): the peer's last-read marker frozen at the
+  // moment the conversation was opened. The mark-read effect below fires within
+  // a tick of selection, so a live read would always report "nothing unread".
+  // Deliberately re-pinned only on peer/source change — NOT on `filtered`,
+  // which changes with every incoming message.
+  const [entryLastRead, setEntryLastRead] = useState<number | null>(null);
+  useEffect(() => {
+    if (!sourceId || !selected) {
+      setEntryLastRead(null);
+      return;
+    }
+    const peer = canonicalizePeerKey(selected, contacts);
+    setEntryLastRead(loadDmLastRead(sourceId)[peer] ?? 0);
+    // `contacts` is intentionally omitted: it re-resolves on every contact
+    // refresh, which would re-pin mid-conversation and erase the line.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- #4607 pin-once-per-conversation is the point
+  }, [sourceId, selected]);
+
   // Mark the open conversation read up to its newest message. Re-runs when a
   // new message arrives for the selected peer (filtered changes), so a
   // conversation you're actively viewing never lingers as unread. markDmRead is
@@ -525,6 +543,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                   onSend={text => actions.sendMessage(text, selected)}
                   onDeleteMessage={canSend ? handleDeleteMessage : undefined}
                   conversationKey={`dm-${selected}`}
+                  unreadAnchorMs={entryLastRead}
                   maxBytes={150}
                 />
               </>

--- a/src/components/MeshCore/MeshCoreMessageStream.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.tsx
@@ -7,6 +7,8 @@ import { getUtf8ByteLength, formatByteCount } from '../../utils/text';
 import LinkPreview from '../LinkPreview';
 import MeshCoreMessageRouteModal from './MeshCoreMessageRouteModal';
 import { UiIcon } from '../icons';
+import UnreadDivider from '../messages/UnreadDivider';
+import { resolveUnreadAnchorId, shouldSuppressDivider } from '../../utils/unreadAnchor';
 
 interface MeshCoreMessageStreamProps {
   messages: MeshCoreMessage[];
@@ -45,6 +47,14 @@ interface MeshCoreMessageStreamProps {
    *  and to know when it's safe to restore scroll position after older
    *  messages are prepended. */
   loadingOlder?: boolean;
+  /** Last-read watermark (ms) PINNED when this conversation was opened (#4607).
+   *  The stream draws the unread divider above the first message newer than it
+   *  and lands the entry scroll there instead of at the bottom.
+   *
+   *  The parent must pin it: the views mark a conversation read on entry, so a
+   *  live value would evaporate before the line could be drawn. `null` /
+   *  omitted means "no divider" (nothing unread, or unknown). */
+  unreadAnchorMs?: number | null;
 }
 
 /** Scroll-to-top distance (px) that triggers a load-older request. */
@@ -101,6 +111,7 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
   onLoadOlder,
   hasMoreOlder,
   loadingOlder,
+  unreadAnchorMs,
 }) => {
   const { t } = useTranslation();
   const [draft, setDraft] = useState('');
@@ -161,7 +172,37 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
     };
   }, [contacts]);
 
-  // Entry scroll: on conversation entry, land at the BOTTOM (newest messages).
+  // Unread divider anchor (#4607): the id of the first message newer than the
+  // pinned last-read watermark. Own outgoing messages can't be "unread", so
+  // they never take the anchor — otherwise replying and coming back would put
+  // the line above something you typed yourself.
+  const unreadAnchorId = useMemo(() => {
+    const ownIds = new Set(
+      selfPublicKey
+        ? messages.filter(m => m.fromPublicKey === selfPublicKey).map(m => m.id)
+        : []
+    );
+    const anchorId = resolveUnreadAnchorId({
+      messages: messages.map(m => ({ id: m.id, sortTime: m.timestamp })),
+      watermarkMs: unreadAnchorMs,
+      mode: 'lastRead',
+      ownMessageIds: ownIds,
+    });
+    return shouldSuppressDivider({
+      anchorId,
+      messages: messages.map(m => ({ id: m.id, sortTime: m.timestamp })),
+      hasMoreOlder,
+    }) ? null : anchorId;
+  }, [messages, selfPublicKey, unreadAnchorMs, hasMoreOlder]);
+
+  // Read through a ref inside the entry scroll: the anchor is derived from
+  // `messages`, and putting it in that effect's deps would re-arm the one-shot
+  // scroll on every incoming message.
+  const unreadAnchorIdRef = useRef<string | null>(unreadAnchorId);
+  unreadAnchorIdRef.current = unreadAnchorId;
+
+  // Entry scroll: on conversation entry, land on the unread divider when there
+  // is one, otherwise at the BOTTOM (newest messages).
   // A channel's backlog is fetched ASYNCHRONOUSLY, so `messages` is often empty
   // when `conversationKey` first flips — scrolling then would fire against empty
   // content and leave the viewport stranded. So we defer until messages are
@@ -190,6 +231,15 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
    */
   const runEntryScroll = useCallback((container: HTMLDivElement): boolean => {
     if (container.scrollHeight === 0) return false;
+    // Jump to the oldest unseen message when there is one (#4607), so switching
+    // between threads drops you where you stopped reading rather than at the
+    // end. `scrollIntoView` on the divider itself keeps the line visible above
+    // the first unread row.
+    const divider = container.querySelector('[data-unread-divider]');
+    if (unreadAnchorIdRef.current && divider) {
+      divider.scrollIntoView({ block: 'start' });
+      return true;
+    }
     container.scrollTop = container.scrollHeight;
     return true;
   }, []);
@@ -448,6 +498,10 @@ export const MeshCoreMessageStream: React.FC<MeshCoreMessageStreamProps> = ({
                   </span>
                 </div>
               )}
+              {/* Unread divider goes AFTER the date separator so the date still
+                  heads its own day and the red line sits directly above the
+                  first unseen message (#4607). */}
+              {unreadAnchorId === m.id && <UnreadDivider />}
               <div className={`mc-message-row ${outgoing ? 'outgoing' : ''}`} data-message-id={m.id}>
               <div className="mc-message-header">
                 {canClick ? (

--- a/src/components/MeshCore/MeshCoreMessageStream.unreadDivider.test.tsx
+++ b/src/components/MeshCore/MeshCoreMessageStream.unreadDivider.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Unread divider + jump-to-first-unread entry scroll in the MeshCore stream
+ * (issue #4607).
+ *
+ * The behaviours pinned here are the ones the feature lives or dies on:
+ *  - the line lands ABOVE the first message newer than the pinned watermark,
+ *  - it never lands above one of our own sends,
+ *  - the entry scroll targets it instead of the bottom,
+ *  - and it survives the conversation being marked read (the caller pins the
+ *    watermark, so a later re-render with the same prop keeps the line).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) =>
+      (typeof fallback === 'string' ? fallback : key),
+  }),
+  Trans: ({ children }: { children?: unknown }) => children,
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+import { MeshCoreMessageStream } from './MeshCoreMessageStream';
+import type { MeshCoreMessage } from './hooks/useMeshCore';
+
+const SELF = 'ffffffffffffffff';
+
+function msg(id: string, timestamp: number, from = 'abcdef0123456789'): MeshCoreMessage {
+  return { id, fromPublicKey: from, text: `text-${id}`, timestamp };
+}
+
+function renderStream(props: Partial<React.ComponentProps<typeof MeshCoreMessageStream>> = {}) {
+  return render(
+    <MeshCoreMessageStream
+      messages={[]}
+      onSend={async () => true}
+      conversationKey="channel-0"
+      {...props}
+    />,
+  );
+}
+
+/** Ids of message rows, in DOM order, with the divider marked. */
+function domOrder(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('[data-message-id], [data-unread-divider]'))
+    .map(el => el.getAttribute('data-message-id') ?? 'DIVIDER');
+}
+
+describe('MeshCoreMessageStream unread divider (#4607)', () => {
+  it('renders no divider without a watermark', () => {
+    const { container } = renderStream({
+      messages: [msg('a', 1000), msg('b', 2000)],
+    });
+    expect(container.querySelector('[data-unread-divider]')).toBeNull();
+  });
+
+  it('renders no divider when every message predates the watermark', () => {
+    const { container } = renderStream({
+      messages: [msg('a', 1000), msg('b', 2000)],
+      unreadAnchorMs: 5000,
+    });
+    expect(container.querySelector('[data-unread-divider]')).toBeNull();
+  });
+
+  it('places the divider immediately above the first message newer than the watermark', () => {
+    const { container } = renderStream({
+      messages: [msg('a', 1000), msg('b', 2000), msg('c', 3000)],
+      unreadAnchorMs: 2000,
+      // Older history exists, so the "line above the very first row" guard
+      // does not apply here.
+      hasMoreOlder: true,
+    });
+    expect(domOrder(container)).toEqual(['a', 'b', 'DIVIDER', 'c']);
+  });
+
+  it('never anchors on our own outgoing message', () => {
+    // Replying and returning must not draw the line above what we just typed.
+    const { container } = renderStream({
+      messages: [msg('a', 1000), msg('mine', 2500, SELF), msg('c', 3000)],
+      selfPublicKey: SELF,
+      unreadAnchorMs: 2000,
+      hasMoreOlder: true,
+    });
+    expect(domOrder(container)).toEqual(['a', 'mine', 'DIVIDER', 'c']);
+  });
+
+  it('suppresses a line above the very first message of a fully-loaded thread', () => {
+    // "Everything below is new" in a thread never opened is not information.
+    const { container } = renderStream({
+      messages: [msg('a', 1000), msg('b', 2000)],
+      unreadAnchorMs: 0,
+      hasMoreOlder: false,
+    });
+    expect(container.querySelector('[data-unread-divider]')).toBeNull();
+  });
+
+  it('keeps the line at the top when older history has not been paged in', () => {
+    const { container } = renderStream({
+      messages: [msg('a', 1000), msg('b', 2000)],
+      unreadAnchorMs: 0,
+      hasMoreOlder: true,
+    });
+    expect(domOrder(container)).toEqual(['DIVIDER', 'a', 'b']);
+  });
+
+  it('keeps the divider across re-renders once the caller has pinned the watermark', () => {
+    // The views mark a conversation read on entry. Because the watermark is a
+    // pinned PROP rather than a live lookup, that must not erase the line.
+    const { container, rerender } = renderStream({
+      messages: [msg('a', 1000), msg('b', 2000), msg('c', 3000)],
+      unreadAnchorMs: 2000,
+      hasMoreOlder: true,
+    });
+    expect(container.querySelector('[data-unread-divider]')).not.toBeNull();
+
+    rerender(
+      <MeshCoreMessageStream
+        messages={[msg('a', 1000), msg('b', 2000), msg('c', 3000), msg('d', 4000)]}
+        onSend={async () => true}
+        conversationKey="channel-0"
+        unreadAnchorMs={2000}
+        hasMoreOlder
+      />,
+    );
+    expect(domOrder(container)).toEqual(['a', 'b', 'DIVIDER', 'c', 'd']);
+  });
+});
+
+describe('MeshCoreMessageStream entry scroll (#4607)', () => {
+  let scrollSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    scrollSpy = vi.fn();
+    // jsdom implements neither.
+    Element.prototype.scrollIntoView = scrollSpy as unknown as typeof Element.prototype.scrollIntoView;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() { return 1000; },
+    });
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  it('scrolls to the divider instead of the bottom when there is one', () => {
+    const { container } = renderStream({
+      messages: [msg('a', 1000), msg('b', 2000), msg('c', 3000)],
+      unreadAnchorMs: 2000,
+      hasMoreOlder: true,
+    });
+
+    expect(scrollSpy).toHaveBeenCalled();
+    // The container is left where scrollIntoView put it, NOT slammed to the end.
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    expect(list.scrollTop).not.toBe(1000);
+  });
+
+  it('falls back to the bottom when there is no divider', () => {
+    const { container } = renderStream({
+      messages: [msg('a', 1000), msg('b', 2000)],
+    });
+
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    expect(list.scrollTop).toBe(1000);
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
+
+  it('re-arms the entry scroll when the conversation changes', () => {
+    const { container, rerender } = renderStream({
+      messages: [msg('a', 1000)],
+      conversationKey: 'channel-0',
+    });
+    const list = container.querySelector('.meshcore-message-list') as HTMLElement;
+    act(() => { list.scrollTop = 0; });
+
+    rerender(
+      <MeshCoreMessageStream
+        messages={[msg('x', 5000)]}
+        onSend={async () => true}
+        conversationKey="channel-1"
+      />,
+    );
+    expect(list.scrollTop).toBe(1000);
+  });
+});

--- a/src/components/MeshCore/MeshCorePage.tsx
+++ b/src/components/MeshCore/MeshCorePage.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { useTxStatus } from '../../hooks/useTxStatus';
 import { useMeshCore, ConnectionStatus } from './hooks/useMeshCore';
 import { useMeshCoreUnread } from './hooks/useMeshCoreUnread';
+import { useReadStateSync } from './hooks/useReadStateSync';
 import { MeshCoreStatusBar } from './MeshCoreStatusBar';
 import { MeshCoreSubToolbar, MeshCoreView } from './MeshCoreSubToolbar';
 import { MeshCoreNodesView } from './MeshCoreNodesView';
@@ -77,6 +78,12 @@ export const MeshCorePage: React.FC<MeshCorePageProps> = ({ baseUrl, sourceId, e
   const [view, setView] = useState<MeshCoreView>('nodes');
   const [toolbarExpanded, setToolbarExpanded] = useState(false);
   const [pendingDmContact, setPendingDmContact] = useState<string | null>(null);
+
+  // Wire the durable per-user read-state transport once per mounted source
+  // (#4607). The store is deliberately fetch-free so it can stay a plain
+  // module; this is the single place that gives it a CSRF-aware fetcher and
+  // pulls the server snapshot into its synchronous cache.
+  useReadStateSync({ sourceId });
 
   // Unread red-dots for the Channels + Node Details (DMs) sidebar icons (#3891).
   const unread = useMeshCoreUnread({

--- a/src/components/MeshCore/hooks/useReadStateSync.ts
+++ b/src/components/MeshCore/hooks/useReadStateSync.ts
@@ -1,0 +1,60 @@
+/**
+ * useReadStateSync (#4607)
+ *
+ * Bridges the fetch-free `meshcoreUnreadStore` module to the server-side
+ * `conversation_read_state` table. Mounted once by `MeshCorePage`: it installs
+ * a transport and pulls this user's watermarks for the active source into the
+ * store's synchronous cache.
+ *
+ * Kept separate from the store so the store stays a plain module (no React, no
+ * fetch) that every conversation view can read during render, and so tests can
+ * exercise the marker logic without a network stub.
+ *
+ * Uses `apiService` rather than `useCsrfFetch` deliberately: ApiService reads
+ * the CSRF token from sessionStorage itself, so this hook adds no context
+ * requirement to `MeshCorePage` (which several tests render without a
+ * CsrfProvider). Note that ApiService returns the raw body, so the `ok(res,
+ * data)` envelope is unwrapped here.
+ *
+ * Everything is best-effort. A 403 (anonymous session, or no `messages:read`
+ * on this source) or an unreachable server leaves the store on its
+ * localStorage-only path rather than breaking the unread UI.
+ */
+import { useEffect } from 'react';
+import apiService from '../../../services/api';
+import {
+  configureReadStateTransport,
+  hydrateReadState,
+  type MeshCoreReadKind,
+} from '../meshcoreUnreadStore';
+
+export function useReadStateSync({ sourceId }: { sourceId: string }): void {
+  useEffect(() => {
+    if (!sourceId) return;
+
+    configureReadStateTransport({
+      async load(id: string) {
+        const body = await apiService.get<{
+          data?: Record<MeshCoreReadKind, Record<string, number>>;
+        }>(`/api/read-state?sourceId=${encodeURIComponent(id)}`);
+        return body?.data ?? null;
+      },
+      async save(id: string, kind: MeshCoreReadKind, conversationKey: string, lastReadAt: number) {
+        await apiService.post('/api/read-state', {
+          sourceId: id,
+          kind,
+          conversationKey,
+          lastReadAt,
+        });
+      },
+    });
+
+    void hydrateReadState(sourceId);
+
+    return () => {
+      // Leaving the MeshCore page must not leave a transport bound to a source
+      // that is no longer mounted; the next mount installs a fresh one.
+      configureReadStateTransport(null);
+    };
+  }, [sourceId]);
+}

--- a/src/components/MeshCore/meshcoreUnreadStore.serverState.test.ts
+++ b/src/components/MeshCore/meshcoreUnreadStore.serverState.test.ts
@@ -1,0 +1,154 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Server-backed read state in the MeshCore unread store (#4607).
+ *
+ * The store used to keep last-read markers in localStorage alone, which is
+ * per-BROWSER — two operators sharing a machine shared one set of markers.
+ * These tests pin the properties that make the durable, per-user server copy
+ * safe to layer on top of the existing synchronous API:
+ *  - reads merge local + server by taking the LATER value, so nothing rewinds;
+ *  - writes reach the server;
+ *  - and with no transport configured the store behaves exactly as before.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  configureReadStateTransport,
+  hydrateReadState,
+  resetReadStateCache,
+  loadChannelLastRead,
+  loadDmLastRead,
+  markChannelRead,
+  markDmRead,
+  channelLastReadKey,
+  dmLastReadKey,
+  type ReadStateTransport,
+} from './meshcoreUnreadStore';
+
+const SRC = 'source-a';
+
+function makeTransport(data: Record<string, Record<string, number>> | null): ReadStateTransport & {
+  saves: Array<[string, string, string, number]>;
+} {
+  const saves: Array<[string, string, string, number]> = [];
+  return {
+    saves,
+    load: vi.fn().mockResolvedValue(data),
+    save: vi.fn(async (sourceId, kind, key, ts) => {
+      saves.push([sourceId, kind, key, ts]);
+    }),
+  } as any;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  resetReadStateCache();
+  configureReadStateTransport(null);
+});
+
+describe('meshcoreUnreadStore — server read state (#4607)', () => {
+  it('behaves as localStorage-only when no transport is configured', async () => {
+    markChannelRead(SRC, 0, 1000);
+    // No throw, no network — and hydration is a quiet no-op.
+    await hydrateReadState(SRC);
+    expect(loadChannelLastRead(SRC)[0]).toBe(1000);
+  });
+
+  it('merges hydrated server markers into synchronous reads', async () => {
+    configureReadStateTransport(makeTransport({
+      meshcore_channel: { '0': 5000 },
+      meshcore_dm: { peerA: 7000 },
+    }));
+
+    await hydrateReadState(SRC);
+
+    expect(loadChannelLastRead(SRC)[0]).toBe(5000);
+    expect(loadDmLastRead(SRC).peerA).toBe(7000);
+  });
+
+  it('keeps the LATER marker when local and server disagree', async () => {
+    // A marker written in this tab may not have round-tripped yet; an older
+    // server value must not overwrite it and re-light the unread dot.
+    localStorage.setItem(channelLastReadKey(SRC), JSON.stringify({ 0: 9000 }));
+    localStorage.setItem(dmLastReadKey(SRC), JSON.stringify({ peerA: 100 }));
+
+    configureReadStateTransport(makeTransport({
+      meshcore_channel: { '0': 1000 },
+      meshcore_dm: { peerA: 8000 },
+    }));
+    await hydrateReadState(SRC);
+
+    expect(loadChannelLastRead(SRC)[0]).toBe(9000); // local ahead
+    expect(loadDmLastRead(SRC).peerA).toBe(8000);   // server ahead
+  });
+
+  it('scopes hydrated markers to their source', async () => {
+    configureReadStateTransport(makeTransport({
+      meshcore_channel: { '0': 5000 },
+      meshcore_dm: {},
+    }));
+    await hydrateReadState(SRC);
+
+    expect(loadChannelLastRead('other-source')[0]).toBeUndefined();
+  });
+
+  it('mirrors a channel mark-read to the server', () => {
+    const transport = makeTransport({ meshcore_channel: {}, meshcore_dm: {} });
+    configureReadStateTransport(transport);
+
+    markChannelRead(SRC, 3, 4242);
+
+    expect(transport.save).toHaveBeenCalledWith(SRC, 'meshcore_channel', '3', 4242);
+  });
+
+  it('mirrors a DM mark-read to the server', () => {
+    const transport = makeTransport({ meshcore_channel: {}, meshcore_dm: {} });
+    configureReadStateTransport(transport);
+
+    markDmRead(SRC, 'peerA', 999);
+
+    expect(transport.save).toHaveBeenCalledWith(SRC, 'meshcore_dm', 'peerA', 999);
+  });
+
+  it('does not write to the server when the marker would move backwards', () => {
+    const transport = makeTransport({ meshcore_channel: {}, meshcore_dm: {} });
+    configureReadStateTransport(transport);
+
+    markChannelRead(SRC, 0, 5000);
+    (transport.save as any).mockClear();
+    markChannelRead(SRC, 0, 1000);
+
+    expect(transport.save).not.toHaveBeenCalled();
+  });
+
+  it('survives a failing server without breaking reads', async () => {
+    const failing: ReadStateTransport = {
+      load: vi.fn().mockRejectedValue(new Error('offline')),
+      save: vi.fn().mockRejectedValue(new Error('offline')),
+    };
+    configureReadStateTransport(failing);
+
+    await expect(hydrateReadState(SRC)).resolves.toBeUndefined();
+    expect(() => markChannelRead(SRC, 0, 1000)).not.toThrow();
+    // localStorage still holds the marker, so the UI keeps working.
+    expect(loadChannelLastRead(SRC)[0]).toBe(1000);
+  });
+
+  it('hydrates a source only once unless forced', async () => {
+    const transport = makeTransport({ meshcore_channel: {}, meshcore_dm: {} });
+    configureReadStateTransport(transport);
+
+    await hydrateReadState(SRC);
+    await hydrateReadState(SRC);
+    expect(transport.load).toHaveBeenCalledTimes(1);
+
+    await hydrateReadState(SRC, true);
+    expect(transport.load).toHaveBeenCalledTimes(2);
+  });
+
+  it('tolerates a server response with no read state at all', async () => {
+    configureReadStateTransport(makeTransport(null));
+    await hydrateReadState(SRC);
+    expect(loadChannelLastRead(SRC)).toEqual({});
+  });
+});

--- a/src/components/MeshCore/meshcoreUnreadStore.ts
+++ b/src/components/MeshCore/meshcoreUnreadStore.ts
@@ -1,20 +1,35 @@
 /**
- * Shared client-side unread-marker store for MeshCore (#3891).
+ * Shared client-side unread-marker store for MeshCore (#3891, #4607).
  *
  * MeshCore messages are NOT covered by the Meshtastic server-side read-tracking
- * (`read_messages` joins the Meshtastic `messages` table only), so we track the
- * operator's last-read markers client-side in localStorage, scoped by sourceId:
+ * (`read_messages` joins the Meshtastic `messages` table only). Originally the
+ * operator's last-read markers therefore lived only in localStorage, scoped by
+ * sourceId:
  *
  *   - channels: `meshmonitor-meshcore-channel-lastread-<sourceId>` → { idx: ms }
  *               (pre-existing key from #3703 — kept as-is for backward compat)
  *   - DMs:      `meshmonitor-meshcore-dm-lastread-<sourceId>`      → { peerKey: ms }
  *
- * Both the views that own a conversation (MeshCoreChannelsView /
- * MeshCoreDirectMessagesView) and the page-level unread hook that drives the
- * sidebar red-dots read/write through here, so a single source of truth keeps
- * the in-view badges and the sidebar dots consistent. Writes dispatch a
- * same-tab `CustomEvent` so listeners update immediately (the native `storage`
- * event only fires in OTHER tabs).
+ * That is per-BROWSER, which is the wrong shape for an app with real
+ * multi-user auth: two operators sharing a machine shared one set of markers,
+ * and the same operator on a second device started from zero. #4607 moved the
+ * durable copy server-side into `conversation_read_state` (per user, per
+ * source, per conversation) and left localStorage in place as (a) a synchronous
+ * cache so the first paint is not blank while the server round-trip is in
+ * flight, and (b) the fallback when there is no server read-state at all.
+ *
+ * The synchronous read API is unchanged on purpose — every caller
+ * (MeshCoreChannelsView / MeshCoreDirectMessagesView / useMeshCoreUnread)
+ * reads markers during render. Reads merge localStorage with the hydrated
+ * server snapshot by taking the MAX per key, so whichever side is ahead wins
+ * and a marker can never appear to rewind. Writes update localStorage
+ * immediately (so the UI reacts at once) and are mirrored to the server
+ * through the injected transport.
+ *
+ * The transport is INJECTED rather than imported so this module stays free of
+ * React and fetch: `MeshCorePage` wires it once with a CSRF-aware fetcher. With
+ * no transport configured the module behaves exactly as it did before #4607,
+ * which is also what keeps the pre-existing unit tests meaningful.
  */
 
 const CHANGE_EVENT = 'meshcore-unread-changed';
@@ -23,6 +38,79 @@ export const channelLastReadKey = (sourceId: string) =>
   `meshmonitor-meshcore-channel-lastread-${sourceId}`;
 export const dmLastReadKey = (sourceId: string) =>
   `meshmonitor-meshcore-dm-lastread-${sourceId}`;
+
+/** Conversation families as named by the server's `conversation_read_state`. */
+export type MeshCoreReadKind = 'meshcore_channel' | 'meshcore_dm';
+
+/** Server-side read-state transport, injected by the page (see module header). */
+export interface ReadStateTransport {
+  /** Fetch every watermark this user holds on `sourceId`. */
+  load(sourceId: string): Promise<Record<MeshCoreReadKind, Record<string, number>> | null>;
+  /** Persist one watermark. Failures are swallowed — markers are best-effort. */
+  save(sourceId: string, kind: MeshCoreReadKind, conversationKey: string, lastReadAt: number): Promise<void>;
+}
+
+let transport: ReadStateTransport | null = null;
+
+/**
+ * Hydrated server snapshots, per sourceId. Populated by {@link hydrateReadState}
+ * and merged into every synchronous read.
+ */
+const serverState = new Map<string, { channels: Record<string, number>; dms: Record<string, number> }>();
+
+/** Sources whose hydration has already been kicked off (once per session). */
+const hydrated = new Set<string>();
+
+/**
+ * Install the server transport. Call once per app; passing `null` restores the
+ * localStorage-only behaviour (used by tests and by builds with no session).
+ */
+export function configureReadStateTransport(next: ReadStateTransport | null): void {
+  transport = next;
+  // A new (or removed) transport means a new session/fetcher, so the cached
+  // snapshot no longer belongs to whoever is now signed in. Dropping it here
+  // stops one user's markers surviving a logout into the next user's view.
+  serverState.clear();
+  hydrated.clear();
+}
+
+/** Test seam: forget every hydrated snapshot and re-arm hydration. */
+export function resetReadStateCache(): void {
+  serverState.clear();
+  hydrated.clear();
+}
+
+/**
+ * Pull this user's server-side watermarks for `sourceId` into the cache.
+ * Idempotent per source unless `force` is set. Safe to call unconditionally:
+ * with no transport, or on a 403 (anonymous / unpermitted), it resolves
+ * quietly and the store keeps using localStorage alone.
+ */
+export async function hydrateReadState(sourceId: string, force = false): Promise<void> {
+  if (!sourceId || !transport) return;
+  if (hydrated.has(sourceId) && !force) return;
+  hydrated.add(sourceId);
+  try {
+    const data = await transport.load(sourceId);
+    if (!data) return;
+    serverState.set(sourceId, {
+      channels: { ...(data.meshcore_channel ?? {}) },
+      dms: { ...(data.meshcore_dm ?? {}) },
+    });
+    notifyChanged();
+  } catch {
+    // Best-effort: an unreachable server must not break the unread UI.
+    hydrated.delete(sourceId);
+  }
+}
+
+function notifyChanged(): void {
+  try {
+    window.dispatchEvent(new CustomEvent(CHANGE_EVENT));
+  } catch {
+    /* non-DOM env (tests) — safe to ignore */
+  }
+}
 
 function loadMap<K extends string | number>(storageKey: string): Record<K, number> {
   try {
@@ -35,16 +123,37 @@ function loadMap<K extends string | number>(storageKey: string): Record<K, numbe
   }
 }
 
+/**
+ * Merge a server snapshot into a local map, keeping the LATER marker per key.
+ * Max rather than "server wins": a marker written in this tab is already in
+ * localStorage but may not have round-tripped yet, and letting an older server
+ * value overwrite it would make the unread dot flicker back on.
+ */
+function mergeLatest(
+  local: Record<string, number>,
+  remote: Record<string, number> | undefined
+): Record<string, number> {
+  if (!remote) return local;
+  const out: Record<string, number> = { ...local };
+  for (const [key, ts] of Object.entries(remote)) {
+    if (!Number.isFinite(ts)) continue;
+    if ((out[key] ?? 0) < ts) out[key] = ts;
+  }
+  return out;
+}
+
 /** Read the per-channel last-read map (channel idx → ms) for a source. */
 export function loadChannelLastRead(sourceId: string): Record<number, number> {
   if (!sourceId) return {};
-  return loadMap<number>(channelLastReadKey(sourceId));
+  const local = loadMap<number>(channelLastReadKey(sourceId)) as Record<string, number>;
+  return mergeLatest(local, serverState.get(sourceId)?.channels) as Record<number, number>;
 }
 
 /** Read the per-peer DM last-read map (canonical peer key → ms) for a source. */
 export function loadDmLastRead(sourceId: string): Record<string, number> {
   if (!sourceId) return {};
-  return loadMap<string>(dmLastReadKey(sourceId));
+  const local = loadMap<string>(dmLastReadKey(sourceId));
+  return mergeLatest(local, serverState.get(sourceId)?.dms);
 }
 
 function persist(storageKey: string, map: Record<string | number, number>): void {
@@ -54,11 +163,28 @@ function persist(storageKey: string, map: Record<string | number, number>): void
     /* storage full / disabled — unread state is best-effort */
   }
   // Notify same-tab listeners (storage event only fires cross-tab).
-  try {
-    window.dispatchEvent(new CustomEvent(CHANGE_EVENT));
-  } catch {
-    /* non-DOM env (tests) — safe to ignore */
-  }
+  notifyChanged();
+}
+
+/**
+ * Mirror a marker to the server and into the local snapshot. Never throws.
+ *
+ * With no transport this is a complete no-op — in particular it must NOT seed
+ * `serverState`. That map is a cache OF the server; populating it without one
+ * would make markers outlive a `localStorage.clear()` and reappear in a
+ * session that never wrote them.
+ */
+function pushToServer(sourceId: string, kind: MeshCoreReadKind, key: string, ts: number): void {
+  if (!transport) return;
+
+  const snapshot = serverState.get(sourceId) ?? { channels: {}, dms: {} };
+  const bucket = kind === 'meshcore_channel' ? snapshot.channels : snapshot.dms;
+  if ((bucket[key] ?? 0) < ts) bucket[key] = ts;
+  serverState.set(sourceId, snapshot);
+
+  void transport.save(sourceId, kind, key, ts).catch(() => {
+    /* best-effort — localStorage already reflects the marker */
+  });
 }
 
 /**
@@ -71,6 +197,7 @@ export function markChannelRead(sourceId: string, idx: number, ts: number = Date
   if ((map[idx] ?? 0) >= ts) return;
   map[idx] = ts;
   persist(channelLastReadKey(sourceId), map);
+  pushToServer(sourceId, 'meshcore_channel', String(idx), ts);
 }
 
 /**
@@ -84,6 +211,7 @@ export function markDmRead(sourceId: string, peerKey: string, ts: number = Date.
   if ((map[peerKey] ?? 0) >= ts) return;
   map[peerKey] = ts;
   persist(dmLastReadKey(sourceId), map);
+  pushToServer(sourceId, 'meshcore_dm', peerKey, ts);
 }
 
 /**

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -64,6 +64,9 @@ import { useCsrfFetch } from '../hooks/useCsrfFetch';
 import { useSource } from '../contexts/SourceContext';
 import { computeMessagesReadOnlyState } from './messagesReadOnlyState';
 import { UiIcon } from './icons';
+import UnreadDivider from './messages/UnreadDivider';
+import { resolveUnreadAnchorId, shouldSuppressDivider } from '../utils/unreadAnchor';
+import { useUnreadDividerAnchors } from '../contexts/MessagingContext';
 
 // Types for node with message metadata
 interface NodeWithMessages extends DeviceInfo {
@@ -508,6 +511,9 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   const { showToast } = useToast();
   const csrfFetch = useCsrfFetch();
   const { sourceId } = useSource();
+  // Oldest-unread timestamp for the open DM, pinned at entry (#4607) — drives
+  // the red "New messages" divider below.
+  const { dm: pinnedFirstUnreadDM } = useUnreadDividerAnchors();
   const queryClient = useQueryClient();
 
   // Purge neighbors state
@@ -1041,6 +1047,31 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
   const selectedDMMessages = selectedDMNode
     ? getDMMessages(selectedDMNode).sort((a, b) => getMessageSortTime(a) - getMessageSortTime(b))
     : [];
+
+  // Unread divider anchor (#4607). `pinnedFirstUnreadDM` is the oldest-unread
+  // timestamp captured when this conversation was opened — read-marking clears
+  // the unread set a tick later, so a live lookup would always come back empty.
+  // Resolved against the same sorted list the rows render from.
+  //
+  // `hasMoreOlder: true` because the DM view renders a window and pages older
+  // history in on scroll, so a top-of-window anchor is not the start of the
+  // conversation.
+  //
+  // Computed inline rather than with useMemo: this point in the component is
+  // BELOW the `messages:read` early return above, so a hook here would be
+  // conditional and React would fault on the render where permission flips.
+  const unreadAnchorId = (() => {
+    const rows = selectedDMMessages.map(m => ({ id: m.id, sortTime: getMessageSortTime(m) }));
+    const anchor = resolveUnreadAnchorId({
+      messages: rows,
+      watermarkMs: pinnedFirstUnreadDM,
+      mode: 'firstUnread',
+      ownMessageIds: new Set(selectedDMMessages.filter(isMyMessage).map(m => m.id)),
+    });
+    return shouldSuppressDivider({ anchorId: anchor, messages: rows, hasMoreOlder: true })
+      ? null
+      : anchor;
+  })();
 
   const selectedNode = selectedDMNode ? nodes.find(n => n.user?.id === selectedDMNode) : null;
 
@@ -1837,6 +1868,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             </span>
                           </div>
                         )}
+                        {unreadAnchorId === msg.id && <UnreadDivider />}
                         <div className="message-item traceroute">
                           <div className="message-header">
                             <span className="message-from">{getSenderLabel(msg.from)}</span>
@@ -1872,6 +1904,9 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                           </span>
                         </div>
                       )}
+                      {/* Red "New messages" line, directly above the oldest
+                          message unseen at entry (#4607). */}
+                      {unreadAnchorId === msg.id && <UnreadDivider />}
                       <div 
                         className={`message-bubble-container ${isMine ? 'mine' : 'theirs'}`}
                         data-message-id={msg.id}

--- a/src/components/messages/UnreadDivider.module.css
+++ b/src/components/messages/UnreadDivider.module.css
@@ -1,0 +1,42 @@
+/**
+ * Unread divider (#4607) — the line between what the operator has already seen
+ * and what arrived since. Shared by the Meshtastic channel/DM views and the
+ * MeshCore message stream so all three read identically.
+ *
+ * Scoped CSS module rather than an addition to the frozen global sheets
+ * (src/styles/messages.css), per the CSS containment rule.
+ *
+ * Colors come from the semantic role layer only. `--color-error` is the app's
+ * red; a raw `--ctp-*` palette name, or a semantic token given a hardcoded
+ * fallback value, would fail src/styles/semanticTokens.test.ts.
+ */
+
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.75rem 0 0.25rem;
+  /* Never let the divider absorb a click meant for a message underneath. */
+  pointer-events: none;
+  /* Scroll-margin so scrollIntoView leaves the line clear of a sticky header
+     instead of jamming it against the very top of the viewport. */
+  scroll-margin-top: 1rem;
+}
+
+.rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-error);
+  /* The rule is decorative; the label carries the meaning. */
+  opacity: 0.8;
+}
+
+.label {
+  flex: 0 0 auto;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-error);
+  white-space: nowrap;
+}

--- a/src/components/messages/UnreadDivider.tsx
+++ b/src/components/messages/UnreadDivider.tsx
@@ -1,0 +1,36 @@
+/**
+ * UnreadDivider (#4607)
+ *
+ * The red "New messages" line drawn immediately above the oldest message the
+ * operator had not seen when they opened the conversation. One component for
+ * all three conversation surfaces (Meshtastic channels, Meshtastic DMs,
+ * MeshCore stream) so the line looks and behaves the same everywhere.
+ *
+ * It carries `data-unread-divider` and an id so the entry-scroll logic in each
+ * view can find it without knowing anything about this component's markup.
+ */
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import styles from './UnreadDivider.module.css';
+
+/** DOM id of the divider. Views scroll to this element on conversation entry. */
+export const UNREAD_DIVIDER_ID = 'unread-divider';
+
+const UnreadDivider: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <div
+      id={UNREAD_DIVIDER_ID}
+      data-unread-divider="true"
+      className={styles.divider}
+      role="separator"
+      aria-label={t('messages.unread_divider', 'New messages')}
+    >
+      <span className={styles.rule} />
+      <span className={styles.label}>{t('messages.unread_divider', 'New messages')}</span>
+      <span className={styles.rule} />
+    </div>
+  );
+};
+
+export default UnreadDivider;

--- a/src/components/messages/UnreadDivider.tsx
+++ b/src/components/messages/UnreadDivider.tsx
@@ -26,9 +26,14 @@ const UnreadDivider: React.FC = () => {
       role="separator"
       aria-label={t('messages.unread_divider', 'New messages')}
     >
-      <span className={styles.rule} />
-      <span className={styles.label}>{t('messages.unread_divider', 'New messages')}</span>
-      <span className={styles.rule} />
+      {/* The separator already carries the accessible name via aria-label;
+          the visible copy is decorative, so hide it from AT rather than
+          announcing "New messages" twice. */}
+      <span className={styles.rule} aria-hidden="true" />
+      <span className={styles.label} aria-hidden="true">
+        {t('messages.unread_divider', 'New messages')}
+      </span>
+      <span className={styles.rule} aria-hidden="true" />
     </div>
   );
 };

--- a/src/contexts/MessagingContext.tsx
+++ b/src/contexts/MessagingContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, useMemo, useRef, ReactNode } from 'react';
 import { MeshMessage } from '../types/message';
 import { useUnreadCounts, useMarkAsRead } from '../hooks/useUnreadCounts';
+import { useFirstUnread } from '../hooks/useFirstUnread';
 import { useAuth } from './AuthContext';
 import { useSource } from './SourceContext';
 import { useUI } from './UIContext';
@@ -46,6 +47,17 @@ interface MessagingContextType {
   markMessagesAsRead: (messageIds?: string[], channelId?: number, nodeId?: string, allDMs?: boolean) => Promise<void>;
   fetchUnreadCounts: () => Promise<UnreadCounts | null>;
   unreadCountsData: UnreadCounts | null;
+  /**
+   * Oldest-unread timestamp (ms) for the OPEN channel, frozen at the moment it
+   * was opened (#4607). `null` when nothing was unread.
+   *
+   * Pinned rather than live because the read-marking effects
+   * (useMessagingView GATED EFFECTS #6/#7) mark a conversation read within a
+   * tick of entry — a live value would be gone before the divider rendered.
+   */
+  pinnedFirstUnreadChannel: number | null;
+  /** Same, for the open DM conversation. */
+  pinnedFirstUnreadDM: number | null;
 }
 
 const MessagingContext = createContext<MessagingContextType | undefined>(undefined);
@@ -129,6 +141,41 @@ export const MessagingProvider: React.FC<MessagingProviderProps> = ({ children, 
   });
   const { mutateAsync: markAsReadMutation } = useMarkAsRead({ baseUrl });
 
+  // Unread-divider anchors (#4607). Polled on the same cadence as the badge
+  // counts, then PINNED per conversation: the read-marking effects clear the
+  // unread set within a tick of entry, so the value has to be captured at the
+  // transition rather than read live.
+  const { data: firstUnreadData } = useFirstUnread({
+    baseUrl,
+    enabled: isAuthenticated,
+    sourceId,
+    excludeMqtt: !showMqttMessages,
+  });
+  const firstUnreadRef = useRef(firstUnreadData);
+  firstUnreadRef.current = firstUnreadData;
+
+  const [pinnedFirstUnreadChannel, setPinnedFirstUnreadChannel] = useState<number | null>(null);
+  const [pinnedFirstUnreadDM, setPinnedFirstUnreadDM] = useState<number | null>(null);
+
+  // Read through the ref so the pin fires ONLY on a conversation change. With
+  // `firstUnreadData` in the deps the 10s poll would re-pin mid-read and the
+  // line would jump (or vanish) while the operator was still scrolled to it.
+  useEffect(() => {
+    if (selectedChannel < 0) {
+      setPinnedFirstUnreadChannel(null);
+      return;
+    }
+    setPinnedFirstUnreadChannel(firstUnreadRef.current?.channels?.[selectedChannel] ?? null);
+  }, [selectedChannel, sourceId]);
+
+  useEffect(() => {
+    if (!selectedDMNode) {
+      setPinnedFirstUnreadDM(null);
+      return;
+    }
+    setPinnedFirstUnreadDM(firstUnreadRef.current?.directMessages?.[selectedDMNode] ?? null);
+  }, [selectedDMNode, sourceId]);
+
   // Wrapper for backward compatibility - returns the data from the query
   const fetchUnreadCounts = useCallback(async (): Promise<UnreadCounts | null> => {
     const result = await refetchUnreadCounts();
@@ -179,6 +226,8 @@ export const MessagingProvider: React.FC<MessagingProviderProps> = ({ children, 
     markMessagesAsRead,
     fetchUnreadCounts,
     unreadCountsData: unreadCountsData || null,
+    pinnedFirstUnreadChannel,
+    pinnedFirstUnreadDM,
   }), [
     selectedDMNode, setSelectedDMNode,
     selectedChannel, setSelectedChannel,
@@ -193,6 +242,8 @@ export const MessagingProvider: React.FC<MessagingProviderProps> = ({ children, 
     markMessagesAsRead,
     fetchUnreadCounts,
     unreadCountsData,
+    pinnedFirstUnreadChannel,
+    pinnedFirstUnreadDM,
   ]);
 
   return (
@@ -208,4 +259,21 @@ export const useMessaging = () => {
     throw new Error('useMessaging must be used within a MessagingProvider');
   }
   return context;
+};
+
+/**
+ * Unread-divider anchors, safe to call outside a MessagingProvider (#4607).
+ *
+ * ChannelsTab and MessagesTab are rendered bare by a number of focused unit
+ * tests that have no provider. The divider is presentational — "no anchors" is
+ * a perfectly good answer — so it must degrade rather than throw, the same way
+ * `useSource()` returns a null sourceId outside a SourceProvider.
+ */
+// eslint-disable-next-line react-refresh/only-export-components -- #4607 this file already exports the useMessaging hook alongside the provider; a second read-only hook follows the same established shape
+export const useUnreadDividerAnchors = (): { channel: number | null; dm: number | null } => {
+  const context = useContext(MessagingContext);
+  return {
+    channel: context?.pinnedFirstUnreadChannel ?? null,
+    dm: context?.pinnedFirstUnreadDM ?? null,
+  };
 };

--- a/src/db/activeSchema.ts
+++ b/src/db/activeSchema.ts
@@ -50,6 +50,11 @@ import {
   readMessagesSqlite, readMessagesPostgres, readMessagesMysql,
 } from './schema/notifications.js';
 
+// Per-user conversation read watermarks (issue #4607)
+import {
+  conversationReadStateSqlite, conversationReadStatePostgres, conversationReadStateMysql,
+} from './schema/conversationReadState.js';
+
 // Packet logging
 import {
   packetLogSqlite, packetLogPostgres, packetLogMysql,
@@ -197,6 +202,10 @@ export interface ActiveSchema {
   userNotificationPreferences: any;
   readMessages: any;
 
+  // Per-user conversation read watermarks (issue #4607)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4607 matches the existing ActiveSchema per-dialect table pattern; typing burn-down is #3962 Phase 6
+  conversationReadState: any;
+
   // Packet logging
   packetLog: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #4124 matches the existing ActiveSchema per-dialect table pattern; typing burn-down is #3962 Phase 6
@@ -307,6 +316,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     pushSubscriptions: pushSubscriptionsSqlite,
     userNotificationPreferences: userNotificationPreferencesSqlite,
     readMessages: readMessagesSqlite,
+    conversationReadState: conversationReadStateSqlite,
     packetLog: packetLogSqlite,
     mqttPacketLog: mqttPacketLogSqlite,
     mqttOkToMqttViolations: mqttOkToMqttViolationsSqlite,
@@ -368,6 +378,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     pushSubscriptions: pushSubscriptionsPostgres,
     userNotificationPreferences: userNotificationPreferencesPostgres,
     readMessages: readMessagesPostgres,
+    conversationReadState: conversationReadStatePostgres,
     packetLog: packetLogPostgres,
     mqttPacketLog: mqttPacketLogPostgres,
     mqttOkToMqttViolations: mqttOkToMqttViolationsPostgres,
@@ -429,6 +440,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     pushSubscriptions: pushSubscriptionsMysql,
     userNotificationPreferences: userNotificationPreferencesMysql,
     readMessages: readMessagesMysql,
+    conversationReadState: conversationReadStateMysql,
     packetLog: packetLogMysql,
     mqttPacketLog: mqttPacketLogMysql,
     mqttOkToMqttViolations: mqttOkToMqttViolationsMysql,

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -151,6 +151,7 @@ import { migration as addMeshCoreObserverKeysMigration, runMigration133Postgres,
 import { migration as clearNullIslandEstimatesMigration, runMigration134Postgres, runMigration134Mysql } from '../server/migrations/134_clear_null_island_estimates.js';
 import { migration as backfillMeshcoreNodesViewOnMapMigration, runMigration135Postgres, runMigration135Mysql } from '../server/migrations/135_backfill_meshcore_nodes_viewonmap.js';
 import { migration as addMeshCoreObserverCredentialsMigration, runMigration136Postgres, runMigration136Mysql } from '../server/migrations/136_add_meshcore_observer_credentials.js';
+import { migration as addConversationReadStateMigration, runMigration137Postgres, runMigration137Mysql } from '../server/migrations/137_add_conversation_read_state.js';
 
 // ============================================================================
 // Registry
@@ -2163,4 +2164,22 @@ registry.register({
   sqlite: (db) => addMeshCoreObserverCredentialsMigration.up(db),
   postgres: (client) => runMigration136Postgres(client),
   mysql: (pool) => runMigration136Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 137: create `conversation_read_state` (issue #4607).
+// Durable PER-USER last-read watermark per (source, conversation), used to
+// anchor the unread divider and the jump-to-first-unread entry scroll. Covers
+// MeshCore, whose read markers previously lived only in browser localStorage
+// (per-browser, not per-user). Meshtastic keeps deriving its anchor from
+// `read_messages` so there is exactly one source of truth per protocol.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 137,
+  name: 'add_conversation_read_state',
+  settingsKey: 'migration_137_add_conversation_read_state',
+  sqlite: (db) => addConversationReadStateMigration.up(db),
+  postgres: (client) => runMigration137Postgres(client),
+  mysql: (pool) => runMigration137Mysql(pool),
 });

--- a/src/db/repositories/conversationReadState.test.ts
+++ b/src/db/repositories/conversationReadState.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Multi-backend tests for ConversationReadStateRepository (#4607).
+ *
+ * The properties under test are the ones the unread divider depends on being
+ * true regardless of backend: watermarks are per-user, per-source, per
+ * conversation, and they never move backwards.
+ *
+ * SQLite always runs (in-memory, schema built from the migration registry).
+ * PostgreSQL / MySQL run only when their test containers are up (5433 / 3307).
+ */
+import { describe, it, expect, beforeEach, afterEach, afterAll, beforeAll } from 'vitest';
+import { ConversationReadStateRepository, emptyReadStateMap, isConversationKind, readStateUserId } from './conversationReadState.js';
+import {
+  TestBackend,
+  createPostgresBackend,
+  createMysqlBackend,
+  clearTable,
+  postgresAvailable,
+  mysqlAvailable,
+} from './test-utils.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
+
+const POSTGRES_CREATE = `
+  DROP TABLE IF EXISTS conversation_read_state CASCADE;
+  CREATE TABLE conversation_read_state (
+    id SERIAL PRIMARY KEY,
+    "userId" INTEGER NOT NULL,
+    "sourceId" TEXT NOT NULL,
+    "conversationKind" TEXT NOT NULL,
+    "conversationKey" TEXT NOT NULL,
+    "lastReadAt" BIGINT NOT NULL,
+    UNIQUE ("userId", "sourceId", "conversationKind", "conversationKey")
+  )
+`;
+
+const MYSQL_CREATE = `
+  DROP TABLE IF EXISTS conversation_read_state;
+  CREATE TABLE conversation_read_state (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    userId INT NOT NULL,
+    sourceId VARCHAR(64) NOT NULL,
+    conversationKind VARCHAR(32) NOT NULL,
+    conversationKey VARCHAR(128) NOT NULL,
+    lastReadAt BIGINT NOT NULL,
+    UNIQUE KEY idx_conversation_read_state_unique (userId, sourceId, conversationKind, conversationKey)
+  )
+`;
+
+const ALL_TABLES = ['conversation_read_state'];
+
+function runReadStateTests(getBackend: () => TestBackend) {
+  let repo: ConversationReadStateRepository;
+
+  beforeEach(() => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    repo = new ConversationReadStateRepository(backend.drizzleDb, backend.dbType);
+  });
+
+  it('returns an empty, fully-populated map when nothing is stored', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    const state = await repo.getForSourceAsync(1, 'src-a');
+    // Every kind must be present so callers can index without guarding.
+    expect(state).toEqual({ meshcore_channel: {}, meshcore_dm: {} });
+  });
+
+  it('round-trips a channel watermark', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    await repo.setLastReadAsync(1, 'src-a', 'meshcore_channel', '3', 1_700_000_000_000);
+
+    const state = await repo.getForSourceAsync(1, 'src-a');
+    expect(state.meshcore_channel['3']).toBe(1_700_000_000_000);
+    expect(state.meshcore_dm).toEqual({});
+  });
+
+  it('never moves a watermark backwards', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    await repo.setLastReadAsync(1, 'src-a', 'meshcore_dm', 'peerA', 5000);
+    // A stale tab / late-landing write must not resurrect dismissed messages.
+    const effective = await repo.setLastReadAsync(1, 'src-a', 'meshcore_dm', 'peerA', 4000);
+
+    expect(effective).toBe(5000);
+    const state = await repo.getForSourceAsync(1, 'src-a');
+    expect(state.meshcore_dm.peerA).toBe(5000);
+  });
+
+  it('moves a watermark forward and reports the new value', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    await repo.setLastReadAsync(1, 'src-a', 'meshcore_dm', 'peerA', 5000);
+    const effective = await repo.setLastReadAsync(1, 'src-a', 'meshcore_dm', 'peerA', 9000);
+
+    expect(effective).toBe(9000);
+    const state = await repo.getForSourceAsync(1, 'src-a');
+    expect(state.meshcore_dm.peerA).toBe(9000);
+  });
+
+  it('keeps watermarks isolated per user', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    // This is the whole reason the table exists — localStorage could not tell
+    // two operators apart on a shared browser.
+    await repo.setLastReadAsync(1, 'src-a', 'meshcore_channel', '0', 1000);
+    await repo.setLastReadAsync(2, 'src-a', 'meshcore_channel', '0', 8000);
+
+    expect((await repo.getForSourceAsync(1, 'src-a')).meshcore_channel['0']).toBe(1000);
+    expect((await repo.getForSourceAsync(2, 'src-a')).meshcore_channel['0']).toBe(8000);
+  });
+
+  it('keeps watermarks isolated per source', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    await repo.setLastReadAsync(1, 'src-a', 'meshcore_channel', '0', 1000);
+    await repo.setLastReadAsync(1, 'src-b', 'meshcore_channel', '0', 8000);
+
+    expect((await repo.getForSourceAsync(1, 'src-a')).meshcore_channel['0']).toBe(1000);
+    expect((await repo.getForSourceAsync(1, 'src-b')).meshcore_channel['0']).toBe(8000);
+  });
+
+  it('keeps channel and DM watermarks apart even when the key collides', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    await repo.setLastReadAsync(1, 'src-a', 'meshcore_channel', '0', 1000);
+    await repo.setLastReadAsync(1, 'src-a', 'meshcore_dm', '0', 8000);
+
+    const state = await repo.getForSourceAsync(1, 'src-a');
+    expect(state.meshcore_channel['0']).toBe(1000);
+    expect(state.meshcore_dm['0']).toBe(8000);
+  });
+
+  it('treats a null userId as the anonymous sentinel, distinct from user 0-less users', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    await repo.setLastReadAsync(null, 'src-a', 'meshcore_channel', '0', 4000);
+    await repo.setLastReadAsync(9, 'src-a', 'meshcore_channel', '0', 7000);
+
+    expect((await repo.getForSourceAsync(null, 'src-a')).meshcore_channel['0']).toBe(4000);
+    expect((await repo.getForSourceAsync(9, 'src-a')).meshcore_channel['0']).toBe(7000);
+  });
+
+  it('ignores writes with an empty source, key, or non-finite timestamp', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    expect(await repo.setLastReadAsync(1, '', 'meshcore_channel', '0', 1000)).toBe(0);
+    expect(await repo.setLastReadAsync(1, 'src-a', 'meshcore_channel', '', 1000)).toBe(0);
+    expect(await repo.setLastReadAsync(1, 'src-a', 'meshcore_channel', '0', Number.NaN)).toBe(0);
+
+    expect(await repo.getForSourceAsync(1, 'src-a')).toEqual({ meshcore_channel: {}, meshcore_dm: {} });
+  });
+
+  it('deletes every watermark for a source without touching the others', async () => {
+    const backend = getBackend();
+    if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+    await repo.setLastReadAsync(1, 'src-a', 'meshcore_channel', '0', 1000);
+    await repo.setLastReadAsync(2, 'src-a', 'meshcore_dm', 'peer', 2000);
+    await repo.setLastReadAsync(1, 'src-b', 'meshcore_channel', '0', 3000);
+
+    await repo.deleteForSourceAsync('src-a');
+
+    expect(await repo.getForSourceAsync(1, 'src-a')).toEqual({ meshcore_channel: {}, meshcore_dm: {} });
+    expect((await repo.getForSourceAsync(1, 'src-b')).meshcore_channel['0']).toBe(3000);
+  });
+}
+
+describe('conversationReadState helpers', () => {
+  it('emptyReadStateMap lists every tracked kind', () => {
+    expect(Object.keys(emptyReadStateMap()).sort()).toEqual(['meshcore_channel', 'meshcore_dm']);
+  });
+
+  it('isConversationKind rejects anything not in the enum', () => {
+    expect(isConversationKind('meshcore_dm')).toBe(true);
+    expect(isConversationKind('meshtastic_channel')).toBe(false);
+    expect(isConversationKind(undefined)).toBe(false);
+    expect(isConversationKind(3)).toBe(false);
+  });
+
+  it('readStateUserId folds null/undefined onto the anonymous sentinel', () => {
+    expect(readStateUserId(null)).toBe(0);
+    expect(readStateUserId(undefined)).toBe(0);
+    expect(readStateUserId(12)).toBe(12);
+  });
+});
+
+// --- SQLite Backend ---
+describe('ConversationReadStateRepository - SQLite Backend', () => {
+  let backend: TestBackend;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    backend = {
+      dbType: 'sqlite',
+      drizzleDb: t.db,
+      exec: async (sql: string) => { t.sqlite.exec(sql); },
+      close: async () => { t.close(); },
+      available: true,
+    };
+  });
+
+  afterEach(async () => {
+    await backend.close();
+  });
+
+  runReadStateTests(() => backend);
+});
+
+// --- PostgreSQL Backend ---
+describe.skipIf(!postgresAvailable)('ConversationReadStateRepository - PostgreSQL Backend', () => {
+  let backend: TestBackend;
+
+  beforeAll(async () => {
+    backend = await createPostgresBackend(POSTGRES_CREATE);
+    if (backend.available) {
+      console.log('✓ PostgreSQL connection established for conversation read-state tests');
+    } else {
+      console.log(`⚠ ${backend.skipReason}`);
+    }
+  });
+
+  afterAll(async () => {
+    if (backend) await backend.close();
+  });
+
+  beforeEach(async () => {
+    if (!backend.available) return;
+    for (const table of ALL_TABLES) {
+      await clearTable(backend, table);
+    }
+  });
+
+  runReadStateTests(() => backend);
+});
+
+// --- MySQL Backend ---
+describe.skipIf(!mysqlAvailable)('ConversationReadStateRepository - MySQL Backend', () => {
+  let backend: TestBackend;
+
+  beforeAll(async () => {
+    backend = await createMysqlBackend(MYSQL_CREATE);
+    if (backend.available) {
+      console.log('✓ MySQL connection established for conversation read-state tests');
+    } else {
+      console.log(`⚠ ${backend.skipReason}`);
+    }
+  });
+
+  afterAll(async () => {
+    if (backend) await backend.close();
+  });
+
+  beforeEach(async () => {
+    if (!backend.available) return;
+    for (const table of ALL_TABLES) {
+      await clearTable(backend, table);
+    }
+  });
+
+  runReadStateTests(() => backend);
+});

--- a/src/db/repositories/conversationReadState.ts
+++ b/src/db/repositories/conversationReadState.ts
@@ -98,7 +98,16 @@ export class ConversationReadStateRepository extends BaseRepository {
     sourceId: string,
     kind: ConversationKind,
     conversationKey: string,
-    lastReadAt: number
+    lastReadAt: number,
+    /**
+     * Internal. The insert below re-resolves once when a concurrent request
+     * wins the race and the UNIQUE index rejects our row. Bounded rather than
+     * open-ended: the catch cannot tell a constraint violation from a
+     * persistent failure (NOT NULL, disk, driver) without sniffing
+     * backend-specific error codes across three engines, and an unbounded
+     * retry on a persistent error recurses forever.
+     */
+    retriesLeft: number = 1
   ): Promise<number> {
     if (!sourceId || !conversationKey || !Number.isFinite(lastReadAt)) return 0;
 
@@ -142,8 +151,15 @@ export class ConversationReadStateRepository extends BaseRepository {
           lastReadAt: ts,
         });
         return ts;
-      } catch {
-        return this.setLastReadAsync(userId, sourceId, kind, conversationKey, ts);
+      } catch (insertError) {
+        if (retriesLeft > 0) {
+          return this.setLastReadAsync(
+            userId, sourceId, kind, conversationKey, ts, retriesLeft - 1
+          );
+        }
+        // Out of retries: this is not a lost race, it is a real failure.
+        logger.error('Conversation read state insert failed after retry:', insertError);
+        return 0;
       }
     } catch (error) {
       logger.error('Error writing conversation read state:', error);

--- a/src/db/repositories/conversationReadState.ts
+++ b/src/db/repositories/conversationReadState.ts
@@ -1,0 +1,166 @@
+/**
+ * ConversationReadStateRepository (issue #4607)
+ *
+ * Durable, per-user last-read watermarks for MeshCore conversations. See
+ * `src/db/schema/conversationReadState.ts` for why this exists alongside
+ * Meshtastic's per-message `read_messages` table rather than replacing it.
+ *
+ * Two invariants the callers rely on:
+ *  - Watermarks are MONOTONIC. `setLastReadAsync` never moves a marker
+ *    backwards, so a stale client (an old tab, a queued write that lands late)
+ *    cannot resurrect messages the operator already dismissed.
+ *  - Reads are scoped to one (user, source) pair and returned grouped by kind,
+ *    because that is exactly the shape the MeshCore views hydrate into.
+ */
+import { and, eq } from 'drizzle-orm';
+import { BaseRepository } from './base.js';
+import {
+  CONVERSATION_KINDS,
+  ANONYMOUS_USER_ID,
+  type ConversationKind,
+} from '../schema/conversationReadState.js';
+import { logger } from '../../utils/logger.js';
+
+/** Watermarks for one (user, source), grouped by conversation kind. */
+export type ConversationReadStateMap = Record<ConversationKind, Record<string, number>>;
+
+/** An empty, fully-populated map — every kind present with no entries. */
+export function emptyReadStateMap(): ConversationReadStateMap {
+  const out = {} as ConversationReadStateMap;
+  for (const kind of CONVERSATION_KINDS) out[kind] = {};
+  return out;
+}
+
+/** True when `kind` is a conversation family this table tracks. */
+export function isConversationKind(kind: unknown): kind is ConversationKind {
+  return typeof kind === 'string' && (CONVERSATION_KINDS as readonly string[]).includes(kind);
+}
+
+/**
+ * Resolve a request's user to the column value. `null` (anonymous / no-auth
+ * install) maps to the `0` sentinel so the UNIQUE index stays total — see the
+ * schema header for why a nullable column cannot work here.
+ */
+export function readStateUserId(userId: number | null | undefined): number {
+  return userId == null ? ANONYMOUS_USER_ID : userId;
+}
+
+export class ConversationReadStateRepository extends BaseRepository {
+  /**
+   * All watermarks this user holds on one source, grouped by kind.
+   * Missing conversations are simply absent (callers treat absent as 0).
+   */
+  async getForSourceAsync(
+    userId: number | null,
+    sourceId: string
+  ): Promise<ConversationReadStateMap> {
+    const out = emptyReadStateMap();
+    if (!sourceId) return out;
+
+    const table = this.tables.conversationReadState;
+    try {
+      const rows: Array<{ conversationKind: string; conversationKey: string; lastReadAt: number }> = await this.db
+        .select({
+          conversationKind: table.conversationKind,
+          conversationKey: table.conversationKey,
+          lastReadAt: table.lastReadAt,
+        })
+        .from(table)
+        .where(
+          and(
+            eq(table.userId, readStateUserId(userId)),
+            eq(table.sourceId, sourceId)
+          )
+        );
+
+      for (const row of rows) {
+        const kind = row.conversationKind as ConversationKind;
+        // Defensive: a row written by a newer version with an unknown kind
+        // must not blow away the whole response.
+        if (!isConversationKind(kind)) continue;
+        out[kind][String(row.conversationKey)] = Number(row.lastReadAt);
+      }
+      return out;
+    } catch (error) {
+      logger.error('Error reading conversation read state:', error);
+      return out;
+    }
+  }
+
+  /**
+   * Move one conversation's watermark forward to `lastReadAt`.
+   * Returns the effective (post-write) watermark, which is the max of the
+   * stored value and the requested one — a backwards request is a no-op that
+   * still reports the value the client should use.
+   */
+  async setLastReadAsync(
+    userId: number | null,
+    sourceId: string,
+    kind: ConversationKind,
+    conversationKey: string,
+    lastReadAt: number
+  ): Promise<number> {
+    if (!sourceId || !conversationKey || !Number.isFinite(lastReadAt)) return 0;
+
+    const table = this.tables.conversationReadState;
+    const uid = readStateUserId(userId);
+    const ts = Math.floor(lastReadAt);
+
+    try {
+      const existing: Array<{ id: number; lastReadAt: number }> = await this.db
+        .select({ id: table.id, lastReadAt: table.lastReadAt })
+        .from(table)
+        .where(
+          and(
+            eq(table.userId, uid),
+            eq(table.sourceId, sourceId),
+            eq(table.conversationKind, kind),
+            eq(table.conversationKey, conversationKey)
+          )
+        )
+        .limit(1);
+
+      if (existing.length > 0) {
+        const current = Number(existing[0].lastReadAt);
+        if (current >= ts) return current; // monotonic: never rewind
+        await this.db
+          .update(table)
+          .set({ lastReadAt: ts })
+          .where(eq(table.id, existing[0].id));
+        return ts;
+      }
+
+      // No row yet. A concurrent request may have inserted one between the
+      // SELECT and here, so treat a UNIQUE violation as "someone else won"
+      // and re-resolve rather than failing the request.
+      try {
+        await this.db.insert(table).values({
+          userId: uid,
+          sourceId,
+          conversationKind: kind,
+          conversationKey,
+          lastReadAt: ts,
+        });
+        return ts;
+      } catch {
+        return this.setLastReadAsync(userId, sourceId, kind, conversationKey, ts);
+      }
+    } catch (error) {
+      logger.error('Error writing conversation read state:', error);
+      return 0;
+    }
+  }
+
+  /** Drop every watermark for a source (used when a source is deleted). */
+  async deleteForSourceAsync(sourceId: string): Promise<number> {
+    if (!sourceId) return 0;
+    const table = this.tables.conversationReadState;
+    try {
+      const result = await this.db.delete(table).where(eq(table.sourceId, sourceId));
+      return this.getAffectedRows(result);
+    } catch (error) {
+      logger.error('Error deleting conversation read state for source:', error);
+      return 0;
+    }
+  }
+}

--- a/src/db/repositories/index.ts
+++ b/src/db/repositories/index.ts
@@ -27,6 +27,8 @@ export type {
   NotificationPreferences,
   PushSubscriptionInput,
 } from './notifications.js';
+export { ConversationReadStateRepository, emptyReadStateMap, isConversationKind, readStateUserId } from './conversationReadState.js';
+export type { ConversationReadStateMap } from './conversationReadState.js';
 export { PacketLogRepository } from './packetLog.js';
 export type { PacketLogFilterOptions } from './packetLog.js';
 export { KeyRepairRepository } from './keyRepair.js';

--- a/src/db/repositories/notifications.test.ts
+++ b/src/db/repositories/notifications.test.ts
@@ -957,6 +957,133 @@ function runNotificationsTests(getBackend: () => TestBackend) {
     });
   });
 
+  // ============ getFirstUnreadTimestampsAsync (#4607) ============
+
+  describe('getFirstUnreadTimestampsAsync — unread divider anchor (#4607)', () => {
+    it('returns the OLDEST unread timestamp per channel, not the newest', async () => {
+      const backend = getBackend();
+      if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+      await backend.exec(insertUserSql(backend, 1, 'testuser'));
+      await backend.exec(insertMessageSql(backend, 'a1', 0, 1, 3000));
+      await backend.exec(insertMessageSql(backend, 'a2', 0, 1, 1000));
+      await backend.exec(insertMessageSql(backend, 'a3', 0, 1, 2000));
+      await backend.exec(insertMessageSql(backend, 'b1', 1, 1, 7000));
+
+      const first = await repo.getFirstUnreadTimestampsAsync(1, undefined, ALL_SOURCES, false);
+      // The divider goes ABOVE the first thing you haven't seen, so this must
+      // be the minimum — a max would bury every unread message but the last.
+      expect(first.channels[0]).toBe(1000);
+      expect(first.channels[1]).toBe(7000);
+    });
+
+    it('advances the anchor past messages the user has already read', async () => {
+      const backend = getBackend();
+      if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+      await backend.exec(insertUserSql(backend, 1, 'testuser'));
+      await backend.exec(insertMessageSql(backend, 'a1', 0, 1, 1000));
+      await backend.exec(insertMessageSql(backend, 'a2', 0, 1, 2000));
+      await backend.exec(insertMessageSql(backend, 'a3', 0, 1, 3000));
+
+      await repo.markMessagesAsReadByIds(['a1', 'a2'], 1);
+
+      const first = await repo.getFirstUnreadTimestampsAsync(1, undefined, ALL_SOURCES, false);
+      expect(first.channels[0]).toBe(3000);
+    });
+
+    it('omits a channel entirely once everything in it is read', async () => {
+      const backend = getBackend();
+      if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+      await backend.exec(insertUserSql(backend, 1, 'testuser'));
+      await backend.exec(insertMessageSql(backend, 'a1', 0, 1, 1000));
+      await repo.markMessagesAsReadByIds(['a1'], 1);
+
+      const first = await repo.getFirstUnreadTimestampsAsync(1, undefined, ALL_SOURCES, false);
+      expect(first.channels[0]).toBeUndefined();
+    });
+
+    it('keeps read state per user — one user reading does not move another\'s anchor', async () => {
+      const backend = getBackend();
+      if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+      await backend.exec(insertUserSql(backend, 1, 'userone'));
+      await backend.exec(insertUserSql(backend, 2, 'usertwo'));
+      await backend.exec(insertMessageSql(backend, 'a1', 0, 1, 1000));
+      await backend.exec(insertMessageSql(backend, 'a2', 0, 1, 2000));
+
+      await repo.markMessagesAsReadByIds(['a1'], 1);
+
+      const one = await repo.getFirstUnreadTimestampsAsync(1, undefined, ALL_SOURCES, false);
+      const two = await repo.getFirstUnreadTimestampsAsync(2, undefined, ALL_SOURCES, false);
+      expect(one.channels[0]).toBe(2000);
+      expect(two.channels[0]).toBe(1000);
+    });
+
+    it('mirrors the excludeMqtt filter used by the badge counts', async () => {
+      const backend = getBackend();
+      if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+      await backend.exec(insertUserSql(backend, 1, 'testuser'));
+      // The oldest unread message on the channel is MQTT-bridged.
+      await backend.exec(insertMqttMessageSql(backend, 'mqtt1', 0, 1000));
+      await backend.exec(insertMessageSql(backend, 'rf1', 0, 1, 2000));
+
+      const withMqtt = await repo.getFirstUnreadTimestampsAsync(1, undefined, ALL_SOURCES, false);
+      expect(withMqtt.channels[0]).toBe(1000);
+
+      // With MQTT hidden the divider must not point at a row the view will
+      // never render — otherwise the line lands above nothing.
+      const rfOnly = await repo.getFirstUnreadTimestampsAsync(1, undefined, ALL_SOURCES, true);
+      expect(rfOnly.channels[0]).toBe(2000);
+    });
+
+    it('excludes our own outgoing messages when localNodeId is known', async () => {
+      const backend = getBackend();
+      if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+      await backend.exec(insertUserSql(backend, 1, 'testuser'));
+      await backend.exec(insertMessageSql(backend, 'mine', 0, 1, 1000, '!me', '!node2'));
+      await backend.exec(insertMessageSql(backend, 'theirs', 0, 1, 2000, '!them', '!me'));
+
+      const first = await repo.getFirstUnreadTimestampsAsync(1, '!me', ALL_SOURCES, false);
+      expect(first.channels[0]).toBe(2000);
+    });
+
+    it('returns DM anchors keyed by sender, and nothing when localNodeId is unknown', async () => {
+      const backend = getBackend();
+      if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+      await backend.exec(insertUserSql(backend, 1, 'testuser'));
+      // channel -1 == DM
+      await backend.exec(insertMessageSql(backend, 'dm1', -1, 1, 5000, '!peer', '!me'));
+      await backend.exec(insertMessageSql(backend, 'dm2', -1, 1, 3000, '!peer', '!me'));
+      await backend.exec(insertMessageSql(backend, 'dm3', -1, 1, 4000, '!other', '!me'));
+
+      const known = await repo.getFirstUnreadTimestampsAsync(1, '!me', ALL_SOURCES, false);
+      expect(known.directMessages['!peer']).toBe(3000);
+      expect(known.directMessages['!other']).toBe(4000);
+      // DMs are meaningless without knowing which node is "us".
+      const unknown = await repo.getFirstUnreadTimestampsAsync(1, undefined, ALL_SOURCES, false);
+      expect(unknown.directMessages).toEqual({});
+    });
+
+    it('scopes to a single source when one is given', async () => {
+      const backend = getBackend();
+      if (!backend.available) { console.log(`⚠ Skipped: ${backend.skipReason}`); return; }
+
+      await backend.exec(insertUserSql(backend, 1, 'testuser'));
+      await backend.exec(insertMessageWithSourceSql(backend, 's1', 0, 1, 1000, 'src-a'));
+      await backend.exec(insertMessageWithSourceSql(backend, 's2', 0, 1, 2000, 'src-b'));
+
+      const a = await repo.getFirstUnreadTimestampsAsync(1, undefined, 'src-a', false);
+      const b = await repo.getFirstUnreadTimestampsAsync(1, undefined, 'src-b', false);
+      expect(a.channels[0]).toBe(1000);
+      expect(b.channels[0]).toBe(2000);
+    });
+  });
+
   describe('markChannelMessagesAsRead', () => {
     it('marks channel messages as read for a user', async () => {
       const backend = getBackend();

--- a/src/db/repositories/notifications.ts
+++ b/src/db/repositories/notifications.ts
@@ -1114,6 +1114,95 @@ export class NotificationsRepository extends BaseRepository {
     }
   }
 
+  /**
+   * Timestamp of the OLDEST still-unread message in each conversation, for the
+   * unread divider and the jump-to-first-unread entry scroll (issue #4607).
+   *
+   * Deliberately mirrors the filters of `getUnreadCountsByChannelAsync` /
+   * `getBatchUnreadDMCountsAsync` — same join, same portnum/channel/source/MQTT
+   * predicates — so the line always lands where the badge said there was
+   * something to read. If the two ever diverged, a channel could show a "3
+   * unread" badge and no divider, or a divider with nothing above it.
+   *
+   * Returns `{ channels: { [channelId]: ms }, directMessages: { [fromNodeId]: ms } }`.
+   * Conversations with nothing unread are simply absent.
+   */
+  async getFirstUnreadTimestampsAsync(
+    userId: number | null,
+    localNodeId?: string,
+    sourceId?: SourceScope,
+    excludeMqtt?: boolean
+  ): Promise<{ channels: { [channelId: number]: number }; directMessages: { [fromNodeId: string]: number } }> {
+    const messages = this.tables.messages;
+    const readMessages = this.tables.readMessages;
+    const out = {
+      channels: {} as { [channelId: number]: number },
+      directMessages: {} as { [fromNodeId: string]: number },
+    };
+
+    try {
+      const channelConditions: (SQL | undefined)[] = [
+        isNull(readMessages.messageId),
+        ne(messages.channel, -1),
+        eq(messages.portnum, 1),
+        this.withSourceScope(messages, sourceId),
+      ];
+      if (localNodeId) channelConditions.push(ne(messages.fromNodeId, localNodeId));
+      if (excludeMqtt) {
+        // `this.tables` is dialect-erased, so `messages.viaMqtt` is already
+        // untyped — no cast needed here.
+        channelConditions.push(or(isNull(messages.viaMqtt), eq(messages.viaMqtt, false)));
+      }
+
+      const channelRows: Array<{ channel: number; firstUnread: number | null }> = await this.db
+        .select({
+          channel: messages.channel,
+          firstUnread: sql<number>`MIN(${messages.timestamp})`,
+        })
+        .from(messages)
+        .leftJoin(readMessages, this.unreadJoinOn(userId)!)
+        .where(and(...channelConditions))
+        .groupBy(messages.channel);
+
+      for (const row of channelRows) {
+        if (row.firstUnread == null) continue;
+        out.channels[Number(row.channel)] = Number(row.firstUnread);
+      }
+
+      // DMs are only meaningful once we know which node is "us" — without it
+      // there is no `toNodeId` to filter on, so skip rather than guess.
+      if (localNodeId) {
+        const dmRows: Array<{ fromNodeId: string; firstUnread: number | null }> = await this.db
+          .select({
+            fromNodeId: messages.fromNodeId,
+            firstUnread: sql<number>`MIN(${messages.timestamp})`,
+          })
+          .from(messages)
+          .leftJoin(readMessages, this.unreadJoinOn(userId)!)
+          .where(
+            and(
+              isNull(readMessages.messageId),
+              eq(messages.portnum, 1),
+              eq(messages.channel, -1),
+              eq(messages.toNodeId, localNodeId),
+              this.withSourceScope(messages, sourceId)
+            )
+          )
+          .groupBy(messages.fromNodeId);
+
+        for (const row of dmRows) {
+          if (row.firstUnread == null) continue;
+          out.directMessages[row.fromNodeId] = Number(row.firstUnread);
+        }
+      }
+
+      return out;
+    } catch (error) {
+      logger.error('Error getting first-unread timestamps:', error);
+      return out;
+    }
+  }
+
   // ============ PRIVATE HELPERS ============
 
   /**

--- a/src/db/schema/conversationReadState.ts
+++ b/src/db/schema/conversationReadState.ts
@@ -1,0 +1,98 @@
+/**
+ * Drizzle schema for `conversation_read_state` (issue #4607).
+ *
+ * A durable, PER-USER "last read" watermark for one conversation on one
+ * source. It answers "what had this operator already seen when they last left
+ * this thread?", which is what the unread divider and the jump-to-first-unread
+ * entry scroll both anchor on.
+ *
+ * Why a watermark table and not more `read_messages` rows: MeshCore messages
+ * were never covered by Meshtastic's per-message `read_messages` join, so the
+ * MeshCore views tracked their markers in `localStorage`, keyed only by
+ * sourceId. That is per-BROWSER, not per-USER — on a multi-user install two
+ * operators sharing a browser shared one set of markers, and the same operator
+ * on a second device started from zero. This table moves that state server-side
+ * where the user identity actually lives.
+ *
+ * Meshtastic deliberately does NOT write here: `read_messages` is already a
+ * durable per-user record, and a second watermark would be a second source of
+ * truth that "Mark all read" could silently desynchronise. Meshtastic derives
+ * its divider anchor from `read_messages` instead (see
+ * `NotificationsRepository.getFirstUnreadTimestampsAsync`).
+ *
+ * `userId` is NOT a foreign key and uses `0` for the anonymous / no-auth
+ * operator. A nullable column cannot participate in the UNIQUE constraint the
+ * upsert depends on (SQLite and PostgreSQL both treat NULLs as distinct, so
+ * every write would append a new row), and a sentinel keeps the uniqueness
+ * total. Orphan rows after a user delete are inert bookkeeping.
+ */
+import { sqliteTable, text, integer, uniqueIndex } from 'drizzle-orm/sqlite-core';
+import {
+  pgTable,
+  text as pgText,
+  integer as pgInteger,
+  bigint as pgBigint,
+  serial as pgSerial,
+  uniqueIndex as pgUniqueIndex,
+} from 'drizzle-orm/pg-core';
+import {
+  mysqlTable,
+  varchar as myVarchar,
+  int as myInt,
+  bigint as myBigint,
+  serial as mySerial,
+  uniqueIndex as myUniqueIndex,
+} from 'drizzle-orm/mysql-core';
+
+/** Conversation families tracked by the watermark table. */
+export const CONVERSATION_KINDS = ['meshcore_channel', 'meshcore_dm'] as const;
+export type ConversationKind = (typeof CONVERSATION_KINDS)[number];
+
+/** Sentinel `userId` for the anonymous / unauthenticated operator. */
+export const ANONYMOUS_USER_ID = 0;
+
+// SQLite
+export const conversationReadStateSqlite = sqliteTable('conversation_read_state', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  userId: integer('user_id').notNull(),
+  sourceId: text('source_id').notNull(),
+  conversationKind: text('conversation_kind').notNull(),
+  conversationKey: text('conversation_key').notNull(),
+  lastReadAt: integer('last_read_at').notNull(),
+}, (t) => ({
+  uniqueConversation: uniqueIndex('idx_conversation_read_state_unique')
+    .on(t.userId, t.sourceId, t.conversationKind, t.conversationKey),
+}));
+
+// PostgreSQL
+export const conversationReadStatePostgres = pgTable('conversation_read_state', {
+  id: pgSerial('id').primaryKey(),
+  userId: pgInteger('userId').notNull(),
+  sourceId: pgText('sourceId').notNull(),
+  conversationKind: pgText('conversationKind').notNull(),
+  conversationKey: pgText('conversationKey').notNull(),
+  lastReadAt: pgBigint('lastReadAt', { mode: 'number' }).notNull(),
+}, (t) => ({
+  uniqueConversation: pgUniqueIndex('idx_conversation_read_state_unique')
+    .on(t.userId, t.sourceId, t.conversationKind, t.conversationKey),
+}));
+
+// MySQL
+export const conversationReadStateMysql = mysqlTable('conversation_read_state', {
+  id: mySerial('id').primaryKey(),
+  userId: myInt('userId').notNull(),
+  sourceId: myVarchar('sourceId', { length: 64 }).notNull(),
+  conversationKind: myVarchar('conversationKind', { length: 32 }).notNull(),
+  // 64-hex MeshCore pubkeys are the longest key in practice; the index below
+  // needs a bounded column, so this is a varchar rather than TEXT.
+  conversationKey: myVarchar('conversationKey', { length: 128 }).notNull(),
+  lastReadAt: myBigint('lastReadAt', { mode: 'number' }).notNull(),
+}, (t) => ({
+  uniqueConversation: myUniqueIndex('idx_conversation_read_state_unique')
+    .on(t.userId, t.sourceId, t.conversationKind, t.conversationKey),
+}));
+
+export type ConversationReadStateSqlite = typeof conversationReadStateSqlite.$inferSelect;
+export type NewConversationReadStateSqlite = typeof conversationReadStateSqlite.$inferInsert;
+export type ConversationReadStatePostgres = typeof conversationReadStatePostgres.$inferSelect;
+export type ConversationReadStateMysql = typeof conversationReadStateMysql.$inferSelect;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -18,6 +18,9 @@ export * from './auth.js';
 // Notification tables
 export * from './notifications.js';
 
+// Per-user conversation read watermarks (issue #4607)
+export * from './conversationReadState.js';
+
 // Packet logging
 export * from './packets.js';
 export * from './mqttPacketLog.js';

--- a/src/hooks/useFirstUnread.ts
+++ b/src/hooks/useFirstUnread.ts
@@ -1,0 +1,84 @@
+/**
+ * First-unread timestamps hook (#4607).
+ *
+ * Companion to `useUnreadCounts`: where that answers "how many unread?", this
+ * answers "which message did I stop reading at?" — the timestamp of the oldest
+ * still-unread message in each Meshtastic conversation, for the unread divider
+ * and the jump-to-first-unread entry scroll.
+ *
+ * Meshtastic has no separate watermark table. Read state already lives in
+ * `read_messages` (durable, per-user), so the anchor is derived from it server
+ * side rather than duplicated — one source of truth, so "Mark all read" can
+ * never disagree with the divider.
+ *
+ * The polled value is a snapshot of what was unread BEFORE the user opened a
+ * conversation. That is exactly right: the views mark a conversation read
+ * within a tick of entry, so consumers pin the value at entry (see
+ * `MessagingContext.pinnedFirstUnread*`) rather than reading it live.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+export interface FirstUnreadData {
+  /** Oldest unread message timestamp (ms) per channel id. */
+  channels: { [channelId: number]: number };
+  /** Oldest unread message timestamp (ms) per DM peer node id. */
+  directMessages: { [nodeId: string]: number };
+}
+
+interface UseFirstUnreadOptions {
+  baseUrl?: string;
+  enabled?: boolean;
+  /** Poll interval in ms (default 10s, matching useUnreadCounts). */
+  refetchInterval?: number;
+  /** Optional source scope — when set, results are filtered to this source. */
+  sourceId?: string | null;
+  /** When true, MQTT/bridge messages are excluded, matching the badge counts. */
+  excludeMqtt?: boolean;
+}
+
+const EMPTY: FirstUnreadData = { channels: {}, directMessages: {} };
+
+export function useFirstUnread({
+  baseUrl = '',
+  enabled = true,
+  refetchInterval = 10000,
+  sourceId,
+  excludeMqtt,
+}: UseFirstUnreadOptions = {}) {
+  return useQuery<FirstUnreadData>({
+    queryKey: ['firstUnread', baseUrl, sourceId ?? null, !!excludeMqtt],
+    queryFn: async (): Promise<FirstUnreadData> => {
+      const params = new URLSearchParams();
+      if (sourceId) params.set('sourceId', sourceId);
+      if (excludeMqtt) params.set('excludeMqtt', 'true');
+      const qs = params.toString();
+      const url = qs
+        ? `${baseUrl}/api/messages/first-unread?${qs}`
+        : `${baseUrl}/api/messages/first-unread`;
+
+      const response = await fetch(url, { credentials: 'include' });
+
+      // An unauthenticated / unpermitted session simply has no divider — the
+      // rest of the messaging UI must keep working.
+      if (response.status === 401 || response.status === 403) return EMPTY;
+      if (!response.ok) {
+        throw new Error(`Failed to fetch first-unread: ${response.status} ${response.statusText}`);
+      }
+
+      // `ok(res, data)` envelope; ApiService does not unwrap, so we do.
+      const body = await response.json();
+      const data = body?.data ?? body;
+      return {
+        channels: data?.channels ?? {},
+        directMessages: data?.directMessages ?? {},
+      };
+    },
+    enabled,
+    refetchInterval,
+    staleTime: Math.max(refetchInterval - 2000, 0),
+    gcTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+}

--- a/src/hooks/useMessagingView.ts
+++ b/src/hooks/useMessagingView.ts
@@ -56,6 +56,41 @@ import { logger } from '../utils/logger';
 import { playSound, playChannelSound, DEFAULT_SOUND_ID } from '../utils/notificationSounds';
 import type { PollData, RawMessage } from './usePoll';
 
+/**
+ * Land the one-time entry scroll on the unread divider when the conversation
+ * has one, otherwise at the bottom (#4607).
+ *
+ * The divider is located by querying the container for `[data-unread-divider]`
+ * rather than by threading the anchor id through this hook. The tabs own the
+ * anchor and already render the element; a DOM lookup keeps this scroll logic
+ * decoupled from how either tab computes it, and it is only run once per
+ * conversation entry, so it costs nothing on the hot path.
+ *
+ * Deliberately confined to the ENTRY scroll. The load-older restore and the
+ * near-bottom auto-scroll are untouched, so prepending older history still
+ * cannot yank the view (#4476).
+ */
+/** True when the conversation currently renders an unread divider (#4607). */
+function hasUnreadDivider(container: HTMLDivElement): boolean {
+  return typeof container.querySelector === 'function'
+    && !!container.querySelector('[data-unread-divider]');
+}
+
+function scrollToUnreadOrBottom(container: HTMLDivElement): void {
+  // Several unit tests drive these effects with a plain `{ scrollTop,
+  // scrollHeight }` stand-in rather than a real element, so treat a missing
+  // querySelector as "no divider" instead of throwing.
+  const divider = typeof container.querySelector === 'function'
+    ? container.querySelector('[data-unread-divider]')
+    : null;
+  if (divider) {
+    divider.scrollIntoView({ block: 'start' });
+    return;
+  }
+  container.scrollTop = container.scrollHeight;
+}
+
+
 export function useMessagingView() {
   const { t } = useTranslation();
   const { showToast } = useToast();
@@ -385,8 +420,9 @@ export function useMessagingView() {
         // Use setTimeout to ensure messages are rendered before scrolling
         setTimeout(() => {
           if (channelMessagesContainerRef.current) {
-            channelMessagesContainerRef.current.scrollTop = channelMessagesContainerRef.current.scrollHeight;
-            setIsChannelScrolledToBottom(true);
+            // #4607: land on the oldest unseen message when there is one.
+            scrollToUnreadOrBottom(channelMessagesContainerRef.current);
+            setIsChannelScrolledToBottom(!hasUnreadDivider(channelMessagesContainerRef.current));
           }
         }, 100);
       }
@@ -505,8 +541,9 @@ export function useMessagingView() {
         pendingDMScrollRef.current = false;
         setTimeout(() => {
           if (dmMessagesContainerRef.current) {
-            dmMessagesContainerRef.current.scrollTop = dmMessagesContainerRef.current.scrollHeight;
-            setIsDMScrolledToBottom(true);
+            // #4607: land on the oldest unseen message when there is one.
+            scrollToUnreadOrBottom(dmMessagesContainerRef.current);
+            setIsDMScrolledToBottom(!hasUnreadDivider(dmMessagesContainerRef.current));
           }
         }, 150);
       }

--- a/src/server/migrations/137_add_conversation_read_state.test.ts
+++ b/src/server/migrations/137_add_conversation_read_state.test.ts
@@ -1,0 +1,130 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it, vi } from 'vitest';
+import { migration, runMigration137Postgres, runMigration137Mysql } from './137_add_conversation_read_state.js';
+
+describe('Migration 137 — conversation_read_state table (#4607)', () => {
+  describe('SQLite', () => {
+    it('creates the table and is idempotent (second up() does not throw)', () => {
+      const db = new Database(':memory:');
+
+      migration.up(db);
+      expect(() => migration.up(db)).not.toThrow();
+
+      const table = db.prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name = 'conversation_read_state'`
+      ).get();
+      expect(table).toBeTruthy();
+
+      const index = db.prepare(
+        `SELECT name FROM sqlite_master WHERE type='index' AND name = 'idx_conversation_read_state_unique'`
+      ).get();
+      expect(index).toBeTruthy();
+
+      db.close();
+    });
+
+    it('enforces one watermark per (user, source, kind, key)', () => {
+      const db = new Database(':memory:');
+      migration.up(db);
+
+      const insert = db.prepare(`
+        INSERT INTO conversation_read_state (user_id, source_id, conversation_kind, conversation_key, last_read_at)
+        VALUES (?, ?, ?, ?, ?)
+      `);
+
+      insert.run(1, 'src-a', 'meshcore_channel', '0', 1000);
+
+      // Same tuple → rejected by the unique index (this is the upsert's
+      // conflict target; without it every write would append a row).
+      expect(() => insert.run(1, 'src-a', 'meshcore_channel', '0', 2000)).toThrow();
+
+      // Each of the four discriminators independently makes it a new row.
+      expect(() => insert.run(2, 'src-a', 'meshcore_channel', '0', 1000)).not.toThrow();
+      expect(() => insert.run(1, 'src-b', 'meshcore_channel', '0', 1000)).not.toThrow();
+      expect(() => insert.run(1, 'src-a', 'meshcore_dm', '0', 1000)).not.toThrow();
+      expect(() => insert.run(1, 'src-a', 'meshcore_channel', '1', 1000)).not.toThrow();
+
+      db.close();
+    });
+
+    it('keeps the anonymous sentinel (user_id 0) distinct from real users', () => {
+      // The sentinel exists because a NULLable user_id cannot participate in
+      // the unique index — SQLite treats NULLs as distinct, so anonymous
+      // writes would append forever instead of updating.
+      const db = new Database(':memory:');
+      migration.up(db);
+
+      const insert = db.prepare(`
+        INSERT INTO conversation_read_state (user_id, source_id, conversation_kind, conversation_key, last_read_at)
+        VALUES (?, ?, ?, ?, ?)
+      `);
+      insert.run(0, 'src-a', 'meshcore_channel', '0', 1000);
+      expect(() => insert.run(0, 'src-a', 'meshcore_channel', '0', 2000)).toThrow();
+      expect(() => insert.run(7, 'src-a', 'meshcore_channel', '0', 2000)).not.toThrow();
+
+      const rows = db.prepare(`SELECT user_id FROM conversation_read_state ORDER BY user_id`).all() as any[];
+      expect(rows.map(r => r.user_id)).toEqual([0, 7]);
+
+      db.close();
+    });
+  });
+
+  describe('PostgreSQL', () => {
+    it('creates the table and unique index with quoted camelCase columns', async () => {
+      const client = { query: vi.fn().mockResolvedValue({ rows: [] }) } as any;
+
+      await runMigration137Postgres(client);
+
+      expect(client.query).toHaveBeenCalledTimes(2);
+      const ddl = client.query.mock.calls[0][0];
+      expect(ddl).toContain('CREATE TABLE IF NOT EXISTS conversation_read_state');
+      expect(ddl).toContain('"userId" INTEGER NOT NULL');
+      expect(ddl).toContain('"sourceId" TEXT NOT NULL');
+      expect(ddl).toContain('"conversationKind" TEXT NOT NULL');
+      expect(ddl).toContain('"conversationKey" TEXT NOT NULL');
+      expect(ddl).toContain('"lastReadAt" BIGINT NOT NULL');
+
+      const idx = client.query.mock.calls[1][0];
+      expect(idx).toContain('CREATE UNIQUE INDEX IF NOT EXISTS idx_conversation_read_state_unique');
+      expect(idx).toContain('"userId", "sourceId", "conversationKind", "conversationKey"');
+    });
+
+    it('is idempotent (running twice does not throw)', async () => {
+      const client = { query: vi.fn().mockResolvedValue({ rows: [] }) } as any;
+      await runMigration137Postgres(client);
+      await expect(runMigration137Postgres(client)).resolves.not.toThrow();
+    });
+  });
+
+  describe('MySQL', () => {
+    function makeConn(existRows: any[]) {
+      return {
+        query: vi.fn().mockResolvedValue([existRows, []]),
+        release: vi.fn(),
+      };
+    }
+
+    it('creates the table with an inline UNIQUE KEY when absent, then skips', async () => {
+      const absentConn = makeConn([]);
+      const absentPool = { getConnection: vi.fn().mockResolvedValue(absentConn) };
+
+      await runMigration137Mysql(absentPool as any);
+
+      expect(absentConn.query).toHaveBeenCalledTimes(2);
+      const ddl = absentConn.query.mock.calls[1][0];
+      expect(ddl).toContain('CREATE TABLE conversation_read_state');
+      // MySQL has no CREATE INDEX IF NOT EXISTS, so the key must be inline or
+      // a re-run after a crash would fail.
+      expect(ddl).toContain('UNIQUE KEY idx_conversation_read_state_unique (userId, sourceId, conversationKind, conversationKey)');
+      expect(absentConn.release).toHaveBeenCalledTimes(1);
+
+      const presentConn = makeConn([{ TABLE_NAME: 'conversation_read_state' }]);
+      const presentPool = { getConnection: vi.fn().mockResolvedValue(presentConn) };
+
+      await runMigration137Mysql(presentPool as any);
+
+      expect(presentConn.query).toHaveBeenCalledTimes(1); // existence check only
+      expect(presentConn.release).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/server/migrations/137_add_conversation_read_state.ts
+++ b/src/server/migrations/137_add_conversation_read_state.ts
@@ -1,0 +1,92 @@
+/**
+ * Migration 137: Create `conversation_read_state` (issue #4607).
+ *
+ * A durable, per-user "last read" watermark per (source, conversation). It is
+ * what the unread divider and the jump-to-first-unread entry scroll anchor on
+ * for MeshCore, whose messages were never covered by Meshtastic's per-message
+ * `read_messages` table and were previously tracked only in browser
+ * localStorage — per-browser rather than per-user.
+ *
+ * `userId` is a plain INTEGER with `0` standing in for the anonymous operator
+ * rather than a nullable FK: the UNIQUE index is the upsert's conflict target,
+ * and SQLite/PostgreSQL both treat NULLs as distinct, so a nullable column
+ * would append a fresh row on every write instead of updating one.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+import { createTableIfMissingMysql } from './helpers.js';
+
+const LABEL = 'Migration 137';
+const TABLE = 'conversation_read_state';
+const UNIQUE_INDEX = 'idx_conversation_read_state_unique';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): creating ${TABLE}...`);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS ${TABLE} (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        source_id TEXT NOT NULL,
+        conversation_kind TEXT NOT NULL,
+        conversation_key TEXT NOT NULL,
+        last_read_at INTEGER NOT NULL
+      )
+    `);
+    db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS ${UNIQUE_INDEX}
+        ON ${TABLE} (user_id, source_id, conversation_kind, conversation_key)
+    `);
+    logger.debug(`${LABEL} (SQLite): ${TABLE} ready`);
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (table drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches the 136 migration-file convention (pg Client)
+export async function runMigration137Postgres(client: any): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): creating ${TABLE}...`);
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS ${TABLE} (
+      "id" SERIAL PRIMARY KEY,
+      "userId" INTEGER NOT NULL,
+      "sourceId" TEXT NOT NULL,
+      "conversationKind" TEXT NOT NULL,
+      "conversationKey" TEXT NOT NULL,
+      "lastReadAt" BIGINT NOT NULL
+    )
+  `);
+  await client.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS ${UNIQUE_INDEX}
+      ON ${TABLE} ("userId", "sourceId", "conversationKind", "conversationKey")
+  `);
+}
+
+// ============ MySQL ============
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches the 136 migration-file convention (mysql2 Pool)
+export async function runMigration137Mysql(pool: any): Promise<void> {
+  logger.info(`${LABEL} (MySQL): creating ${TABLE}...`);
+  // MySQL has no CREATE INDEX IF NOT EXISTS, so the unique key is declared
+  // inline in the CREATE TABLE (per the helpers.ts guidance).
+  await createTableIfMissingMysql(pool, TABLE, `
+    CREATE TABLE ${TABLE} (
+      id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+      userId INT NOT NULL,
+      sourceId VARCHAR(64) NOT NULL,
+      conversationKind VARCHAR(32) NOT NULL,
+      conversationKey VARCHAR(128) NOT NULL,
+      lastReadAt BIGINT NOT NULL,
+      UNIQUE KEY ${UNIQUE_INDEX} (userId, sourceId, conversationKind, conversationKey)
+    )
+  `);
+}

--- a/src/server/routes/messageRoutes.firstUnread.test.ts
+++ b/src/server/routes/messageRoutes.firstUnread.test.ts
@@ -1,0 +1,111 @@
+/**
+ * GET /api/messages/first-unread (#4607)
+ *
+ * The unread-divider anchor endpoint. The query itself is covered against all
+ * three backends in `src/db/repositories/notifications.test.ts`; what matters
+ * here is that the route never hands a caller an anchor for a conversation
+ * whose unread BADGE they are not allowed to see — the same gates
+ * `/unread-counts` applies.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import databaseService from '../../services/database.js';
+
+vi.mock('../utils/resolveSourceManager.js', () => ({
+  resolveSourceManager: () => ({
+    getLocalNodeInfo: () => ({ nodeId: '!me' }),
+    getAllNodesAsync: async () => [
+      { nodeNum: 1, user: { id: '!peer' } },
+      { nodeNum: 2, user: { id: '!hidden' } },
+    ],
+  }),
+}));
+
+vi.mock('../utils/nodeEnhancer.js', () => ({
+  // Only `!peer` is visible to the caller; `!hidden` is filtered by channel
+  // permission, exactly as it would be for the unread counts.
+  filterNodesByChannelPermission: async (nodes: any[]) => nodes.filter(n => n.user?.id === '!peer'),
+}));
+
+import messageRoutes from './messageRoutes.js';
+
+const RAW = {
+  channels: { 0: 1000, 5: 2000 },
+  directMessages: { '!peer': 3000, '!hidden': 4000 },
+};
+
+function createApp(user: any) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res, next) => { req.user = user; next(); });
+  app.use('/api/messages', messageRoutes);
+  return app;
+}
+
+describe('GET /api/messages/first-unread (#4607)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (databaseService as any).getFirstUnreadTimestampsAsync = vi.fn().mockResolvedValue(RAW);
+    (databaseService as any).getUserPermissionSetAsync = vi.fn().mockResolvedValue({});
+    (databaseService as any).checkPermissionAsync = vi.fn().mockResolvedValue(false);
+    (databaseService as any).getChannelDatabaseEntriesAsync = vi.fn().mockResolvedValue([]);
+    (databaseService as any).findUserByIdAsync = vi.fn();
+  });
+
+  it('403s a caller with neither channel nor message read permission', async () => {
+    const res = await request(createApp({ id: 5, isAdmin: false })).get('/api/messages/first-unread');
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('FORBIDDEN');
+  });
+
+  it('returns channel and DM anchors for an admin, in the ok() envelope', async () => {
+    const res = await request(createApp({ id: 1, isAdmin: true })).get('/api/messages/first-unread');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.channels).toEqual({ 0: 1000, 5: 2000 });
+    // `!hidden` is dropped by the node-visibility filter.
+    expect(res.body.data.directMessages).toEqual({ '!peer': 3000 });
+  });
+
+  it('drops channels the caller cannot read', async () => {
+    // channel_0 granted, channel_5 not.
+    (databaseService as any).checkPermissionAsync = vi.fn(
+      async (_uid: number, resource: string) => resource === 'channel_0' || resource === 'messages'
+    );
+
+    const res = await request(createApp({ id: 5, isAdmin: false })).get('/api/messages/first-unread');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.channels).toEqual({ 0: 1000 });
+  });
+
+  it('omits DM anchors entirely without messages:read', async () => {
+    (databaseService as any).checkPermissionAsync = vi.fn(
+      async (_uid: number, resource: string) => resource.startsWith('channel_')
+    );
+
+    const res = await request(createApp({ id: 5, isAdmin: false })).get('/api/messages/first-unread');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.directMessages).toEqual({});
+  });
+
+  it('forwards sourceId and excludeMqtt to the query', async () => {
+    await request(createApp({ id: 1, isAdmin: true }))
+      .get('/api/messages/first-unread?sourceId=src-a&excludeMqtt=true');
+
+    expect((databaseService as any).getFirstUnreadTimestampsAsync)
+      .toHaveBeenCalledWith(1, '!me', 'src-a', true);
+  });
+
+  it('reports 500 through the fail() envelope when the query throws', async () => {
+    (databaseService as any).getFirstUnreadTimestampsAsync = vi.fn().mockRejectedValue(new Error('boom'));
+
+    const res = await request(createApp({ id: 1, isAdmin: true })).get('/api/messages/first-unread');
+
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe('FIRST_UNREAD_FAILED');
+  });
+});

--- a/src/server/routes/messageRoutes.ts
+++ b/src/server/routes/messageRoutes.ts
@@ -20,7 +20,7 @@ import {
 import { parseDestinationNum } from '../utils/parseDestination.js';
 import { transformDbMessageToMeshMessage } from '../utils/transformDbMessage.js';
 import { filterNodesByChannelPermission } from '../utils/nodeEnhancer.js';
-import { fail } from '../utils/apiResponse.js';
+import { ok, fail } from '../utils/apiResponse.js';
 import { isTxDisabledError } from '../errors/txDisabledError.js';
 
 const router = express.Router();
@@ -1215,6 +1215,85 @@ router.get('/unread-counts', optionalAuth(), async (req, res) => {
   } catch (error) {
     logger.error('Error fetching unread counts:', error);
     res.status(500).json({ error: 'Failed to fetch unread counts' });
+  }
+});
+
+/**
+ * GET /api/messages/first-unread
+ *
+ * Timestamp (ms) of the OLDEST still-unread message in each conversation, for
+ * the unread divider and the jump-to-first-unread entry scroll (issue #4607).
+ * Shaped and permission-filtered exactly like `/unread-counts` above — same
+ * gates, same per-channel/per-node visibility filtering, same mute handling —
+ * so the line can never appear in a conversation whose badge the caller is not
+ * allowed to see.
+ *
+ * The client reads this ONCE per conversation entry and pins the value: the
+ * views mark a conversation read the moment you open it, so a live value would
+ * evaporate before it could be drawn.
+ */
+router.get('/first-unread', optionalAuth(), async (req, res) => {
+  try {
+    const isAdmin = req.user?.isAdmin === true;
+    const hasChannelsRead = isAdmin || (req.user ? await hasPermission(req.user, 'channel_0', 'read') : false);
+    const hasMessagesRead = isAdmin || (req.user ? await hasPermission(req.user, 'messages', 'read') : false);
+    const readableVirtual = await getUserReadableVirtualChannelIds(req.user, isAdmin);
+    const hasVirtualRead = hasAnyReadableVirtualChannel(readableVirtual);
+
+    if (!hasChannelsRead && !hasMessagesRead && !hasVirtualRead) {
+      return fail(res, 403, 'FORBIDDEN', 'Insufficient permissions');
+    }
+
+    const userId = req.user?.id ?? null;
+    const scopedSourceId = typeof req.query.sourceId === 'string' && req.query.sourceId.length > 0
+      ? req.query.sourceId
+      : undefined;
+    const excludeMqtt = req.query.excludeMqtt === 'true';
+    const manager = resolveSourceManager(scopedSourceId);
+    const localNodeInfo = manager.getLocalNodeInfo();
+
+    const raw = await databaseService.getFirstUnreadTimestampsAsync(
+      userId,
+      localNodeInfo?.nodeId,
+      scopedSourceId ?? ALL_SOURCES, // intentional cross-source when sourceId omitted
+      excludeMqtt
+    );
+
+    const result: {
+      channels: { [channelId: number]: number };
+      directMessages: { [nodeId: string]: number };
+    } = { channels: {}, directMessages: {} };
+
+    if (hasChannelsRead || hasVirtualRead) {
+      for (const [channelIdStr, ts] of Object.entries(raw.channels)) {
+        const channelId = Number(channelIdStr);
+        if (isVirtualChannelNumber(channelId)) {
+          if (!isAdmin && !canReadVirtualChannelNumber(channelId, readableVirtual)) continue;
+        } else if (!hasChannelsRead) {
+          continue;
+        } else if (!isAdmin && req.user) {
+          const channelResource = `channel_${channelId}` as import('../../types/permission.js').ResourceType;
+          if (!(await hasPermission(req.user, channelResource, 'read'))) continue;
+        } else if (!req.user && !isAdmin) {
+          continue;
+        }
+        result.channels[channelId] = ts as number;
+      }
+    }
+
+    if (hasMessagesRead && localNodeInfo) {
+      const allNodes = await manager.getAllNodesAsync(scopedSourceId);
+      const visibleNodes = await filterNodesByChannelPermission(allNodes, req.user, scopedSourceId);
+      const visibleNodeIds = new Set(visibleNodes.map(n => n.user?.id).filter(Boolean));
+      for (const [nodeId, ts] of Object.entries(raw.directMessages)) {
+        if (visibleNodeIds.has(nodeId)) result.directMessages[nodeId] = ts as number;
+      }
+    }
+
+    return ok(res, result);
+  } catch (error) {
+    logger.error('Error fetching first-unread timestamps:', error);
+    return fail(res, 500, 'FIRST_UNREAD_FAILED', 'Failed to fetch first-unread timestamps');
   }
 });
 

--- a/src/server/routes/readStateRoutes.test.ts
+++ b/src/server/routes/readStateRoutes.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Conversation read-state routes (#4607) — permission + behaviour tests.
+ *
+ * Uses the real-middleware harness so `messages:read` is enforced by actual
+ * SQL, not a hand-rolled lambda. The property that matters most here is
+ * per-user isolation: the whole reason this table replaced localStorage is
+ * that two operators must not share one set of read markers.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import readStateRoutes from './readStateRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+describe('readStateRoutes (#4607)', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/', readStateRoutes),
+    });
+    await harness.grant(harness.limited.id, 'messages', 'read', harness.sourceA);
+    // Deliberately no grant on sourceB.
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  describe('GET /', () => {
+    it('400s without a sourceId', async () => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.get('/');
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('SOURCE_ID_REQUIRED');
+    });
+
+    it('returns an empty map for a source with no markers', async () => {
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.get(`/?sourceId=${harness.sourceA}`);
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual({ meshcore_channel: {}, meshcore_dm: {} });
+    });
+
+    it('403s on a source the user has no messages:read grant for', async () => {
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.get(`/?sourceId=${harness.sourceB}`);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('POST /', () => {
+    it('rejects an unknown conversation kind', async () => {
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent.post('/').send({
+        sourceId: harness.sourceA,
+        kind: 'meshtastic_channel',
+        conversationKey: '0',
+        lastReadAt: 1000,
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('INVALID_CONVERSATION_KIND');
+    });
+
+    it('rejects a missing conversationKey and a non-numeric lastReadAt', async () => {
+      const agent = await harness.loginAs(harness.admin);
+
+      const noKey = await agent.post('/').send({
+        sourceId: harness.sourceA, kind: 'meshcore_dm', conversationKey: '', lastReadAt: 1,
+      });
+      expect(noKey.status).toBe(400);
+      expect(noKey.body.code).toBe('CONVERSATION_KEY_REQUIRED');
+
+      const badTs = await agent.post('/').send({
+        sourceId: harness.sourceA, kind: 'meshcore_dm', conversationKey: 'peer', lastReadAt: 'soon',
+      });
+      expect(badTs.status).toBe(400);
+      expect(badTs.body.code).toBe('INVALID_LAST_READ_AT');
+    });
+
+    it('403s on a source the user has no messages:read grant for', async () => {
+      const agent = await harness.loginAs(harness.limited);
+      const res = await agent.post('/').send({
+        sourceId: harness.sourceB, kind: 'meshcore_channel', conversationKey: '0', lastReadAt: 1000,
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('persists a marker and reads it back', async () => {
+      const agent = await harness.loginAs(harness.limited);
+
+      const write = await agent.post('/').send({
+        sourceId: harness.sourceA, kind: 'meshcore_channel', conversationKey: '2', lastReadAt: 4242,
+      });
+      expect(write.status).toBe(200);
+      expect(write.body.data).toEqual({ lastReadAt: 4242 });
+
+      const read = await agent.get(`/?sourceId=${harness.sourceA}`);
+      expect(read.body.data.meshcore_channel['2']).toBe(4242);
+    });
+
+    it('never rewinds a marker, and reports the effective value', async () => {
+      const agent = await harness.loginAs(harness.limited);
+
+      await agent.post('/').send({
+        sourceId: harness.sourceA, kind: 'meshcore_dm', conversationKey: 'peerA', lastReadAt: 9000,
+      });
+      const stale = await agent.post('/').send({
+        sourceId: harness.sourceA, kind: 'meshcore_dm', conversationKey: 'peerA', lastReadAt: 100,
+      });
+
+      expect(stale.status).toBe(200);
+      expect(stale.body.data).toEqual({ lastReadAt: 9000 });
+    });
+
+    it('keeps two users\' markers apart on the same source and conversation', async () => {
+      // The multi-user defect the localStorage store could not express.
+      const limitedAgent = await harness.loginAs(harness.limited);
+      const adminAgent = await harness.loginAs(harness.admin);
+
+      await limitedAgent.post('/').send({
+        sourceId: harness.sourceA, kind: 'meshcore_channel', conversationKey: '0', lastReadAt: 1000,
+      });
+      await adminAgent.post('/').send({
+        sourceId: harness.sourceA, kind: 'meshcore_channel', conversationKey: '0', lastReadAt: 8000,
+      });
+
+      const limitedRead = await limitedAgent.get(`/?sourceId=${harness.sourceA}`);
+      const adminRead = await adminAgent.get(`/?sourceId=${harness.sourceA}`);
+
+      expect(limitedRead.body.data.meshcore_channel['0']).toBe(1000);
+      expect(adminRead.body.data.meshcore_channel['0']).toBe(8000);
+    });
+
+    it('keeps one user\'s markers apart across sources', async () => {
+      const agent = await harness.loginAs(harness.admin);
+
+      await agent.post('/').send({
+        sourceId: harness.sourceA, kind: 'meshcore_channel', conversationKey: '0', lastReadAt: 1000,
+      });
+      await agent.post('/').send({
+        sourceId: harness.sourceB, kind: 'meshcore_channel', conversationKey: '0', lastReadAt: 8000,
+      });
+
+      const a = await agent.get(`/?sourceId=${harness.sourceA}`);
+      const b = await agent.get(`/?sourceId=${harness.sourceB}`);
+      expect(a.body.data.meshcore_channel['0']).toBe(1000);
+      expect(b.body.data.meshcore_channel['0']).toBe(8000);
+    });
+  });
+});

--- a/src/server/routes/readStateRoutes.ts
+++ b/src/server/routes/readStateRoutes.ts
@@ -1,0 +1,106 @@
+/**
+ * Conversation read-state routes (issue #4607).
+ *
+ * The durable, per-user last-read watermark that the MeshCore unread divider
+ * and the jump-to-first-unread entry scroll anchor on. MeshCore messages are
+ * not covered by Meshtastic's per-message `read_messages` table, so before
+ * this the markers lived in browser localStorage — per-browser, not per-user,
+ * which is the wrong shape for an app with real multi-user auth.
+ *
+ * Mounted at `/api/read-state`. Deliberately NOT under the MeshCore router:
+ * the table is conversation-kind-tagged rather than protocol-specific, so a
+ * future surface can reuse it without moving the endpoint.
+ *
+ * Permission: `messages:read` on the source. Writing your own read marker is
+ * private bookkeeping, not a mutation of anyone else's data, so the write
+ * endpoint carries the same read-level gate rather than `messages:write` —
+ * a read-only viewer must still be able to dismiss what they have read.
+ */
+import express from 'express';
+import databaseService from '../../services/database.js';
+import { isConversationKind } from '../../db/repositories/conversationReadState.js';
+import { optionalAuth, hasPermission } from '../auth/authMiddleware.js';
+import { ok, fail } from '../utils/apiResponse.js';
+import { logger } from '../../utils/logger.js';
+
+const router = express.Router();
+
+/** Resolve the `sourceId` query/body value, or null when absent/malformed. */
+function readSourceId(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * `messages:read` on this source. `optionalAuth()` attaches the real
+ * `anonymous` DB user when there is no session, so an anonymous-readable
+ * deployment resolves through the normal permission path and gets its own
+ * (shared) watermark row — the same treatment `read_messages` gives it.
+ */
+async function canReadSource(req: express.Request, sourceId: string): Promise<boolean> {
+  if (req.user?.isAdmin === true) return true;
+  if (!req.user) return false;
+  return hasPermission(req.user, 'messages', 'read', sourceId);
+}
+
+/**
+ * GET /api/read-state?sourceId=...
+ * All of this user's watermarks on one source, grouped by conversation kind.
+ */
+router.get('/', optionalAuth(), async (req, res) => {
+  const sourceId = readSourceId(req.query.sourceId);
+  if (!sourceId) return fail(res, 400, 'SOURCE_ID_REQUIRED', 'sourceId is required');
+
+  try {
+    if (!(await canReadSource(req, sourceId))) {
+      return fail(res, 403, 'FORBIDDEN', 'Insufficient permissions');
+    }
+    const state = await databaseService.getConversationReadStateAsync(req.user?.id ?? null, sourceId);
+    return ok(res, state);
+  } catch (error) {
+    logger.error('Error reading conversation read state:', error);
+    return fail(res, 500, 'READ_STATE_FAILED', 'Failed to read conversation read state');
+  }
+});
+
+/**
+ * POST /api/read-state
+ * Body: `{ sourceId, kind, conversationKey, lastReadAt }`
+ *
+ * Moves one conversation's watermark forward. Monotonic on the server, so a
+ * late-landing write from a stale tab cannot resurrect dismissed messages.
+ * Responds with the effective watermark so the client can reconcile.
+ */
+router.post('/', optionalAuth(), async (req, res) => {
+  const sourceId = readSourceId(req.body?.sourceId);
+  if (!sourceId) return fail(res, 400, 'SOURCE_ID_REQUIRED', 'sourceId is required');
+
+  const { kind, conversationKey, lastReadAt } = req.body ?? {};
+  if (!isConversationKind(kind)) {
+    return fail(res, 400, 'INVALID_CONVERSATION_KIND', 'Unknown conversation kind');
+  }
+  if (typeof conversationKey !== 'string' || conversationKey.length === 0) {
+    return fail(res, 400, 'CONVERSATION_KEY_REQUIRED', 'conversationKey is required');
+  }
+  if (typeof lastReadAt !== 'number' || !Number.isFinite(lastReadAt) || lastReadAt < 0) {
+    return fail(res, 400, 'INVALID_LAST_READ_AT', 'lastReadAt must be a non-negative number');
+  }
+
+  try {
+    if (!(await canReadSource(req, sourceId))) {
+      return fail(res, 403, 'FORBIDDEN', 'Insufficient permissions');
+    }
+    const effective = await databaseService.setConversationReadStateAsync(
+      req.user?.id ?? null,
+      sourceId,
+      kind,
+      conversationKey,
+      lastReadAt
+    );
+    return ok(res, { lastReadAt: effective });
+  } catch (error) {
+    logger.error('Error writing conversation read state:', error);
+    return fail(res, 500, 'READ_STATE_WRITE_FAILED', 'Failed to write conversation read state');
+  }
+});
+
+export default router;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -581,6 +581,7 @@ import securityRoutes from './routes/securityRoutes.js';
 import packetRoutes from './routes/packetRoutes.js';
 import solarRoutes from './routes/solarRoutes.js';
 import messageRoutes from './routes/messageRoutes.js';
+import readStateRoutes from './routes/readStateRoutes.js';
 import linkPreviewRoutes from './routes/linkPreviewRoutes.js';
 import scriptContentRoutes from './routes/scriptContentRoutes.js';
 import apiTokenRoutes from './routes/apiTokenRoutes.js';
@@ -702,6 +703,10 @@ apiRouter.use('/news', newsRoutes);
 
 // Message routes (requires appropriate write permissions)
 apiRouter.use('/messages', optionalAuth(), messageRoutes);
+
+// Per-user conversation read watermarks (#4607) — the durable anchor for the
+// unread divider and the jump-to-first-unread entry scroll on MeshCore.
+apiRouter.use('/read-state', readStateRoutes);
 
 // MeshCore routes — nested under `/api/sources/:id/meshcore/*` so each
 // request resolves the manager bound to a specific source. The legacy

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -37,6 +37,8 @@ import {
   TraceroutesRepository,
   NeighborsRepository,
   NotificationsRepository,
+  ConversationReadStateRepository,
+  emptyReadStateMap,
   PacketLogRepository,
   KeyRepairRepository,
   ChannelDatabaseRepository,
@@ -70,6 +72,8 @@ import {
   ALL_SOURCES,
 } from '../db/repositories/index.js';
 import type { EstimatedPosition, EstimatedPositionInput, SourceScope } from '../db/repositories/index.js';
+import type { ConversationReadStateMap } from '../db/repositories/index.js';
+import type { ConversationKind } from '../db/schema/conversationReadState.js';
 import type { DatabaseType, DbPacketLog as DbTypesPacketLog, DbPacketCountByNode, DbPacketCountByPortnum, DbDistinctRelayNode } from '../db/types.js';
 import { updateNodeMobility } from '../server/services/nodeMobilityService.js';
 import { selectNodeNeedingTraceroute } from '../server/services/autoTracerouteSelectionService.js';
@@ -477,6 +481,7 @@ class DatabaseService {
   public traceroutesRepo: TraceroutesRepository | null = null;
   public neighborsRepo: NeighborsRepository | null = null;
   public notificationsRepo: NotificationsRepository | null = null;
+  public conversationReadStateRepo: ConversationReadStateRepository | null = null;
   public packetLogRepo: PacketLogRepository | null = null;
   public keyRepairRepo: KeyRepairRepository | null = null;
   public channelDatabaseRepo: ChannelDatabaseRepository | null = null;
@@ -640,6 +645,11 @@ class DatabaseService {
   get notifications(): NotificationsRepository {
     if (!this.notificationsRepo) throw new Error('Database not initialized');
     return this.notificationsRepo;
+  }
+
+  get conversationReadState(): ConversationReadStateRepository {
+    if (!this.conversationReadStateRepo) throw new Error('Database not initialized');
+    return this.conversationReadStateRepo;
   }
 
   get packetLog(): PacketLogRepository {
@@ -932,6 +942,7 @@ class DatabaseService {
       this.traceroutesRepo = new TraceroutesRepository(drizzleDb, this.drizzleDbType);
       this.neighborsRepo = new NeighborsRepository(drizzleDb, this.drizzleDbType);
       this.notificationsRepo = new NotificationsRepository(drizzleDb, this.drizzleDbType);
+      this.conversationReadStateRepo = new ConversationReadStateRepository(drizzleDb, this.drizzleDbType);
       this.packetLogRepo = new PacketLogRepository(drizzleDb, this.drizzleDbType);
       this.keyRepairRepo = new KeyRepairRepository(drizzleDb, this.drizzleDbType);
       this.channelDatabaseRepo = new ChannelDatabaseRepository(drizzleDb, this.drizzleDbType);
@@ -4087,6 +4098,47 @@ class DatabaseService {
     }
     if (!this.notificationsRepo) return {};
     return this.notificationsRepo.getBatchUnreadDMCountsAsync(localNodeId, userId, sourceId);
+  }
+
+  /**
+   * Oldest still-unread message timestamp per Meshtastic conversation, for the
+   * unread divider / jump-to-first-unread entry scroll (issue #4607).
+   * Drizzle on every backend — no raw-SQL sync twin.
+   */
+  async getFirstUnreadTimestampsAsync(
+    userId: number | null,
+    localNodeId?: string,
+    sourceId?: SourceScope,
+    excludeMqtt?: boolean
+  ): Promise<{ channels: { [channelId: number]: number }; directMessages: { [fromNodeId: string]: number } }> {
+    if (!this.notificationsRepo) return { channels: {}, directMessages: {} };
+    return this.notificationsRepo.getFirstUnreadTimestampsAsync(userId, localNodeId, sourceId, excludeMqtt);
+  }
+
+  /**
+   * All of this user's MeshCore last-read watermarks on one source (#4607).
+   */
+  async getConversationReadStateAsync(
+    userId: number | null,
+    sourceId: string
+  ): Promise<ConversationReadStateMap> {
+    if (!this.conversationReadStateRepo) return emptyReadStateMap();
+    return this.conversationReadStateRepo.getForSourceAsync(userId, sourceId);
+  }
+
+  /**
+   * Move one MeshCore conversation's watermark forward (#4607). Monotonic —
+   * returns the effective watermark after the write.
+   */
+  async setConversationReadStateAsync(
+    userId: number | null,
+    sourceId: string,
+    kind: ConversationKind,
+    conversationKey: string,
+    lastReadAt: number
+  ): Promise<number> {
+    if (!this.conversationReadStateRepo) return 0;
+    return this.conversationReadStateRepo.setLastReadAsync(userId, sourceId, kind, conversationKey, lastReadAt);
   }
 
   cleanupOldReadMessages(days: number): number {

--- a/src/utils/unreadAnchor.test.ts
+++ b/src/utils/unreadAnchor.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { resolveUnreadAnchorId, shouldSuppressDivider } from './unreadAnchor.js';
+
+const msgs = (...pairs: Array<[string, number]>) =>
+  pairs.map(([id, sortTime]) => ({ id, sortTime }));
+
+describe('resolveUnreadAnchorId (#4607)', () => {
+  it('returns null without a watermark', () => {
+    expect(resolveUnreadAnchorId({
+      messages: msgs(['a', 1], ['b', 2]),
+      watermarkMs: null,
+      mode: 'lastRead',
+    })).toBeNull();
+    expect(resolveUnreadAnchorId({
+      messages: msgs(['a', 1]),
+      watermarkMs: Number.NaN,
+      mode: 'lastRead',
+    })).toBeNull();
+  });
+
+  it('returns null for an empty conversation', () => {
+    expect(resolveUnreadAnchorId({ messages: [], watermarkMs: 5, mode: 'lastRead' })).toBeNull();
+  });
+
+  describe("mode 'lastRead' (MeshCore — watermark is the last message SEEN)", () => {
+    it('anchors on the first message strictly newer than the watermark', () => {
+      expect(resolveUnreadAnchorId({
+        messages: msgs(['a', 1000], ['b', 2000], ['c', 3000]),
+        watermarkMs: 2000,
+        mode: 'lastRead',
+      })).toBe('c');
+    });
+
+    it('does NOT anchor on a message exactly at the watermark — that one was read', () => {
+      expect(resolveUnreadAnchorId({
+        messages: msgs(['a', 1000], ['b', 2000]),
+        watermarkMs: 2000,
+        mode: 'lastRead',
+      })).toBeNull();
+    });
+
+    it('anchors on the very first message when the watermark predates everything', () => {
+      expect(resolveUnreadAnchorId({
+        messages: msgs(['a', 1000], ['b', 2000]),
+        watermarkMs: 0,
+        mode: 'lastRead',
+      })).toBe('a');
+    });
+  });
+
+  describe("mode 'firstUnread' (Meshtastic — watermark IS the oldest unread message)", () => {
+    it('anchors on the message at the watermark, inclusive', () => {
+      expect(resolveUnreadAnchorId({
+        messages: msgs(['a', 1000], ['b', 2000], ['c', 3000]),
+        watermarkMs: 2000,
+        mode: 'firstUnread',
+      })).toBe('b');
+    });
+
+    it('falls forward when the exact watermark row is not loaded', () => {
+      // The server computed the anchor from a row the client filtered out
+      // (hidden MQTT, a reaction). The line still lands at the right boundary
+      // rather than disappearing.
+      expect(resolveUnreadAnchorId({
+        messages: msgs(['a', 1000], ['c', 3000]),
+        watermarkMs: 2000,
+        mode: 'firstUnread',
+      })).toBe('c');
+    });
+
+    it('returns null when everything loaded predates the watermark', () => {
+      expect(resolveUnreadAnchorId({
+        messages: msgs(['a', 1000]),
+        watermarkMs: 5000,
+        mode: 'firstUnread',
+      })).toBeNull();
+    });
+  });
+
+  it('skips the operator\'s own messages when picking the anchor', () => {
+    // Our own outgoing message is never "unread" — anchoring on it would put
+    // the line above something we just typed.
+    expect(resolveUnreadAnchorId({
+      messages: msgs(['mine', 2500], ['theirs', 2600]),
+      watermarkMs: 2000,
+      mode: 'lastRead',
+      ownMessageIds: new Set(['mine']),
+    })).toBe('theirs');
+  });
+
+  it('returns null when every unread message is our own', () => {
+    expect(resolveUnreadAnchorId({
+      messages: msgs(['mine1', 2500], ['mine2', 2600]),
+      watermarkMs: 2000,
+      mode: 'lastRead',
+      ownMessageIds: new Set(['mine1', 'mine2']),
+    })).toBeNull();
+  });
+});
+
+describe('shouldSuppressDivider (#4607)', () => {
+  it('suppresses when there is no anchor', () => {
+    expect(shouldSuppressDivider({ anchorId: null, messages: msgs(['a', 1]) })).toBe(true);
+  });
+
+  it('suppresses a line above the very first message of a fully-loaded thread', () => {
+    // "Everything is new" in a thread you have never opened is not information.
+    expect(shouldSuppressDivider({
+      anchorId: 'a',
+      messages: msgs(['a', 1], ['b', 2]),
+      hasMoreOlder: false,
+    })).toBe(true);
+  });
+
+  it('keeps the line at the top when older history exists but is not loaded', () => {
+    // There genuinely are read messages above; they just have not been paged in.
+    expect(shouldSuppressDivider({
+      anchorId: 'a',
+      messages: msgs(['a', 1], ['b', 2]),
+      hasMoreOlder: true,
+    })).toBe(false);
+  });
+
+  it('keeps the line when the anchor is mid-conversation', () => {
+    expect(shouldSuppressDivider({
+      anchorId: 'b',
+      messages: msgs(['a', 1], ['b', 2]),
+      hasMoreOlder: false,
+    })).toBe(false);
+  });
+});

--- a/src/utils/unreadAnchor.ts
+++ b/src/utils/unreadAnchor.ts
@@ -1,0 +1,83 @@
+/**
+ * Unread-anchor helpers (#4607).
+ *
+ * The divider and the jump-to-first-unread entry scroll both need one thing:
+ * the id of the oldest message in the open conversation that the operator had
+ * NOT seen at the moment they opened it.
+ *
+ * "At the moment they opened it" is the load-bearing part. Every conversation
+ * view marks itself read on entry and again on every incoming message
+ * (useMessagingView GATED EFFECTS #6/#7, MeshCoreChannelsView's mark-read
+ * effect). A live "is this unread?" lookup therefore returns nothing a tick
+ * after the view mounts, which is exactly when the divider would be drawn. So
+ * the views PIN a watermark when the conversation key changes and resolve the
+ * anchor against that frozen value for as long as they stay in the thread.
+ *
+ * Pure functions, no React — so the rule can be tested without mounting three
+ * different conversation views.
+ */
+
+/** Minimal message shape the anchor resolution needs. */
+export interface AnchorableMessage {
+  id: string;
+  /** Sort time in ms — whatever the view already orders the list by. */
+  sortTime: number;
+}
+
+/**
+ * Resolve the divider anchor from a pinned watermark.
+ *
+ * `watermarkMs` semantics differ slightly per protocol and both are supported
+ * by the same rule:
+ *  - MeshCore stores a LAST-READ timestamp, so the anchor is the first message
+ *    STRICTLY newer than it. Pass `mode: 'lastRead'`.
+ *  - Meshtastic derives the FIRST-UNREAD timestamp from `read_messages`, so
+ *    the anchor is the first message at or after it. Pass `mode: 'firstUnread'`.
+ *
+ * Returns `null` when there is nothing unread, when the watermark is unknown,
+ * or when the only unread messages are ones the operator sent themselves
+ * (callers filter those out before calling — see `ownMessageIds`).
+ */
+export function resolveUnreadAnchorId(params: {
+  messages: ReadonlyArray<AnchorableMessage>;
+  watermarkMs: number | null | undefined;
+  mode: 'lastRead' | 'firstUnread';
+  /** Message ids that must never be the anchor (e.g. our own sent messages). */
+  ownMessageIds?: ReadonlySet<string>;
+}): string | null {
+  const { messages, watermarkMs, mode, ownMessageIds } = params;
+  if (watermarkMs == null || !Number.isFinite(watermarkMs)) return null;
+  if (messages.length === 0) return null;
+
+  for (const msg of messages) {
+    const isUnread = mode === 'lastRead'
+      ? msg.sortTime > watermarkMs
+      : msg.sortTime >= watermarkMs;
+    if (!isUnread) continue;
+    if (ownMessageIds?.has(msg.id)) continue;
+    return msg.id;
+  }
+  return null;
+}
+
+/**
+ * Should the divider be suppressed entirely?
+ *
+ * Drawing a line above the very first message in a conversation is noise — it
+ * says "everything below is new" in a thread the operator has never opened,
+ * where that is trivially true. Suppress it when the anchor is the oldest
+ * message currently loaded AND no older history exists to scroll back to.
+ *
+ * When older history DOES exist, keep the line: the operator genuinely has
+ * read messages above, they just aren't loaded yet.
+ */
+export function shouldSuppressDivider(params: {
+  anchorId: string | null;
+  messages: ReadonlyArray<AnchorableMessage>;
+  hasMoreOlder?: boolean;
+}): boolean {
+  const { anchorId, messages, hasMoreOlder } = params;
+  if (!anchorId) return true;
+  if (hasMoreOlder) return false;
+  return messages.length > 0 && messages[0].id === anchorId;
+}


### PR DESCRIPTION
Closes #4607 — both halves of the request: a divider separating seen from unseen messages, and an entry scroll that jumps to the oldest unread.

## The real work wasn't the divider

**MeshCore read markers were per-browser, not per-user.** They lived in `localStorage` keyed by sourceId, so two operators sharing a machine shared each other's read state, and the same operator on a second device started from zero. Meshtastic already had durable per-user state (`read_messages`), but only unread *counts* ever reached the client — there was nothing to anchor a line to.

**The trap this had to be designed around:** `useMessagingView.ts` (gated effects #6/#7) and `MeshCoreChannelsView` mark a conversation read **within a tick of opening it**. Any live "what's unread?" lookup is already empty by the time the divider would render. The anchor is therefore **pinned at conversation entry** — a naive implementation renders no line at all and looks like it simply doesn't work.

## Where the watermark lives

Migration **138** → `conversation_read_state (userId, sourceId, conversationKind, conversationKey, lastReadAt)`, unique across all four. Per user, per source, per conversation.

`userId` is a plain int with `0` for anonymous rather than a nullable FK: SQLite and PostgreSQL both treat NULLs as distinct, so a nullable column would append a row on every write instead of hitting the upsert's conflict target. Writes are monotonic server-side.

**Meshtastic deliberately does not write to it.** `read_messages` is already durable and per-user; a second watermark would be a second source of truth that "Mark all read" could silently desynchronise. Instead `GET /api/messages/first-unread` derives the oldest-unread timestamp from **the same join `/unread-counts` uses**, with the same permission and MQTT filtering — so the divider can never point at a row whose badge the caller can't see, or at a row the view hides.

## Coverage — nothing deferred

| | divider | auto-scroll |
|---|---|---|
| Meshtastic channels (`ChannelsTab`) | ✅ | ✅ |
| Meshtastic DMs (`MessagesTab`) | ✅ | ✅ |
| MeshCore channels + DMs (`MeshCoreMessageStream`) | ✅ | ✅ |

Scroll changes are confined to the one-shot **entry** scroll, which already had a per-entry pending flag. The load-older restore and near-bottom auto-scroll are untouched, so **#4476 does not regress**. Styling is a CSS module on `--color-error` from the semantic role layer — no raw `--ctp-*`.

MeshCore's store keeps its synchronous read API (callers read during render): localStorage stays as first-paint cache and offline fallback, reads merge it with the hydrated server snapshot by taking the **later** value per key, and writes mirror through an injected transport so the store stays React- and fetch-free.

## Two real bugs found while wiring

- Seeding the server-snapshot cache with no transport configured made markers **outlive `localStorage.clear()`** — caught by an existing `MeshCoreChannelsView` test.
- `configureReadStateTransport` now clears the cache, so **one user's markers can't survive a logout** into the next user's view.

## Migration renumbered 137 → 138

#4609 claimed 137 on `main` while this was in progress. Renumbered here — files, exported `runMigration138*` symbols, registry entry, `settingsKey`, and the header comment — and `main` merged in. Both migrations now coexist; `migrations.test.ts`, both migration suites and `cli/migrationTables.test.ts` pass together (30 assertions).

## Verification

- Full suite **with PostgreSQL (5433) and MySQL (3307) up**: `success: true`, **14,448 passed, 0 failed**, 4,235 suites. Only **109 pending** rather than the usual ~727 — confirming the multi-backend suites genuinely ran rather than skipping silently, which matters for a schema change.
- `tsc` clean on both configs; `lint:ci` no in-repo failures.
- New tests: migration 138 ×3 backends; `ConversationReadStateRepository` ×3 backends (per-user / per-source / per-kind isolation, monotonic writes); `getFirstUnreadTimestampsAsync` ×3 backends; read-state route permission gates via the real harness; first-unread route filtering; pure anchor-resolution rules; MeshCore divider placement + entry scroll; server-backed store merge/fallback.

## One thing for a reviewer to weigh in on

`useUnreadDividerAnchors` in `MessagingContext.tsx` carries a targeted `react-refresh/only-export-components` disable. Several focused tests render `ChannelsTab`/`MessagesTab` with no provider, and the divider must degrade rather than throw. If you'd rather restructure than disable, that's a reasonable ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX