### PR TITLE
fix: clear auto-traceroute and auto-time-sync allowlists on node purge

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1673,6 +1673,7 @@
   "settings.confirm_purge_nodes_item1": "All node information will be deleted",
   "settings.confirm_purge_nodes_item2": "All traceroute history will be deleted",
   "settings.confirm_purge_nodes_item3": "A node refresh will be triggered to repopulate the list",
+  "settings.confirm_purge_nodes_item4": "Auto-Traceroute and Auto-Time-Sync node selections will be cleared",
   "settings.confirm_cannot_undo": "This action cannot be undone!",
   "settings.confirm_purge_telemetry_title": "Are you sure you want to purge all telemetry data?",
   "settings.confirm_purge_telemetry_item1": "All historical telemetry records will be deleted",

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -1263,7 +1263,11 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       t('settings.confirm_purge_nodes_impact') + '\n' +
       '• ' + t('settings.confirm_purge_nodes_item1') + '\n' +
       '• ' + t('settings.confirm_purge_nodes_item2') + '\n' +
-      '• ' + t('settings.confirm_purge_nodes_item3') + '\n\n' +
+      '• ' + t('settings.confirm_purge_nodes_item3') + '\n' +
+      // #4629: the purge now also clears the Auto-Traceroute / Auto-Time-Sync
+      // node allowlists. That is a curated selection the user built by hand, so
+      // it has to be named in the impact list rather than vanishing silently.
+      '• ' + t('settings.confirm_purge_nodes_item4') + '\n\n' +
       t('settings.confirm_cannot_undo')
     );
 

--- a/src/services/database.purgeAllNodes.test.ts
+++ b/src/services/database.purgeAllNodes.test.ts
@@ -105,6 +105,36 @@ describe('DatabaseService.purgeAllNodesAsync — packet_log integration (#2637)'
   });
 });
 
+describe('DatabaseService.purgeAllNodesAsync — auto-traceroute/time-sync allowlists (#4629)', () => {
+  beforeAll(async () => {
+    await databaseService.waitForReady();
+    for (let i = 0; i < 50 && !databaseService.autoTracerouteRepo; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+  });
+
+  it('clears the auto-traceroute and auto-time-sync node allowlists so purged nodes do not linger as orphaned selections', async () => {
+    // Seed two real nodes and explicitly select them for auto-traceroute + auto-time-sync
+    await databaseService.upsertNodeAsync({ nodeNum: 5001, nodeId: '!00001389', longName: 'Gamma', shortName: 'G' });
+    await databaseService.upsertNodeAsync({ nodeNum: 5002, nodeId: '!0000138a', longName: 'Delta', shortName: 'D' });
+
+    await databaseService.autoTraceroute.setAutoTracerouteNodes([5001, 5002]);
+    await databaseService.timeSync.setAutoTimeSyncNodes([5001, 5002]);
+
+    expect(await databaseService.autoTraceroute.getAutoTracerouteNodes()).toEqual([5001, 5002]);
+    expect(await databaseService.timeSync.getAutoTimeSyncNodes()).toEqual([5001, 5002]);
+
+    // Exercise the actual code path under test
+    await databaseService.purgeAllNodesAsync();
+
+    // The explicit allowlists must be empty — this is the #4629 regression assertion.
+    // Without the fix these survive the purge (and a container restart) because
+    // they're stored in their own tables, decoupled from `nodes`.
+    expect(await databaseService.autoTraceroute.getAutoTracerouteNodes()).toEqual([]);
+    expect(await databaseService.timeSync.getAutoTimeSyncNodes()).toEqual([]);
+  });
+});
+
 describe('DatabaseService.deleteNodeAsync — packet_log integration (#2637)', () => {
   beforeAll(async () => {
     await databaseService.waitForReady();

--- a/src/services/database.purgeAllNodes.test.ts
+++ b/src/services/database.purgeAllNodes.test.ts
@@ -111,6 +111,12 @@ describe('DatabaseService.purgeAllNodesAsync — auto-traceroute/time-sync allow
     for (let i = 0; i < 50 && !databaseService.autoTracerouteRepo; i++) {
       await new Promise((r) => setTimeout(r, 20));
     }
+    // Assert rather than fall through: purgeAllNodesAsync guards both clears
+    // behind `if (this.<repo>)`, so an uninitialised repo would make the fix a
+    // silent no-op and the failure would surface later as a confusing error
+    // instead of "the repo never came up".
+    expect(databaseService.autoTracerouteRepo).toBeTruthy();
+    expect(databaseService.timeSyncRepo).toBeTruthy();
   });
 
   it('clears the auto-traceroute and auto-time-sync node allowlists so purged nodes do not linger as orphaned selections', async () => {
@@ -132,6 +138,27 @@ describe('DatabaseService.purgeAllNodesAsync — auto-traceroute/time-sync allow
     // they're stored in their own tables, decoupled from `nodes`.
     expect(await databaseService.autoTraceroute.getAutoTracerouteNodes()).toEqual([]);
     expect(await databaseService.timeSync.getAutoTimeSyncNodes()).toEqual([]);
+  });
+
+  // The test above purges globally, but EVERY production caller passes a
+  // sourceId (purgeRoutes.ts, sourceRoutes.ts, deviceRoutes.ts), so the scoped
+  // branch is the one users actually hit. It takes a different path through the
+  // repos — `delete ... where sourceId = ?` instead of an unfiltered delete —
+  // and getting it wrong in the other direction (wiping every source's
+  // selection when one source is purged) would be a worse bug than #4629.
+  it('scoped to one source, clears only that source and leaves other sources selected', async () => {
+    await databaseService.autoTraceroute.setAutoTracerouteNodes([7001], 'srcA');
+    await databaseService.autoTraceroute.setAutoTracerouteNodes([7002], 'srcB');
+    await databaseService.timeSync.setAutoTimeSyncNodes([7001], 'srcA');
+    await databaseService.timeSync.setAutoTimeSyncNodes([7002], 'srcB');
+
+    await databaseService.purgeAllNodesAsync('srcA');
+
+    expect(await databaseService.autoTraceroute.getAutoTracerouteNodes('srcA')).toEqual([]);
+    expect(await databaseService.timeSync.getAutoTimeSyncNodes('srcA')).toEqual([]);
+    // Cross-source isolation — purging A must not disturb B's selection.
+    expect(await databaseService.autoTraceroute.getAutoTracerouteNodes('srcB')).toEqual([7002]);
+    expect(await databaseService.timeSync.getAutoTimeSyncNodes('srcB')).toEqual([7002]);
   });
 });
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -3435,6 +3435,25 @@ class DatabaseService {
           logger.error('Failed to purge ATAK contacts during purge:', err);
         }
       }
+      // Clear the auto-traceroute and auto-time-sync explicit node allowlists so
+      // purged nodes don't linger as orphaned selections (issue #4629) — these
+      // are separate persisted tables, not derived from the `nodes` table, so
+      // they survive a node purge (and a container restart) unless cleared here.
+      if (this.autoTracerouteRepo) {
+        try {
+          await this.autoTracerouteRepo.setAutoTracerouteNodes([], sourceId);
+        } catch (err) {
+          logger.error('Failed to clear auto-traceroute node list during purge:', err);
+        }
+      }
+      if (this.timeSyncRepo) {
+        try {
+          await this.timeSyncRepo.setAutoTimeSyncNodes([], sourceId);
+        } catch (err) {
+          logger.error('Failed to clear auto-time-sync node list during purge:', err);
+        }
+      }
+
       // Finally delete the nodes themselves
       if (this.nodesRepo) {
         await this.nodesRepo.deleteAllNodes(sourceId);


### PR DESCRIPTION
## Summary
- `purgeAllNodesAsync` deleted messages, telemetry, traceroutes, neighbor info, packet log, ATAK contacts, and nodes, but never cleared the `auto_traceroute_nodes` / `auto_time_sync_nodes` tables — the explicit node allowlists backing the "Filter by specific nodes" option on Auto-Traceroute and Auto-Time-Sync.
- Those tables store an allowlist of `nodeNum`s independent of the `nodes` table, so after a full node-database purge (even with a container restart) the UI kept reporting the old selection count, and once the same physical nodes reappeared on the mesh, auto-traceroute/time-sync silently resumed targeting them.
- Fix: `purgeAllNodesAsync` (`src/services/database.ts`) now also calls `setAutoTracerouteNodes([], sourceId)` and `setAutoTimeSyncNodes([], sourceId)`, scoped the same way as the other purge steps (empty list = clear when scoped to a source, or delete all rows on a global admin purge).

Fixes #4629

## Test plan
- [x] Added a regression test in `src/services/database.purgeAllNodes.test.ts` that seeds two nodes, explicitly selects them for both auto-traceroute and auto-time-sync, purges, and asserts both allowlists come back empty.
- [x] `npx vitest run src/services/database.purgeAllNodes.test.ts src/db/repositories/autoTraceroute.test.ts src/db/repositories/timeSync.test.ts src/server/routes/purgeRoutes.test.ts` — all passing.
- [x] `npx tsc --noEmit -p tsconfig.server.json` — clean.
- [x] `npm run lint:ci` — no new ratchet failures.

-- Authored by Roger 🤓


---
_Generated by [Claude Code](https://claude.ai/code/session_01HrzRbptUSviv5GRCVjSTuV)_