### PR TITLE
docs(agents): document the agent-worktree trap and make the review-token refresh a PR step

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -63,6 +63,40 @@ Push the branch using an **explicit branch ref** (this checkout may be shared wi
 git push -u origin <branch-name>
 ```
 
+## Step 3b: Refresh the Claude review token — do this on EVERY PR
+
+```bash
+bash ~/Development/homelab/tools/gh-secret.sh
+```
+
+Run it **every time you open a PR**, before `gh pr create`. It re-pushes the
+current local Claude credential into the repo's `CLAUDE_CODE_OAUTH_TOKEN`
+secret, which the `claude-review` workflow authenticates with.
+
+That token gets revoked often — three times in a single working session at one
+point. When it is stale, `claude-review` fails with:
+
+```
+API Error: 401 {"type":"error","error":{"type":"authentication_error",
+"message":"OAuth access token has been revoked."}}
+```
+
+which reads as a red CI check on a PR whose code is fine. Refreshing up front
+costs a second and removes the most common source of spurious failures here.
+
+**Do not confuse it with the other `claude-review` failure.** If the log instead
+says:
+
+```
+##[error]Service Unavailable
+##[error]Failed to resolve action download info.
+```
+
+that is GitHub failing to serve the action itself — a platform incident, not
+auth. Refreshing the secret does nothing; check
+[githubstatus.com](https://www.githubstatus.com/) and re-run once Actions
+recovers. Always read the failure before reaching for the script.
+
 ## Step 4: Create the Pull Request
 
 Use `gh pr create` with a detailed description following this structure:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,36 @@ For the full "adding a migration" recipe see [Migration recipe](#migration-recip
 - When sending test messages, use the `gauntlet` channel — never the Primary channel.
 - Tileserver runs on port 8082. Only shut it down (and the dev container) when you are running `tests/system-tests.sh` locally to debug a system-test failure — CI runs system tests on every PR, so you should not be invoking that script as part of normal feature/bugfix work.
 
+## Agent worktrees (`isolation: "worktree"`)
+
+A worktree created by the Agent tool is **not** set up by the `/worktree` slash
+command — none of that command's setup steps run. The tree is a bare checkout:
+submodules are uninitialised and `node_modules` is absent or partial. Every
+agent that has run in one has hit the same two failures, and both look like
+bugs in the agent's own diff until you check.
+
+Do these two things **before** trusting any test run inside an agent worktree:
+
+```bash
+git submodule update --init --recursive        # else ~9 protobuf suites fail "encode failed"
+ln -s ../../../node_modules node_modules       # or symlink individual packages
+```
+
+- **Uninitialised submodules** — the `protobufs/` submodule is empty, so protobuf
+  encode/decode suites fail with `encode failed`. Nothing to do with your change.
+- **Unresolvable `ts-overlapping-marker-spiderfier-leaflet`** — 6 map/hook suites
+  fail to *collect* (0 assertions run, `success: false` with 0 failed tests).
+  The package is present in the parent checkout but has **no `dist/`**, which
+  affects the main checkout too. Symlinking the parent's `node_modules` is the
+  quickest unblock; it is gitignored and changes no lockfile.
+
+**Read the whole result, not the headline.** A run can report thousands passing
+and still be `success: false` purely from suite-level *collection* errors like
+these. Before concluding your change broke something, stash it and re-run: if
+the identical failures persist, they are environmental. Say so explicitly in the
+PR rather than quoting a clean-looking number you do not trust — and let CI,
+which installs fresh, be the authority.
+
 ## Workflow
 
 - System tests (`tests/system-tests.sh`) are run by CI on every PR. Do not run them locally as part of normal feature or bugfix work — only run them locally when you are specifically debugging a system-test failure.


### PR DESCRIPTION
Two pieces of guidance whose absence cost real time across seven agent runs in this session.

## 1. Agent worktrees — `CLAUDE.md`

A worktree created by the Agent tool's `isolation: "worktree"` **does not run the `/worktree` slash command**, so none of that command's setup happens.

That's the crux, and it's why this kept recurring: **`/worktree` already documented `git submodule update --init`.** The guidance existed — just somewhere agents never read. Five separate agents rediscovered the same two failures independently.

Both look like a bug in the agent's own diff:
- **Uninitialised `protobufs` submodule** → ~9 suites fail `encode failed`
- **`ts-overlapping-marker-spiderfier-leaflet` has no `dist/`** → 6 map/hook suites fail to **collect**, so a run reports thousands passing, **0 failed**, and still `success: false`

That last shape is the real trap, so the new section says it outright: read the whole result, not the headline; stash and re-run to prove a failure is environmental; then say so explicitly in the PR rather than quoting a clean-looking number you don't trust, and let CI — which installs fresh — be the authority. Two agents did exactly that on #4600 and #4602, and CI vindicated them both.

Note the package having no `dist/` **affects the main checkout too**, not just worktrees — worth fixing at the source separately.

## 2. Review token — `create-pr.md`, new Step 3b

```bash
bash ~/Development/homelab/tools/gh-secret.sh
```

Run it before **every** `gh pr create`, not after a failure. `CLAUDE_CODE_OAUTH_TOKEN` was revoked **three times in this session alone** (Aug 6 ×2, Aug 9); each time `claude-review` went red on a PR whose code was fine. Refreshing up front costs a second.

The step also documents the failure it explicitly does **not** fix:

```
##[error]Service Unavailable
##[error]Failed to resolve action download info.
```

That's GitHub failing to serve the action — a platform incident. Refreshing the secret does nothing, and reaching for the script on every red review is the wrong reflex. Read the log first.

## Also updated (not in this diff)

The two corresponding project memories, since I create PRs with bare `gh pr create` at least as often as via `/create-pr` — a command-file-only change wouldn't have altered behaviour. They also now record the **migration-number collision** hazard: two agents independently picked `137` (#4607 / #4609), and renumbering means files, exported `runMigrationNNN*` symbols, registry `number`, `settingsKey` **and** the header comment — not just the filename.

Docs only — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX