### PR TITLE
refactor(theme): read role tokens from script, not palette vars

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -402,22 +402,23 @@ function App() {
 
   // Get computed CSS color values for Leaflet Polyline components (which don't support CSS variables)
   const [themeColors, setThemeColors] = useState({
-    mauve: '#cba6f7', // Default to Mocha theme colors
-    red: '#f38ba8',
-    blue: '#89b4fa', // For forward traceroute path
-    overlay0: '#6c7086', // For MQTT segments (muted gray)
+    // Fallbacks only, replaced on mount by the effect below.
+    accentAlt: '#cba6f7',
+    error: '#f38ba8',
+    accent: '#89b4fa', // forward traceroute path
+    faint: '#6c7086', // MQTT segments
   });
 
   // Update theme colors when theme changes
   useEffect(() => {
     const rootStyle = getComputedStyle(document.documentElement);
-    const mauve = rootStyle.getPropertyValue('--ctp-mauve').trim();
-    const red = rootStyle.getPropertyValue('--ctp-red').trim();
-    const blue = rootStyle.getPropertyValue('--ctp-blue').trim();
-    const overlay0 = rootStyle.getPropertyValue('--ctp-overlay0').trim();
+    const accentAlt = rootStyle.getPropertyValue('--color-accent-alt').trim();
+    const error = rootStyle.getPropertyValue('--color-error').trim();
+    const accent = rootStyle.getPropertyValue('--color-accent').trim();
+    const faint = rootStyle.getPropertyValue('--color-text-faint').trim();
 
-    if (mauve && red && blue && overlay0) {
-      setThemeColors({ mauve, red, blue, overlay0 });
+    if (accentAlt && error && accent && faint) {
+      setThemeColors({ accentAlt, error, accent, faint });
     }
   }, [theme]);
 

--- a/src/components/LinkQualityChart.tsx
+++ b/src/components/LinkQualityChart.tsx
@@ -87,19 +87,19 @@ const LinkQualityChart: React.FC<LinkQualityChartProps> = ({
 
   // Get computed CSS color values for chart styling
   const [chartColors, setChartColors] = useState({
-    base: '#1e1e2e',
-    surface0: '#45475a',
+    bg: '#1e1e2e',
+    surface: '#45475a',
     text: '#cdd6f4',
   });
 
   useEffect(() => {
     const updateColors = () => {
       const rootStyle = getComputedStyle(document.documentElement);
-      const base = rootStyle.getPropertyValue('--ctp-base').trim();
-      const surface0 = rootStyle.getPropertyValue('--ctp-surface0').trim();
-      const text = rootStyle.getPropertyValue('--ctp-text').trim();
-      if (base && surface0 && text) {
-        setChartColors({ base, surface0, text });
+      const bg = rootStyle.getPropertyValue('--color-bg').trim();
+      const surface = rootStyle.getPropertyValue('--color-surface').trim();
+      const text = rootStyle.getPropertyValue('--color-text').trim();
+      if (bg && surface && text) {
+        setChartColors({ bg, surface, text });
       }
     };
     updateColors();
@@ -246,8 +246,8 @@ const LinkQualityChart: React.FC<LinkQualityChartProps> = ({
           <ReferenceLine y={7} stroke="#a6e3a1" strokeDasharray="3 3" strokeOpacity={0.5} />
           <Tooltip
             contentStyle={{
-              backgroundColor: chartColors.base,
-              border: `1px solid ${chartColors.surface0}`,
+              backgroundColor: chartColors.bg,
+              border: `1px solid ${chartColors.surface}`,
               borderRadius: '4px',
               color: chartColors.text,
             }}

--- a/src/components/LinkQualityGraph.tsx
+++ b/src/components/LinkQualityGraph.tsx
@@ -99,8 +99,8 @@ const LinkQualityGraph: React.FC<LinkQualityGraphProps> = React.memo(
 
     // Get computed CSS color values for chart styling
     const [chartColors, setChartColors] = useState({
-      base: '#1e1e2e',
-      surface0: '#45475a',
+      bg: '#1e1e2e',
+      surface: '#45475a',
       text: '#cdd6f4',
     });
 
@@ -108,12 +108,12 @@ const LinkQualityGraph: React.FC<LinkQualityGraphProps> = React.memo(
     useEffect(() => {
       const updateColors = () => {
         const rootStyle = getComputedStyle(document.documentElement);
-        const base = rootStyle.getPropertyValue('--ctp-base').trim();
-        const surface0 = rootStyle.getPropertyValue('--ctp-surface0').trim();
-        const text = rootStyle.getPropertyValue('--ctp-text').trim();
+        const bg = rootStyle.getPropertyValue('--color-bg').trim();
+        const surface = rootStyle.getPropertyValue('--color-surface').trim();
+        const text = rootStyle.getPropertyValue('--color-text').trim();
 
-        if (base && surface0 && text) {
-          setChartColors({ base, surface0, text });
+        if (bg && surface && text) {
+          setChartColors({ bg, surface, text });
         }
       };
 
@@ -233,8 +233,8 @@ const LinkQualityGraph: React.FC<LinkQualityGraphProps> = React.memo(
                 <ReferenceLine y={7} stroke="#a6e3a1" strokeDasharray="3 3" strokeOpacity={0.5} />
                 <Tooltip
                   contentStyle={{
-                    backgroundColor: chartColors.base,
-                    border: `1px solid ${chartColors.surface0}`,
+                    backgroundColor: chartColors.bg,
+                    border: `1px solid ${chartColors.surface}`,
                     borderRadius: '4px',
                     color: chartColors.text,
                   }}

--- a/src/components/PacketRateChart.tsx
+++ b/src/components/PacketRateChart.tsx
@@ -137,19 +137,19 @@ const PacketRateChart: React.FC<PacketRateChartProps> = ({
 
   // Get computed CSS color values for chart styling
   const [chartColors, setChartColors] = useState({
-    base: '#1e1e2e',
-    surface0: '#45475a',
+    bg: '#1e1e2e',
+    surface: '#45475a',
     text: '#cdd6f4',
   });
 
   useEffect(() => {
     const updateColors = () => {
       const rootStyle = getComputedStyle(document.documentElement);
-      const base = rootStyle.getPropertyValue('--ctp-base').trim();
-      const surface0 = rootStyle.getPropertyValue('--ctp-surface0').trim();
-      const text = rootStyle.getPropertyValue('--ctp-text').trim();
-      if (base && surface0 && text) {
-        setChartColors({ base, surface0, text });
+      const bg = rootStyle.getPropertyValue('--color-bg').trim();
+      const surface = rootStyle.getPropertyValue('--color-surface').trim();
+      const text = rootStyle.getPropertyValue('--color-text').trim();
+      if (bg && surface && text) {
+        setChartColors({ bg, surface, text });
       }
     };
     updateColors();
@@ -277,8 +277,8 @@ const PacketRateChart: React.FC<PacketRateChartProps> = ({
           <YAxis tick={{ fontSize: 12 }} domain={[0, 'auto']} tickFormatter={value => value.toFixed(1)} />
           <Tooltip
             contentStyle={{
-              backgroundColor: chartColors.base,
-              border: `1px solid ${chartColors.surface0}`,
+              backgroundColor: chartColors.bg,
+              border: `1px solid ${chartColors.surface}`,
               borderRadius: '4px',
               color: chartColors.text,
             }}

--- a/src/components/PacketRateGraphs.tsx
+++ b/src/components/PacketRateGraphs.tsx
@@ -152,8 +152,8 @@ const PacketRateGraphs: React.FC<PacketRateGraphsProps> = React.memo(
 
     // Get computed CSS color values for chart styling
     const [chartColors, setChartColors] = useState({
-      base: '#1e1e2e',
-      surface0: '#45475a',
+      bg: '#1e1e2e',
+      surface: '#45475a',
       text: '#cdd6f4',
     });
 
@@ -161,12 +161,12 @@ const PacketRateGraphs: React.FC<PacketRateGraphsProps> = React.memo(
     useEffect(() => {
       const updateColors = () => {
         const rootStyle = getComputedStyle(document.documentElement);
-        const base = rootStyle.getPropertyValue('--ctp-base').trim();
-        const surface0 = rootStyle.getPropertyValue('--ctp-surface0').trim();
-        const text = rootStyle.getPropertyValue('--ctp-text').trim();
+        const bg = rootStyle.getPropertyValue('--color-bg').trim();
+        const surface = rootStyle.getPropertyValue('--color-surface').trim();
+        const text = rootStyle.getPropertyValue('--color-text').trim();
 
-        if (base && surface0 && text) {
-          setChartColors({ base, surface0, text });
+        if (bg && surface && text) {
+          setChartColors({ bg, surface, text });
         }
       };
 
@@ -268,8 +268,8 @@ const PacketRateGraphs: React.FC<PacketRateGraphsProps> = React.memo(
               />
               <Tooltip
                 contentStyle={{
-                  backgroundColor: chartColors.base,
-                  border: `1px solid ${chartColors.surface0}`,
+                  backgroundColor: chartColors.bg,
+                  border: `1px solid ${chartColors.surface}`,
                   borderRadius: '4px',
                   color: chartColors.text,
                 }}

--- a/src/components/SmartHopsChart.tsx
+++ b/src/components/SmartHopsChart.tsx
@@ -95,19 +95,19 @@ const SmartHopsChart: React.FC<SmartHopsChartProps> = ({
 
   // Get computed CSS color values for chart styling
   const [chartColors, setChartColors] = useState({
-    base: '#1e1e2e',
-    surface0: '#45475a',
+    bg: '#1e1e2e',
+    surface: '#45475a',
     text: '#cdd6f4',
   });
 
   useEffect(() => {
     const updateColors = () => {
       const rootStyle = getComputedStyle(document.documentElement);
-      const base = rootStyle.getPropertyValue('--ctp-base').trim();
-      const surface0 = rootStyle.getPropertyValue('--ctp-surface0').trim();
-      const text = rootStyle.getPropertyValue('--ctp-text').trim();
-      if (base && surface0 && text) {
-        setChartColors({ base, surface0, text });
+      const bg = rootStyle.getPropertyValue('--color-bg').trim();
+      const surface = rootStyle.getPropertyValue('--color-surface').trim();
+      const text = rootStyle.getPropertyValue('--color-text').trim();
+      if (bg && surface && text) {
+        setChartColors({ bg, surface, text });
       }
     };
     updateColors();
@@ -240,8 +240,8 @@ const SmartHopsChart: React.FC<SmartHopsChartProps> = ({
           />
           <Tooltip
             contentStyle={{
-              backgroundColor: chartColors.base,
-              border: `1px solid ${chartColors.surface0}`,
+              backgroundColor: chartColors.bg,
+              border: `1px solid ${chartColors.surface}`,
               borderRadius: '4px',
               color: chartColors.text,
             }}

--- a/src/components/SmartHopsGraphs.tsx
+++ b/src/components/SmartHopsGraphs.tsx
@@ -104,8 +104,8 @@ const SmartHopsGraphs: React.FC<SmartHopsGraphsProps> = React.memo(
 
     // Get computed CSS color values for chart styling
     const [chartColors, setChartColors] = useState({
-      base: '#1e1e2e',
-      surface0: '#45475a',
+      bg: '#1e1e2e',
+      surface: '#45475a',
       text: '#cdd6f4',
     });
 
@@ -113,12 +113,12 @@ const SmartHopsGraphs: React.FC<SmartHopsGraphsProps> = React.memo(
     useEffect(() => {
       const updateColors = () => {
         const rootStyle = getComputedStyle(document.documentElement);
-        const base = rootStyle.getPropertyValue('--ctp-base').trim();
-        const surface0 = rootStyle.getPropertyValue('--ctp-surface0').trim();
-        const text = rootStyle.getPropertyValue('--ctp-text').trim();
+        const bg = rootStyle.getPropertyValue('--color-bg').trim();
+        const surface = rootStyle.getPropertyValue('--color-surface').trim();
+        const text = rootStyle.getPropertyValue('--color-text').trim();
 
-        if (base && surface0 && text) {
-          setChartColors({ base, surface0, text });
+        if (bg && surface && text) {
+          setChartColors({ bg, surface, text });
         }
       };
 
@@ -210,8 +210,8 @@ const SmartHopsGraphs: React.FC<SmartHopsGraphsProps> = React.memo(
                 />
                 <Tooltip
                   contentStyle={{
-                    backgroundColor: chartColors.base,
-                    border: `1px solid ${chartColors.surface0}`,
+                    backgroundColor: chartColors.bg,
+                    border: `1px solid ${chartColors.surface}`,
                     borderRadius: '4px',
                     color: chartColors.text,
                   }}

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -156,7 +156,7 @@ interface TelemetryGraphWidgetProps {
   openMenu: string | null;
   menuPosition: { x: number; y: number } | null;
   handlePurgeData: (type: string) => void;
-  chartColors: { base: string; surface0: string; text: string };
+  chartColors: { bg: string; surface: string; text: string };
   getTelemetryLabel: (type: string) => string;
   getColor: (type: string) => string;
   prepareChartData: (data: TelemetryData[], isTemperature?: boolean, globalMinTime?: number) => ChartData[];
@@ -386,8 +386,8 @@ const TelemetryGraphWidget: React.FC<TelemetryGraphWidgetProps> = ({
             />
             <Tooltip
               contentStyle={{
-                backgroundColor: chartColors.base,
-                border: `1px solid ${chartColors.surface0}`,
+                backgroundColor: chartColors.bg,
+                border: `1px solid ${chartColors.surface}`,
                 borderRadius: '4px',
                 color: chartColors.text,
               }}
@@ -582,8 +582,8 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
 
     // Get computed CSS color values for chart styling (Recharts doesn't support CSS variables in inline styles)
     const [chartColors, setChartColors] = useState({
-      base: '#1e1e2e',
-      surface0: '#45475a',
+      bg: '#1e1e2e',
+      surface: '#45475a',
       text: '#cdd6f4',
     });
 
@@ -591,12 +591,12 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
     useEffect(() => {
       const updateColors = () => {
         const rootStyle = getComputedStyle(document.documentElement);
-        const base = rootStyle.getPropertyValue('--ctp-base').trim();
-        const surface0 = rootStyle.getPropertyValue('--ctp-surface0').trim();
-        const text = rootStyle.getPropertyValue('--ctp-text').trim();
+        const bg = rootStyle.getPropertyValue('--color-bg').trim();
+        const surface = rootStyle.getPropertyValue('--color-surface').trim();
+        const text = rootStyle.getPropertyValue('--color-text').trim();
 
-        if (base && surface0 && text) {
-          setChartColors({ base, surface0, text });
+        if (bg && surface && text) {
+          setChartColors({ bg, surface, text });
         }
       };
 

--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -172,10 +172,10 @@ export interface TracerouteDigest {
  * Theme colors for path rendering
  */
 export interface ThemeColors {
-  mauve: string;
-  red: string;
-  blue: string;
-  overlay0: string;
+  accentAlt: string;
+  error: string;
+  accent: string;
+  faint: string;
   // Overlay scheme colors (override theme CSS colors when set)
   tracerouteForward?: string;
   tracerouteReturn?: string;
@@ -717,7 +717,7 @@ export function useTraceroutePaths({
         segments={renderSegments}
         snrColors={themeColors.snrColors ?? FALLBACK_SNR_COLORS}
         colorMode="snr"
-        mqttColor={themeColors.mqttSegment ?? themeColors.overlay0}
+        mqttColor={themeColors.mqttSegment ?? themeColors.faint}
         curvature={0}
         weight={seg => weightByUsage(seg.usageCount ?? 1)}
         opacity={seg => getSegmentSnrOpacity(seg.snrSamples, seg.isMqtt)}
@@ -727,7 +727,7 @@ export function useTraceroutePaths({
         segmentClassName={baseSegmentClassName}
       />,
     ];
-  }, [showPaths, traceroutesDigest, nodesPositionDigest, distanceUnit, maxNodeAgeHours, themeColors.snrColors, themeColors.mqttSegment, themeColors.overlay0, callbacks, visibleNodeNums, mapZoom, liveNodePositions]);
+  }, [showPaths, traceroutesDigest, nodesPositionDigest, distanceUnit, maxNodeAgeHours, themeColors.snrColors, themeColors.mqttSegment, themeColors.faint, callbacks, visibleNodeNums, mapZoom, liveNodePositions]);
 
   // Separate memoization for selected node traceroute (showRoute)
   // This can change independently without re-rendering the base map markers
@@ -849,8 +849,8 @@ export function useTraceroutePaths({
           snrColors={themeColors.snrColors ?? FALLBACK_SNR_COLORS}
           colorMode="fixed-leg"
           legColors={{
-            forward: themeColors.tracerouteForward ?? themeColors.blue,
-            return: themeColors.tracerouteReturn ?? themeColors.red,
+            forward: themeColors.tracerouteForward ?? themeColors.accent,
+            return: themeColors.tracerouteReturn ?? themeColors.error,
           }}
           curvature={0.2}
           weight={tracerouteSegmentWeight}
@@ -864,7 +864,7 @@ export function useTraceroutePaths({
       logger.error('Error rendering selected node traceroute:', error);
       return null;
     }
-  }, [showRoute, selectedNodeId, traceroutesDigest, nodesPositionDigest, currentNodeId, distanceUnit, themeColors.red, themeColors.blue, themeColors.tracerouteForward, themeColors.tracerouteReturn, themeColors.snrColors, liveNodePositions]);
+  }, [showRoute, selectedNodeId, traceroutesDigest, nodesPositionDigest, currentNodeId, distanceUnit, themeColors.error, themeColors.accent, themeColors.tracerouteForward, themeColors.tracerouteReturn, themeColors.snrColors, liveNodePositions]);
 
   // Compute the set of node numbers involved in the selected traceroute.
   // Used for filtering map markers to only show nodes in the active

--- a/src/styles/semanticTokens.test.ts
+++ b/src/styles/semanticTokens.test.ts
@@ -473,6 +473,27 @@ describe('raw palette references outside App.css', () => {
     expect(Array.from(new Set(raw))).toEqual([]);
   });
 
+  it('has no script reading a palette var back out of the computed style', () => {
+    // A fourth spelling, and the only one that survives in JS rather than CSS:
+    // `getComputedStyle(root).getPropertyValue('--ctp-base')`. Charts used it to
+    // pass colors to Recharts and Leaflet, which cannot take a `var()`.
+    //
+    // It is the most dangerous spelling of the lot. Every call site guarded on
+    // truthiness — `if (base && surface0 && text) setChartColors(...)` — so once
+    // the palette layer goes away the read returns '', the guard fails, and the
+    // component keeps its hardcoded Mocha fallback forever. No error, no blank
+    // chart, just colors frozen to one theme.
+    const offenders: string[] = [];
+    for (const file of walk(resolve('src'))) {
+      if (!/\.(ts|tsx)$/.test(file)) continue;
+      const text = stripComments(readFileSync(file, 'utf8'));
+      for (const m of text.matchAll(/getPropertyValue\(\s*['"](--ctp-[A-Za-z0-9-]+)/g)) {
+        offenders.push(`${m[1]} (${file.replace(resolve('.') + '/', '')})`);
+      }
+    }
+    expect(Array.from(new Set(offenders))).toEqual([]);
+  });
+
   it('references no --ctp-* var that nothing defines', () => {
     // The sharper guard, and the one that would have caught both shipped bugs:
     // `--ctp-red-rgb` (#4617) and `--ctp-yellow-soft` were never defined


### PR DESCRIPTION
**Phase 3a — a prerequisite for the schema flip, not the flip itself.**

While mapping the theme system for Phase 3, I found a **fourth spelling** of the defect that #4617, #4619 and #4620 have been chasing — and the one that would have broken things worst.

## The problem

Recharts and Leaflet can't accept a CSS `var()`, so charts read colors back out of the computed style. 25 of those reads, across 8 files, still asked for palette vars:

```js
const base     = rootStyle.getPropertyValue('--ctp-base').trim();
const surface0 = rootStyle.getPropertyValue('--ctp-surface0').trim();
const text     = rootStyle.getPropertyValue('--ctp-text').trim();
if (base && surface0 && text) setChartColors({ base, surface0, text });
```

Look at that guard. **Phase 3b deletes `--ctp-*`.** The moment it does, every one of these reads returns `''`, the truthiness check fails, and the component silently keeps its hardcoded Mocha fallback — forever.

No error. No blank chart. No console warning. Just every chart's background, gridline and label colour frozen to one theme while the rest of the app themes correctly around them. That's the worst failure mode of the five spellings so far, and it's the reason this is a separate PR that lands first.

## What changed

All 25 reads now ask for the role token they were already standing in for:

| was | now |
|---|---|
| `--ctp-base` | `--color-bg` |
| `--ctp-surface0` | `--color-surface` |
| `--ctp-text` | `--color-text` |
| `--ctp-mauve` | `--color-accent-alt` |
| `--ctp-red` | `--color-error` |
| `--ctp-blue` | `--color-accent` |
| `--ctp-overlay0` | `--color-text-faint` |

Keys that named a palette colour rather than its meaning are renamed alongside: `surface0`→`surface`, `mauve`→`accentAlt`, `overlay0`→`faint`, `red`/`blue`→`error`/`accent`.

That includes the exported **`ThemeColors`** interface and its consumers in `useTraceroutePaths` — deliberately, so the compiler checks every use site including the memo dependency arrays. A stale `themeColors.red` would otherwise be a silent rendering bug rather than a build error. `npx tsc --noEmit`: **0 errors**.

## Guard

New test catching this spelling, verified by reintroducing one read into `SmartHopsChart` → fails; reverted → passes.

## Deliberately not covered

Mocha hex literals as `useState` fallbacks (`surface: '#45475a'`) — a **fifth** spelling. They're transient, replaced by the effect on mount, and a hex detector would have to distinguish them from theme definitions, which are legitimately hex. Left alone rather than half-guarded, and called out here so the guard suite isn't read as total.

## Verification

- Full Vitest suite: `success: true`, **13,806 passed / 0 failed / 0 suites failed** (+1, the new guard).
- `npx tsc --noEmit`: 0 errors.
- `npm run lint:ci`: 0 in-repo failures.

## Next

**Phase 3b** — flip `REQUIRED_THEME_COLORS` to role names, expose `--chart-N`/`--seq-N` for authoring, add the translator for stored palette-keyed themes, and delete `--ctp-*`. That's the change that actually answers the original complaint: users shouldn't have to map "blue" to `#ff0000` to get a red accent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf