### PR TITLE
refactor(theme): retire the last raw palette references from components

### DIFF
--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -1933,8 +1933,8 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
             onClick={handleReloadConfig}
             disabled={isReloading}
             style={{
-              backgroundColor: 'var(--ctp-teal)',
-              color: '#fff',
+              backgroundColor: 'var(--color-info)',
+              color: 'var(--color-bg)',
               padding: '0.75rem 1.5rem',
               border: 'none',
               borderRadius: '4px',

--- a/src/components/GeofenceTriggersSection.tsx
+++ b/src/components/GeofenceTriggersSection.tsx
@@ -826,7 +826,7 @@ const GeofenceTriggerItem: React.FC<GeofenceTriggerItemProps> = ({
             style={{
               padding: '0.25rem 0.5rem',
               fontSize: '12px',
-              background: 'var(--ctp-teal)',
+              background: 'var(--color-info)',
               color: 'var(--color-bg)',
               border: 'none',
               borderRadius: '4px',

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -81,7 +81,7 @@
   font-size: 0.85rem;
 }
 
-.meshcore-status-bar button:hover { background: var(--ctp-pink); }
+.meshcore-status-bar button:hover { background: color-mix(in srgb, var(--color-accent-alt) 85%, var(--color-text)); }
 .meshcore-status-bar button:disabled {
   background: var(--color-surface-active);
   color: var(--color-text-faint);
@@ -831,7 +831,7 @@
   font-weight: 500;
 }
 
-.meshcore-send-bar button:hover { background: var(--ctp-pink); }
+.meshcore-send-bar button:hover { background: color-mix(in srgb, var(--color-accent-alt) 85%, var(--color-text)); }
 .meshcore-send-bar button:disabled {
   background: var(--color-surface-active);
   color: var(--color-text-faint);
@@ -983,7 +983,7 @@
   margin-top: 0.5rem;
 }
 
-.meshcore-form-view button:hover { background: var(--ctp-pink); }
+.meshcore-form-view button:hover { background: color-mix(in srgb, var(--color-accent-alt) 85%, var(--color-text)); }
 .meshcore-form-view button:disabled {
   background: var(--color-surface-active);
   color: var(--color-text-faint);
@@ -1403,7 +1403,7 @@
 }
 
 .mc-message-from-link:hover {
-  color: var(--ctp-pink);
+  color: var(--color-accent-alt);
   text-decoration-style: solid;
 }
 

--- a/src/components/MeshCore/MeshCoreRemoteConsole.css
+++ b/src/components/MeshCore/MeshCoreRemoteConsole.css
@@ -52,7 +52,7 @@
 /* Saved-password-available (not yet logged in): teal, distinct from the
    green "session active" so it doesn't read as an active session. */
 .mrc-status-saved {
-  background: var(--ctp-teal);
+  background: var(--color-info);
   color: var(--color-bg-sunken);
 }
 
@@ -124,7 +124,7 @@
 }
 
 .mrc-btn-primary:hover:not(:disabled) {
-  background: var(--ctp-pink);
+  background: color-mix(in srgb, var(--color-accent-alt) 85%, var(--color-text));
 }
 
 .mrc-btn-primary:disabled {

--- a/src/components/MeshCore/MeshCoreTab.css
+++ b/src/components/MeshCore/MeshCoreTab.css
@@ -100,7 +100,7 @@
 }
 
 .meshcore-tab button:hover {
-  background: var(--ctp-pink);
+  background: color-mix(in srgb, var(--color-accent-alt) 85%, var(--color-text));
 }
 
 .meshcore-tab button:disabled {

--- a/src/components/PacketMonitorPanel.css
+++ b/src/components/PacketMonitorPanel.css
@@ -365,7 +365,7 @@
 }
 
 .packet-table .transport-7 { /* API */
-  color: var(--ctp-teal, #94e2d5);
+  color: var(--color-info);
 }
 
 .packet-table .transport-unknown {

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -115,8 +115,8 @@
 }
 
 .sidebar-pin.pinned:hover {
-  background: var(--ctp-teal);
-  border-color: var(--ctp-teal);
+  background: color-mix(in srgb, var(--color-success) 85%, var(--color-text));
+  border-color: color-mix(in srgb, var(--color-success) 85%, var(--color-text));
   color: var(--color-bg-sunken);
 }
 

--- a/src/components/ThemeEditor.css
+++ b/src/components/ThemeEditor.css
@@ -245,7 +245,7 @@
 
 .theme-accessibility-report.success {
   background: var(--color-success);
-  border-color: var(--ctp-teal);
+  border-color: color-mix(in srgb, var(--color-success) 70%, var(--color-text));
 }
 
 .theme-accessibility-report.warning {

--- a/src/components/TimerTriggersSection.tsx
+++ b/src/components/TimerTriggersSection.tsx
@@ -875,7 +875,7 @@ const TimerTriggerItem: React.FC<TimerTriggerItemProps> = ({
                 style={{
                   padding: '0.25rem 0.5rem',
                   fontSize: '12px',
-                  background: 'var(--ctp-teal)',
+                  background: 'var(--color-info)',
                   color: 'var(--color-bg)',
                   border: 'none',
                   borderRadius: '4px',

--- a/src/components/admin-commands/DeviceConfigurationSection.tsx
+++ b/src/components/admin-commands/DeviceConfigurationSection.tsx
@@ -367,7 +367,7 @@ export const DeviceConfigurationSection: React.FC<DeviceConfigurationSectionProp
               style={{
                 marginTop: '0.75rem',
                 padding: '0.75rem 1rem',
-                background: 'var(--ctp-yellow-soft, rgba(249, 226, 175, 0.15))',
+                background: 'color-mix(in srgb, var(--color-warning) 15%, transparent)',
                 border: '1px solid var(--color-warning)',
                 borderLeft: '4px solid var(--color-warning)',
                 borderRadius: '6px',

--- a/src/components/auto-responder/TriggerItem.tsx
+++ b/src/components/auto-responder/TriggerItem.tsx
@@ -703,7 +703,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                   <span style={{
                     fontSize: '0.7rem',
                     padding: '0.15rem 0.4rem',
-                    background: 'var(--ctp-teal)',
+                    background: 'var(--color-info)',
                     color: 'var(--color-bg)',
                     borderRadius: '3px',
                     fontWeight: 'bold'
@@ -726,7 +726,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                 <span style={{
                   fontSize: '0.7rem',
                   padding: '0.15rem 0.4rem',
-                  background: trigger.responseType === 'text' ? 'var(--color-success)' : trigger.responseType === 'script' ? 'var(--color-warning)' : trigger.responseType === 'traceroute' ? 'var(--color-accent-hover)' : trigger.responseType === 'mailbox' ? 'var(--ctp-pink)' : 'var(--color-accent-alt)',
+                  background: trigger.responseType === 'text' ? 'var(--chart-3)' : trigger.responseType === 'script' ? 'var(--chart-5)' : trigger.responseType === 'traceroute' ? 'var(--chart-1)' : trigger.responseType === 'mailbox' ? 'var(--chart-7)' : 'var(--chart-2)',
                   color: 'var(--color-bg)',
                   borderRadius: '3px',
                   fontWeight: 'bold'
@@ -766,7 +766,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                   style={{
                     padding: '0.25rem 0.5rem',
                     fontSize: '12px',
-                    background: 'var(--ctp-teal)',
+                    background: 'var(--color-info)',
                     color: 'var(--color-bg)',
                     border: 'none',
                     borderRadius: '4px',

--- a/src/components/traceroute/TracerouteStrip.module.css
+++ b/src/components/traceroute/TracerouteStrip.module.css
@@ -35,10 +35,13 @@
 .returnEdge,
 .statEdge {
   fill: none;
-  /* Raw palette on purpose (#4579): this is a diagram series color, not a
-     role. Routing data-viz strokes through a semantic token would make the
-     role vocabulary meaningless. */
-  stroke: var(--ctp-pink);
+  /* A diagram series color, not a role — the earlier note (#4579) kept this on
+     the raw palette because the only alternative was a role token, and routing
+     data-viz through one would have made the role vocabulary meaningless. The
+     categorical scale now covers exactly this case: --chart-N slots are picked
+     to stay mutually distinct in every theme, which is the only property a
+     series color needs. */
+  stroke: var(--chart-2);
   stroke-width: 2;
 }
 
@@ -55,7 +58,7 @@
 }
 
 .arrowHead {
-  fill: var(--ctp-pink);
+  fill: var(--chart-2);
 }
 
 .node {

--- a/src/styles/SecurityTab.css
+++ b/src/styles/SecurityTab.css
@@ -467,7 +467,7 @@
 }
 
 .digest-send-btn:hover:not(:disabled) {
-  background: var(--ctp-teal);
+  background: color-mix(in srgb, var(--color-success) 85%, var(--color-text));
 }
 
 .digest-save-btn:disabled,

--- a/src/styles/messages.css
+++ b/src/styles/messages.css
@@ -442,7 +442,7 @@
 }
 
 .status-received-node {
-  color: var(--ctp-teal);
+  color: var(--color-info);
   font-size: 0.8rem;
 }
 

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1820,7 +1820,7 @@
 }
 
 .traceroute-btn:hover:not(:disabled) {
-  background: var(--ctp-pink);
+  background: color-mix(in srgb, var(--color-accent-alt) 85%, var(--color-text));
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }

--- a/src/styles/semanticTokens.test.ts
+++ b/src/styles/semanticTokens.test.ts
@@ -414,6 +414,16 @@ describe('raw palette references outside App.css', () => {
       .replace(/^\s*\/\/.*$/gm, ' ');
   }
 
+  // SCOPE — what this guard does NOT catch: a hardcoded `rgba(166, 227, 161,
+  // 0.3)` is the same theme-blind defect as `--ctp-yellow-soft`, spelled so it
+  // isn't a custom-property reference at all. A sweep found 82 such swatch
+  // approximations across 22 files, several sitting right next to a role token
+  // (`background: rgba(<mocha green>)` beside `color: var(--color-success)`),
+  // so on Nord or Gruvbox the two halves disagree. Fixing them needs per-site
+  // judgement — shadow vs fill vs border, and the right opacity — so it is its
+  // own pass, tracked separately, and the detector lands with the fixes rather
+  // than red against 82 pre-existing sites. Until then: passing this file does
+  // not mean a component is theme-clean.
   function referencedPaletteVars(): { name: string; file: string }[] {
     const hits: { name: string; file: string }[] = [];
     for (const file of walk(resolve('src'))) {

--- a/src/styles/semanticTokens.test.ts
+++ b/src/styles/semanticTokens.test.ts
@@ -387,3 +387,78 @@ describe('sequential scale (--seq-N)', () => {
     expect(text).not.toMatch(/var\(--ctp-/);
   });
 });
+
+describe('raw palette references outside App.css', () => {
+  // The four optional chat-bubble keys are a different mechanism: they are
+  // user-supplied overrides (OPTIONAL_THEME_COLORS), undefined until someone
+  // sets them, which is exactly why they carry a role token as their fallback.
+  // They keep the --ctp- prefix only because the stored theme schema still uses
+  // it; Phase 3 renames the prefix along with the rest of the schema.
+  const optionalKeys = new Set(
+    (readFileSync(resolve('src/utils/themeValidation.ts'), 'utf8')
+      .match(/OPTIONAL_THEME_COLORS\s*=\s*\[([\s\S]*?)\]/)?.[1] ?? '')
+      .split(',')
+      .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+      .filter(Boolean)
+      .map((k) => `--ctp-${k}`),
+  );
+
+  // Comments must go before scanning. A file that *documents* a retired
+  // palette var — as CustomTilesetManager.css does, naming `--ctp-red-rgb` in
+  // the header comment explaining the bug that removal fixed — is not a file
+  // that references it. Only full-line `//` comments are stripped, never a
+  // trailing one, so a `//` inside a string can't swallow real code after it.
+  function stripComments(text: string): string {
+    return text
+      .replace(/\/\*[\s\S]*?\*\//g, ' ')
+      .replace(/^\s*\/\/.*$/gm, ' ');
+  }
+
+  function referencedPaletteVars(): { name: string; file: string }[] {
+    const hits: { name: string; file: string }[] = [];
+    for (const file of walk(resolve('src'))) {
+      if (file.endsWith('/App.css')) continue;
+      const text = stripComments(readFileSync(file, 'utf8'));
+      for (const m of text.matchAll(/var\((--ctp-[A-Za-z0-9-]+)/g)) {
+        hits.push({ name: m[1], file: file.replace(resolve('.') + '/', '') });
+      }
+    }
+    return hits;
+  }
+
+  it('sanity-checks that the optional-key list was actually parsed', () => {
+    // Without this, a rename in themeValidation.ts would empty the allowlist
+    // and the tests below would still pass — for the wrong reason.
+    expect(optionalKeys.has('--ctp-chatBubbleSentBg')).toBe(true);
+    expect(optionalKeys.size).toBe(4);
+  });
+
+  it('has no component reaching past the role layer to a raw palette var', () => {
+    // Phase 2b: every remaining `var(--ctp-blue)`-style reference in a
+    // component was either a role in disguise (a hover shade, a status color)
+    // or a categorical series color. Both now have a home, so a new raw
+    // reference means someone skipped the vocabulary rather than extended it.
+    const raw = referencedPaletteVars()
+      .filter((h) => !optionalKeys.has(h.name))
+      .map((h) => `${h.name} (${h.file})`);
+    expect(Array.from(new Set(raw))).toEqual([]);
+  });
+
+  it('references no --ctp-* var that nothing defines', () => {
+    // The sharper guard, and the one that would have caught both shipped bugs:
+    // `--ctp-red-rgb` (#4617) and `--ctp-yellow-soft` were never defined
+    // anywhere, so their inline fallbacks — hardcoded Catppuccin Mocha — were
+    // what every theme actually rendered. A fallback makes this invisible at
+    // runtime: nothing breaks, the color is just silently wrong.
+    const defined = new Set<string>();
+    for (const m of appCss.matchAll(/(--ctp-[A-Za-z0-9-]+)\s*:/g)) defined.add(m[1]);
+    expect(defined.size).toBeGreaterThan(10);
+
+    const dangling = referencedPaletteVars().filter(
+      (h) => !defined.has(h.name) && !optionalKeys.has(h.name),
+    );
+    expect(
+      Array.from(new Set(dangling.map((h) => `${h.name} (${h.file})`))),
+    ).toEqual([]);
+  });
+});

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -309,7 +309,7 @@
 }
 
 .settings-button-primary:hover:not(:disabled) {
-  background: var(--ctp-teal);
+  background: color-mix(in srgb, var(--color-success) 85%, var(--color-text));
 }
 
 .save-button {
@@ -330,7 +330,7 @@
 }
 
 .save-button:hover:not(:disabled) {
-  background: var(--ctp-teal);
+  background: color-mix(in srgb, var(--color-success) 85%, var(--color-text));
   transform: translateY(-1px);
 }
 


### PR DESCRIPTION
Phase 2b-2 of the semantic-color work (follow-on to #4617). This removes the
last raw `var(--ctp-X)` references from components, leaving `src/App.css` as
the only file that names a palette color.

## Why these were left until now

Phase 2b-1 fixed the ones that were outright **bugs** (`--ctp-*-rgb`, defined
nowhere, so every tint rendered hardcoded Mocha). The 26 remaining looked like
deliberate palette choices. Reading each in context, none were — they were
roles, hover shades, and series colors that had no home when they were written.

| Pattern | Count | Became |
|---|---|---|
| Hover shade of a `--color-success` button | 5 | `color-mix(in srgb, var(--color-success) 85%, var(--color-text))` |
| Hover shade of a `--color-accent-alt` button | 6 | `color-mix(in srgb, var(--color-accent-alt) 85%, var(--color-text))` |
| "Not success" status / informational | 7 | `var(--color-info)` |
| Categorical series | 3 | `var(--chart-N)` |
| Never-defined var w/ hardcoded fallback | 1 | `color-mix(… var(--color-warning) 15%, transparent)` |

**Hover shades were unthemeable.** `green → teal` and `mauve → pink` are hue
*shifts*. No theme can follow a hue shift — the hover just landed on whatever
that theme happened to call "teal". The `color-mix` toward `--color-text`
brightens on dark themes and darkens on light ones, which is what a hover
actually means.

**Series colors finally have a home.** `TracerouteStrip.module.css` carried a
comment arguing for raw palette *on purpose* (#4579): a diagram edge is not a
role, and routing it through one would make the role vocabulary meaningless.
That was right at the time — the only alternative was a role token. The
categorical scale added in Phase 2 is exactly this case, so the comment is
updated rather than deleted. Same for the auto-responder `responseType` badges,
which were borrowing `success`/`warning` for categories that mean neither.

## Second instance of the #4617 bug

`--ctp-yellow-soft` is defined nowhere. The router-role warning banner in
`DeviceConfigurationSection` therefore rendered its inline fallback —
hardcoded Catppuccin Mocha — in all 15 themes. Same shape as the `-rgb` vars,
missed because it is spelled differently.

This class of bug is invisible at runtime: nothing errors, the fallback just
renders, and the color is silently wrong. Hence the guard below.

## Guards

Three new tests in `semanticTokens.test.ts`, **each verified to fail on an
injected violation** (not just to pass today):

1. No component reaches past the role layer to a raw palette var.
2. No component references a `--ctp-*` that nothing defines — this is the one
   that would have caught both shipped bugs.
3. The optional-key allowlist actually parses. Without this, renaming
   `OPTIONAL_THEME_COLORS` would empty the allowlist and tests 1–2 would still
   pass, for the wrong reason.

The scanner strips comments first. `CustomTilesetManager.css` *documents*
`--ctp-red-rgb` in the header comment explaining the bug its removal fixed —
naming a var in prose is not referencing it. (This is the second time a
comment has fooled a scanner in this file; `rootBlock()` had the same trap.)

## Deliberately not changed

The four `--ctp-chatBubble*` references in `messages.css`. These are a
different mechanism — user-supplied optional overrides (`OPTIONAL_THEME_COLORS`),
undefined until someone sets one, which is why they carry a role token as
fallback. They keep the prefix only because the stored theme schema still uses
it. **Phase 3** renames it along with the rest of the schema, which is what
actually answers the original complaint (users shouldn't have to map "blue" to
`#ff0000` to get a red accent).

## Verification

- Full Vitest suite: `success: true`, **13,803 passed / 0 failed / 0 suites failed**.
- `npm run lint:ci`: 0 in-repo failures.
- Purely presentational + one test file — no DB, route, or protocol surface,
  so the 763 skipped tests (PostgreSQL/MySQL containers not running locally)
  cover nothing this diff touches. CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf