### PR TITLE
chore(release): bump to 4.14.1-rc2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.14.1-rc1",
+  "version": "4.14.1-rc2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.14.1-rc1",
+  "version": "4.14.1-rc2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.14.1-rc1
-appVersion: "4.14.1-rc1"
+version: 4.14.1-rc2
+appVersion: "4.14.1-rc2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.1-rc1",
+  "version": "4.14.1-rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.14.1-rc1",
+      "version": "4.14.1-rc2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.1-rc1",
+  "version": "4.14.1-rc2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump only — no functional change.

## Files

All five, per the versioning checklist:

| file | |
|---|---|
| `package.json` | 4.14.1-rc1 → 4.14.1-rc2 |
| `package-lock.json` | regenerated with `--package-lock-only` |
| `helm/meshmonitor/Chart.yaml` | `version` **and** `appVersion` |
| `desktop/package.json` | |
| `desktop/src-tauri/tauri.conf.json` | |

The lock diff is the two version fields and nothing else — no dependency churn.

## What's in rc2

Since `v4.14.1-rc1`, almost entirely the semantic-colour epic (#4567), finished across six PRs:

- **#4617** — tinted backgrounds ignored the active theme (`--ctp-*-rgb` was defined nowhere, so every tint rendered hardcoded Catppuccin Mocha in all 15 themes)
- **#4619** — retired the last raw palette references from components
- **#4620** — replaced 87 hardcoded palette swatches written as `rgba()` literals
- **#4622** — charts read role tokens instead of palette vars from the computed style
- **#4623** — **the schema flip**: themes are authored by role
- **#4624** — gallery regenerated against the new stylesheet

Plus **#4621**, making `replaceAnchors` atomic in position estimation.

## The one thing worth calling out for release notes

#4623 changes the custom-theme format. A theme is now:

```jsonc
{ "accent": "#ff0000", "bg": "#1e1e2e", "textFaint": "#6c7086" }
```

rather than 26 Catppuccin swatch names, where getting a red accent meant writing `blue: "#ff0000"`.

**Existing themes keep working.** Stored definitions in the swatch format are translated on read — nothing is rewritten on disk, and the translation is one-way and non-destructive, so downgrading is safe. Verified value-identical on #4623 by resolving both stylesheets through a browser cascade: 15 themes × 39 tokens, 0 differences.

## Labels

Carries `system-test` — this repo runs hardware system tests on release version-bump chores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf