### PR TITLE
fix(theme): replace hardcoded palette swatches with theme-following colors

### DIFF
--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -3164,7 +3164,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                   padding: '1rem',
                   backgroundColor: channel ? 'var(--color-surface)' : 'var(--color-bg-raised)',
                   opacity: channel?.role === 0 ? 0.5 : 1,
-                  boxShadow: channel?.role === 1 ? '0 0 10px rgba(137, 180, 250, 0.3)' : 'none'
+                  boxShadow: channel?.role === 1 ? '0 0 10px color-mix(in srgb, var(--color-accent) 30%, transparent)' : 'none'
                 }}
               >
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '0.75rem' }}>

--- a/src/components/AppHeader/AppHeader.css
+++ b/src/components/AppHeader/AppHeader.css
@@ -164,13 +164,13 @@
 
 @keyframes pulse {
   0% {
-    box-shadow: 0 0 0 0 rgba(166, 227, 161, 0.7);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-success) 70%, transparent);
   }
   70% {
-    box-shadow: 0 0 0 10px rgba(166, 227, 161, 0);
+    box-shadow: 0 0 0 10px transparent;
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(166, 227, 161, 0);
+    box-shadow: 0 0 0 0 transparent;
   }
 }
 
@@ -239,7 +239,7 @@
 .login-button:hover {
   background: var(--color-accent-hover);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(137, 180, 250, 0.3);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--color-accent) 30%, transparent);
 }
 
 /* Mobile responsive */

--- a/src/components/AutoAcknowledgeSection.tsx
+++ b/src/components/AutoAcknowledgeSection.tsx
@@ -801,7 +801,7 @@ const AutoAcknowledgeSection: React.FC<AutoAcknowledgeSectionProps> = ({
                       alignItems: 'center',
                       padding: '0.25rem 0.5rem',
                       marginBottom: '0.15rem',
-                      backgroundColor: matches ? 'rgba(166, 227, 161, 0.1)' : 'rgba(243, 139, 168, 0.1)',
+                      backgroundColor: matches ? 'color-mix(in srgb, var(--color-success) 10%, transparent)' : 'color-mix(in srgb, var(--color-error) 10%, transparent)',
                       border: `1px solid ${matches ? 'var(--color-success)' : 'var(--color-error)'}`,
                       borderRadius: '4px',
                       fontFamily: 'monospace',

--- a/src/components/AutoResponderSection.tsx
+++ b/src/components/AutoResponderSection.tsx
@@ -946,7 +946,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                   <span
                                     key={groupIdx}
                                     style={{
-                                      backgroundColor: segment.type === 'parameter' ? 'rgba(166, 227, 161, 0.4)' : 'rgba(137, 180, 250, 0.4)',
+                                      backgroundColor: segment.type === 'parameter' ? 'color-mix(in srgb, var(--color-success) 40%, transparent)' : 'color-mix(in srgb, var(--color-accent) 40%, transparent)',
                                       padding: '2px 4px',
                                       borderRadius: '2px',
                                       fontWeight: segment.type === 'parameter' ? 'bold' : 'normal',
@@ -966,7 +966,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                       alignItems: 'center',
                                       borderRadius: '2px',
                                       overflow: 'hidden',
-                                      border: '1px solid rgba(166, 227, 161, 0.5)'
+                                      border: '1px solid color-mix(in srgb, var(--color-success) 50%, transparent)'
                                     }}
                                     title={group.map(s => s.type === 'parameter' ? `{${s.paramName}}` : s.text).join('')}
                                   >
@@ -974,7 +974,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                       <React.Fragment key={segIdx}>
                                         <span
                                           style={{
-                                            backgroundColor: segment.type === 'parameter' ? 'rgba(166, 227, 161, 0.4)' : 'rgba(137, 180, 250, 0.4)',
+                                            backgroundColor: segment.type === 'parameter' ? 'color-mix(in srgb, var(--color-success) 40%, transparent)' : 'color-mix(in srgb, var(--color-accent) 40%, transparent)',
                                             padding: '2px 4px',
                                             fontWeight: segment.type === 'parameter' ? 'bold' : 'normal',
                                             color: 'var(--color-text)'
@@ -986,7 +986,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                           <span style={{
                                             width: '1px',
                                             height: '100%',
-                                            backgroundColor: 'rgba(205, 214, 244, 0.3)',
+                                            backgroundColor: 'color-mix(in srgb, var(--color-text) 30%, transparent)',
                                             margin: '0'
                                           }} />
                                         )}
@@ -1005,11 +1005,11 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                     </div>
                     <div style={{ marginTop: '0.5rem', fontSize: '0.7rem', color: 'var(--color-text-subtle)', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
                       <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.25rem' }}>
-                        <span style={{ display: 'inline-block', width: '12px', height: '12px', backgroundColor: 'rgba(137, 180, 250, 0.4)', borderRadius: '2px' }}></span>
+                        <span style={{ display: 'inline-block', width: '12px', height: '12px', backgroundColor: 'color-mix(in srgb, var(--color-accent) 40%, transparent)', borderRadius: '2px' }}></span>
                         Literal text
                       </span>
                       <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.25rem' }}>
-                        <span style={{ display: 'inline-block', width: '12px', height: '12px', backgroundColor: 'rgba(166, 227, 161, 0.4)', borderRadius: '2px' }}></span>
+                        <span style={{ display: 'inline-block', width: '12px', height: '12px', backgroundColor: 'color-mix(in srgb, var(--color-success) 40%, transparent)', borderRadius: '2px' }}></span>
                         Parameter
                       </span>
                     </div>
@@ -1171,7 +1171,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                         {testMatch ? (
                           <div style={{ 
                             padding: '0.75rem', 
-                            background: 'rgba(166, 227, 161, 0.1)', 
+                            background: 'color-mix(in srgb, var(--color-success) 10%, transparent)', 
                             border: '1px solid var(--color-success)', 
                             borderRadius: '4px' 
                           }}>
@@ -1200,7 +1200,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                       <span
                                         key={pos}
                                         style={{
-                                          backgroundColor: posInfo ? (posInfo.type === 'parameter' ? 'rgba(166, 227, 161, 0.4)' : 'rgba(137, 180, 250, 0.4)') : 'transparent',
+                                          backgroundColor: posInfo ? (posInfo.type === 'parameter' ? 'color-mix(in srgb, var(--color-success) 40%, transparent)' : 'color-mix(in srgb, var(--color-accent) 40%, transparent)') : 'transparent',
                                           padding: '2px',
                                           borderRadius: posInfo ? '2px' : '0',
                                           fontWeight: posInfo?.type === 'parameter' ? 'bold' : 'normal'
@@ -1302,7 +1302,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                 {newTriggerLiveTestResult.error ? (
                                   <div style={{ 
                                     padding: '0.5rem', 
-                                    background: 'rgba(243, 139, 168, 0.1)', 
+                                    background: 'color-mix(in srgb, var(--color-error) 10%, transparent)', 
                                     border: '1px solid var(--color-error)', 
                                     borderRadius: '4px',
                                     color: 'var(--color-error)',
@@ -1353,7 +1353,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                         ) : (
                           <div style={{ 
                             padding: '0.75rem', 
-                            background: 'rgba(243, 139, 168, 0.1)', 
+                            background: 'color-mix(in srgb, var(--color-error) 10%, transparent)', 
                             border: '1px solid var(--color-error)', 
                             borderRadius: '4px',
                             color: 'var(--color-error)',
@@ -1522,8 +1522,8 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                     display: 'inline-block',
                     width: '12px', 
                     height: '12px', 
-                    backgroundColor: 'rgba(137, 180, 250, 0.3)', 
-                    border: '1px solid rgba(137, 180, 250, 0.5)',
+                    backgroundColor: 'color-mix(in srgb, var(--color-accent) 30%, transparent)', 
+                    border: '1px solid color-mix(in srgb, var(--color-accent) 50%, transparent)',
                     borderRadius: '2px' 
                   }}></span>
                   <span style={{ color: 'var(--color-text)' }}>{t('auto_responder.literal')}</span>
@@ -1537,8 +1537,8 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                     display: 'inline-block',
                     width: '12px',
                     height: '12px',
-                    backgroundColor: 'rgba(166, 227, 161, 0.3)',
-                    border: '1px solid rgba(166, 227, 161, 0.5)',
+                    backgroundColor: 'color-mix(in srgb, var(--color-success) 30%, transparent)',
+                    border: '1px solid color-mix(in srgb, var(--color-success) 50%, transparent)',
                     borderRadius: '2px'
                   }}></span>
                   <span style={{ color: 'var(--color-text)' }}>{t('auto_responder.parameter')}</span>
@@ -1738,7 +1738,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                   <div style={{
                     marginTop: '0.5rem',
                     padding: '0.5rem',
-                    background: realtimeMatch ? 'rgba(166, 227, 161, 0.1)' : 'rgba(243, 139, 168, 0.1)',
+                    background: realtimeMatch ? 'color-mix(in srgb, var(--color-success) 10%, transparent)' : 'color-mix(in srgb, var(--color-error) 10%, transparent)',
                     border: `1px solid ${realtimeMatch ? 'var(--color-success)' : 'var(--color-error)'}`,
                     borderRadius: '4px',
                     fontSize: '0.85rem'
@@ -1810,14 +1810,14 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                   <span
                                     key={groupIdx}
                                     style={{
-                                      backgroundColor: segment.type === 'parameter' ? 'rgba(166, 227, 161, 0.3)' : 'rgba(137, 180, 250, 0.2)',
+                                      backgroundColor: segment.type === 'parameter' ? 'color-mix(in srgb, var(--color-success) 30%, transparent)' : 'color-mix(in srgb, var(--color-accent) 20%, transparent)',
                                       padding: '0.2rem 0.4rem',
                                       borderRadius: '4px',
                                       fontWeight: segment.type === 'parameter' ? 'bold' : 'normal',
                                       color: segment.type === 'parameter' ? 'var(--color-success)' : 'var(--color-accent)',
                                       fontFamily: 'monospace',
                                       fontSize: '0.85rem',
-                                      border: segment.type === 'parameter' ? '1px solid rgba(166, 227, 161, 0.5)' : '1px solid rgba(137, 180, 250, 0.3)'
+                                      border: segment.type === 'parameter' ? '1px solid color-mix(in srgb, var(--color-success) 50%, transparent)' : '1px solid color-mix(in srgb, var(--color-accent) 30%, transparent)'
                                     }}
                                   >
                                     {segment.type === 'literal' ? segment.text.trim() : segment.text}
@@ -1832,7 +1832,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                       alignItems: 'center',
                                       borderRadius: '4px',
                                       overflow: 'hidden',
-                                      border: '1px solid rgba(166, 227, 161, 0.5)',
+                                      border: '1px solid color-mix(in srgb, var(--color-success) 50%, transparent)',
                                       fontFamily: 'monospace',
                                       fontSize: '0.85rem'
                                     }}
@@ -1841,7 +1841,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                       <React.Fragment key={segIdx}>
                                         <span
                                           style={{
-                                            backgroundColor: segment.type === 'parameter' ? 'rgba(166, 227, 161, 0.3)' : 'rgba(137, 180, 250, 0.2)',
+                                            backgroundColor: segment.type === 'parameter' ? 'color-mix(in srgb, var(--color-success) 30%, transparent)' : 'color-mix(in srgb, var(--color-accent) 20%, transparent)',
                                             padding: '0.2rem 0.4rem',
                                             fontWeight: segment.type === 'parameter' ? 'bold' : 'normal',
                                             color: segment.type === 'parameter' ? 'var(--color-success)' : 'var(--color-accent)'
@@ -1853,7 +1853,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                           <span style={{
                                             width: '1px',
                                             height: '100%',
-                                            backgroundColor: 'rgba(205, 214, 244, 0.3)',
+                                            backgroundColor: 'color-mix(in srgb, var(--color-text) 30%, transparent)',
                                             margin: '0'
                                           }} />
                                         )}
@@ -1937,7 +1937,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                             {quickTestResult.error ? (
                               <div style={{
                                 padding: '0.5rem',
-                                background: 'rgba(243, 139, 168, 0.1)',
+                                background: 'color-mix(in srgb, var(--color-error) 10%, transparent)',
                                 border: '1px solid var(--color-error)',
                                 borderRadius: '4px',
                                 color: 'var(--color-error)',
@@ -2020,7 +2020,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                       style={{
                         padding: '0.5rem',
                         marginBottom: '0.5rem',
-                        backgroundColor: match ? 'rgba(166, 227, 161, 0.1)' : 'rgba(243, 139, 168, 0.1)',
+                        backgroundColor: match ? 'color-mix(in srgb, var(--color-success) 10%, transparent)' : 'color-mix(in srgb, var(--color-error) 10%, transparent)',
                         border: `1px solid ${match ? (hasConflict ? 'var(--color-caution)' : 'var(--color-success)') : 'var(--color-error)'}`,
                         borderRadius: '4px',
                         fontFamily: 'monospace',
@@ -2081,7 +2081,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                           marginLeft: '1.25rem', 
                           marginBottom: '0.25rem',
                           padding: '0.25rem',
-                          background: 'rgba(250, 179, 135, 0.2)',
+                          background: 'color-mix(in srgb, var(--color-caution) 20%, transparent)',
                           borderRadius: '3px',
                           fontSize: '0.75rem',
                           color: 'var(--color-caution)'
@@ -2288,7 +2288,7 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                         <span
                                           key={pos}
                                           style={{
-                                            backgroundColor: posInfo ? (posInfo.type === 'parameter' ? 'rgba(166, 227, 161, 0.4)' : 'rgba(137, 180, 250, 0.4)') : 'transparent',
+                                            backgroundColor: posInfo ? (posInfo.type === 'parameter' ? 'color-mix(in srgb, var(--color-success) 40%, transparent)' : 'color-mix(in srgb, var(--color-accent) 40%, transparent)') : 'transparent',
                                             padding: '2px',
                                             borderRadius: posInfo ? '2px' : '0',
                                             fontWeight: posInfo?.type === 'parameter' ? 'bold' : 'normal'
@@ -2302,11 +2302,11 @@ const AutoResponderSection: React.FC<AutoResponderSectionProps> = ({
                                   </div>
                                   <div style={{ marginTop: '0.5rem', fontSize: '0.7rem', color: 'var(--color-text-subtle)', display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
                                     <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.25rem' }}>
-                                      <span style={{ display: 'inline-block', width: '12px', height: '12px', backgroundColor: 'rgba(137, 180, 250, 0.4)', borderRadius: '2px' }}></span>
+                                      <span style={{ display: 'inline-block', width: '12px', height: '12px', backgroundColor: 'color-mix(in srgb, var(--color-accent) 40%, transparent)', borderRadius: '2px' }}></span>
                                       Literal text
                                     </span>
                                     <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.25rem' }}>
-                                      <span style={{ display: 'inline-block', width: '12px', height: '12px', backgroundColor: 'rgba(166, 227, 161, 0.4)', borderRadius: '2px' }}></span>
+                                      <span style={{ display: 'inline-block', width: '12px', height: '12px', backgroundColor: 'color-mix(in srgb, var(--color-success) 40%, transparent)', borderRadius: '2px' }}></span>
                                       Parameter match
                                     </span>
                                   </div>

--- a/src/components/MeshCore/MeshCoreAutoAckSection.tsx
+++ b/src/components/MeshCore/MeshCoreAutoAckSection.tsx
@@ -584,7 +584,7 @@ export const MeshCoreAutoAckSection: React.FC<MeshCoreAutoAckSectionProps> = ({ 
                         alignItems: 'center',
                         padding: '0.25rem 0.5rem',
                         marginBottom: '0.15rem',
-                        backgroundColor: matches ? 'rgba(166, 227, 161, 0.1)' : 'rgba(243, 139, 168, 0.1)',
+                        backgroundColor: matches ? 'color-mix(in srgb, var(--color-success) 10%, transparent)' : 'color-mix(in srgb, var(--color-error) 10%, transparent)',
                         border: `1px solid ${matches ? 'var(--color-success)' : 'var(--color-error)'}`,
                         borderRadius: '4px',
                         fontFamily: 'monospace',

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -462,14 +462,14 @@
   background: var(--color-surface-hover);
   border-color: var(--color-accent);
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px -5px rgba(137, 180, 250, 0.3);
+  box-shadow: 0 8px 25px -5px color-mix(in srgb, var(--color-accent) 30%, transparent);
 }
 
 .mc-channel-row.selected {
   background: var(--color-accent);
   border-color: var(--color-accent);
   color: var(--color-accent-text);
-  box-shadow: 0 8px 25px -5px rgba(137, 180, 250, 0.5);
+  box-shadow: 0 8px 25px -5px color-mix(in srgb, var(--color-accent) 50%, transparent);
 }
 
 .mc-channel-row-name {

--- a/src/components/NodeInfoModal/NodeInfoModal.css
+++ b/src/components/NodeInfoModal/NodeInfoModal.css
@@ -70,7 +70,7 @@
 
 /* Warning Banner */
 .node-info-warning {
-  background-color: rgba(250, 179, 135, 0.15);
+  background-color: color-mix(in srgb, var(--color-caution) 15%, transparent);
   border: 1px solid var(--color-caution);
   border-radius: var(--radius-md);
   padding: 0.75rem 1rem;
@@ -100,7 +100,7 @@
 
 /* Success Message */
 .node-info-success {
-  background-color: rgba(166, 227, 161, 0.15);
+  background-color: color-mix(in srgb, var(--color-success) 15%, transparent);
   border: 1px solid var(--color-success);
   color: var(--color-success);
   padding: 0.75rem;
@@ -162,7 +162,7 @@
 .node-info-field input:focus {
   outline: none;
   border-color: var(--color-accent);
-  box-shadow: 0 0 0 2px rgba(137, 180, 250, 0.2);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 20%, transparent);
 }
 
 .node-info-field input.input-error {
@@ -170,7 +170,7 @@
 }
 
 .node-info-field input.input-error:focus {
-  box-shadow: 0 0 0 2px rgba(243, 139, 168, 0.2);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-error) 20%, transparent);
 }
 
 .node-info-field .error-message {

--- a/src/components/PositionOverrideModal/PositionOverrideModal.css
+++ b/src/components/PositionOverrideModal/PositionOverrideModal.css
@@ -107,7 +107,7 @@
 .position-override-field input:focus {
   outline: none;
   border-color: var(--color-accent);
-  box-shadow: 0 0 0 2px rgba(137, 180, 250, 0.2);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 20%, transparent);
 }
 
 .position-override-field input.input-error {
@@ -115,7 +115,7 @@
 }
 
 .position-override-field input.input-error:focus {
-  box-shadow: 0 0 0 2px rgba(243, 139, 168, 0.2);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-error) 20%, transparent);
 }
 
 .position-override-field .error-message {
@@ -139,7 +139,7 @@
 }
 
 .position-override-error {
-  background-color: rgba(243, 139, 168, 0.1);
+  background-color: color-mix(in srgb, var(--color-error) 10%, transparent);
   border: 1px solid var(--color-error);
   color: var(--color-error);
   padding: 0.75rem;

--- a/src/components/RebootModal.tsx
+++ b/src/components/RebootModal.tsx
@@ -221,7 +221,7 @@ export const RebootModal: React.FC<RebootModalProps> = ({ isOpen, onClose }) => 
           borderRadius: '8px',
           padding: '2rem',
           border: '2px solid var(--color-accent)',
-          boxShadow: '0 0 20px rgba(137, 180, 250, 0.5)'
+          boxShadow: '0 0 20px color-mix(in srgb, var(--color-accent) 50%, transparent)'
         }}
       >
         <div style={{ textAlign: 'center' }}>

--- a/src/components/ScriptTestModal.tsx
+++ b/src/components/ScriptTestModal.tsx
@@ -387,7 +387,7 @@ const ScriptTestModal: React.FC<ScriptTestModalProps> = ({
                   padding: '0.75rem',
                   marginBottom: '1rem',
                   borderRadius: '6px',
-                  background: testResult.success ? 'rgba(166, 227, 161, 0.15)' : 'rgba(243, 139, 168, 0.15)',
+                  background: testResult.success ? 'color-mix(in srgb, var(--color-success) 15%, transparent)' : 'color-mix(in srgb, var(--color-error) 15%, transparent)',
                   border: `1px solid ${testResult.success ? 'var(--color-success)' : 'var(--color-error)'}`,
                 }}
               >

--- a/src/components/SearchModal/SearchModal.css
+++ b/src/components/SearchModal/SearchModal.css
@@ -84,7 +84,7 @@
 .search-input-row input[type="text"]:focus {
   outline: none;
   border-color: var(--color-accent);
-  box-shadow: 0 0 0 2px rgba(137, 180, 250, 0.2);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 20%, transparent);
 }
 
 .search-submit-btn {
@@ -145,7 +145,7 @@
 .search-filter-group input[type="date"]:focus {
   outline: none;
   border-color: var(--color-accent);
-  box-shadow: 0 0 0 2px rgba(137, 180, 250, 0.2);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 20%, transparent);
 }
 
 .search-case-toggle {
@@ -311,8 +311,8 @@
 
 /* Highlight animation for scroll-to-message from search */
 @keyframes search-highlight-pulse {
-  0% { background-color: rgba(249, 226, 175, 0.3); }
-  50% { background-color: rgba(249, 226, 175, 0.15); }
+  0% { background-color: color-mix(in srgb, var(--color-warning) 30%, transparent); }
+  50% { background-color: color-mix(in srgb, var(--color-warning) 15%, transparent); }
   100% { background-color: transparent; }
 }
 

--- a/src/components/admin-commands/RadioConfigurationSection.tsx
+++ b/src/components/admin-commands/RadioConfigurationSection.tsx
@@ -235,7 +235,7 @@ export const RadioConfigurationSection: React.FC<RadioConfigurationSectionProps>
                 padding: '0.6rem 0.75rem',
                 border: '1px solid var(--color-warning)',
                 borderRadius: '4px',
-                backgroundColor: 'rgba(249, 226, 175, 0.12)',
+                backgroundColor: 'color-mix(in srgb, var(--color-warning) 12%, transparent)',
                 color: 'var(--color-warning)',
                 lineHeight: '1.4'
               }}
@@ -490,7 +490,7 @@ export const RadioConfigurationSection: React.FC<RadioConfigurationSectionProps>
                   padding: '1rem',
                   backgroundColor: channel ? 'var(--color-surface)' : 'var(--color-bg-raised)',
                   opacity: channel?.role === 0 ? 0.5 : 1,
-                  boxShadow: channel?.role === 1 ? '0 0 10px rgba(137, 180, 250, 0.3)' : 'none'
+                  boxShadow: channel?.role === 1 ? '0 0 10px color-mix(in srgb, var(--color-accent) 30%, transparent)' : 'none'
                 }}
               >
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '0.75rem' }}>

--- a/src/components/auto-responder/TriggerItem.tsx
+++ b/src/components/auto-responder/TriggerItem.tsx
@@ -601,8 +601,8 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                                     key={groupIdx}
                                     style={{
                                       backgroundColor: segment.type === 'parameter'
-                                        ? 'rgba(166, 227, 161, 0.3)'
-                                        : 'rgba(137, 180, 250, 0.2)',
+                                        ? 'color-mix(in srgb, var(--color-success) 30%, transparent)'
+                                        : 'color-mix(in srgb, var(--color-accent) 20%, transparent)',
                                       padding: '0.2rem 0.4rem',
                                       borderRadius: '4px',
                                       fontWeight: segment.type === 'parameter' ? 'bold' : 'normal',
@@ -610,8 +610,8 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                                       fontFamily: 'monospace',
                                       fontSize: '0.85rem',
                                       border: segment.type === 'parameter'
-                                        ? '1px solid rgba(166, 227, 161, 0.5)'
-                                        : '1px solid rgba(137, 180, 250, 0.3)'
+                                        ? '1px solid color-mix(in srgb, var(--color-success) 50%, transparent)'
+                                        : '1px solid color-mix(in srgb, var(--color-accent) 30%, transparent)'
                                     }}
                                     title={segment.type === 'parameter' ? `Parameter: ${segment.paramName}` : 'Literal text'}
                                   >
@@ -628,7 +628,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                                       alignItems: 'center',
                                       borderRadius: '4px',
                                       overflow: 'hidden',
-                                      border: '1px solid rgba(166, 227, 161, 0.5)',
+                                      border: '1px solid color-mix(in srgb, var(--color-success) 50%, transparent)',
                                       fontFamily: 'monospace',
                                       fontSize: '0.85rem'
                                     }}
@@ -639,8 +639,8 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                                         <span
                                           style={{
                                             backgroundColor: segment.type === 'parameter'
-                                              ? 'rgba(166, 227, 161, 0.3)'
-                                              : 'rgba(137, 180, 250, 0.2)',
+                                              ? 'color-mix(in srgb, var(--color-success) 30%, transparent)'
+                                              : 'color-mix(in srgb, var(--color-accent) 20%, transparent)',
                                             padding: '0.2rem 0.4rem',
                                             fontWeight: segment.type === 'parameter' ? 'bold' : 'normal',
                                             color: segment.type === 'parameter' ? 'var(--color-success)' : 'var(--color-accent)'
@@ -652,7 +652,7 @@ const TriggerItem: React.FC<TriggerItemProps> = ({
                                           <span style={{
                                             width: '1px',
                                             height: '100%',
-                                            backgroundColor: 'rgba(205, 214, 244, 0.3)',
+                                            backgroundColor: 'color-mix(in srgb, var(--color-text) 30%, transparent)',
                                             margin: '0'
                                           }} />
                                         )}

--- a/src/components/configuration/ChannelsConfigSection.tsx
+++ b/src/components/configuration/ChannelsConfigSection.tsx
@@ -534,7 +534,7 @@ const ChannelsConfigSection: React.FC<ChannelsConfigSectionProps> = ({
                       backgroundColor: channel ? 'var(--color-surface)' : 'var(--color-bg-raised)',
                       opacity: channel?.role === 0 ? 0.5 : 1,
                       boxShadow: (hasReorderChanges ? displaySlot === 0 : channel?.role === 1)
-                        ? '0 0 10px rgba(137, 180, 250, 0.3)' : 'none'
+                        ? '0 0 10px color-mix(in srgb, var(--color-accent) 30%, transparent)' : 'none'
                     }}
                   >
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '0.75rem' }}>

--- a/src/components/configuration/LoRaConfigSection.tsx
+++ b/src/components/configuration/LoRaConfigSection.tsx
@@ -422,7 +422,7 @@ const LoRaConfigSection: React.FC<LoRaConfigSectionProps> = ({
               padding: '0.6rem 0.75rem',
               border: '1px solid var(--color-warning)',
               borderRadius: '4px',
-              backgroundColor: 'rgba(249, 226, 175, 0.12)',
+              backgroundColor: 'color-mix(in srgb, var(--color-warning) 12%, transparent)',
               color: 'var(--color-warning)',
               lineHeight: '1.4'
             }}

--- a/src/components/configuration/MQTTConfigSection.tsx
+++ b/src/components/configuration/MQTTConfigSection.tsx
@@ -305,7 +305,7 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
             margin: '8px 0',
             padding: '10px 12px',
             borderRadius: 6,
-            background: 'rgba(137, 180, 250, 0.10)', // ctp-blue @ low alpha
+            background: 'color-mix(in srgb, var(--color-accent) 10%, transparent)',
             border: '1px solid var(--color-accent)',
             color: 'var(--color-text)',
             fontSize: 13,
@@ -331,7 +331,7 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
             margin: '8px 0',
             padding: '10px 12px',
             borderRadius: 6,
-            background: 'rgba(243, 139, 168, 0.10)', // ctp-red @ low alpha
+            background: 'color-mix(in srgb, var(--color-error) 10%, transparent)',
             border: '1px solid var(--color-error)',
             color: 'var(--color-text)',
             fontSize: 13,
@@ -354,7 +354,7 @@ const MQTTConfigSection: React.FC<MQTTConfigSectionProps> = ({
             margin: '8px 0',
             padding: '10px 12px',
             borderRadius: 6,
-            background: 'rgba(249, 226, 175, 0.10)', // ctp-yellow @ low alpha
+            background: 'color-mix(in srgb, var(--color-warning) 10%, transparent)',
             border: '1px solid var(--color-warning)',
             color: 'var(--color-text)',
             fontSize: 13,

--- a/src/components/configuration/NetworkConfigSection.tsx
+++ b/src/components/configuration/NetworkConfigSection.tsx
@@ -164,7 +164,7 @@ const NetworkConfigSection: React.FC<NetworkConfigSectionProps> = ({
             margin: '8px 0',
             padding: '10px 12px',
             borderRadius: 6,
-            background: 'rgba(137, 180, 250, 0.10)', // ctp-blue @ low alpha
+            background: 'color-mix(in srgb, var(--color-accent) 10%, transparent)',
             border: '1px solid var(--color-accent)',
             color: 'var(--color-text)',
             fontSize: 13,

--- a/src/styles/audit.css
+++ b/src/styles/audit.css
@@ -229,12 +229,12 @@
 }
 
 .detail-section.before .detail-pre {
-  background: rgba(243, 139, 168, 0.1);
+  background: color-mix(in srgb, var(--color-error) 10%, transparent);
   border-color: var(--color-error);
 }
 
 .detail-section.after .detail-pre {
-  background: rgba(166, 227, 161, 0.1);
+  background: color-mix(in srgb, var(--color-success) 10%, transparent);
   border-color: var(--color-success);
 }
 

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -619,7 +619,7 @@
 .dashboard-signin-btn:hover {
   background: var(--color-accent-hover);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(137, 180, 250, 0.3);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--color-accent) 30%, transparent);
 }
 
 .dashboard-add-source-btn {

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1070,7 +1070,7 @@
 }
 
 .overlay-content {
-  background: rgba(30, 30, 46, 0.95);
+  background: color-mix(in srgb, var(--color-bg) 95%, transparent);
   border: 2px solid var(--color-surface-active);
   border-radius: var(--radius-xl);
   padding: 2rem;
@@ -1111,7 +1111,7 @@
   flex-direction: column;
   align-items: center;
   gap: 0.75rem;
-  background: rgba(30, 30, 46, 0.95);
+  background: color-mix(in srgb, var(--color-bg) 95%, transparent);
   border: 2px solid var(--color-surface-active);
   border-radius: var(--radius-xl);
   padding: 2rem;
@@ -1500,7 +1500,7 @@
 .sender-dot.clickable:hover {
   background-color: var(--color-accent);
   transform: scale(1.1);
-  box-shadow: 0 2px 8px rgba(137, 180, 250, 0.3);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--color-accent) 30%, transparent);
 }
 
 /* Node Popup Styles */
@@ -2660,8 +2660,8 @@
 }
 
 @keyframes node-highlight-pulse {
-  0%, 100% { filter: drop-shadow(0 0 4px rgba(137, 180, 250, 0.6)); }
-  50% { filter: drop-shadow(0 0 12px rgba(137, 180, 250, 1)); }
+  0%, 100% { filter: drop-shadow(0 0 4px color-mix(in srgb, var(--color-accent) 60%, transparent)); }
+  50% { filter: drop-shadow(0 0 12px var(--color-accent)); }
 }
 
 /* Smooth transition for hover-to-isolate on route/neighbor polylines */

--- a/src/styles/semanticTokens.test.ts
+++ b/src/styles/semanticTokens.test.ts
@@ -41,22 +41,50 @@ function rootBlock(): string {
   // inside prose counts as a closing brace to any scanner that does not strip
   // them. Verified by dropping a lone `}` into a comment above --chart-1 —
   // brace-counting alone still truncated there.
-  const css = appCss.replace(/\/\*[\s\S]*?\*\//g, (m) => ' '.repeat(m.length));
-  const start = css.search(/:root\s*\{/);
+  const start = blankedCss.search(/:root\s*\{/);
   if (start === -1) return '';
-  const open = css.indexOf('{', start);
+  return balancedBody(blankedCss.indexOf('{', start));
+}
+
+/**
+ * `appCss` with every comment replaced by an equal-length run of spaces, so
+ * byte offsets still line up with the original text.
+ */
+const blankedCss = appCss.replace(/\/\*[\s\S]*?\*\//g, (m) => ' '.repeat(m.length));
+
+/**
+ * Body of the block whose opening `{` is at `open`, brace-balanced.
+ *
+ * Scans the comment-blanked copy but slices the ORIGINAL, so declarations come
+ * back verbatim while a `}` in prose can't end the block early.
+ */
+function balancedBody(open: number): string {
   let depth = 0;
-  for (let i = open; i < css.length; i++) {
-    if (css[i] === '{') depth++;
-    else if (css[i] === '}') {
+  for (let i = open; i < blankedCss.length; i++) {
+    if (blankedCss[i] === '{') depth++;
+    else if (blankedCss[i] === '}') {
       depth--;
-      // Slice from the ORIGINAL text so declarations are returned verbatim;
-      // only the brace scan runs on the blanked copy. Lengths match because
-      // comments are replaced with equal-length spaces, so offsets are stable.
       if (depth === 0) return appCss.slice(open + 1, i);
     }
   }
   return '';
+}
+
+/**
+ * Every `:root[data-theme='x']` block, body extracted brace-balanced.
+ *
+ * The theme extractors used to match the body with `([^}]*)`, which stops at
+ * the first `}` from any source — a nested rule, or a comment containing one.
+ * That is the same trap `rootBlock` above documents, and it is worse here: a
+ * truncated theme block silently drops palette vars, so the "defined in every
+ * theme" checks would pass by simply not seeing them.
+ */
+function themeBlockBodies(): { theme: string; body: string }[] {
+  const out: { theme: string; body: string }[] = [];
+  for (const m of blankedCss.matchAll(/:root\[data-theme='([^']+)'\]\s*\{/g)) {
+    out.push({ theme: m[1], body: balancedBody(m.index! + m[0].length - 1) });
+  }
+  return out;
 }
 
 /** Semantic tokens and the palette var each points at, from the :root block. */
@@ -69,27 +97,22 @@ function semanticDefinitions(): Map<string, string> {
 
 /** Palette vars defined inside a given `:root[data-theme='x']` block. */
 function paletteVarsInThemeBlocks(): { theme: string; vars: Set<string> }[] {
-  const blocks: { theme: string; vars: Set<string> }[] = [];
-  const re = /:root\[data-theme='([^']+)'\]\s*\{([^}]*)\}/g;
-  for (const m of appCss.matchAll(re)) {
+  return themeBlockBodies().map(({ theme, body }) => {
     const vars = new Set<string>();
-    for (const v of m[2].matchAll(/(--ctp-[a-z0-9-]+)\s*:/g)) vars.add(v[1]);
-    blocks.push({ theme: m[1], vars });
-  }
-  return blocks;
+    for (const v of body.matchAll(/(--ctp-[a-z0-9-]+)\s*:/g)) vars.add(v[1]);
+    return { theme, vars };
+  });
 }
 
 /** Palette var -> literal value, per `:root[data-theme='x']` block. */
 function paletteValuesInThemeBlocks(): { theme: string; values: Map<string, string> }[] {
-  const blocks: { theme: string; values: Map<string, string> }[] = [];
-  for (const m of appCss.matchAll(/:root\[data-theme='([^']+)'\]\s*\{([^}]*)\}/g)) {
+  return themeBlockBodies().map(({ theme, body }) => {
     const values = new Map<string, string>();
-    for (const v of m[2].matchAll(/(--ctp-[a-z0-9-]+)\s*:\s*([^;]+);/g)) {
+    for (const v of body.matchAll(/(--ctp-[a-z0-9-]+)\s*:\s*([^;]+);/g)) {
       values.set(v[1], v[2].trim().toLowerCase());
     }
-    blocks.push({ theme: m[1], values });
-  }
-  return blocks;
+    return { theme, values };
+  });
 }
 
 function walk(dir: string, out: string[] = []): string[] {
@@ -127,8 +150,10 @@ describe('semantic color tokens (#4567)', () => {
     // per-theme override slip through with the test still green — assert the
     // property that actually has to hold: it is defined exactly once, on the
     // base :root.
-    const baseRoot = appCss.match(/:root\s*\{([\s\S]*?)\}/)?.[1] ?? '';
-    expect(baseRoot).toMatch(/--ctp-accent-text\s*:/);
+    // rootBlock() rather than a lazy `[\s\S]*?` match: the two disagree the
+    // moment a comment in that block contains a `}`, and a truncated body here
+    // would turn this presence check into a false failure.
+    expect(rootBlock()).toMatch(/--ctp-accent-text\s*:/);
     const themeBlocksDefiningIt = paletteVarsInThemeBlocks().filter((t) =>
       t.vars.has('--ctp-accent-text'),
     );

--- a/src/styles/semanticTokens.test.ts
+++ b/src/styles/semanticTokens.test.ts
@@ -414,16 +414,10 @@ describe('raw palette references outside App.css', () => {
       .replace(/^\s*\/\/.*$/gm, ' ');
   }
 
-  // SCOPE — what this guard does NOT catch: a hardcoded `rgba(166, 227, 161,
-  // 0.3)` is the same theme-blind defect as `--ctp-yellow-soft`, spelled so it
-  // isn't a custom-property reference at all. A sweep found 82 such swatch
-  // approximations across 22 files, several sitting right next to a role token
-  // (`background: rgba(<mocha green>)` beside `color: var(--color-success)`),
-  // so on Nord or Gruvbox the two halves disagree. Fixing them needs per-site
-  // judgement — shadow vs fill vs border, and the right opacity — so it is its
-  // own pass, tracked separately, and the detector lands with the fixes rather
-  // than red against 82 pre-existing sites. Until then: passing this file does
-  // not mean a component is theme-clean.
+  // This guard covers the `var(--ctp-*)` spelling. The other spelling of the
+  // same defect — a hardcoded `rgba(166, 227, 161, 0.3)`, the Mocha green
+  // swatch written so it is not a custom-property reference at all — is covered
+  // by the swatch-literal suite at the bottom of this file.
   function referencedPaletteVars(): { name: string; file: string }[] {
     const hits: { name: string; file: string }[] = [];
     for (const file of walk(resolve('src'))) {
@@ -470,5 +464,72 @@ describe('raw palette references outside App.css', () => {
     expect(
       Array.from(new Set(dangling.map((h) => `${h.name} (${h.file})`))),
     ).toEqual([]);
+  });
+});
+
+describe('hardcoded palette swatch literals', () => {
+  // The third spelling of one defect. `--ctp-red-rgb` (#4617) and
+  // `--ctp-yellow-soft` were undefined vars whose hardcoded fallbacks rendered
+  // Mocha in all 15 themes; this is the same wrong color written directly as
+  // `rgba(243, 139, 168, 0.1)`, with no var involved for a scanner to notice.
+  //
+  // The worst shape of it put `background: rgba(<mocha green>)` on the same
+  // element as `color: var(--color-success)` — so on Nord or Gruvbox the two
+  // halves of one badge disagreed with each other.
+
+  // Swatches are read out of App.css rather than hardcoded here, so this
+  // catches every theme's palette, not just Mocha, and cannot drift as themes
+  // are edited.
+  function swatchTriples(): Map<string, string[]> {
+    const byTriple = new Map<string, string[]>();
+    for (const m of appCss.matchAll(/(--ctp-[A-Za-z0-9-]+)\s*:\s*#([0-9a-fA-F]{6})\b/g)) {
+      const hex = m[2];
+      const triple = [0, 2, 4].map((i) => parseInt(hex.slice(i, i + 2), 16)).join(',');
+      const names = byTriple.get(triple) ?? [];
+      if (!names.includes(m[1])) names.push(m[1]);
+      byTriple.set(triple, names);
+    }
+    return byTriple;
+  }
+
+  it('reads a real palette out of App.css', () => {
+    // Without this, a change to how App.css spells colors (say, to `hsl()`)
+    // would empty the swatch set and the check below would pass vacuously.
+    const swatches = swatchTriples();
+    expect(swatches.size).toBeGreaterThan(20);
+    expect(swatches.has('166,227,161')).toBe(true); // Mocha green
+  });
+
+  it('has no component writing a palette swatch as a raw rgb/rgba literal', () => {
+    const swatches = swatchTriples();
+    const offenders: string[] = [];
+    for (const file of walk(resolve('src'))) {
+      if (file.endsWith('/App.css')) continue; // where the palette is *defined*
+      const text = readFileSync(file, 'utf8');
+      const lines = text.split('\n');
+      lines.forEach((line, i) => {
+        for (const m of line.matchAll(
+          /rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})/g,
+        )) {
+          const [r, g, b] = m.slice(1, 4).map(Number);
+          // Achromatic values are exempt. A drop shadow is black and a scrim is
+          // white in every theme — that is a deliberate, theme-independent
+          // idiom, not a palette pick. They would otherwise all match, because
+          // some themes do define a pure-black --ctp-base and a pure-white
+          // --ctp-text, which drowns the real hits ~75:1.
+          if (r === g && g === b) continue;
+          const triple = [r, g, b].join(',');
+          const names = swatches.get(triple);
+          if (!names) continue;
+          offenders.push(
+            `${file.replace(resolve('.') + '/', '')}:${i + 1} rgb(${triple}) = ${names.join('/')}`,
+          );
+        }
+      });
+    }
+    // Use color-mix(in srgb, var(--color-ROLE) N%, transparent): it follows the
+    // theme, and premultiplies exactly the way an rgba alpha does, so it is a
+    // faithful replacement for a fill, a border and a shadow alike.
+    expect(offenders).toEqual([]);
   });
 });

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -192,7 +192,7 @@
   border: 2px solid var(--color-error);
   border-radius: var(--radius-lg);
   padding: 1.5rem;
-  background: rgba(243, 139, 168, 0.05);
+  background: color-mix(in srgb, var(--color-error) 5%, transparent);
   margin-top: 2rem;
   position: relative;
   z-index: 1; /* Keep below modals and popups */

--- a/src/styles/users.css
+++ b/src/styles/users.css
@@ -71,7 +71,7 @@
 .user-item.selected {
   background: var(--color-surface-hover);
   border-color: var(--color-accent);
-  box-shadow: 0 0 0 2px rgba(137, 180, 250, 0.2);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 20%, transparent);
 }
 
 .user-item-info {
@@ -94,7 +94,7 @@
 
 .inactive-badge {
   padding: 2px 8px;
-  background: rgba(243, 139, 168, 0.2);
+  background: color-mix(in srgb, var(--color-error) 20%, transparent);
   border: 1px solid var(--color-error);
   border-radius: var(--radius-sm);
   font-size: 0.75em;


### PR DESCRIPTION
Phase 2c. Closes out the raw-color work that #4617 and #4619 started, and lands the detector the #4619 review asked for.

## One defect, three spellings

| PR | Spelling | Why it was invisible |
|---|---|---|
| #4617 | `rgba(var(--ctp-red-rgb, 243, 139, 168), .15)` | var undefined → inline Mocha fallback rendered |
| #4619 | `var(--ctp-yellow-soft, rgba(249, 226, 175, .15))` | same, spelled differently |
| **this** | `rgba(166, 227, 161, 0.3)` | no var at all — nothing for a scanner to catch |

All three render hardcoded Catppuccin Mocha in every one of the 15 themes. None of them error, which is what made them survive: the fallback just quietly paints the wrong color.

**87 sites across 23 files.** The worst shape is the one the reviewer spotted — `background: rgba(<mocha green>)` on the same element as `color: var(--color-success)`. On Nord or Gruvbox the two halves of a single badge disagree with each other. Two overlay panels in `nodes.css` did the same with Mocha's `base` behind a themed border.

## The conversion is mechanical

I said on #4619 that this would need per-site judgement. That was wrong, and worth correcting: the property **doesn't** change the transformation. `color-mix` toward `transparent` premultiplies exactly the way an `rgba` alpha does, so a fill, a border and a shadow all convert identically:

```
rgba(166, 227, 161, 0.3)  ->  color-mix(in srgb, var(--color-success) 30%, transparent)
```

Only alpha varies, and it carries straight through. Endpoints keep their simpler spellings — `0` is `transparent`, `1` is the bare role token.

Every one of the 87 maps to exactly one role:

| swatch | role | n |
|---|---|---|
| blue | `--color-accent` | 32 |
| green | `--color-success` | 28 |
| red | `--color-error` | 15 |
| yellow | `--color-warning` | 5 |
| text | `--color-text` | 3 |
| peach | `--color-caution` | 2 |
| base | `--color-bg` | 2 |

## The detector

Reads swatches **out of `App.css`** rather than hardcoding Mocha, so it covers every theme's palette and can't drift as themes are edited. That strictness paid for itself immediately — it found the two `nodes.css` panels my own sweep missed, because my sweep only knew the six swatches with an obvious role.

**Achromatic values are exempt.** A drop shadow is black and a scrim is white in every theme — deliberate, theme-independent idiom. Since some themes define a pure-black `--ctp-base` and a pure-white `--ctp-text`, including them buried the 2 real hits under 148 false positives at roughly 75:1.

Verified in **both** directions, not just that it passes today:
- a chromatic swatch literal reintroduced into `audit.css` → fails ✓
- a black `box-shadow` appended to the same file → still passes ✓
- a tripwire asserting the swatch set actually parsed, so a change to how `App.css` spells colors (say, to `hsl()`) can't empty it and make the check pass vacuously ✓

## Verification

- Full Vitest suite: `success: true`, **13,805 passed / 0 failed / 0 suites failed** (+2, the new tests).
- `npm run lint:ci`: 0 in-repo failures.
- Presentational + one test file; no DB, route or protocol surface, so the 763 locally-skipped PostgreSQL/MySQL tests cover nothing this touches. CI runs them.

## What's left

`--ctp-chatBubble*` in `messages.css` — user-supplied optional overrides, not palette picks. **Phase 3** renames that prefix as part of flipping the theme schema to semantic keys, which is the change that actually answers the original complaint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf