### PR TITLE
fix(themes): tinted backgrounds ignored the active theme (Phase 2b-1)

### DIFF
--- a/src/components/CustomTilesetManager.css
+++ b/src/components/CustomTilesetManager.css
@@ -1,7 +1,17 @@
-/* Some colors below deliberately stay on raw `--ctp-*` palette names (#4579):
- * the `--ctp-*-rgb` variants are a separate mechanism (numeric triplets fed to
- * rgba()), and teal/pink/overlay0/overlay2 have no semantic role yet. Roles get
- * added when a real one appears, not to reach 100%. */
+/* Fully on the token layers (roles / --chart-N), no raw `--ctp-*`.
+ *
+ * The `--ctp-*-rgb` triplets this file used were never DEFINED anywhere, so
+ * every `rgba(var(--ctp-red-rgb, 243, 139, 168), .15)` silently fell back to
+ * its hardcoded Catppuccin Mocha literal and ignored the active theme
+ * entirely. `color-mix` on the role removes both the phantom variable and the
+ * theme-blindness: each tint now derives from the same role its adjacent
+ * foreground already used.
+ *
+ * The vector/raster badges are two CATEGORIES, so they take categorical slots
+ * rather than roles (--chart-2 is mauve, so vector is visually unchanged).
+ * The two hover shades derive from their own base mixed toward --color-text,
+ * so they gain contrast on light and dark themes alike instead of jumping to
+ * an unrelated hue. */
 .custom-tileset-manager {
   margin-top: 1rem;
   padding: 1rem;
@@ -91,15 +101,15 @@
 }
 
 .tileset-badge.vector {
-  background-color: rgba(var(--ctp-mauve-rgb, 203, 166, 247), 0.2);
-  color: var(--color-accent-alt);
-  border: 1px solid var(--color-accent-alt);
+  background-color: color-mix(in srgb, var(--chart-2) 20%, transparent);
+  color: var(--chart-2);
+  border: 1px solid var(--chart-2);
 }
 
 .tileset-badge.raster {
-  background-color: rgba(var(--ctp-teal-rgb, 148, 226, 213), 0.2);
-  color: var(--ctp-teal);
-  border: 1px solid var(--ctp-teal);
+  background-color: color-mix(in srgb, var(--chart-6) 20%, transparent);
+  color: var(--chart-6);
+  border: 1px solid var(--chart-6);
 }
 
 .tileset-url {
@@ -233,7 +243,7 @@
 
 .form-field small.example {
   font-family: var(--font-mono);
-  color: var(--ctp-overlay2);
+  color: var(--color-text-subtle);
 }
 
 .validation-message {
@@ -244,13 +254,13 @@
 }
 
 .validation-message.error {
-  background-color: rgba(var(--ctp-red-rgb, 243, 139, 168), 0.15);
+  background-color: color-mix(in srgb, var(--color-error) 15%, transparent);
   color: var(--color-error);
   border-left: 3px solid var(--color-error);
 }
 
 .validation-message.warning {
-  background-color: rgba(var(--ctp-yellow-rgb, 249, 226, 175), 0.15);
+  background-color: color-mix(in srgb, var(--color-warning) 15%, transparent);
   color: var(--color-warning);
   border-left: 3px solid var(--color-warning);
 }
@@ -317,7 +327,7 @@
 
 .btn-add-tileset:hover:not(:disabled) {
   border-color: var(--color-accent);
-  background-color: rgba(var(--ctp-blue-rgb, 137, 180, 250), 0.1);
+  background-color: color-mix(in srgb, var(--color-accent) 10%, transparent);
 }
 
 .btn-add-tileset:disabled {
@@ -370,17 +380,17 @@
 }
 
 .test-result-success {
-  background-color: rgba(var(--ctp-green-rgb, 166, 227, 161), 0.15);
+  background-color: color-mix(in srgb, var(--color-success) 15%, transparent);
   border: 1px solid var(--color-success);
 }
 
 .test-result-warning {
-  background-color: rgba(var(--ctp-yellow-rgb, 249, 226, 175), 0.15);
+  background-color: color-mix(in srgb, var(--color-warning) 15%, transparent);
   border: 1px solid var(--color-warning);
 }
 
 .test-result-error {
-  background-color: rgba(var(--ctp-red-rgb, 243, 139, 168), 0.15);
+  background-color: color-mix(in srgb, var(--color-error) 15%, transparent);
   border: 1px solid var(--color-error);
 }
 
@@ -430,7 +440,7 @@
 .test-result .test-result-warning {
   margin-top: 0.5rem;
   padding: 0.4rem 0.6rem;
-  background-color: rgba(var(--ctp-yellow-rgb, 249, 226, 175), 0.1);
+  background-color: color-mix(in srgb, var(--color-warning) 10%, transparent);
   border-radius: var(--radius-sm);
   color: var(--color-warning);
   font-size: 0.85rem;
@@ -440,7 +450,7 @@
 .test-result .test-result-error {
   margin-top: 0.5rem;
   padding: 0.4rem 0.6rem;
-  background-color: rgba(var(--ctp-red-rgb, 243, 139, 168), 0.1);
+  background-color: color-mix(in srgb, var(--color-error) 10%, transparent);
   border-radius: var(--radius-sm);
   color: var(--color-error);
   font-size: 0.85rem;
@@ -505,7 +515,7 @@
 }
 
 .btn-autodetect:hover:not(:disabled) {
-  background-color: var(--ctp-pink);
+  background-color: color-mix(in srgb, var(--color-accent-alt) 85%, var(--color-text));
 }
 
 .btn-autodetect:disabled {
@@ -553,12 +563,12 @@
 }
 
 .autodetect-result.success {
-  background-color: rgba(var(--ctp-green-rgb, 166, 227, 161), 0.15);
+  background-color: color-mix(in srgb, var(--color-success) 15%, transparent);
   border: 1px solid var(--color-success);
 }
 
 .autodetect-result.error {
-  background-color: rgba(var(--ctp-red-rgb, 243, 139, 168), 0.15);
+  background-color: color-mix(in srgb, var(--color-error) 15%, transparent);
   border: 1px solid var(--color-error);
 }
 
@@ -615,13 +625,13 @@
 }
 
 .btn-use-url:hover {
-  background-color: var(--ctp-teal);
+  background-color: color-mix(in srgb, var(--color-success) 85%, var(--color-text));
 }
 
 .autodetect-error {
   margin-top: 0.5rem;
   padding: 0.4rem 0.6rem;
-  background-color: rgba(var(--ctp-red-rgb, 243, 139, 168), 0.1);
+  background-color: color-mix(in srgb, var(--color-error) 10%, transparent);
   border-radius: var(--radius-sm);
   color: var(--color-error);
   font-size: 0.85rem;
@@ -631,7 +641,7 @@
 .reload-notice {
   margin-bottom: 1rem;
   padding: 0.75rem 1rem;
-  background-color: rgba(var(--ctp-yellow-rgb, 249, 226, 175), 0.15);
+  background-color: color-mix(in srgb, var(--color-warning) 15%, transparent);
   border: 1px solid var(--color-warning);
   border-radius: var(--radius-md);
 }


### PR DESCRIPTION
## Summary

Phase 2b's first file, and it turned out to contain an actual bug rather than cosmetic token swaps.

`CustomTilesetManager.css` painted every tinted background with `rgba(var(--ctp-red-rgb, 243, 139, 168), 0.15)` and friends. **Those `--ctp-*-rgb` triplets are defined nowhere in the codebase** — I grepped the whole tree. So the inline fallback always won, and the tint was hardcoded Catppuccin Mocha regardless of theme.

In Latte, Nord and Gruvbox, the app drew a Mocha-pink wash behind its own correctly-themed error text.

## The fix

`color-mix` on the role the adjacent foreground **already used** — the pairing made the intent unambiguous:

| tint | paired foreground | now |
|---|---|---|
| `--ctp-red-rgb` | `color: var(--color-error)` | `color-mix(… var(--color-error) 15% …)` |
| `--ctp-green-rgb` | `border: 1px solid var(--color-success)` | `… var(--color-success) 15% …` |
| `--ctp-blue-rgb` | `border-color: var(--color-accent)` | `… var(--color-accent) 10% …` |

Removes the phantom variable and the theme-blindness together.

**Measured in a browser, before and after** — the tint now tracks each theme's own error color:

```
mocha         error rgb(243,139,168)  tint .953 .545 .659 / .15
latte         error rgb(210, 15, 57)  tint .824 .059 .224 / .15
nord          error rgb(191, 97,106)  tint .749 .380 .416 / .15
gruvbox-dark  error rgb(251, 73, 52)  tint .984 .286 .204 / .15
```

Previously all four rendered the same Mocha literal.

## Two judgement calls, not mechanical swaps

**The vector/raster badges are two categories**, so they take categorical slots rather than roles. `--chart-2` *is* mauve, so the vector badge is visually unchanged; raster moves teal → sapphire, which — unlike teal — is guaranteed distinct from mauve in every theme (teal and sapphire coincide in Nord, Dracula, Solarized, Gruvbox and high-contrast-dark).

**Two hover states used unrelated hues as shades**: `.btn-autodetect` (base `--color-accent-alt`) hovered to pink, `.btn-use-url` (base `--color-success`) hovered to teal. Both now mix their *own* base toward `--color-text`, so the hover gains contrast on light and dark themes alike instead of hopping to a different colour.

## About the header comment

The file documented these as a deliberate exemption — *"teal/pink/overlay0/overlay2 have no semantic role yet. Roles get added when a real one appears, not to reach 100%"* (#4579). That reasoning held while roles were the only option. With the categorical scale and `color-mix` it no longer does, so the comment is **replaced rather than left to mislead** the next reader.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint:ci` — clean
- [x] Full `npx vitest run`: **success=true, 13,800 passed, 0 failed, 0 failed suites**
- [x] Browser-measured across 4 themes, confirming the tint follows `--color-error` (table above)
- [x] Deployed and confirmed `color-mix` present in the served bundle before measuring
- [x] Data volumes unchanged (3 before, 3 after)

19 of the 51 remaining raw `--ctp-*` occurrences, and the only ones that were a functional defect.

## Scope

**2b-2** covers the remaining 16 files / 32 occurrences. Those are plain `var(--ctp-X)` role swaps needing per-usage judgement — no known bug among them — so they're kept separate rather than buried behind this one.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf