### PR TITLE
fix(meshcore): verify out_path write on lost ack instead of failing (#4625)

### DIFF
--- a/src/server/meshcoreManager.setContactOutPathTimeout.test.ts
+++ b/src/server/meshcoreManager.setContactOutPathTimeout.test.ts
@@ -86,6 +86,19 @@ describe('MeshCoreManager.setContactOutPath — lost-ack verification (#4625)', 
     expect(ok).toBe(false);
   });
 
+  it('returns false (not an uncaught throw) when verification itself fails to reach the device', async () => {
+    const m = makeManager();
+    (m as any).sendBridgeCommand = vi.fn(async (cmd: string) => {
+      if (cmd === 'set_out_path') return { id: '1', success: false, error: TIMEOUT_ERROR };
+      if (cmd === 'get_contacts') throw new Error('bridge command channel closed');
+      return { id: '1', success: true, data: {} };
+    });
+
+    const ok = await m.setContactOutPath(TARGET_KEY, Uint8Array.from([0xa3, 0x7f, 0x02]), 1);
+
+    expect(ok).toBe(false);
+  });
+
   it('returns false without calling get_contacts when the device explicitly rejects (non-timeout)', async () => {
     const m = makeManager();
     const calls: string[] = [];

--- a/src/server/meshcoreManager.setContactOutPathTimeout.test.ts
+++ b/src/server/meshcoreManager.setContactOutPathTimeout.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression tests for MeshCoreManager.setContactOutPath's lost-ack handling (#4625).
+ *
+ * meshcore.js resolves CMD_ADD_UPDATE_CONTACT on the device's Ok ack, but that ack
+ * is frequently lost in radio chatter even though the device applied the write.
+ * Previously a lost ack (bridge command timeout) was reported straight to the
+ * caller as failure, which surfaced to the UI as "Set out_path failed — the
+ * device did not respond in time" (issue #4625) even when the path had actually
+ * been written. setContactOutPath now re-reads the contact via get_contacts on a
+ * timeout and only reports failure if the device-side path still doesn't match
+ * what was sent.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const upsertNode = vi.fn().mockResolvedValue(undefined);
+const getNodesBySource = vi.fn().mockResolvedValue([]);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      upsertNode: (...args: unknown[]) => upsertNode(...args),
+      getNodesBySource: (...args: unknown[]) => getNodesBySource(...args),
+    },
+  },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: new Proxy({}, { get: () => vi.fn() }),
+}));
+
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+const TARGET_KEY = 'a'.repeat(64);
+const TIMEOUT_ERROR = 'Native command timeout: set_out_path';
+
+function makeManager(): MeshCoreManager {
+  const m = new MeshCoreManager('src-a');
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  (m as any).connected = true;
+  return m;
+}
+
+describe('MeshCoreManager.setContactOutPath — lost-ack verification (#4625)', () => {
+  beforeEach(() => {
+    upsertNode.mockClear();
+    getNodesBySource.mockClear();
+  });
+
+  it('reports success when the ack times out but get_contacts confirms the path was applied', async () => {
+    const m = makeManager();
+    (m as any).sendBridgeCommand = vi.fn(async (cmd: string) => {
+      if (cmd === 'set_out_path') return { id: '1', success: false, error: TIMEOUT_ERROR };
+      if (cmd === 'get_contacts') {
+        return {
+          id: '1',
+          success: true,
+          data: [{ public_key: TARGET_KEY, adv_name: 'Repeater', out_path: 'a3,7f,02', path_len: 3 }],
+        };
+      }
+      return { id: '1', success: true, data: {} };
+    });
+
+    const ok = await m.setContactOutPath(TARGET_KEY, Uint8Array.from([0xa3, 0x7f, 0x02]), 1);
+
+    expect(ok).toBe(true);
+    expect(m.getContact(TARGET_KEY)?.outPath).toBe('a3,7f,02');
+  });
+
+  it('reports failure when the ack times out and get_contacts shows the path was never applied', async () => {
+    const m = makeManager();
+    (m as any).sendBridgeCommand = vi.fn(async (cmd: string) => {
+      if (cmd === 'set_out_path') return { id: '1', success: false, error: TIMEOUT_ERROR };
+      if (cmd === 'get_contacts') {
+        return {
+          id: '1',
+          success: true,
+          // Device still reports the old (empty) path — the write did not land.
+          data: [{ public_key: TARGET_KEY, adv_name: 'Repeater', out_path: '', path_len: 0 }],
+        };
+      }
+      return { id: '1', success: true, data: {} };
+    });
+
+    const ok = await m.setContactOutPath(TARGET_KEY, Uint8Array.from([0xa3, 0x7f, 0x02]), 1);
+
+    expect(ok).toBe(false);
+  });
+
+  it('returns false without calling get_contacts when the device explicitly rejects (non-timeout)', async () => {
+    const m = makeManager();
+    const calls: string[] = [];
+    (m as any).sendBridgeCommand = vi.fn(async (cmd: string) => {
+      calls.push(cmd);
+      if (cmd === 'set_out_path') return { id: '1', success: false, error: 'Device rejected write' };
+      return { id: '1', success: true, data: {} };
+    });
+
+    const ok = await m.setContactOutPath(TARGET_KEY, Uint8Array.from([0xa3]), 1);
+
+    expect(ok).toBe(false);
+    expect(calls).toEqual(['set_out_path']);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -4564,9 +4564,12 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
             return false;
           }
           logger.debug(`[MeshCore] set_out_path verified applied for ${publicKey} despite lost ack`);
-          // Falls through to the shared success path below — refreshContacts()
-          // already mirrored the verified contact, but re-run it so lastSeen/
-          // events stay consistent with the non-timeout success path.
+          // Falls through to the shared success path below. refreshContacts()
+          // already wrote the device-reported outPath onto the contact (which
+          // is what we just compared against `hex`), but the fall-through still
+          // matters: it's what fires `contacts_updated`/emitMeshCoreContactUpdated
+          // and stamps lastSeen with Date.now() instead of the device's
+          // (possibly stale) last-advert epoch.
         } else {
           logger.warn(`[MeshCore] set_out_path rejected for ${publicKey}: ${response.error}`);
           return false;

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -4520,6 +4520,27 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         out_path: outPathBytes,
         hash_bytes: hashBytes,
       }, timeoutMs);
+      // Group the flat byte buffer into hashBytes-wide hop tokens so the
+      // mirrored outPath string carries the per-hop width (e.g. "a3f2,7f01"
+      // for a 2-byte path) and pathLen reflects hop COUNT, not byte count.
+      // formatOutPath() (meshcoreNativeBackend.ts) drops all-zero hop tokens
+      // when it decodes a device-reported path, so mirror that here too —
+      // otherwise the verification compare below can false-negative on a
+      // (vanishingly unlikely but possible) all-zero hop hash.
+      const hopCount = outPathBytes.length / hashBytes;
+      const hopTokens: string[] = [];
+      for (let i = 0; i + hashBytes <= outPathBytes.length; i += hashBytes) {
+        let allZero = true;
+        let tok = '';
+        for (let j = 0; j < hashBytes; j++) {
+          const b = outPathBytes[i + j];
+          if (b !== 0) allZero = false;
+          tok += b.toString(16).padStart(2, '0');
+        }
+        if (allZero) continue;
+        hopTokens.push(tok);
+      }
+      const hex = hopTokens.join(',');
       if (!response.success) {
         // NOTE: matches on meshcore.js's timeout error text — fragile if the
         // library changes its wording; revisit if a structured error code lands.
@@ -4527,28 +4548,30 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         if (isTimeout) {
           // meshcore.js resolves CMD_ADD_UPDATE_CONTACT on its Ok ack, which is
           // frequently lost in unrelated radio chatter even though the device
-          // applied the write. Treat a timeout as a non-fatal "ack not seen" —
-          // not a connectivity error — so it doesn't spam warnings on a path
-          // that did install (e.g. region discovery, #3743).
-          logger.debug(`[MeshCore] set_out_path ack not seen for ${publicKey} (write likely applied)`);
+          // applied the write. A lost ack used to be reported to the caller as
+          // an outright failure (409 "device did not respond in time", #4625)
+          // even when the write had actually landed — verify by re-reading the
+          // contact from the device instead of guessing.
+          logger.debug(`[MeshCore] set_out_path ack not seen for ${publicKey}; verifying via get_contacts`);
+          try {
+            await this.refreshContacts();
+          } catch (refreshError) {
+            logger.debug(`[MeshCore] set_out_path verification refresh failed for ${publicKey}: ${(refreshError as Error).message}`);
+          }
+          const verified = this.contacts.get(publicKey);
+          if (!verified || verified.outPath !== hex) {
+            logger.warn(`[MeshCore] set_out_path could not be verified for ${publicKey} after a lost ack; the write may not have applied`);
+            return false;
+          }
+          logger.debug(`[MeshCore] set_out_path verified applied for ${publicKey} despite lost ack`);
+          // Falls through to the shared success path below — refreshContacts()
+          // already mirrored the verified contact, but re-run it so lastSeen/
+          // events stay consistent with the non-timeout success path.
         } else {
           logger.warn(`[MeshCore] set_out_path rejected for ${publicKey}: ${response.error}`);
+          return false;
         }
-        return false;
       }
-      // Group the flat byte buffer into hashBytes-wide hop tokens so the
-      // mirrored outPath string carries the per-hop width (e.g. "a3f2,7f01"
-      // for a 2-byte path) and pathLen reflects hop COUNT, not byte count.
-      const hopCount = outPathBytes.length / hashBytes;
-      const hopTokens: string[] = [];
-      for (let i = 0; i + hashBytes <= outPathBytes.length; i += hashBytes) {
-        let tok = '';
-        for (let j = 0; j < hashBytes; j++) {
-          tok += outPathBytes[i + j].toString(16).padStart(2, '0');
-        }
-        hopTokens.push(tok);
-      }
-      const hex = hopTokens.join(',');
       const existing = this.contacts.get(publicKey);
       if (existing) {
         const updated: MeshCoreContact = {


### PR DESCRIPTION
## Summary

- Fixes #4625 — `PUT /contacts/:publicKey/out-path` (manual forwarding-path set) was returning a 409 "Set out_path failed — the device did not respond in time" even in cases where the write had actually landed on the device.
- `MeshCoreManager.setContactOutPath()` sends `CMD_ADD_UPDATE_CONTACT` via `set_out_path` and waits for meshcore.js to resolve on the firmware's ack. That ack is frequently lost in radio chatter even though the device applied the write (this was already known — see #3664, which shortened the timeout and reworded the error, but didn't change the fact that a lost ack was still reported as an outright failure).
- On an ack timeout, the manager now re-reads the contact from the device via `get_contacts` and compares the reported forwarding path against what was just sent. A match is treated as a verified success (mirrors local state as before); only a genuine mismatch, or an explicit device rejection (non-timeout error), is reported as a failure.
- Also aligned the mirrored `outPath` hex formatting with `formatOutPath()`'s existing all-zero-hop-token skip, so the verification compare (and the locally mirrored value) matches what a subsequent `get_contacts` refresh would report.

## Root cause

Traced in `src/server/meshcoreManager.ts` `setContactOutPath()`: the timeout branch already had a comment acknowledging "the device applied the write" but still unconditionally `return false`d, which the route layer (`meshcoreContactsRoutes.ts`) turns into a 409 shown to the user.

## Test plan

- [x] Added `src/server/meshcoreManager.setContactOutPathTimeout.test.ts` covering: (1) verified-success-after-timeout, (2) genuine-failure-after-timeout (device path still doesn't match), (3) explicit device rejection short-circuits without calling `get_contacts`.
- [x] `npx vitest run src/server/meshcoreManager` — 47 files / 453 tests passing.
- [x] `npx vitest run src/server/routes/meshcore` — 8 files / 336 tests passing.
- [x] `npx tsc --noEmit -p tsconfig.server.json` — clean.
- [x] `npm run lint:ci` — gate passes, no new violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RKrgswyzCy29Z2bBELFca

---
_Generated by [Claude Code](https://claude.ai/code/session_016RKrgswyzCy29Z2bBELFca)_