### PR TITLE
fix(positions): make replaceAnchors atomic and document its empty-nodeNums contract (#4614)

### DIFF
--- a/src/db/repositories/estimatedPositionAnchors.test.ts
+++ b/src/db/repositories/estimatedPositionAnchors.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression tests for `replaceAnchors` (#4614, follow-ups from #4613's review).
+ *
+ * Two properties, both of which were unproven when the method shipped:
+ *
+ *  1. **Atomicity.** The delete and the inserts must be one transaction. Without
+ *     it, a reader landing between them sees zero anchors for a node whose
+ *     estimate still exists, and the API reports "no rationale" for a pin that
+ *     has one. A concurrency race is flaky to test directly, so the test below
+ *     forces the INSERT half to fail and asserts the DELETE half rolled back —
+ *     which only holds if the two share a transaction.
+ *
+ *  2. **The empty-`nodeNums` contract.** Passing no nodeNums with a non-empty
+ *     anchors array means "replace exactly the nodes these anchors belong to",
+ *     NOT "clear everything". Today's single caller never does it; the test is
+ *     here to protect the next one.
+ *
+ * SQLite only. The transaction is a per-backend branch mirroring
+ * `meshcorePathfindingTargets.setTargets`, and the migration suite already
+ * covers the table on all three backends.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EstimatedPositionsRepository } from './estimatedPositions.js';
+import { createTestDb, type TestDb } from '../../server/test-helpers/testDb.js';
+
+describe('replaceAnchors (#4614)', () => {
+  let testDb: TestDb;
+  let repo: EstimatedPositionsRepository;
+
+  const anchor = (nodeNum: number, anchorNodeNum: number, weight: number) => ({
+    nodeNum,
+    anchorNodeNum,
+    anchorNodeId: `!${anchorNodeNum.toString(16).padStart(8, '0')}`,
+    anchorLat: 37.4 + anchorNodeNum / 1000,
+    anchorLon: -122.1,
+    kind: 'traceroute' as const,
+    snrDb: 5.5,
+    observedAt: 1_700_000_000_000,
+    weight,
+    createdAt: 1_700_000_100_000,
+  });
+
+  beforeEach(() => {
+    testDb = createTestDb();
+    repo = new EstimatedPositionsRepository(testDb.db, 'sqlite');
+  });
+
+  afterEach(() => {
+    testDb.close?.();
+  });
+
+  it('replaces only the targeted nodes, leaving others untouched', async () => {
+    await repo.replaceAnchors([1, 2], [anchor(1, 10, 0.9), anchor(2, 20, 0.8)]);
+    await repo.replaceAnchors([1], [anchor(1, 11, 0.7)]);
+
+    const forOne = await repo.getAnchorsByNodeNum(1);
+    const forTwo = await repo.getAnchorsByNodeNum(2);
+
+    expect(forOne.map((a) => a.anchorNodeNum)).toEqual([11]);
+    // Node 2 was not in the second call's target set.
+    expect(forTwo.map((a) => a.anchorNodeNum)).toEqual([20]);
+  });
+
+  it('clears a node that solved with no retained anchors', async () => {
+    await repo.replaceAnchors([1], [anchor(1, 10, 0.9)]);
+    // nodeNums without anchors is the "solved, nothing worth keeping" case.
+    await repo.replaceAnchors([1], []);
+    expect(await repo.getAnchorsByNodeNum(1)).toEqual([]);
+  });
+
+  it('derives targets from anchors when nodeNums is empty, and clears nothing else', async () => {
+    // The contract #4614 asked to pin: empty nodeNums does NOT mean "wipe all".
+    await repo.replaceAnchors([1, 2], [anchor(1, 10, 0.9), anchor(2, 20, 0.8)]);
+    await repo.replaceAnchors([], [anchor(1, 12, 0.6)]);
+
+    expect((await repo.getAnchorsByNodeNum(1)).map((a) => a.anchorNodeNum)).toEqual([12]);
+    expect((await repo.getAnchorsByNodeNum(2)).map((a) => a.anchorNodeNum)).toEqual([20]);
+  });
+
+  it('is a no-op when both arguments are empty', async () => {
+    await repo.replaceAnchors([1], [anchor(1, 10, 0.9)]);
+    await repo.replaceAnchors([], []);
+    expect((await repo.getAnchorsByNodeNum(1)).map((a) => a.anchorNodeNum)).toEqual([10]);
+  });
+
+  it('rolls the delete back when the insert fails — proving the two are atomic', async () => {
+    await repo.replaceAnchors([1], [anchor(1, 10, 0.9), anchor(1, 11, 0.8)]);
+    expect(await repo.getAnchorsByNodeNum(1)).toHaveLength(2);
+
+    // `kind` is NOT NULL. Passing null makes the INSERT half throw *after* the
+    // DELETE half has run. Pre-transaction, this wiped the node's anchors and
+    // left it with none; with the transaction the delete is rolled back.
+    const bad = { ...anchor(1, 12, 0.7), kind: null as unknown as 'traceroute' };
+    await expect(repo.replaceAnchors([1], [bad])).rejects.toThrow();
+
+    const surviving = await repo.getAnchorsByNodeNum(1);
+    expect(surviving.map((a) => a.anchorNodeNum).sort()).toEqual([10, 11]);
+  });
+});

--- a/src/db/repositories/estimatedPositions.ts
+++ b/src/db/repositories/estimatedPositions.ts
@@ -173,6 +173,19 @@ export class EstimatedPositionsRepository extends BaseRepository {
    *
    * `nodeNums` is passed separately from `anchors` on purpose: a node can solve
    * with zero retained anchors, and its stale rows must still be cleared.
+   *
+   * **Contract when `nodeNums` is empty (#4614).** An empty `nodeNums` with a
+   * non-empty `anchors` is legal and means "replace exactly the nodes these
+   * anchors belong to" — the target set is derived from `anchors`. It does NOT
+   * mean "clear everything"; use `deleteAll()` for that. Both empty is a no-op.
+   *
+   * **Atomic (#4614).** The delete and the inserts run in one transaction, so a
+   * concurrent reader never observes the window between them. Without it a read
+   * landing mid-write sees zero anchors for a node whose estimate still exists,
+   * and the API reports "no rationale" for a pin that has one. Per-backend
+   * branch rather than `this.db.transaction`, matching
+   * `meshcorePathfindingTargets.setTargets` — better-sqlite3's transaction
+   * callback is synchronous while the PG and MySQL drivers are async.
    */
   async replaceAnchors(nodeNums: number[], anchors: EstimatedPositionAnchorInput[]): Promise<void> {
     if (nodeNums.length === 0 && anchors.length === 0) return;
@@ -180,14 +193,44 @@ export class EstimatedPositionsRepository extends BaseRepository {
     const targets = nodeNums.length > 0
       ? nodeNums
       : [...new Set(anchors.map((a) => a.nodeNum))];
-    await this.deleteAnchorsByNodeNums(targets);
-
-    if (anchors.length === 0) return;
 
     const { estimatedPositionAnchors } = this.tables;
+    const batches: EstimatedPositionAnchorInput[][] = [];
     for (let i = 0; i < anchors.length; i += ANCHOR_INSERT_BATCH) {
-      const batch = anchors.slice(i, i + ANCHOR_INSERT_BATCH);
-      await this.db.insert(estimatedPositionAnchors).values(batch);
+      batches.push(anchors.slice(i, i + ANCHOR_INSERT_BATCH));
+    }
+
+    if (this.isSQLite()) {
+      this.getSqliteDb().transaction((tx) => {
+        if (targets.length > 0) {
+          tx.delete(estimatedPositionAnchors)
+            .where(inArray(estimatedPositionAnchors.nodeNum, targets))
+            .run();
+        }
+        for (const batch of batches) {
+          tx.insert(estimatedPositionAnchors).values(batch).run();
+        }
+      });
+    } else if (this.isPostgres()) {
+      await this.getPostgresDb().transaction(async (tx) => {
+        if (targets.length > 0) {
+          await tx.delete(estimatedPositionAnchors)
+            .where(inArray(estimatedPositionAnchors.nodeNum, targets));
+        }
+        for (const batch of batches) {
+          await tx.insert(estimatedPositionAnchors).values(batch);
+        }
+      });
+    } else {
+      await this.getMysqlDb().transaction(async (tx) => {
+        if (targets.length > 0) {
+          await tx.delete(estimatedPositionAnchors)
+            .where(inArray(estimatedPositionAnchors.nodeNum, targets));
+        }
+        for (const batch of batches) {
+          await tx.insert(estimatedPositionAnchors).values(batch);
+        }
+      });
     }
   }
 


### PR DESCRIPTION
Closes #4614 — two of the three follow-ups from #4613's review. The third is closed as a non-issue.

## 1. Atomicity — fixed

`replaceAnchors` deleted then inserted with no transaction, so a reader landing between the two saw **zero anchors for a node whose estimate still existed** — the API reporting "no rationale" for a pin that has one. The window is small (6-hour batch job) but real.

Wrapped in a **per-backend transaction branch** rather than `this.db.transaction`, matching `meshcorePathfindingTargets.setTargets`. That shape isn't stylistic: better-sqlite3's transaction callback is *synchronous* while the PG and MySQL drivers are async, so there is no uniform call.

**The test proves the property rather than assuming it.** A concurrency race is flaky to test directly, so it forces the INSERT half to fail (NOT NULL violation) and asserts the DELETE half rolled back — which only holds if the two share a transaction.

And I checked the test is load-bearing rather than trusting a green tick:

```
WITHOUT transaction: success=False passed=4 failed=1
  FAILS AS EXPECTED: rolls the delete back when the insert fails
```

Reverting only the transaction makes exactly that test fail, and only that one.

## 2. SQLite `real` vs PG/MySQL `double` — closed, the premise doesn't hold

The concern was that `real` is single-precision. **SQLite's `REAL` is an 8-byte IEEE double** — identical to PostgreSQL `double precision` and MySQL `DOUBLE`. Verified empirically rather than from documentation:

```
inserted : 37.42199981234567
read back: 37.42199981234567
identical: true
delta    : 0
```

A coordinate far more precise than any GPS fix round-trips bit-exact. Drizzle's `real()` maps to SQLite `REAL`, and SQLite is the only backend using it — PG/MySQL already use `doublePrecision`/`double`.

The naming reads inconsistent; the storage isn't. Renaming would mean a migration touching every coordinate-bearing table across three backends for **zero** behavioural difference, so it isn't done here.

## 3. Empty-`nodeNums` contract — documented, not changed

`replaceAnchors` already handled this correctly: it derives the target set from `anchors`. It was **undocumented, not unimplemented**. Now stated in the doc comment — empty `nodeNums` means "replace exactly these anchors' nodes", **not** "clear everything" (that's `deleteAll()`) — and pinned by a test so the next caller can't misread it.

## Verification

- Full Vitest suite: `success: true`, **13,808 passed, 0 failed, 0 failed suites**
- New: 5 `replaceAnchors` tests — targeted replacement, clear-on-empty-anchors, the empty-`nodeNums` contract, both-empty no-op, and the atomicity rollback
- `tsc --noEmit` clean; `lint:ci` clean

SQLite-only for the new tests: the transaction is a per-backend branch mirroring existing prior art, and the migration suite already covers the table on all three backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX