### PR TITLE
feat: became-mobile and left-home automation triggers

### DIFF
--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -65,7 +65,7 @@ Every automation has exactly one trigger (the **WHEN**). Each trigger exposes a 
 | **A system event** | An engine/source lifecycle event | `System start`, `Source came online`, `Source went offline`, `Upgrade available` |
 | **A node enters/leaves a region** | A node crosses a geofence | `Enters` / `Leaves` / `Moves while inside (dwell)`, plus a map region editor |
 | **A watched node becomes mobile** | A hand-selected node flips from stationary → mobile | Multi-select of nodes (stationary candidates highlighted); MeshMonitor’s >100 m position-history heuristic |
-| **A watched node leaves its home position** | A hand-selected node moves farther than a threshold from its home/anchor | Multi-select of nodes, threshold in metres (default 100). Home is captured on first position and persists across restarts |
+| **A watched node leaves its home position** | A hand-selected node moves farther than a threshold from its home/anchor | Multi-select of nodes, threshold in metres (default 300). Home is seeded from position-history inliers when available (else first live fix); while within half the threshold, home is gently averaged. Saved automations can **Reset homes from history** |
 
 ### Became mobile & left home (tamper / theft monitoring)
 

--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -64,6 +64,18 @@ Every automation has exactly one trigger (the **WHEN**). Each trigger exposes a 
 | **On a schedule** | A cron expression fires | 5-field cron expression |
 | **A system event** | An engine/source lifecycle event | `System start`, `Source came online`, `Source went offline`, `Upgrade available` |
 | **A node enters/leaves a region** | A node crosses a geofence | `Enters` / `Leaves` / `Moves while inside (dwell)`, plus a map region editor |
+| **A watched node becomes mobile** | A hand-selected node flips from stationary → mobile | Multi-select of nodes (stationary candidates highlighted); MeshMonitor’s >100 m position-history heuristic |
+| **A watched node leaves its home position** | A hand-selected node moves farther than a threshold from its home/anchor | Multi-select of nodes, threshold in metres (default 100). Home is captured on first position and persists across restarts |
+
+### Became mobile & left home (tamper / theft monitoring)
+
+These two triggers are designed for fleets of **stationary** GPS nodes (rooftops, towers, gateways).
+
+- **Watch nodes** — hand-select the nodes to monitor. The picker lists MeshMonitor’s stationary nodes (`mobile = 0`) first with a **Stationary** badge, and offers **Select all stationary**. Mobile nodes remain selectable.
+- **Became mobile** — fires when MeshMonitor’s mobility flag flips from `0` → `1` (the bounding box of recent GPS history spans more than 100 m). Good for “this site started moving”.
+- **Left home** — on the first position after you add a node to the rule, MeshMonitor stores that fix as the node’s **home** for this automation. Later fixes farther than **Threshold (metres)** fire the automation. Returning within the threshold re-arms it. Homes are stored in the database so a MeshMonitor restart does not silently re-home a stolen node.
+- Prefer **Cooldown applies to = node** so one stolen site does not suppress alerts for the rest of the fleet.
+- Pair with **Send a message** (channel) and/or **Send a notification** (Apprise) actions.
 
 ### Message trigger & channel-name matching
 

--- a/src/cli/migrationTables.ts
+++ b/src/cli/migrationTables.ts
@@ -102,11 +102,13 @@ export const TABLE_ORDER = [
   'dead_drop_messages',
   // 3653: global Automation Engine tables. No sourceId / no FK to users; the
   // run-log FKs to automations and variable values FK to automation_variables,
-  // so parents precede children here.
+  // so parents precede children here. Home anchors (left-home trigger) are
+  // keyed by automationId + nodeNum, so they follow automations.
   'automations',
   'automation_runs',
   'automation_variables',
   'automation_variable_values',
+  'automation_home_anchors',
   // 3770: global MeshCore saved-regions catalog. No sourceId / no FK.
   'meshcore_saved_regions',
 ];

--- a/src/components/automations/AutomationBuilder.tsx
+++ b/src/components/automations/AutomationBuilder.tsx
@@ -7,7 +7,7 @@
  */
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { TRIGGERS, CONDITIONS, ACTIONS, BLOCK_BY_TYPE, fieldsFor, fieldVisible, type BlockDef, type FieldDef } from './catalog';
+import { TRIGGERS, CONDITIONS, ACTIONS, BLOCK_BY_TYPE, fieldsFor, fieldVisible, fieldPlaceholder, type BlockDef, type FieldDef } from './catalog';
 import type { WorkflowForm, FormBlock, Rule } from './compile';
 import SubstitutionsHelpDrawer from './SubstitutionsHelp';
 import GeofenceFieldInput from './GeofenceFieldInput';
@@ -80,16 +80,17 @@ function FieldInput({ field, value, onChange, variables, sources, channels, scri
   const { t } = useTranslation();
   let control;
   const varNames = variables.map((v) => v.name);
+  const placeholder = fieldPlaceholder(field, triggerType);
   switch (field.kind) {
     case 'number':
-      control = <input className="ae-input" type="number" value={(value ?? '') as string} placeholder={field.placeholder}
+      control = <input className="ae-input" type="number" value={(value ?? '') as string} placeholder={placeholder}
         onChange={(e) => onChange(e.target.value === '' ? '' : Number(e.target.value))} />;
       break;
     case 'textarea':
       control = field.tokens
-        ? <TokenTextField multiline value={(value ?? '') as string} placeholder={field.placeholder}
+        ? <TokenTextField multiline value={(value ?? '') as string} placeholder={placeholder}
             triggerType={triggerType} variableNames={varNames} onChange={onChange} />
-        : <textarea className="ae-textarea" value={(value ?? '') as string} placeholder={field.placeholder} onChange={(e) => onChange(e.target.value)} />;
+        : <textarea className="ae-textarea" value={(value ?? '') as string} placeholder={placeholder} onChange={(e) => onChange(e.target.value)} />;
       break;
     case 'select':
       control = (
@@ -157,7 +158,7 @@ function FieldInput({ field, value, onChange, variables, sources, channels, scri
       control = (
         <>
           <input className="ae-input" list="ae-regions" value={(value ?? '') as string}
-            placeholder={field.placeholder} onChange={(e) => onChange(e.target.value)} />
+            placeholder={placeholder} onChange={(e) => onChange(e.target.value)} />
           <datalist id="ae-regions">
             {regions.map((r) => <option key={r} value={r} />)}
           </datalist>
@@ -222,9 +223,9 @@ function FieldInput({ field, value, onChange, variables, sources, channels, scri
     }
     default:
       control = field.tokens
-        ? <TokenTextField value={(value ?? '') as string} placeholder={field.placeholder}
+        ? <TokenTextField value={(value ?? '') as string} placeholder={placeholder}
             triggerType={triggerType} variableNames={varNames} onChange={onChange} />
-        : <input className="ae-input" value={(value ?? '') as string} placeholder={field.placeholder} onChange={(e) => onChange(e.target.value)} />;
+        : <input className="ae-input" value={(value ?? '') as string} placeholder={placeholder} onChange={(e) => onChange(e.target.value)} />;
   }
   return (
     <div className="ae-field">

--- a/src/components/automations/AutomationBuilder.tsx
+++ b/src/components/automations/AutomationBuilder.tsx
@@ -11,6 +11,7 @@ import { TRIGGERS, CONDITIONS, ACTIONS, BLOCK_BY_TYPE, fieldsFor, fieldVisible, 
 import type { WorkflowForm, FormBlock, Rule } from './compile';
 import SubstitutionsHelpDrawer from './SubstitutionsHelp';
 import GeofenceFieldInput from './GeofenceFieldInput';
+import NodeMultiFieldInput, { type NodeMultiOption } from './NodeMultiFieldInput';
 import TokenTextField from './TokenTextField';
 import type { GeofenceShape } from '../auto-responder/types';
 import { UiIcon } from '../icons';
@@ -31,6 +32,7 @@ export interface UnifiedChannelOption {
   sources?: Array<{ sourceId: string; sourceName?: string; slot: number }>;
 }
 export interface ScriptOption { value: string; label: string; }
+export type { NodeMultiOption };
 
 /** Sendable = enabled and not an MQTT (receive-only) source. */
 const isSendableSource = (s: SourceOption): boolean =>
@@ -51,6 +53,7 @@ interface Props {
   channels: UnifiedChannelOption[];
   scripts: ScriptOption[];
   regions: string[];
+  nodes?: NodeMultiOption[];
   onChange: (form: WorkflowForm) => void;
 }
 
@@ -71,8 +74,8 @@ function defaultParams(type: string, triggerType: string): Record<string, unknow
   return params;
 }
 
-function FieldInput({ field, value, onChange, variables, sources, channels, scripts, regions, triggerType }: {
-  field: FieldDef; value: unknown; onChange: (v: unknown) => void; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; regions: string[]; triggerType: string;
+function FieldInput({ field, value, onChange, variables, sources, channels, scripts, regions, nodes, triggerType }: {
+  field: FieldDef; value: unknown; onChange: (v: unknown) => void; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; regions: string[]; nodes: NodeMultiOption[]; triggerType: string;
 }) {
   const { t } = useTranslation();
   let control;
@@ -134,6 +137,9 @@ function FieldInput({ field, value, onChange, variables, sources, channels, scri
       break;
     case 'geofence':
       control = <GeofenceFieldInput value={value as GeofenceShape | undefined} onChange={onChange} />;
+      break;
+    case 'nodeMulti':
+      control = <NodeMultiFieldInput value={value} onChange={onChange} nodes={nodes} />;
       break;
     case 'scriptselect':
       control = (
@@ -229,8 +235,8 @@ function FieldInput({ field, value, onChange, variables, sources, channels, scri
   );
 }
 
-function BlockFields({ block, triggerType, variables, sources, channels, scripts, regions, onParams }: {
-  block: FormBlock; triggerType: string; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; regions: string[]; onParams: (p: Record<string, unknown>) => void;
+function BlockFields({ block, triggerType, variables, sources, channels, scripts, regions, nodes, onParams }: {
+  block: FormBlock; triggerType: string; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; regions: string[]; nodes: NodeMultiOption[]; onParams: (p: Record<string, unknown>) => void;
 }) {
   const def = BLOCK_BY_TYPE[block.type];
   if (!def) return null;
@@ -238,15 +244,15 @@ function BlockFields({ block, triggerType, variables, sources, channels, scripts
     <>
       {def.fields.filter((f) => fieldVisible(f, block.params)).map((f) => {
         const field = f.kind === 'fieldselect' ? { ...f, groups: fieldsFor(block.type, triggerType) } : f;
-        return <FieldInput key={f.name} field={field} value={block.params[f.name]} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} triggerType={triggerType}
+        return <FieldInput key={f.name} field={field} value={block.params[f.name]} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} nodes={nodes} triggerType={triggerType}
           onChange={(v) => onParams({ ...block.params, [f.name]: v })} />;
       })}
     </>
   );
 }
 
-function BlockListEditor({ blocks, options, triggerType, variables, sources, channels, scripts, regions, onChange, addLabel }: {
-  blocks: FormBlock[]; options: BlockDef[]; triggerType: string; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; regions: string[];
+function BlockListEditor({ blocks, options, triggerType, variables, sources, channels, scripts, regions, nodes, onChange, addLabel }: {
+  blocks: FormBlock[]; options: BlockDef[]; triggerType: string; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; regions: string[]; nodes: NodeMultiOption[];
   onChange: (b: FormBlock[]) => void; addLabel: string;
 }) {
   const update = (i: number, b: FormBlock) => { const l = [...blocks]; l[i] = b; onChange(l); };
@@ -261,7 +267,7 @@ function BlockListEditor({ blocks, options, triggerType, variables, sources, cha
             </select>
             <button className="ae-btn ae-btn--ghost" onClick={() => onChange(blocks.filter((_, j) => j !== i))} aria-label="Remove block"><UiIcon name="close" size={15} /></button>
           </div>
-          <BlockFields block={b} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} onParams={(p) => update(i, { ...b, params: p })} />
+          <BlockFields block={b} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} nodes={nodes} onParams={(p) => update(i, { ...b, params: p })} />
         </div>
       ))}
       <button className="ae-btn" onClick={() => onChange([...blocks, { type: options[0].type, params: defaultParams(options[0].type, triggerType) }])}>{addLabel}</button>
@@ -269,7 +275,7 @@ function BlockListEditor({ blocks, options, triggerType, variables, sources, cha
   );
 }
 
-export default function AutomationBuilder({ form, variables, sources, channels, scripts, regions, onChange }: Props) {
+export default function AutomationBuilder({ form, variables, sources, channels, scripts, regions, nodes = [], onChange }: Props) {
   const triggerType = form.trigger.type;
   const [showHelp, setShowHelp] = useState(false);
   const setTrigger = (type: string) => onChange({ ...form, trigger: { type, params: defaultParams(type, type) } });
@@ -298,7 +304,7 @@ export default function AutomationBuilder({ form, variables, sources, channels, 
             </select>
             <div className="ae-help-text">{BLOCK_BY_TYPE[triggerType]?.description}</div>
           </div>
-          <BlockFields block={form.trigger} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} onParams={setTriggerParams} />
+          <BlockFields block={form.trigger} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} nodes={nodes} onParams={setTriggerParams} />
         </div>
       </div>
 
@@ -312,10 +318,10 @@ export default function AutomationBuilder({ form, variables, sources, channels, 
           <div className="ae-section-body">
             <div className="ae-field-label" style={{ marginBottom: '0.4rem' }}>IF — all of these are true (optional)</div>
             {rule.conditions.length === 0 && <div className="ae-muted" style={{ marginBottom: '0.5rem' }}>No conditions — runs every time the trigger fires.</div>}
-            <BlockListEditor blocks={rule.conditions} options={CONDITIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions}
+            <BlockListEditor blocks={rule.conditions} options={CONDITIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} nodes={nodes}
               onChange={(c) => updateRule(i, { ...rule, conditions: c })} addLabel="+ Add condition" />
             <div className="ae-field-label" style={{ margin: '0.9rem 0 0.4rem' }}>THEN — do this</div>
-            <BlockListEditor blocks={rule.actions} options={ACTIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions}
+            <BlockListEditor blocks={rule.actions} options={ACTIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} nodes={nodes}
               onChange={(a) => updateRule(i, { ...rule, actions: a })} addLabel="+ Add action" />
           </div>
         </div>
@@ -344,7 +350,7 @@ export default function AutomationBuilder({ form, variables, sources, channels, 
               <div className="ae-help-text">“Matched” means a rule’s IF conditions passed.</div>
             </div>
             <div className="ae-field-label" style={{ margin: '0.6rem 0 0.4rem' }}>THEN — do this</div>
-            <BlockListEditor blocks={form.combine.actions} options={ACTIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions}
+            <BlockListEditor blocks={form.combine.actions} options={ACTIONS} triggerType={triggerType} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} nodes={nodes}
               onChange={(a) => setCombine({ ...form.combine!, actions: a })} addLabel="+ Add action" />
           </div>
         </div>

--- a/src/components/automations/AutomationTester.leftHome.test.tsx
+++ b/src/components/automations/AutomationTester.leftHome.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Left-home Test panel input-mode helpers.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  leftHomeInputMode,
+  leftHomeModeHint,
+  leftHomeThresholdFromConfig,
+} from './AutomationTester';
+
+describe('leftHome test input helpers', () => {
+  it('reads threshold from the automation config (default 300)', () => {
+    expect(leftHomeThresholdFromConfig({
+      nodes: [{ type: 'trigger.leftHome', params: { thresholdMeters: 250 } }],
+    })).toBe(250);
+    expect(leftHomeThresholdFromConfig({ nodes: [{ type: 'trigger.leftHome', params: {} }] })).toBe(300);
+    expect(leftHomeThresholdFromConfig(null)).toBe(300);
+  });
+
+  it('coordinates win when home + current lat/lon are all set', () => {
+    expect(leftHomeInputMode(
+      { homeLat: '1', homeLon: '2', distanceMeters: '999' },
+      { latitude: '3', longitude: '4' },
+    )).toBe('coordinates');
+  });
+
+  it('falls back to distance when coords are incomplete', () => {
+    expect(leftHomeInputMode(
+      { homeLat: '1', distanceMeters: '80' },
+      { latitude: '3', longitude: '4' },
+    )).toBe('distance');
+    expect(leftHomeInputMode({ distanceMeters: '80' }, {})).toBe('distance');
+  });
+
+  it('hint names the active path and the automation threshold', () => {
+    const coords = leftHomeModeHint(
+      { homeLat: '1', homeLon: '2', distanceMeters: '999' },
+      { latitude: '3', longitude: '4' },
+      150,
+    );
+    expect(coords).toMatch(/150 m/);
+    expect(coords).toMatch(/coordinates/i);
+    expect(coords).toMatch(/ignored/i);
+
+    const dist = leftHomeModeHint({ distanceMeters: '80' }, {}, 150);
+    expect(dist).toMatch(/distance field/);
+    expect(dist).toMatch(/80/);
+  });
+});

--- a/src/components/automations/AutomationTester.leftHome.test.tsx
+++ b/src/components/automations/AutomationTester.leftHome.test.tsx
@@ -8,7 +8,7 @@ import {
   leftHomeInputMode,
   leftHomeModeHint,
   leftHomeThresholdFromConfig,
-} from './AutomationTester';
+} from './automationTesterHelpers';
 
 describe('leftHome test input helpers', () => {
   it('reads threshold from the automation config (default 300)', () => {

--- a/src/components/automations/AutomationTester.tsx
+++ b/src/components/automations/AutomationTester.tsx
@@ -53,10 +53,43 @@ function numOrUndef(v: string | undefined): number | undefined {
   return Number.isFinite(n) ? n : undefined;
 }
 
+/** Read thresholdMeters from the compiled leftHome trigger (default 300). */
+export function leftHomeThresholdFromConfig(config: unknown): number {
+  const nodes = (config as { nodes?: Array<{ type?: string; params?: Record<string, unknown> }> } | null)?.nodes;
+  const trigger = nodes?.find((n) => n.type === 'trigger.leftHome');
+  const thr = Number(trigger?.params?.thresholdMeters ?? 300);
+  return Number.isFinite(thr) && thr > 0 ? thr : 300;
+}
+
+/** Which leftHome dry-run input path is active given the Test panel fields. */
+export function leftHomeInputMode(ev: EventState, facts: FactState): 'coordinates' | 'distance' | 'none' {
+  const hasCoords =
+    numOrUndef(facts.latitude) != null &&
+    numOrUndef(facts.longitude) != null &&
+    numOrUndef(ev.homeLat) != null &&
+    numOrUndef(ev.homeLon) != null;
+  if (hasCoords) return 'coordinates';
+  if (numOrUndef(ev.distanceMeters) != null) return 'distance';
+  return 'none';
+}
+
+export function leftHomeModeHint(ev: EventState, facts: FactState, automationThreshold: number): string {
+  const mode = leftHomeInputMode(ev, facts);
+  const thr = `Threshold: ${automationThreshold} m (from the automation — not editable here).`;
+  if (mode === 'coordinates') {
+    return `${thr} Using home + current coordinates to compute distance. The distance field is ignored while all four coords are set.`;
+  }
+  if (mode === 'distance') {
+    return `${thr} Using the distance field (${ev.distanceMeters} m). Fill home lat/lon and current lat/lon to compute distance from coordinates instead (coordinates take precedence).`;
+  }
+  return `${thr} Set either (1) home lat/lon + current lat/lon, or (2) a distance in metres. Dry-run fires only when the node is on the watch list and distance > threshold.`;
+}
+
 export default function AutomationTester({ getConfig, variables, sources }: Props) {
   const cfg = getConfig();
   const triggerType = cfg.triggerType ?? '';
   const kind = KIND_BY_TRIGGER[triggerType] ?? 'message';
+  const automationThreshold = kind === 'leftHome' ? leftHomeThresholdFromConfig(cfg.config) : 300;
 
   const [ev, setEv] = useState<EventState>({});
   const [facts, setFacts] = useState<FactState>({});
@@ -89,15 +122,20 @@ export default function AutomationTester({ getConfig, variables, sources }: Prop
         return { ...base, nodeNum: numOrUndef(ev.nodeNum) };
       case 'becameMobile':
         return { ...base, nodeNum: numOrUndef(ev.nodeNum), previousMobile: 0, mobile: 1 };
-      case 'leftHome':
-        return {
-          ...base,
-          nodeNum: numOrUndef(ev.nodeNum),
-          distanceMeters: numOrUndef(ev.distanceMeters) ?? 250,
-          thresholdMeters: numOrUndef(ev.thresholdMeters) ?? 100,
-          homeLat: numOrUndef(ev.homeLat),
-          homeLon: numOrUndef(ev.homeLon),
-        };
+      case 'leftHome': {
+        // Never send thresholdMeters — the simulator always uses the automation's value.
+        // Distance is omitted when coordinates are complete (coords take precedence).
+        const out: Record<string, unknown> = { ...base, nodeNum: numOrUndef(ev.nodeNum) };
+        const homeLat = numOrUndef(ev.homeLat);
+        const homeLon = numOrUndef(ev.homeLon);
+        if (homeLat != null) out.homeLat = homeLat;
+        if (homeLon != null) out.homeLon = homeLon;
+        if (leftHomeInputMode(ev, facts) === 'distance') {
+          const dist = numOrUndef(ev.distanceMeters);
+          if (dist != null) out.distanceMeters = dist;
+        }
+        return out;
+      }
       default:
         return base; // schedule
     }
@@ -162,7 +200,12 @@ export default function AutomationTester({ getConfig, variables, sources }: Prop
             </select>
           </div>
         )}
-        {renderEventInputs(kind, ev, setEvField)}
+        {renderEventInputs(kind, ev, setEvField, {
+          facts,
+          setFact,
+          automationThreshold,
+          leftHomeHint: kind === 'leftHome' ? leftHomeModeHint(ev, facts, automationThreshold) : undefined,
+        })}
       </div>
 
       <button className="ae-btn ae-btn--ghost" style={{ marginTop: '0.4rem' }} onClick={() => setShowAdvanced((s) => !s)}>
@@ -234,7 +277,17 @@ const TELEMETRY_METRIC_OPTIONS: Array<{ value: string; label: string }> = [
   { value: 'airUtilTx', label: 'Air util TX' },
 ];
 
-function renderEventInputs(kind: string, ev: EventState, set: (k: string, v: string) => void) {
+function renderEventInputs(
+  kind: string,
+  ev: EventState,
+  set: (k: string, v: string) => void,
+  opts?: {
+    facts?: FactState;
+    setFact?: (k: string, v: string) => void;
+    automationThreshold?: number;
+    leftHomeHint?: string;
+  },
+) {
   const f = (label: string, key: string, type?: string) => (
     <Field label={label} value={ev[key]} onChange={(v) => set(key, v)} type={type} key={key} />
   );
@@ -270,15 +323,35 @@ function renderEventInputs(kind: string, ev: EventState, set: (k: string, v: str
       return <>{f('Node #', 'nodeNum', 'number')}<div className="ae-muted" style={{ alignSelf: 'end' }}>Set the node’s position under “Subject-node facts”.</div></>;
     case 'becameMobile':
       return <>{f('Node #', 'nodeNum', 'number')}<div className="ae-muted" style={{ alignSelf: 'end' }}>Simulates a stationary → mobile flip.</div></>;
-    case 'leftHome':
+    case 'leftHome': {
+      const facts = opts?.facts ?? {};
+      const setFact = opts?.setFact ?? (() => {});
+      const mode = leftHomeInputMode(ev, facts);
+      const thr = opts?.automationThreshold ?? 300;
       return <>
         {f('Node #', 'nodeNum', 'number')}
-        {f('Distance from home (m)', 'distanceMeters', 'number')}
-        {f('Threshold (m)', 'thresholdMeters', 'number')}
-        {f('Home lat', 'homeLat', 'number')}
-        {f('Home lon', 'homeLon', 'number')}
-        <div className="ae-muted" style={{ alignSelf: 'end' }}>Also set the node’s current position under “Subject-node facts”.</div>
+        <Field label="Home lat" value={ev.homeLat} onChange={(v) => set('homeLat', v)} type="number" />
+        <Field label="Home lon" value={ev.homeLon} onChange={(v) => set('homeLon', v)} type="number" />
+        <Field label="Current lat" value={facts.latitude} onChange={(v) => setFact('latitude', v)} type="number" />
+        <Field label="Current lon" value={facts.longitude} onChange={(v) => setFact('longitude', v)} type="number" />
+        <Field
+          label={mode === 'coordinates' ? 'Distance from home (m) — ignored (coords set)' : 'Distance from home (m)'}
+          value={ev.distanceMeters}
+          onChange={(v) => set('distanceMeters', v)}
+          type="number"
+        />
+        <div className="ae-field">
+          <label className="ae-field-label">Threshold (m)</label>
+          <input className="ae-input" type="number" value={thr} disabled readOnly title="From the automation trigger" />
+        </div>
+        <div className="ae-muted" style={{ gridColumn: '1 / -1' }}>
+          {opts?.leftHomeHint}
+          {mode === 'coordinates' && <div>Active input: <strong>coordinates</strong></div>}
+          {mode === 'distance' && <div>Active input: <strong>distance field</strong></div>}
+          {mode === 'none' && <div>Active input: <strong>none</strong> (treated as 0 m / still at home)</div>}
+        </div>
       </>;
+    }
     default:
       return <div className="ae-muted">No event input needed — this trigger has no payload.</div>;
   }
@@ -348,6 +421,18 @@ function TestResult({ result }: { result: SimResult }) {
           ? <span className={`ae-test-badge ae-test-badge--${statusCls}`}>Trigger matched · {result.status}</span>
           : <span className="ae-test-badge ae-test-badge--no">Trigger filtered out — would not fire</span>}
       </div>
+
+      {result.fields?.distanceSource != null && (
+        <div className="ae-muted" style={{ marginTop: '0.35rem' }}>
+          Left-home inputs:{' '}
+          {result.fields.distanceSource === 'coordinates' && 'distance computed from home + current coordinates'}
+          {result.fields.distanceSource === 'distance' && 'distance taken from the distance field'}
+          {result.fields.distanceSource === 'none' && 'no distance/coords supplied (0 m)'}
+          {' · '}
+          {String(result.fields.distanceMeters ?? '?')} m vs threshold {String(result.fields.thresholdMeters ?? '?')} m
+          {' '}(automation)
+        </div>
+      )}
 
       {result.matched && (
         <>

--- a/src/components/automations/AutomationTester.tsx
+++ b/src/components/automations/AutomationTester.tsx
@@ -10,6 +10,14 @@
 import { useState, type ReactNode } from 'react';
 import apiService from '../../services/api';
 import type { VariableOption, SourceOption } from './AutomationBuilder';
+import {
+  type EventState,
+  type FactState,
+  numOrUndef,
+  leftHomeThresholdFromConfig,
+  leftHomeInputMode,
+  leftHomeModeHint,
+} from './automationTesterHelpers';
 import SubstitutionsHelpDrawer from './SubstitutionsHelp';
 import { OUTCOME_META } from './outcomeMeta';
 import { UiIcon } from '../icons';
@@ -43,47 +51,6 @@ const KIND_BY_TRIGGER: Record<string, string> = {
   'trigger.leftHome': 'leftHome',
   'trigger.schedule': 'schedule',
 };
-
-type EventState = Record<string, string>;
-type FactState = Record<string, string>;
-
-function numOrUndef(v: string | undefined): number | undefined {
-  if (v === undefined || v === '') return undefined;
-  const n = Number(v);
-  return Number.isFinite(n) ? n : undefined;
-}
-
-/** Read thresholdMeters from the compiled leftHome trigger (default 300). */
-export function leftHomeThresholdFromConfig(config: unknown): number {
-  const nodes = (config as { nodes?: Array<{ type?: string; params?: Record<string, unknown> }> } | null)?.nodes;
-  const trigger = nodes?.find((n) => n.type === 'trigger.leftHome');
-  const thr = Number(trigger?.params?.thresholdMeters ?? 300);
-  return Number.isFinite(thr) && thr > 0 ? thr : 300;
-}
-
-/** Which leftHome dry-run input path is active given the Test panel fields. */
-export function leftHomeInputMode(ev: EventState, facts: FactState): 'coordinates' | 'distance' | 'none' {
-  const hasCoords =
-    numOrUndef(facts.latitude) != null &&
-    numOrUndef(facts.longitude) != null &&
-    numOrUndef(ev.homeLat) != null &&
-    numOrUndef(ev.homeLon) != null;
-  if (hasCoords) return 'coordinates';
-  if (numOrUndef(ev.distanceMeters) != null) return 'distance';
-  return 'none';
-}
-
-export function leftHomeModeHint(ev: EventState, facts: FactState, automationThreshold: number): string {
-  const mode = leftHomeInputMode(ev, facts);
-  const thr = `Threshold: ${automationThreshold} m (from the automation — not editable here).`;
-  if (mode === 'coordinates') {
-    return `${thr} Using home + current coordinates to compute distance. The distance field is ignored while all four coords are set.`;
-  }
-  if (mode === 'distance') {
-    return `${thr} Using the distance field (${ev.distanceMeters} m). Fill home lat/lon and current lat/lon to compute distance from coordinates instead (coordinates take precedence).`;
-  }
-  return `${thr} Set either (1) home lat/lon + current lat/lon, or (2) a distance in metres. Dry-run fires only when the node is on the watch list and distance > threshold.`;
-}
 
 export default function AutomationTester({ getConfig, variables, sources }: Props) {
   const cfg = getConfig();

--- a/src/components/automations/AutomationTester.tsx
+++ b/src/components/automations/AutomationTester.tsx
@@ -39,6 +39,8 @@ const KIND_BY_TRIGGER: Record<string, string> = {
   'trigger.nodeDiscovered': 'nodeDiscovered',
   'trigger.system': 'system',
   'trigger.geofence': 'geofence',
+  'trigger.becameMobile': 'becameMobile',
+  'trigger.leftHome': 'leftHome',
   'trigger.schedule': 'schedule',
 };
 
@@ -85,6 +87,17 @@ export default function AutomationTester({ getConfig, variables, sources }: Prop
         return { ...base, event: ev.event || undefined, latestVersion: ev.latestVersion || undefined, currentVersion: ev.currentVersion || undefined, reason: ev.reason || undefined };
       case 'geofence':
         return { ...base, nodeNum: numOrUndef(ev.nodeNum) };
+      case 'becameMobile':
+        return { ...base, nodeNum: numOrUndef(ev.nodeNum), previousMobile: 0, mobile: 1 };
+      case 'leftHome':
+        return {
+          ...base,
+          nodeNum: numOrUndef(ev.nodeNum),
+          distanceMeters: numOrUndef(ev.distanceMeters) ?? 250,
+          thresholdMeters: numOrUndef(ev.thresholdMeters) ?? 100,
+          homeLat: numOrUndef(ev.homeLat),
+          homeLon: numOrUndef(ev.homeLon),
+        };
       default:
         return base; // schedule
     }
@@ -255,6 +268,17 @@ function renderEventInputs(kind: string, ev: EventState, set: (k: string, v: str
       return <>{sel('Event', 'event', SYSTEM_EVENT_OPTIONS, 'bootup')}{f('Latest version', 'latestVersion')}{f('Current version', 'currentVersion')}</>;
     case 'geofence':
       return <>{f('Node #', 'nodeNum', 'number')}<div className="ae-muted" style={{ alignSelf: 'end' }}>Set the node’s position under “Subject-node facts”.</div></>;
+    case 'becameMobile':
+      return <>{f('Node #', 'nodeNum', 'number')}<div className="ae-muted" style={{ alignSelf: 'end' }}>Simulates a stationary → mobile flip.</div></>;
+    case 'leftHome':
+      return <>
+        {f('Node #', 'nodeNum', 'number')}
+        {f('Distance from home (m)', 'distanceMeters', 'number')}
+        {f('Threshold (m)', 'thresholdMeters', 'number')}
+        {f('Home lat', 'homeLat', 'number')}
+        {f('Home lon', 'homeLon', 'number')}
+        <div className="ae-muted" style={{ alignSelf: 'end' }}>Also set the node’s current position under “Subject-node facts”.</div>
+      </>;
     default:
       return <div className="ae-muted">No event input needed — this trigger has no payload.</div>;
   }

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -320,8 +320,8 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
           ? `Reset ${res.reset} home(s); seeded ${res.seeded} from position history.`
           : `Reset ${res.reset} home(s); seeded ${res.seeded} from history. No history yet for node #(s) ${pending.join(', ')} — next live fix will set those.`,
       );
-    } catch (e: any) {
-      setResetHomesMsg(e?.message ?? 'Failed to reset homes');
+    } catch (e) {
+      setResetHomesMsg(e instanceof Error ? e.message : 'Failed to reset homes');
     } finally {
       setResettingHomes(false);
     }

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { isValidCron } from 'cron-validator';
 import apiService from '../../services/api';
-import AutomationBuilder, { type VariableOption, type SourceOption, type UnifiedChannelOption, type ScriptOption } from './AutomationBuilder';
+import AutomationBuilder, { type VariableOption, type SourceOption, type UnifiedChannelOption, type ScriptOption, type NodeMultiOption } from './AutomationBuilder';
 import AutomationTester from './AutomationTester';
 import LiveTracePanel from './LiveTracePanel';
 import { UiIcon } from '../icons';
@@ -47,6 +47,18 @@ function validateForm(form: WorkflowForm): string[] {
     const shape = form.trigger.params.shape as { type?: string; vertices?: unknown[] } | undefined;
     if (!shape || (shape.type === 'polygon' && (shape.vertices?.length ?? 0) < 3)) {
       errs.push('Draw a geofence region (circle or polygon) on the map.');
+    }
+  }
+  if (form.trigger.type === 'trigger.becameMobile' || form.trigger.type === 'trigger.leftHome') {
+    const nums = form.trigger.params.nodeNums;
+    if (!Array.isArray(nums) || nums.length === 0) {
+      errs.push('Select at least one node to watch.');
+    }
+  }
+  if (form.trigger.type === 'trigger.leftHome') {
+    const thr = form.trigger.params.thresholdMeters;
+    if (thr != null && thr !== '' && !(Number(thr) > 0)) {
+      errs.push('Home-distance threshold must be greater than 0 metres.');
     }
   }
   if (form.trigger.type === 'trigger.schedule') {
@@ -168,6 +180,7 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
   const [channels, setChannels] = useState<UnifiedChannelOption[]>([]);
   const [scripts, setScripts] = useState<ScriptOption[]>([]);
   const [regions, setRegions] = useState<string[]>([]);
+  const [nodes, setNodes] = useState<NodeMultiOption[]>([]);
 
   // Decide builder vs JSON from the existing config.
   const parsedInitial = (() => { try { return initial ? decompile(JSON.parse(initial.config)) : DEFAULT_FORM; } catch { return null; } })();
@@ -215,6 +228,19 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
     apiService.get<{ regions: Array<{ name: string }> }>('/api/automations/regions')
       .then((r) => setRegions((r.regions ?? []).map((x) => x.name)))
       .catch(() => setRegions([]));
+    apiService.get<Array<{
+      nodeNum: number; longName?: string; shortName?: string; nodeId?: string;
+      mobile?: number; isMobile?: boolean;
+    }>>('/api/nodes')
+      .then((list) => setNodes((list ?? []).map((n) => ({
+        nodeNum: Number(n.nodeNum),
+        longName: n.longName,
+        shortName: n.shortName,
+        nodeId: n.nodeId,
+        mobile: n.mobile,
+        isMobile: n.isMobile,
+      }))))
+      .catch(() => setNodes([]));
   }, []);
 
   const switchToJson = () => { setJsonText(JSON.stringify(compile(form), null, 2)); setMode('json'); };
@@ -269,7 +295,7 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
       </div>
 
       {mode === 'builder'
-        ? <AutomationBuilder form={form} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} onChange={setForm} />
+        ? <AutomationBuilder form={form} variables={variables} sources={sources} channels={channels} scripts={scripts} regions={regions} nodes={nodes} onChange={setForm} />
         : (
           <div className="ae-field">
             <label className="ae-field-label">Workflow graph (JSON)</label>

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -229,17 +229,35 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
       .then((r) => setRegions((r.regions ?? []).map((x) => x.name)))
       .catch(() => setRegions([]));
     apiService.get<Array<{
-      nodeNum: number; longName?: string; shortName?: string; nodeId?: string;
-      mobile?: number; isMobile?: boolean;
+      nodeNum: number;
+      longName?: string;
+      shortName?: string;
+      nodeId?: string;
+      mobile?: number;
+      isMobile?: boolean;
+      user?: { id?: string; longName?: string; shortName?: string };
     }>>('/api/nodes')
-      .then((list) => setNodes((list ?? []).map((n) => ({
-        nodeNum: Number(n.nodeNum),
-        longName: n.longName,
-        shortName: n.shortName,
-        nodeId: n.nodeId,
-        mobile: n.mobile,
-        isMobile: n.isMobile,
-      }))))
+      .then((list) => {
+        const rows = Array.isArray(list) ? list : [];
+        setNodes(rows
+          .filter((n) => {
+            const num = Number(n.nodeNum);
+            // Drop broadcast / unset MeshCore stubs from the hand-picker.
+            return Number.isFinite(num) && num > 0 && num !== 0xffffffff;
+          })
+          .map((n) => {
+            const nodeNum = Number(n.nodeNum);
+            const nodeId = n.nodeId || n.user?.id || `!${(nodeNum >>> 0).toString(16).padStart(8, '0')}`;
+            return {
+              nodeNum,
+              longName: n.longName || n.user?.longName,
+              shortName: n.shortName || n.user?.shortName,
+              nodeId,
+              mobile: n.mobile,
+              isMobile: n.isMobile,
+            };
+          }));
+      })
       .catch(() => setNodes([]));
   }, []);
 

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -190,6 +190,8 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
   const [errors, setErrors] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
   const [showTest, setShowTest] = useState(false);
+  const [resettingHomes, setResettingHomes] = useState(false);
+  const [resetHomesMsg, setResetHomesMsg] = useState<string | null>(null);
 
   /** Compile the current editor state → graph config for the Test panel. */
   const getTestConfig = () => {
@@ -291,6 +293,45 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
     } finally { setSaving(false); }
   };
 
+  const resetHomes = async () => {
+    if (isNew || !initial?.id) return;
+    if (form.trigger.type !== 'trigger.leftHome' && mode === 'builder') {
+      setResetHomesMsg('Switch the WHEN trigger to “Left home” (and save) before resetting homes.');
+      return;
+    }
+    setResettingHomes(true);
+    setResetHomesMsg(null);
+    try {
+      // Persist current builder config first so watched nodes / threshold match the reset.
+      if (mode === 'builder') {
+        const formErrors = validateForm(form);
+        if (formErrors.length > 0) { setErrors(formErrors); setResettingHomes(false); return; }
+        await apiService.put(`/api/automations/${initial.id}`, {
+          name, description, enabled, config: compile(form),
+        });
+      }
+      const res = await apiService.post<{
+        reset: number; seeded: number;
+        results: Array<{ nodeNum: number; seeded: boolean; sampleCount?: number; inlierCount?: number }>;
+      }>(`/api/automations/${initial.id}/reset-homes`, {});
+      const pending = (res.results ?? []).filter((r) => !r.seeded).map((r) => r.nodeNum);
+      setResetHomesMsg(
+        pending.length === 0
+          ? `Reset ${res.reset} home(s); seeded ${res.seeded} from position history.`
+          : `Reset ${res.reset} home(s); seeded ${res.seeded} from history. No history yet for node #(s) ${pending.join(', ')} — next live fix will set those.`,
+      );
+    } catch (e: any) {
+      setResetHomesMsg(e?.message ?? 'Failed to reset homes');
+    } finally {
+      setResettingHomes(false);
+    }
+  };
+
+  const showResetHomes = !isNew && (
+    (mode === 'builder' && form.trigger.type === 'trigger.leftHome')
+    || (mode === 'json' && jsonText.includes('trigger.leftHome'))
+  );
+
   return (
     <div>
       <div className="ae-btn-row" style={{ marginBottom: '0.75rem' }}>
@@ -325,7 +366,18 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
       <div className="ae-btn-row" style={{ marginTop: '0.75rem' }}>
         <button className="ae-btn ae-btn--primary" disabled={saving} onClick={save}>{saving ? 'Saving…' : 'Save automation'}</button>
         <button className="ae-btn" onClick={() => setShowTest((s) => !s)}>{!showTest && <UiIcon name="play" size={15} />} {showTest ? 'Hide test' : 'Test'}</button>
+        {showResetHomes && (
+          <button
+            className="ae-btn"
+            disabled={resettingHomes}
+            onClick={resetHomes}
+            title="Delete stored home anchors and re-seed each watched node from its position-history cluster (outliers dropped)"
+          >
+            {resettingHomes ? 'Resetting homes…' : 'Reset homes from history'}
+          </button>
+        )}
       </div>
+      {resetHomesMsg && <div className="ae-muted" style={{ marginTop: '0.4rem' }}>{resetHomesMsg}</div>}
 
       {showTest && <AutomationTester getConfig={getTestConfig} variables={variables} sources={sources} />}
     </div>

--- a/src/components/automations/LiveTracePanel.tsx
+++ b/src/components/automations/LiveTracePanel.tsx
@@ -48,6 +48,11 @@ function summarizeEvent(triggerType: string, event: Record<string, unknown>): st
     bits.push(`${event.telemetryType ?? '?'} = ${event.value ?? '?'}`);
   } else if (triggerType === 'trigger.geofence') {
     bits.push(`${event.event ?? '?'} · node ${event.nodeNum ?? '?'}`);
+  } else if (triggerType === 'trigger.becameMobile') {
+    bits.push(`became mobile · node ${event.nodeNum ?? '?'}`);
+  } else if (triggerType === 'trigger.leftHome') {
+    const dist = typeof event.distanceMeters === 'number' ? `${Math.round(event.distanceMeters)}m` : '?';
+    bits.push(`left home ${dist} · node ${event.nodeNum ?? '?'}`);
   } else if (triggerType === 'trigger.system') {
     bits.push(String(event.event ?? ''));
   } else if (event.nodeNum != null) {

--- a/src/components/automations/NodeMultiFieldInput.test.tsx
+++ b/src/components/automations/NodeMultiFieldInput.test.tsx
@@ -5,7 +5,8 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import NodeMultiFieldInput, { labelOf } from './NodeMultiFieldInput';
+import NodeMultiFieldInput from './NodeMultiFieldInput';
+import { labelOf } from './nodeLabel';
 
 const nodes = [
   { nodeNum: 1, longName: 'Mobile Rover', shortName: 'ROVR', nodeId: '!00000001', isMobile: true },

--- a/src/components/automations/NodeMultiFieldInput.test.tsx
+++ b/src/components/automations/NodeMultiFieldInput.test.tsx
@@ -5,21 +5,32 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import NodeMultiFieldInput from './NodeMultiFieldInput';
+import NodeMultiFieldInput, { labelOf } from './NodeMultiFieldInput';
 
 const nodes = [
-  { nodeNum: 1, longName: 'Mobile Rover', isMobile: true },
-  { nodeNum: 2, longName: 'Roof Site', isMobile: false },
-  { nodeNum: 3, longName: 'Tower Alpha', mobile: 0 },
+  { nodeNum: 1, longName: 'Mobile Rover', shortName: 'ROVR', nodeId: '!00000001', isMobile: true },
+  { nodeNum: 2, longName: 'Roof Site', shortName: 'ROOF', nodeId: '!00000002', isMobile: false },
+  { nodeNum: 3, longName: 'Tower Alpha', shortName: 'TWR', nodeId: '!00000003', mobile: 0 },
+  { nodeNum: 4, nodeId: '!00000004', isMobile: false }, // no name — falls back to id
 ];
 
+describe('labelOf', () => {
+  it('prefers longName, then shortName, then nodeId, then hex nodeNum', () => {
+    expect(labelOf({ nodeNum: 1, longName: 'A', shortName: 'B', nodeId: '!x' })).toBe('A');
+    expect(labelOf({ nodeNum: 1, shortName: 'B', nodeId: '!x' })).toBe('B');
+    expect(labelOf({ nodeNum: 1, nodeId: '!x' })).toBe('!x');
+    expect(labelOf({ nodeNum: 255 })).toBe('!000000ff');
+  });
+});
+
 describe('NodeMultiFieldInput', () => {
-  it('lists stationary nodes before mobile ones and badges them', () => {
+  it('lists stationary nodes before mobile ones and shows human names', () => {
     render(<NodeMultiFieldInput value={[]} onChange={() => {}} nodes={nodes} />);
     const labels = screen.getAllByRole('checkbox').map((el) => el.parentElement?.textContent ?? '');
     expect(labels[0]).toMatch(/Roof Site/);
     expect(labels[1]).toMatch(/Tower Alpha/);
-    expect(labels[2]).toMatch(/Mobile Rover/);
+    expect(labels.some((t) => t.includes('Mobile Rover'))).toBe(true);
+    expect(labels.every((t) => !/#\d+Stationary/.test(t.replace(/\s/g, '')))).toBe(true);
     expect(screen.getAllByText('Stationary').length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText('Mobile')).toBeTruthy();
   });
@@ -28,7 +39,7 @@ describe('NodeMultiFieldInput', () => {
     const onChange = vi.fn();
     render(<NodeMultiFieldInput value={[]} onChange={onChange} nodes={nodes} />);
     fireEvent.click(screen.getByRole('button', { name: /Select all stationary/i }));
-    expect(onChange).toHaveBeenCalledWith([2, 3]);
+    expect(onChange).toHaveBeenCalledWith([2, 3, 4]);
   });
 
   it('toggles a node into the selection', () => {

--- a/src/components/automations/NodeMultiFieldInput.test.tsx
+++ b/src/components/automations/NodeMultiFieldInput.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * NodeMultiFieldInput — stationary-first ordering and selection helpers.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NodeMultiFieldInput from './NodeMultiFieldInput';
+
+const nodes = [
+  { nodeNum: 1, longName: 'Mobile Rover', isMobile: true },
+  { nodeNum: 2, longName: 'Roof Site', isMobile: false },
+  { nodeNum: 3, longName: 'Tower Alpha', mobile: 0 },
+];
+
+describe('NodeMultiFieldInput', () => {
+  it('lists stationary nodes before mobile ones and badges them', () => {
+    render(<NodeMultiFieldInput value={[]} onChange={() => {}} nodes={nodes} />);
+    const labels = screen.getAllByRole('checkbox').map((el) => el.parentElement?.textContent ?? '');
+    expect(labels[0]).toMatch(/Roof Site/);
+    expect(labels[1]).toMatch(/Tower Alpha/);
+    expect(labels[2]).toMatch(/Mobile Rover/);
+    expect(screen.getAllByText('Stationary').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText('Mobile')).toBeTruthy();
+  });
+
+  it('Select all stationary adds only stationary nodeNums', () => {
+    const onChange = vi.fn();
+    render(<NodeMultiFieldInput value={[]} onChange={onChange} nodes={nodes} />);
+    fireEvent.click(screen.getByRole('button', { name: /Select all stationary/i }));
+    expect(onChange).toHaveBeenCalledWith([2, 3]);
+  });
+
+  it('toggles a node into the selection', () => {
+    const onChange = vi.fn();
+    render(<NodeMultiFieldInput value={[]} onChange={onChange} nodes={nodes} />);
+    const roof = screen.getAllByRole('checkbox').find((el) =>
+      (el.parentElement?.textContent ?? '').includes('Roof Site')
+    );
+    expect(roof).toBeTruthy();
+    fireEvent.click(roof!);
+    expect(onChange).toHaveBeenCalledWith([2]);
+  });
+});

--- a/src/components/automations/NodeMultiFieldInput.tsx
+++ b/src/components/automations/NodeMultiFieldInput.tsx
@@ -6,6 +6,7 @@
  * @vitest-environment jsdom
  */
 import { useMemo, useState } from 'react';
+import { labelOf } from './nodeLabel';
 
 export interface NodeMultiOption {
   nodeNum: number;
@@ -28,16 +29,6 @@ function isStationary(n: NodeMultiOption): boolean {
   if (n.isMobile === false) return true;
   if (n.mobile === 1 || n.mobile === true) return false;
   return true; // unknown / 0 / false → treat as stationary candidate
-}
-
-/** Primary human label: long name → short name → node id → decimal nodeNum. */
-export function labelOf(n: NodeMultiOption): string {
-  const long = (n.longName || '').trim();
-  const short = (n.shortName || '').trim();
-  if (long) return long;
-  if (short) return short;
-  if (n.nodeId) return n.nodeId;
-  return `!${(Number(n.nodeNum) >>> 0).toString(16).padStart(8, '0')}`;
 }
 
 /** Secondary identity chip — prefer short name when long name is shown, else node id. */

--- a/src/components/automations/NodeMultiFieldInput.tsx
+++ b/src/components/automations/NodeMultiFieldInput.tsx
@@ -1,0 +1,111 @@
+/**
+ * NodeMultiFieldInput — searchable multi-select of mesh nodes for automation
+ * triggers (becameMobile / leftHome). Stationary nodes (mobile === 0 / !isMobile)
+ * are listed first with a Stationary badge.
+ */
+import { useMemo, useState } from 'react';
+
+export interface NodeMultiOption {
+  nodeNum: number;
+  longName?: string;
+  shortName?: string;
+  nodeId?: string;
+  /** MeshMonitor mobility flag: 0/false = stationary, 1/true = mobile. */
+  mobile?: number | boolean;
+  isMobile?: boolean;
+}
+
+interface Props {
+  value: unknown;
+  onChange: (v: number[]) => void;
+  nodes: NodeMultiOption[];
+}
+
+function isStationary(n: NodeMultiOption): boolean {
+  if (n.isMobile === true) return false;
+  if (n.isMobile === false) return true;
+  if (n.mobile === 1 || n.mobile === true) return false;
+  return true; // unknown / 0 / false → treat as stationary candidate
+}
+
+function labelOf(n: NodeMultiOption): string {
+  return n.longName || n.shortName || n.nodeId || String(n.nodeNum);
+}
+
+export default function NodeMultiFieldInput({ value, onChange, nodes }: Props) {
+  const [search, setSearch] = useState('');
+  const selected = useMemo(() => {
+    if (!Array.isArray(value)) return [] as number[];
+    return value.map((x) => Number(x)).filter((n) => Number.isInteger(n));
+  }, [value]);
+
+  const sorted = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    const filtered = !term
+      ? nodes
+      : nodes.filter((n) => {
+          const hay = `${labelOf(n)} ${n.nodeId ?? ''} ${n.nodeNum}`.toLowerCase();
+          return hay.includes(term);
+        });
+    return [...filtered].sort((a, b) => {
+      const sa = isStationary(a) ? 0 : 1;
+      const sb = isStationary(b) ? 0 : 1;
+      if (sa !== sb) return sa - sb;
+      return labelOf(a).localeCompare(labelOf(b));
+    });
+  }, [nodes, search]);
+
+  const toggle = (nodeNum: number, checked: boolean) => {
+    onChange(checked ? [...selected, nodeNum] : selected.filter((n) => n !== nodeNum));
+  };
+
+  const selectStationary = () => {
+    const stationaryNums = nodes.filter(isStationary).map((n) => n.nodeNum);
+    const merged = Array.from(new Set([...selected, ...stationaryNums]));
+    onChange(merged);
+  };
+
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.4rem', flexWrap: 'wrap' }}>
+        <input
+          className="ae-input"
+          value={search}
+          placeholder="Search nodes…"
+          onChange={(e) => setSearch(e.target.value)}
+          style={{ flex: 1, minWidth: '10rem' }}
+        />
+        <button type="button" className="ae-btn" onClick={selectStationary}>
+          Select all stationary
+        </button>
+        {selected.length > 0 && (
+          <button type="button" className="ae-btn" onClick={() => onChange([])}>
+            Clear ({selected.length})
+          </button>
+        )}
+      </div>
+      {nodes.length === 0 && <div className="ae-muted">No nodes loaded yet.</div>}
+      <div style={{ maxHeight: '14rem', overflowY: 'auto', border: '1px solid var(--border-color, #444)', borderRadius: 4, padding: '0.35rem 0.5rem' }}>
+        {sorted.map((n) => {
+          const stationary = isStationary(n);
+          return (
+            <label key={n.nodeNum} className="ae-switch" style={{ display: 'block', marginBottom: '0.2rem' }}>
+              <input
+                type="checkbox"
+                checked={selected.includes(n.nodeNum)}
+                onChange={(e) => toggle(n.nodeNum, e.target.checked)}
+              />
+              {' '}
+              {labelOf(n)}
+              <span className="ae-chip">#{n.nodeNum}</span>
+              {stationary
+                ? <span className="ae-chip" title="MeshMonitor marks this node stationary (mobile = 0)">Stationary</span>
+                : <span className="ae-chip" title="MeshMonitor marks this node mobile">Mobile</span>}
+            </label>
+          );
+        })}
+        {sorted.length === 0 && nodes.length > 0 && <div className="ae-muted">No matches.</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/automations/NodeMultiFieldInput.tsx
+++ b/src/components/automations/NodeMultiFieldInput.tsx
@@ -2,6 +2,8 @@
  * NodeMultiFieldInput — searchable multi-select of mesh nodes for automation
  * triggers (becameMobile / leftHome). Stationary nodes (mobile === 0 / !isMobile)
  * are listed first with a Stationary badge.
+ *
+ * @vitest-environment jsdom
  */
 import { useMemo, useState } from 'react';
 
@@ -28,8 +30,23 @@ function isStationary(n: NodeMultiOption): boolean {
   return true; // unknown / 0 / false → treat as stationary candidate
 }
 
-function labelOf(n: NodeMultiOption): string {
-  return n.longName || n.shortName || n.nodeId || String(n.nodeNum);
+/** Primary human label: long name → short name → node id → decimal nodeNum. */
+export function labelOf(n: NodeMultiOption): string {
+  const long = (n.longName || '').trim();
+  const short = (n.shortName || '').trim();
+  if (long) return long;
+  if (short) return short;
+  if (n.nodeId) return n.nodeId;
+  return `!${(Number(n.nodeNum) >>> 0).toString(16).padStart(8, '0')}`;
+}
+
+/** Secondary identity chip — prefer short name when long name is shown, else node id. */
+function secondaryOf(n: NodeMultiOption): string | null {
+  const long = (n.longName || '').trim();
+  const short = (n.shortName || '').trim();
+  if (long && short && short !== long) return short;
+  if (n.nodeId && labelOf(n) !== n.nodeId) return n.nodeId;
+  return null;
 }
 
 export default function NodeMultiFieldInput({ value, onChange, nodes }: Props) {
@@ -44,14 +61,18 @@ export default function NodeMultiFieldInput({ value, onChange, nodes }: Props) {
     const filtered = !term
       ? nodes
       : nodes.filter((n) => {
-          const hay = `${labelOf(n)} ${n.nodeId ?? ''} ${n.nodeNum}`.toLowerCase();
+          const hay = `${labelOf(n)} ${n.shortName ?? ''} ${n.nodeId ?? ''} ${n.nodeNum}`.toLowerCase();
           return hay.includes(term);
         });
     return [...filtered].sort((a, b) => {
       const sa = isStationary(a) ? 0 : 1;
       const sb = isStationary(b) ? 0 : 1;
       if (sa !== sb) return sa - sb;
-      return labelOf(a).localeCompare(labelOf(b));
+      // Named nodes before id-only fallbacks within the same mobility group.
+      const na = (a.longName || a.shortName) ? 0 : 1;
+      const nb = (b.longName || b.shortName) ? 0 : 1;
+      if (na !== nb) return na - nb;
+      return labelOf(a).localeCompare(labelOf(b), undefined, { sensitivity: 'base' });
     });
   }, [nodes, search]);
 
@@ -71,7 +92,7 @@ export default function NodeMultiFieldInput({ value, onChange, nodes }: Props) {
         <input
           className="ae-input"
           value={search}
-          placeholder="Search nodes…"
+          placeholder="Search by name or node id…"
           onChange={(e) => setSearch(e.target.value)}
           style={{ flex: 1, minWidth: '10rem' }}
         />
@@ -88,16 +109,16 @@ export default function NodeMultiFieldInput({ value, onChange, nodes }: Props) {
       <div style={{ maxHeight: '14rem', overflowY: 'auto', border: '1px solid var(--border-color, #444)', borderRadius: 4, padding: '0.35rem 0.5rem' }}>
         {sorted.map((n) => {
           const stationary = isStationary(n);
+          const secondary = secondaryOf(n);
           return (
-            <label key={n.nodeNum} className="ae-switch" style={{ display: 'block', marginBottom: '0.2rem' }}>
+            <label key={n.nodeNum} className="ae-switch" style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', marginBottom: '0.25rem', flexWrap: 'wrap' }}>
               <input
                 type="checkbox"
                 checked={selected.includes(n.nodeNum)}
                 onChange={(e) => toggle(n.nodeNum, e.target.checked)}
               />
-              {' '}
-              {labelOf(n)}
-              <span className="ae-chip">#{n.nodeNum}</span>
+              <span style={{ fontWeight: 600 }}>{labelOf(n)}</span>
+              {secondary ? <span className="ae-chip">{secondary}</span> : null}
               {stationary
                 ? <span className="ae-chip" title="MeshMonitor marks this node stationary (mobile = 0)">Stationary</span>
                 : <span className="ae-chip" title="MeshMonitor marks this node mobile">Mobile</span>}

--- a/src/components/automations/SubstitutionsHelp.tsx
+++ b/src/components/automations/SubstitutionsHelp.tsx
@@ -41,12 +41,15 @@ export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
   'trigger.nodeDiscovered': [['nodeNum', 'Node number'], ['changed', 'Changed field names (list)']],
   'trigger.system': [['event', 'System event'], ['nodeNum', 'Node number (if any)'], ['reason', 'Detail / reason'], ['latestVersion', 'Latest version (upgrade-available)'], ['currentVersion', 'Current version (upgrade-available)']],
   'trigger.geofence': [['event', 'enter / exit / dwell'], ['nodeNum', 'Node number'], ['latitude', 'Node latitude'], ['longitude', 'Node longitude'], ['distanceKm', 'Distance from the region centre (km)']],
+  'trigger.becameMobile': [['nodeNum', 'Node number'], ['previousMobile', 'Previous mobile flag (0)'], ['mobile', 'New mobile flag (1)'], ['latitude', 'Node latitude'], ['longitude', 'Node longitude']],
+  'trigger.leftHome': [['nodeNum', 'Node number'], ['latitude', 'Node latitude'], ['longitude', 'Node longitude'], ['homeLat', 'Home latitude'], ['homeLon', 'Home longitude'], ['distanceMeters', 'Distance from home (m)'], ['thresholdMeters', 'Configured threshold (m)']],
   'trigger.schedule': [],
 };
 export const UNIVERSAL_TOKENS: Array<[string, string]> = [['sourceId', 'The source the event came from'], ['timestamp', 'Event time (rendered as a local date/time)']];
 const TRIGGER_LABEL: Record<string, string> = {
   'trigger.message': 'Message', 'trigger.telemetry': 'Telemetry', 'trigger.nodeUpdated': 'Node updated',
-  'trigger.nodeDiscovered': 'Node discovered', 'trigger.system': 'System event', 'trigger.geofence': 'Geofence', 'trigger.schedule': 'Schedule',
+  'trigger.nodeDiscovered': 'Node discovered', 'trigger.system': 'System event', 'trigger.geofence': 'Geofence',
+  'trigger.becameMobile': 'Became mobile', 'trigger.leftHome': 'Left home', 'trigger.schedule': 'Schedule',
 };
 
 /** Drawer listing every available substitution token (current trigger first). */

--- a/src/components/automations/SubstitutionsHelp.tsx
+++ b/src/components/automations/SubstitutionsHelp.tsx
@@ -45,6 +45,39 @@ export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
   'trigger.leftHome': [['nodeNum', 'Node number'], ['latitude', 'Node latitude'], ['longitude', 'Node longitude'], ['homeLat', 'Home latitude'], ['homeLon', 'Home longitude'], ['distanceMeters', 'Distance from home (m)'], ['thresholdMeters', 'Configured threshold (m)']],
   'trigger.schedule': [],
 };
+
+/**
+ * Hydrated subject-node tokens (`{{ node.longName }}`, …). Available on every
+ * trigger that has a subject node — same paths conditions use in fieldselect.
+ * Not under `trigger.*`: they hydrate from the DB node row at evaluation time.
+ */
+export const NODE_TOKENS: Array<[string, string]> = [
+  ['longName', 'Node long name'],
+  ['shortName', 'Node short name'],
+  ['nodeId', 'Node id (!hex)'],
+  ['roleName', 'Role name (e.g. ROUTER)'],
+  ['batteryLevel', 'Battery level (%)'],
+  ['voltage', 'Voltage'],
+  ['hopsAway', 'Hops away'],
+  ['latitude', 'Latitude'],
+  ['longitude', 'Longitude'],
+  ['altitude', 'Altitude'],
+  ['mobile', 'Mobile flag (1 = mobile, 0 = stationary)'],
+  ['ageMinutes', 'Minutes since last heard'],
+  ['completeness', 'Node info completeness (complete / incomplete / unknown)'],
+];
+
+/** Triggers whose event carries a subject node (so `{{ node.* }}` can hydrate). */
+export const SUBJECT_NODE_TRIGGER_TYPES = [
+  'trigger.message',
+  'trigger.nodeDiscovered',
+  'trigger.nodeUpdated',
+  'trigger.telemetry',
+  'trigger.geofence',
+  'trigger.becameMobile',
+  'trigger.leftHome',
+] as const;
+
 export const UNIVERSAL_TOKENS: Array<[string, string]> = [['sourceId', 'The source the event came from'], ['timestamp', 'Event time (rendered as a local date/time)']];
 const TRIGGER_LABEL: Record<string, string> = {
   'trigger.message': 'Message', 'trigger.telemetry': 'Telemetry', 'trigger.nodeUpdated': 'Node updated',
@@ -71,6 +104,19 @@ export default function SubstitutionsHelpDrawer({ triggerType, variables, onClos
         <dt>{'{{ var.NAME.a.b }}'}</dt><dd>Index into a <strong>json</strong> variable (e.g. a “Run a script” result) — dotted path into the stored object/array. A whole object renders as JSON.</dd>
         <dt>{'{{ NOW }}'}</dt><dd>Current time (rendered as a local date/time).</dd>
       </dl>
+
+      {(SUBJECT_NODE_TRIGGER_TYPES as readonly string[]).includes(triggerType) && (
+        <div>
+          <h3>Subject node — current trigger</h3>
+          <p className="ae-muted">Hydrated from the node DB row at fire time. Use these for names on Became mobile / Left home / Node updated / …</p>
+          <dl>
+            {NODE_TOKENS.flatMap(([k, d]) => [
+              <dt key={`${k}-t`}>{`{{ node.${k} }}`}</dt>,
+              <dd key={`${k}-d`}>{d}</dd>,
+            ])}
+          </dl>
+        </div>
+      )}
 
       {order.filter((t) => TRIGGER_TOKENS[t]).map((t) => (
         <div key={t}>

--- a/src/components/automations/SubstitutionsHelp.tsx
+++ b/src/components/automations/SubstitutionsHelp.tsx
@@ -7,6 +7,7 @@
  */
 import { UiIcon } from '../icons';
 import { HOP_COUNT_EMOJIS, HOP_EMOJI_MAX, MQTT_SOURCE_EMOJI } from '../../utils/hopEmoji';
+import { NODE_TOKENS, SUBJECT_NODE_TRIGGER_TYPES } from './substitutionNodeTokens';
 
 // All `{{ trigger.* }}` tokens, by trigger type. `sourceId`/`timestamp` are added to every group.
 export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
@@ -45,38 +46,6 @@ export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
   'trigger.leftHome': [['nodeNum', 'Node number'], ['latitude', 'Node latitude'], ['longitude', 'Node longitude'], ['homeLat', 'Home latitude'], ['homeLon', 'Home longitude'], ['distanceMeters', 'Distance from home (m)'], ['thresholdMeters', 'Configured threshold (m)']],
   'trigger.schedule': [],
 };
-
-/**
- * Hydrated subject-node tokens (`{{ node.longName }}`, …). Available on every
- * trigger that has a subject node — same paths conditions use in fieldselect.
- * Not under `trigger.*`: they hydrate from the DB node row at evaluation time.
- */
-export const NODE_TOKENS: Array<[string, string]> = [
-  ['longName', 'Node long name'],
-  ['shortName', 'Node short name'],
-  ['nodeId', 'Node id (!hex)'],
-  ['roleName', 'Role name (e.g. ROUTER)'],
-  ['batteryLevel', 'Battery level (%)'],
-  ['voltage', 'Voltage'],
-  ['hopsAway', 'Hops away'],
-  ['latitude', 'Latitude'],
-  ['longitude', 'Longitude'],
-  ['altitude', 'Altitude'],
-  ['mobile', 'Mobile flag (1 = mobile, 0 = stationary)'],
-  ['ageMinutes', 'Minutes since last heard'],
-  ['completeness', 'Node info completeness (complete / incomplete / unknown)'],
-];
-
-/** Triggers whose event carries a subject node (so `{{ node.* }}` can hydrate). */
-export const SUBJECT_NODE_TRIGGER_TYPES = [
-  'trigger.message',
-  'trigger.nodeDiscovered',
-  'trigger.nodeUpdated',
-  'trigger.telemetry',
-  'trigger.geofence',
-  'trigger.becameMobile',
-  'trigger.leftHome',
-] as const;
 
 export const UNIVERSAL_TOKENS: Array<[string, string]> = [['sourceId', 'The source the event came from'], ['timestamp', 'Event time (rendered as a local date/time)']];
 const TRIGGER_LABEL: Record<string, string> = {

--- a/src/components/automations/automationTesterHelpers.ts
+++ b/src/components/automations/automationTesterHelpers.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure helpers for the automation Test panel (kept out of the component file so
+ * the `.tsx` exports only a component — react-refresh/only-export-components).
+ */
+export type EventState = Record<string, string>;
+export type FactState = Record<string, string>;
+
+export function numOrUndef(v: string | undefined): number | undefined {
+  if (v === undefined || v === '') return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/** Read thresholdMeters from the compiled leftHome trigger (default 300). */
+export function leftHomeThresholdFromConfig(config: unknown): number {
+  const nodes = (config as { nodes?: Array<{ type?: string; params?: Record<string, unknown> }> } | null)?.nodes;
+  const trigger = nodes?.find((n) => n.type === 'trigger.leftHome');
+  const thr = Number(trigger?.params?.thresholdMeters ?? 300);
+  return Number.isFinite(thr) && thr > 0 ? thr : 300;
+}
+
+/** Which leftHome dry-run input path is active given the Test panel fields. */
+export function leftHomeInputMode(ev: EventState, facts: FactState): 'coordinates' | 'distance' | 'none' {
+  const hasCoords =
+    numOrUndef(facts.latitude) != null &&
+    numOrUndef(facts.longitude) != null &&
+    numOrUndef(ev.homeLat) != null &&
+    numOrUndef(ev.homeLon) != null;
+  if (hasCoords) return 'coordinates';
+  if (numOrUndef(ev.distanceMeters) != null) return 'distance';
+  return 'none';
+}
+
+export function leftHomeModeHint(ev: EventState, facts: FactState, automationThreshold: number): string {
+  const mode = leftHomeInputMode(ev, facts);
+  const thr = `Threshold: ${automationThreshold} m (from the automation — not editable here).`;
+  if (mode === 'coordinates') {
+    return `${thr} Using home + current coordinates to compute distance. The distance field is ignored while all four coords are set.`;
+  }
+  if (mode === 'distance') {
+    return `${thr} Using the distance field (${ev.distanceMeters} m). Fill home lat/lon and current lat/lon to compute distance from coordinates instead (coordinates take precedence).`;
+  }
+  return `${thr} Set either (1) home lat/lon + current lat/lon, or (2) a distance in metres. Dry-run fires only when the node is on the watch list and distance > threshold.`;
+}

--- a/src/components/automations/catalog.showIf.test.ts
+++ b/src/components/automations/catalog.showIf.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { fieldVisible, ACTIONS, CONDITIONS, TRIGGERS, numericFields, stringFields, STRING_OP_OPTIONS, type FieldDef } from './catalog';
+import { fieldVisible, fieldPlaceholder, ACTIONS, CONDITIONS, TRIGGERS, numericFields, stringFields, STRING_OP_OPTIONS, type FieldDef } from './catalog';
 import { HOP_COUNT_EMOJIS, MQTT_SOURCE_EMOJI } from '../../utils/hopEmoji';
 
 describe('fieldVisible', () => {
@@ -282,5 +282,24 @@ describe("trigger.message regex case-sensitivity hint (#4507 follow-up)", () => 
     // Pins the contrast the new copy draws. If this ever becomes
     // case-sensitive, the regex field's help becomes a lie.
     expect(field('textContains')?.help).toMatch(/case-insensitive/i);
+  });
+});
+
+describe('movement trigger message hints', () => {
+  it('sendMessage and notify use Tolkien placeholders for leftHome / becameMobile', () => {
+    const send = ACTIONS.find((a) => a.type === 'action.sendMessage')?.fields.find((f) => f.name === 'text');
+    const notify = ACTIONS.find((a) => a.type === 'action.notify')?.fields.find((f) => f.name === 'body');
+    expect(send).toBeTruthy();
+    expect(notify).toBeTruthy();
+    expect(fieldPlaceholder(send!, 'trigger.leftHome')).toBe(
+      'A quiet little node {{ node.longName }} has left the Shire and gone off on an unexpected adventure.',
+    );
+    expect(fieldPlaceholder(send!, 'trigger.becameMobile')).toBe(
+      'A wild stationary node {{ node.longName }} just uprooted itself and headed towards Isengard!',
+    );
+    expect(fieldPlaceholder(notify!, 'trigger.leftHome')).toBe(fieldPlaceholder(send!, 'trigger.leftHome'));
+    expect(fieldPlaceholder(notify!, 'trigger.becameMobile')).toBe(fieldPlaceholder(send!, 'trigger.becameMobile'));
+    // Other triggers keep the generic default.
+    expect(fieldPlaceholder(send!, 'trigger.message')).toBe('Hello {{ trigger.senderLabel }}!');
   });
 });

--- a/src/components/automations/catalog.showIf.test.ts
+++ b/src/components/automations/catalog.showIf.test.ts
@@ -135,7 +135,7 @@ describe('action.tapback catalog entry', () => {
 // five trigger blocks that already carry cooldownSeconds (SUBJECT_NODE_TRIGGERS
 // in catalog.ts, verified as the same five in §1 finding #8).
 describe('trigger.* cooldownScope catalog entries (#4340 Phase 2)', () => {
-  const COOLDOWN_BEARING_TYPES = ['trigger.message', 'trigger.nodeDiscovered', 'trigger.nodeUpdated', 'trigger.telemetry', 'trigger.geofence'];
+  const COOLDOWN_BEARING_TYPES = ['trigger.message', 'trigger.nodeDiscovered', 'trigger.nodeUpdated', 'trigger.telemetry', 'trigger.geofence', 'trigger.becameMobile', 'trigger.leftHome'];
   const NO_COOLDOWN_TYPES = ['trigger.schedule', 'trigger.system'];
 
   it.each(COOLDOWN_BEARING_TYPES)('%s lists cooldownScope immediately after cooldownSeconds', (type) => {

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -20,6 +20,11 @@ export interface FieldDef {
   /** Grouped options for `fieldselect` (event / node / telemetry). Computed at render time. */
   groups?: FieldGroup[];
   placeholder?: string;
+  /**
+   * Optional per-trigger placeholders for tokenised message fields. When the
+   * current WHEN trigger matches a key, that string wins over `placeholder`.
+   */
+  placeholderByTrigger?: Record<string, string>;
   help?: string;
   advanced?: boolean;
   /** This `text`/`textarea` field accepts `{{ }}` tokens → highlight + typo-check. */
@@ -36,6 +41,11 @@ export interface FieldDef {
      *  Covers "a number field that is unset, blank, or 0" in one operator (#4340 Phase 2). */
     truthy?: boolean;
   };
+}
+
+/** Resolve the placeholder shown for a field under the current WHEN trigger. */
+export function fieldPlaceholder(field: FieldDef, triggerType: string): string | undefined {
+  return field.placeholderByTrigger?.[triggerType] ?? field.placeholder;
 }
 
 /** Should this field render, given the block's current params? Pure — unit-tested without React. */
@@ -443,6 +453,11 @@ export const CONDITIONS: BlockDef[] = [
   },
 ];
 
+const MOVEMENT_MESSAGE_HINTS: Record<string, string> = {
+  'trigger.leftHome': 'A quiet little node {{ node.longName }} has left the Shire and gone off on an unexpected adventure.',
+  'trigger.becameMobile': 'A wild stationary node {{ node.longName }} just uprooted itself and headed towards Isengard!',
+};
+
 // ─── Actions (THEN) ──────────────────────────────────────────────────────────
 
 export const ACTIONS: BlockDef[] = [
@@ -472,7 +487,12 @@ export const ACTIONS: BlockDef[] = [
     label: 'Send a message',
     description: 'Send text to a channel or as a DM.',
     fields: [
-      { name: 'text', label: 'Message', kind: 'textarea', tokens: true, placeholder: 'Hello {{ trigger.senderLabel }}!', help: 'Use {{ trigger.field }}, {{ node.longName }}, or {{ var.name }} to insert values. On Became mobile / Left home, prefer {{ node.longName }} (or {{ node.nodeId }}) — those triggers have no senderLabel.' },
+      {
+        name: 'text', label: 'Message', kind: 'textarea', tokens: true,
+        placeholder: 'Hello {{ trigger.senderLabel }}!',
+        placeholderByTrigger: MOVEMENT_MESSAGE_HINTS,
+        help: 'Use {{ trigger.field }}, {{ node.longName }}, or {{ var.name }} to insert values. On Became mobile / Left home, prefer {{ node.longName }} (or {{ node.nodeId }}) — those triggers have no senderLabel.',
+      },
       { name: 'sourceIds', label: 'Send via sources', kind: 'sendSourceMulti', help: 'Which radios to send through (MQTT sources are receive-only and excluded). Leave none to use the source that triggered the automation — but a source IS required for source-less triggers like System events and Schedules.' },
       { name: 'channels', label: 'On channels', kind: 'channelMulti', help: 'Channels to post to, unified by name + key across your sources (the correct local slot is resolved per source). Leave none to use the triggering channel.' },
       { name: 'to', label: 'DM to node #', kind: 'text', tokens: true, placeholder: 'blank = channel; {{ trigger.from }} replies to sender', advanced: true },
@@ -564,7 +584,11 @@ export const ACTIONS: BlockDef[] = [
     description: 'Send an external notification (Apprise).',
     fields: [
       { name: 'title', label: 'Title', kind: 'text', tokens: true, placeholder: 'MeshMonitor alert' },
-      { name: 'body', label: 'Body', kind: 'textarea', tokens: true, placeholder: 'Node {{ trigger.fromId }} said {{ trigger.text }}' },
+      {
+        name: 'body', label: 'Body', kind: 'textarea', tokens: true,
+        placeholder: 'Node {{ trigger.fromId }} said {{ trigger.text }}',
+        placeholderByTrigger: MOVEMENT_MESSAGE_HINTS,
+      },
       {
         name: 'type', label: 'Severity', kind: 'select', advanced: true,
         options: [

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -472,7 +472,7 @@ export const ACTIONS: BlockDef[] = [
     label: 'Send a message',
     description: 'Send text to a channel or as a DM.',
     fields: [
-      { name: 'text', label: 'Message', kind: 'textarea', tokens: true, placeholder: 'Hello {{ trigger.senderLabel }}!', help: 'Use {{ trigger.field }} or {{ var.name }} to insert values. {{ trigger.senderLabel }} is the universal "who sent this" label (works on Meshtastic and MeshCore).' },
+      { name: 'text', label: 'Message', kind: 'textarea', tokens: true, placeholder: 'Hello {{ trigger.senderLabel }}!', help: 'Use {{ trigger.field }}, {{ node.longName }}, or {{ var.name }} to insert values. On Became mobile / Left home, prefer {{ node.longName }} (or {{ node.nodeId }}) — those triggers have no senderLabel.' },
       { name: 'sourceIds', label: 'Send via sources', kind: 'sendSourceMulti', help: 'Which radios to send through (MQTT sources are receive-only and excluded). Leave none to use the source that triggered the automation — but a source IS required for source-less triggers like System events and Schedules.' },
       { name: 'channels', label: 'On channels', kind: 'channelMulti', help: 'Channels to post to, unified by name + key across your sources (the correct local slot is resolved per source). Leave none to use the triggering channel.' },
       { name: 'to', label: 'DM to node #', kind: 'text', tokens: true, placeholder: 'blank = channel; {{ trigger.from }} replies to sender', advanced: true },

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -206,10 +206,10 @@ export const TRIGGERS: BlockDef[] = [
   {
     type: 'trigger.leftHome',
     label: 'A watched node leaves its home position',
-    description: 'Fires when a hand-selected node moves farther than a threshold from its home/anchor position. Home is captured on the first position after you add the node (and survives restarts).',
+    description: 'Fires when a hand-selected node moves farther than a threshold from its home/anchor position. Home is seeded from position-history inliers when available (else the first live fix), then gently averaged while within half the threshold. Use “Reset homes from history” on a saved automation to clear and re-seed. Default threshold is 300 m.',
     fields: [
       { name: 'nodeNums', label: 'Watch nodes', kind: 'nodeMulti', help: 'Pick the nodes to watch. Stationary nodes (mobile = 0) are listed first with a Stationary badge.' },
-      { name: 'thresholdMeters', label: 'Threshold (meters)', kind: 'number', placeholder: '100', help: 'Alert when the node is farther than this many metres from its home position. Default 100.' },
+      { name: 'thresholdMeters', label: 'Threshold (meters)', kind: 'number', placeholder: '300', help: 'Alert when the node is farther than this many metres from its home position. Default 300. History seeding and live refine both use half this distance as the inlier / average radius.' },
       COOLDOWN,
       COOLDOWN_SCOPE,
     ],

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -7,7 +7,7 @@
  */
 import { HOP_COUNT_EMOJIS, HOP_EMOJI_MAX, MQTT_SOURCE_EMOJI } from '../../utils/hopEmoji';
 
-export type FieldKind = 'text' | 'number' | 'textarea' | 'select' | 'checkbox' | 'variable' | 'emoji' | 'fieldselect' | 'sourceMulti' | 'sendSourceMulti' | 'channelMulti' | 'geofence' | 'scriptselect' | 'regionSelect';
+export type FieldKind = 'text' | 'number' | 'textarea' | 'select' | 'checkbox' | 'variable' | 'emoji' | 'fieldselect' | 'sourceMulti' | 'sendSourceMulti' | 'channelMulti' | 'geofence' | 'scriptselect' | 'regionSelect' | 'nodeMulti';
 
 export interface FieldOpt { value: string; label: string; }
 export interface FieldGroup { label: string; options: FieldOpt[]; }
@@ -183,11 +183,32 @@ export const TRIGGERS: BlockDef[] = [
       COOLDOWN_SCOPE,
     ],
   },
+  {
+    type: 'trigger.becameMobile',
+    label: 'A watched node becomes mobile',
+    description: 'Fires when a hand-selected node flips from stationary to mobile (MeshMonitor’s >100 m position-history heuristic). Useful for tamper / theft alerts on fixed sites.',
+    fields: [
+      { name: 'nodeNums', label: 'Watch nodes', kind: 'nodeMulti', help: 'Pick the nodes to watch. Stationary nodes (mobile = 0) are listed first with a Stationary badge.' },
+      COOLDOWN,
+      COOLDOWN_SCOPE,
+    ],
+  },
+  {
+    type: 'trigger.leftHome',
+    label: 'A watched node leaves its home position',
+    description: 'Fires when a hand-selected node moves farther than a threshold from its home/anchor position. Home is captured on the first position after you add the node (and survives restarts).',
+    fields: [
+      { name: 'nodeNums', label: 'Watch nodes', kind: 'nodeMulti', help: 'Pick the nodes to watch. Stationary nodes (mobile = 0) are listed first with a Stationary badge.' },
+      { name: 'thresholdMeters', label: 'Threshold (meters)', kind: 'number', placeholder: '100', help: 'Alert when the node is farther than this many metres from its home position. Default 100.' },
+      COOLDOWN,
+      COOLDOWN_SCOPE,
+    ],
+  },
 ];
 
 // ─── Comparison field registry (event / node / latest-telemetry) ─────────────
 
-const SUBJECT_NODE_TRIGGERS = ['trigger.message', 'trigger.nodeDiscovered', 'trigger.nodeUpdated', 'trigger.telemetry', 'trigger.geofence'];
+const SUBJECT_NODE_TRIGGERS = ['trigger.message', 'trigger.nodeDiscovered', 'trigger.nodeUpdated', 'trigger.telemetry', 'trigger.geofence', 'trigger.becameMobile', 'trigger.leftHome'];
 const hasSubjectNode = (t: string) => SUBJECT_NODE_TRIGGERS.includes(t);
 
 const EVENT_NUMERIC: Record<string, FieldOpt[]> = {
@@ -213,6 +234,16 @@ const EVENT_NUMERIC: Record<string, FieldOpt[]> = {
   'trigger.telemetry': [{ value: 'value', label: 'Reading value' }, { value: 'nodeNum', label: 'Node #' }],
   'trigger.nodeUpdated': [{ value: 'nodeNum', label: 'Node #' }],
   'trigger.nodeDiscovered': [{ value: 'nodeNum', label: 'Node #' }],
+  'trigger.becameMobile': [{ value: 'nodeNum', label: 'Node #' }, { value: 'mobile', label: 'Mobile flag (1)' }, { value: 'previousMobile', label: 'Previous mobile flag' }],
+  'trigger.leftHome': [
+    { value: 'nodeNum', label: 'Node #' },
+    { value: 'distanceMeters', label: 'Distance from home (m)' },
+    { value: 'thresholdMeters', label: 'Threshold (m)' },
+    { value: 'latitude', label: 'Latitude' },
+    { value: 'longitude', label: 'Longitude' },
+    { value: 'homeLat', label: 'Home latitude' },
+    { value: 'homeLon', label: 'Home longitude' },
+  ],
 };
 const EVENT_STRING: Record<string, FieldOpt[]> = {
   'trigger.message': [
@@ -236,6 +267,7 @@ const NODE_NUMERIC: FieldOpt[] = [
   { value: 'node.channelUtilization', label: 'Channel utilization' }, { value: 'node.airUtilTx', label: 'Air util TX' },
   { value: 'node.snr', label: 'Last SNR' },
   { value: 'node.latitude', label: 'Latitude' }, { value: 'node.longitude', label: 'Longitude' }, { value: 'node.altitude', label: 'Altitude' },
+  { value: 'node.mobile', label: 'Mobile flag (1 = mobile, 0 = stationary)' },
 ];
 const NODE_STRING: FieldOpt[] = [
   { value: 'node.longName', label: 'Long name' }, { value: 'node.shortName', label: 'Short name' },

--- a/src/components/automations/nodeLabel.ts
+++ b/src/components/automations/nodeLabel.ts
@@ -1,0 +1,15 @@
+/**
+ * Pure label helper for the node multi-picker (kept out of the component file so
+ * the `.tsx` exports only a component — react-refresh/only-export-components).
+ */
+import type { NodeMultiOption } from './NodeMultiFieldInput';
+
+/** Primary human label: long name → short name → node id → decimal nodeNum. */
+export function labelOf(n: NodeMultiOption): string {
+  const long = (n.longName || '').trim();
+  const short = (n.shortName || '').trim();
+  if (long) return long;
+  if (short) return short;
+  if (n.nodeId) return n.nodeId;
+  return `!${(Number(n.nodeNum) >>> 0).toString(16).padStart(8, '0')}`;
+}

--- a/src/components/automations/substitutionNodeTokens.ts
+++ b/src/components/automations/substitutionNodeTokens.ts
@@ -1,0 +1,37 @@
+/**
+ * Subject-node substitution tokens shared by the help drawer and the token
+ * typo-checker. Kept out of SubstitutionsHelp.tsx so that component file exports
+ * only a component (react-refresh/only-export-components).
+ */
+
+/**
+ * Hydrated subject-node tokens (`{{ node.longName }}`, …). Available on every
+ * trigger that has a subject node — same paths conditions use in fieldselect.
+ * Not under `trigger.*`: they hydrate from the DB node row at evaluation time.
+ */
+export const NODE_TOKENS: Array<[string, string]> = [
+  ['longName', 'Node long name'],
+  ['shortName', 'Node short name'],
+  ['nodeId', 'Node id (!hex)'],
+  ['roleName', 'Role name (e.g. ROUTER)'],
+  ['batteryLevel', 'Battery level (%)'],
+  ['voltage', 'Voltage'],
+  ['hopsAway', 'Hops away'],
+  ['latitude', 'Latitude'],
+  ['longitude', 'Longitude'],
+  ['altitude', 'Altitude'],
+  ['mobile', 'Mobile flag (1 = mobile, 0 = stationary)'],
+  ['ageMinutes', 'Minutes since last heard'],
+  ['completeness', 'Node info completeness (complete / incomplete / unknown)'],
+];
+
+/** Triggers whose event carries a subject node (so `{{ node.* }}` can hydrate). */
+export const SUBJECT_NODE_TRIGGER_TYPES = [
+  'trigger.message',
+  'trigger.nodeDiscovered',
+  'trigger.nodeUpdated',
+  'trigger.telemetry',
+  'trigger.geofence',
+  'trigger.becameMobile',
+  'trigger.leftHome',
+] as const;

--- a/src/components/automations/tokenHints.test.ts
+++ b/src/components/automations/tokenHints.test.ts
@@ -10,6 +10,17 @@ describe('validTokenSet', () => {
     expect(set.has('var.threshold')).toBe(true);
     expect(set.has('trigger.asfd')).toBe(false);
   });
+  it('includes node.* on subject-node triggers (becameMobile / leftHome / …)', () => {
+    const set = validTokenSet('trigger.becameMobile', []);
+    expect(set.has('node.longName')).toBe(true);
+    expect(set.has('node.nodeId')).toBe(true);
+    expect(set.has('node.shortName')).toBe(true);
+    expect(set.has('trigger.nodeNum')).toBe(true);
+  });
+  it('omits node.* on schedule / system (no subject node)', () => {
+    expect(validTokenSet('trigger.schedule', []).has('node.longName')).toBe(false);
+    expect(validTokenSet('trigger.system', []).has('node.longName')).toBe(false);
+  });
 });
 
 describe('classifyToken', () => {
@@ -23,33 +34,41 @@ describe('classifyToken', () => {
     const valid = validTokenSet('trigger.message', []);
     expect(classifyToken('trigger.hopEmoji', valid)).toBe('ok');
   });
+  it('ok for {{ node.longName }} on becameMobile', () => {
+    const valid = validTokenSet('trigger.becameMobile', []);
+    expect(classifyToken('node.longName', valid)).toBe('ok');
+  });
   it('foreign for a real token that belongs to a DIFFERENT trigger', () => {
     const sys = validTokenSet('trigger.system', []);
     // trigger.from is a message token — valid somewhere, but not for system
     expect(classifyToken('trigger.from', sys)).toBe('foreign');
+    expect(classifyToken('node.longName', sys)).toBe('foreign');
   });
   it('bad for genuine typos and unknown var names', () => {
     const valid = validTokenSet('trigger.message', ['flag']);
     expect(classifyToken('trigger.asfd', valid)).toBe('bad');
     expect(classifyToken('var.nope', valid)).toBe('bad');
+    expect(classifyToken('node.notAThing', valid)).toBe('bad');
   });
 });
 
 describe('diagnoseTokens', () => {
   it('gives a type-specific message per problematic token, in order, deduped', () => {
     const sys = validTokenSet('trigger.system', ['known']);
-    const text = 'Hi {{ trigger.from }} {{ trigger.asfd }} {{ var.asfd }} {{ trigger.event }} {{ NOW }} {{ foo }}';
+    const text = 'Hi {{ trigger.from }} {{ trigger.asfd }} {{ var.asfd }} {{ trigger.event }} {{ NOW }} {{ foo }} {{ node.longName }} {{ node.nope }}';
     expect(diagnoseTokens(text, sys)).toEqual([
       { token: 'trigger.from', severity: 'warn', detail: 'is undefined for this trigger' },
       { token: 'trigger.asfd', severity: 'error', detail: 'is not a recognized trigger field' },
       { token: 'var.asfd', severity: 'error', detail: 'does not exist' },
       // trigger.event (system token) and NOW are valid → omitted
       { token: 'foo', severity: 'error', detail: 'is not a recognized token' },
+      { token: 'node.longName', severity: 'warn', detail: 'needs a subject-node trigger' },
+      { token: 'node.nope', severity: 'error', detail: 'is not a recognized node field' },
     ]);
   });
   it('returns nothing when all tokens are valid for the trigger', () => {
     const msg = validTokenSet('trigger.message', ['flag']);
-    expect(diagnoseTokens('{{ trigger.from }} {{ var.flag }} {{ NOW }}', msg)).toEqual([]);
+    expect(diagnoseTokens('{{ trigger.from }} {{ var.flag }} {{ NOW }} {{ node.longName }}', msg)).toEqual([]);
   });
   it('ignores empty tokens and de-dups repeats', () => {
     const msg = validTokenSet('trigger.message', []);

--- a/src/components/automations/tokenHints.ts
+++ b/src/components/automations/tokenHints.ts
@@ -11,9 +11,8 @@
 import {
   TRIGGER_TOKENS,
   UNIVERSAL_TOKENS,
-  NODE_TOKENS,
-  SUBJECT_NODE_TRIGGER_TYPES,
 } from './SubstitutionsHelp';
+import { NODE_TOKENS, SUBJECT_NODE_TRIGGER_TYPES } from './substitutionNodeTokens';
 
 // Mirrors the engine's interpolate TOKEN regex.
 const TOKEN_RE = /\{\{\s*([^}]+?)\s*\}\}/g;

--- a/src/components/automations/tokenHints.ts
+++ b/src/components/automations/tokenHints.ts
@@ -1,25 +1,35 @@
 /**
  * `{{ }}` token hinting for builder text fields (#3653 follow-up).
  *
- * Classifies each `{{ trigger.* }}` / `{{ var.* }}` / `{{ NOW }}` token so the
- * editor can highlight it and catch typos:
+ * Classifies each `{{ trigger.* }}` / `{{ node.* }}` / `{{ var.* }}` / `{{ NOW }}`
+ * token so the editor can highlight it and catch typos:
  *   - 'ok'      valid for the CURRENT trigger (or a known var / NOW)
  *   - 'foreign' a real token, but it belongs to a DIFFERENT trigger (it'll
  *               render blank here) — not a typo, just not available
  *   - 'bad'     unrecognized everywhere → likely a typo
  */
-import { TRIGGER_TOKENS, UNIVERSAL_TOKENS } from './SubstitutionsHelp';
+import {
+  TRIGGER_TOKENS,
+  UNIVERSAL_TOKENS,
+  NODE_TOKENS,
+  SUBJECT_NODE_TRIGGER_TYPES,
+} from './SubstitutionsHelp';
 
 // Mirrors the engine's interpolate TOKEN regex.
 const TOKEN_RE = /\{\{\s*([^}]+?)\s*\}\}/g;
 
 export type TokenStatus = 'ok' | 'foreign' | 'bad';
 
+const SUBJECT_NODE_SET = new Set<string>(SUBJECT_NODE_TRIGGER_TYPES);
+
 /** Valid token paths for a trigger type + the defined variables (the 'ok' set). */
 export function validTokenSet(triggerType: string, variableNames: string[]): Set<string> {
   const set = new Set<string>(['NOW']);
   for (const [k] of TRIGGER_TOKENS[triggerType] ?? []) set.add(`trigger.${k}`);
   for (const [k] of UNIVERSAL_TOKENS) set.add(`trigger.${k}`);
+  if (SUBJECT_NODE_SET.has(triggerType)) {
+    for (const [k] of NODE_TOKENS) set.add(`node.${k}`);
+  }
   for (const name of variableNames) set.add(`var.${name}`);
   return set;
 }
@@ -35,10 +45,19 @@ export function anyTriggerTokenSet(): Set<string> {
   return set;
 }
 
+/** Every known `node.*` path — valid on subject-node triggers, foreign elsewhere. */
+let anyNodeCache: Set<string> | null = null;
+export function anyNodeTokenSet(): Set<string> {
+  if (anyNodeCache) return anyNodeCache;
+  anyNodeCache = new Set(NODE_TOKENS.map(([k]) => `node.${k}`));
+  return anyNodeCache;
+}
+
 /** Classify a single token path against the current-trigger valid set. */
 export function classifyToken(path: string, valid: Set<string>): TokenStatus {
   if (path.length === 0 || valid.has(path)) return 'ok';
   if (path.startsWith('trigger.') && anyTriggerTokenSet().has(path)) return 'foreign';
+  if (path.startsWith('node.') && anyNodeTokenSet().has(path)) return 'foreign';
   return 'bad';
 }
 
@@ -68,7 +87,9 @@ export interface TokenDiag { token: string; severity: TokenSeverity; detail: str
  *   - `{{ var.x }}` with no such variable   → error "does not exist"
  *   - `{{ trigger.x }}` of another trigger   → warn  "is undefined for this trigger"
  *   - `{{ trigger.x }}` of no trigger        → error "is not a recognized trigger field"
- *   - anything else (no var./trigger. prefix)→ error "is not a recognized token"
+ *   - `{{ node.x }}` with no subject node    → warn  "needs a subject-node trigger"
+ *   - `{{ node.x }}` unknown prop            → error "is not a recognized node field"
+ *   - anything else                          → error "is not a recognized token"
  */
 export function diagnoseTokens(text: string, valid: Set<string>): TokenDiag[] {
   const seen = new Set<string>();
@@ -83,6 +104,10 @@ export function diagnoseTokens(text: string, valid: Set<string>): TokenDiag[] {
       out.push(anyTriggerTokenSet().has(path)
         ? { token: path, severity: 'warn', detail: 'is undefined for this trigger' }
         : { token: path, severity: 'error', detail: 'is not a recognized trigger field' });
+    } else if (path.startsWith('node.')) {
+      out.push(anyNodeTokenSet().has(path)
+        ? { token: path, severity: 'warn', detail: 'needs a subject-node trigger' }
+        : { token: path, severity: 'error', detail: 'is not a recognized node field' });
     } else {
       out.push({ token: path, severity: 'error', detail: 'is not a recognized token' });
     }

--- a/src/db/activeSchema.ts
+++ b/src/db/activeSchema.ts
@@ -128,6 +128,9 @@ import {
   automationVariablesSqlite, automationVariablesPostgres, automationVariablesMysql,
   automationVariableValuesSqlite, automationVariableValuesPostgres, automationVariableValuesMysql,
 } from './schema/automationVariables.js';
+import {
+  automationHomeAnchorsSqlite, automationHomeAnchorsPostgres, automationHomeAnchorsMysql,
+} from './schema/automationHomeAnchors.js';
 
 // MeshCore saved-regions catalog (global — no sourceId) (#3770)
 import {
@@ -261,6 +264,8 @@ export interface ActiveSchema {
   automationRuns: any;
   automationVariables: any;
   automationVariableValues: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches ActiveSchema per-dialect table pattern
+  automationHomeAnchors: any;
 
   // MeshCore saved-regions catalog (global — no sourceId) (#3770)
   meshcoreSavedRegions: any;
@@ -358,6 +363,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     automationRuns: automationRunsSqlite,
     automationVariables: automationVariablesSqlite,
     automationVariableValues: automationVariableValuesSqlite,
+    automationHomeAnchors: automationHomeAnchorsSqlite,
     meshcoreSavedRegions: meshcoreSavedRegionsSqlite,
     waypoints: waypointsSqlite,
     sources: sourcesSqlite,
@@ -421,6 +427,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     automationRuns: automationRunsPostgres,
     automationVariables: automationVariablesPostgres,
     automationVariableValues: automationVariableValuesPostgres,
+    automationHomeAnchors: automationHomeAnchorsPostgres,
     meshcoreSavedRegions: meshcoreSavedRegionsPostgres,
     waypoints: waypointsPostgres,
     sources: sourcesPostgres,
@@ -484,6 +491,7 @@ const SCHEMA_MAP: Record<DatabaseType, ActiveSchema> = {
     automationRuns: automationRunsMysql,
     automationVariables: automationVariablesMysql,
     automationVariableValues: automationVariableValuesMysql,
+    automationHomeAnchors: automationHomeAnchorsMysql,
     meshcoreSavedRegions: meshcoreSavedRegionsMysql,
     waypoints: waypointsMysql,
     sources: sourcesMysql,

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -153,6 +153,7 @@ import { migration as backfillMeshcoreNodesViewOnMapMigration, runMigration135Po
 import { migration as addMeshCoreObserverCredentialsMigration, runMigration136Postgres, runMigration136Mysql } from '../server/migrations/136_add_meshcore_observer_credentials.js';
 import { migration as estimatedPositionAnchorsMigration, runMigration137Postgres, runMigration137Mysql } from '../server/migrations/137_estimated_position_anchors.js';
 import { migration as addConversationReadStateMigration, runMigration138Postgres, runMigration138Mysql } from '../server/migrations/138_add_conversation_read_state.js';
+import { migration as automationHomeAnchorsMigration, runMigration139Postgres, runMigration139Mysql } from '../server/migrations/139_automation_home_anchors.js';
 
 // ============================================================================
 // Registry
@@ -2203,4 +2204,19 @@ registry.register({
   sqlite: (db) => addConversationReadStateMigration.up(db),
   postgres: (client) => runMigration138Postgres(client),
   mysql: (pool) => runMigration138Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 139: create `automation_home_anchors` for trigger.leftHome.
+// Persists per-(automation, node) home coordinates so left-home automations
+// survive restarts without silently re-homing a stolen node. GLOBAL.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 139,
+  name: 'automation_home_anchors',
+  settingsKey: 'migration_139_automation_home_anchors',
+  sqlite: (db) => automationHomeAnchorsMigration.up(db),
+  postgres: (client) => runMigration139Postgres(client),
+  mysql: (pool) => runMigration139Mysql(pool),
 });

--- a/src/db/repositories/automationHomeAnchors.ts
+++ b/src/db/repositories/automationHomeAnchors.ts
@@ -26,7 +26,7 @@ export class AutomationHomeAnchorsRepository extends BaseRepository {
     return this.tables.automationHomeAnchors;
   }
 
-  private rowToRecord(row: any): AutomationHomeAnchor {
+  private rowToRecord(row: Record<string, unknown>): AutomationHomeAnchor {
     return {
       id: Number(row.id),
       automationId: String(row.automationId),

--- a/src/db/repositories/automationHomeAnchors.ts
+++ b/src/db/repositories/automationHomeAnchors.ts
@@ -1,0 +1,86 @@
+/**
+ * Automation Home Anchors Repository
+ *
+ * CRUD for `automation_home_anchors` — per-(automation, node) home positions
+ * used by `trigger.leftHome`. GLOBAL (no sourceId), matching automations.
+ */
+import { and, eq } from 'drizzle-orm';
+import { BaseRepository, DrizzleDatabase } from './base.js';
+import { DatabaseType } from '../types.js';
+
+export interface AutomationHomeAnchor {
+  id: number;
+  automationId: string;
+  nodeNum: number;
+  latitude: number;
+  longitude: number;
+  setAt: number;
+}
+
+export class AutomationHomeAnchorsRepository extends BaseRepository {
+  constructor(db: DrizzleDatabase, dbType: DatabaseType) {
+    super(db, dbType);
+  }
+
+  private get table() {
+    return this.tables.automationHomeAnchors;
+  }
+
+  private rowToRecord(row: any): AutomationHomeAnchor {
+    return {
+      id: Number(row.id),
+      automationId: String(row.automationId),
+      nodeNum: Number(row.nodeNum),
+      latitude: Number(row.latitude),
+      longitude: Number(row.longitude),
+      setAt: Number(row.setAt),
+    };
+  }
+
+  async getAnchor(automationId: string, nodeNum: number): Promise<AutomationHomeAnchor | null> {
+    const t = this.table;
+    const rows = await this.db
+      .select()
+      .from(t)
+      .where(and(eq(t.automationId, automationId), eq(t.nodeNum, nodeNum)))
+      .limit(1);
+    return rows[0] ? this.rowToRecord(rows[0]) : null;
+  }
+
+  async upsertAnchor(
+    automationId: string,
+    nodeNum: number,
+    latitude: number,
+    longitude: number,
+    setAt: number = Date.now(),
+  ): Promise<void> {
+    const existing = await this.getAnchor(automationId, nodeNum);
+    const t = this.table;
+    if (existing) {
+      await this.db
+        .update(t)
+        .set({ latitude, longitude, setAt })
+        .where(and(eq(t.automationId, automationId), eq(t.nodeNum, nodeNum)));
+      return;
+    }
+    await this.db.insert(t).values({
+      automationId,
+      nodeNum,
+      latitude,
+      longitude,
+      setAt,
+    });
+  }
+
+  async deleteAnchor(automationId: string, nodeNum: number): Promise<void> {
+    const t = this.table;
+    await this.db
+      .delete(t)
+      .where(and(eq(t.automationId, automationId), eq(t.nodeNum, nodeNum)));
+  }
+
+  async deleteByAutomation(automationId: string): Promise<void> {
+    const t = this.table;
+    await this.db.delete(t).where(eq(t.automationId, automationId));
+  }
+}

--- a/src/db/repositories/index.ts
+++ b/src/db/repositories/index.ts
@@ -69,6 +69,8 @@ export type {
   UpdateVariableInput,
   AutomationVariableValueRecord,
 } from './automationVariables.js';
+export { AutomationHomeAnchorsRepository } from './automationHomeAnchors.js';
+export type { AutomationHomeAnchor } from './automationHomeAnchors.js';
 export { SavedRegionsRepository, normalizeRegionName } from './savedRegions.js';
 export type { SavedRegion } from './savedRegions.js';
 export { SourcesRepository } from './sources.js';

--- a/src/db/schema/automationHomeAnchors.ts
+++ b/src/db/schema/automationHomeAnchors.ts
@@ -1,0 +1,50 @@
+/**
+ * Drizzle schema for Automation Engine home anchors (left-home / tamper triggers).
+ *
+ * One row per (automationId, nodeNum): the lat/lon captured on first sighting so
+ * `trigger.leftHome` survives MeshMonitor restarts without silently re-homing a
+ * stolen node on the next GPS fix. GLOBAL — no sourceId (automations are global).
+ */
+import { sqliteTable, text, integer, real, uniqueIndex } from 'drizzle-orm/sqlite-core';
+import { pgTable, text as pgText, integer as pgInteger, doublePrecision, bigint as pgBigint, uniqueIndex as pgUniqueIndex } from 'drizzle-orm/pg-core';
+import { mysqlTable, varchar as myVarchar, int as myInt, double as myDouble, bigint as myBigint, uniqueIndex as myUniqueIndex } from 'drizzle-orm/mysql-core';
+
+// SQLite
+export const automationHomeAnchorsSqlite = sqliteTable('automation_home_anchors', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  automationId: text('automationId').notNull(),
+  nodeNum: integer('nodeNum').notNull(),
+  latitude: real('latitude').notNull(),
+  longitude: real('longitude').notNull(),
+  setAt: integer('setAt').notNull(),
+}, (t) => ({
+  uniq: uniqueIndex('aha_automation_node_idx').on(t.automationId, t.nodeNum),
+}));
+
+// PostgreSQL
+export const automationHomeAnchorsPostgres = pgTable('automation_home_anchors', {
+  id: pgInteger('id').primaryKey().generatedAlwaysAsIdentity(),
+  automationId: pgText('automationId').notNull(),
+  nodeNum: pgBigint('nodeNum', { mode: 'number' }).notNull(),
+  latitude: doublePrecision('latitude').notNull(),
+  longitude: doublePrecision('longitude').notNull(),
+  setAt: pgBigint('setAt', { mode: 'number' }).notNull(),
+}, (t) => ({
+  uniq: pgUniqueIndex('aha_automation_node_idx').on(t.automationId, t.nodeNum),
+}));
+
+// MySQL
+export const automationHomeAnchorsMysql = mysqlTable('automation_home_anchors', {
+  id: myInt('id').primaryKey().autoincrement(),
+  automationId: myVarchar('automationId', { length: 36 }).notNull(),
+  nodeNum: myBigint('nodeNum', { mode: 'number' }).notNull(),
+  latitude: myDouble('latitude').notNull(),
+  longitude: myDouble('longitude').notNull(),
+  setAt: myBigint('setAt', { mode: 'number' }).notNull(),
+}, (t) => ({
+  uniq: myUniqueIndex('aha_automation_node_idx').on(t.automationId, t.nodeNum),
+}));
+
+export type AutomationHomeAnchorSqlite = typeof automationHomeAnchorsSqlite.$inferSelect;
+export type AutomationHomeAnchorPostgres = typeof automationHomeAnchorsPostgres.$inferSelect;
+export type AutomationHomeAnchorMysql = typeof automationHomeAnchorsMysql.$inferSelect;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -49,6 +49,7 @@ export * from './embedProfiles.js';
 // Automation Engine tables (global — no sourceId)
 export * from './automations.js';
 export * from './automationVariables.js';
+export * from './automationHomeAnchors.js';
 
 // MeshCore saved-regions catalog (global — no sourceId) (#3770)
 export * from './savedRegions.js';

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7097,8 +7097,14 @@ class MeshtasticManager implements ISourceManager {
             dataEventEmitter.emitNodeUpdate(fromNum, nodeData, this.sourceId);
           }
 
-          // Update mobility detection for this node (fire and forget)
-          databaseService.updateNodeMobilityAsync(nodeId).catch(err =>
+          // Update mobility detection for this node; emit 0→1 transitions for
+          // trigger.becameMobile automations.
+          databaseService.updateNodeMobilityAsync(nodeId).then((mob) => {
+            if (typeof mob !== 'object' || mob == null) return;
+            if (mob.previous === 0 && mob.current === 1) {
+              dataEventEmitter.emitNodeMobility(fromNum, mob.previous, mob.current, this.sourceId);
+            }
+          }).catch(err =>
             logger.error(`Failed to update mobility for ${nodeId}:`, err)
           );
 
@@ -9130,9 +9136,15 @@ class MeshtasticManager implements ISourceManager {
         await databaseService.telemetry.insertTelemetryBatch(telemetryBatch, this.sourceId);
       }
 
-      // Update mobility detection once position was persisted (fire and forget)
+      // Update mobility detection once position was persisted; emit 0→1 for
+      // trigger.becameMobile automations.
       if (positionTelemetryData) {
-        databaseService.updateNodeMobilityAsync(nodeId).catch(err =>
+        databaseService.updateNodeMobilityAsync(nodeId).then((mob) => {
+          if (typeof mob !== 'object' || mob == null) return;
+          if (mob.previous === 0 && mob.current === 1) {
+            dataEventEmitter.emitNodeMobility(nodeNumForTelemetry, mob.previous, mob.current, this.sourceId);
+          }
+        }).catch(err =>
           logger.error(`Failed to update mobility for ${nodeId}:`, err)
         );
       }

--- a/src/server/migrations/139_automation_home_anchors.test.ts
+++ b/src/server/migrations/139_automation_home_anchors.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Migration 139 tests — automation_home_anchors table creation.
+ */
+import Database from 'better-sqlite3';
+import { describe, expect, it, vi } from 'vitest';
+import { migration, runMigration139Postgres, runMigration139Mysql } from './139_automation_home_anchors.js';
+
+describe('Migration 139 — automation_home_anchors', () => {
+  describe('SQLite', () => {
+    it('creates the table and unique index, and is idempotent', () => {
+      const db = new Database(':memory:');
+      migration.up(db);
+      expect(() => migration.up(db)).not.toThrow();
+
+      const table = db.prepare(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name = 'automation_home_anchors'`
+      ).get();
+      expect(table).toBeTruthy();
+
+      const index = db.prepare(
+        `SELECT name FROM sqlite_master WHERE type='index' AND name = 'aha_automation_node_idx'`
+      ).get();
+      expect(index).toBeTruthy();
+      db.close();
+    });
+
+    it('enforces one home per (automationId, nodeNum)', () => {
+      const db = new Database(':memory:');
+      migration.up(db);
+      const insert = db.prepare(`
+        INSERT INTO automation_home_anchors (automationId, nodeNum, latitude, longitude, setAt)
+        VALUES (?, ?, ?, ?, ?)
+      `);
+      insert.run('auto-1', 42, 1.0, 2.0, 1000);
+      expect(() => insert.run('auto-1', 42, 3.0, 4.0, 2000)).toThrow();
+      db.close();
+    });
+  });
+
+  describe('PostgreSQL', () => {
+    it('creates the table', async () => {
+      const client = { query: vi.fn().mockResolvedValue(undefined) };
+      await runMigration139Postgres(client as any);
+      const sql = client.query.mock.calls.map((c: any[]) => String(c[0])).join('\n');
+      expect(sql).toMatch(/automation_home_anchors/);
+      expect(sql).toMatch(/aha_automation_node_idx/);
+    });
+  });
+
+  describe('MySQL', () => {
+    function makeConn(existRows: any[]) {
+      return {
+        query: vi.fn().mockResolvedValue([existRows, []]),
+        release: vi.fn(),
+      };
+    }
+
+    it('creates the table when missing', async () => {
+      const absentConn = makeConn([]);
+      const absentPool = { getConnection: vi.fn().mockResolvedValue(absentConn) };
+
+      await runMigration139Mysql(absentPool as any);
+
+      expect(absentConn.query).toHaveBeenCalled();
+      const ddl = absentConn.query.mock.calls.map((c: any[]) => String(c[0])).join('\n');
+      expect(ddl).toMatch(/CREATE TABLE automation_home_anchors/);
+      expect(absentConn.release).toHaveBeenCalled();
+    });
+
+    it('skips create when the table already exists', async () => {
+      const presentConn = makeConn([{ TABLE_NAME: 'automation_home_anchors' }]);
+      const presentPool = { getConnection: vi.fn().mockResolvedValue(presentConn) };
+
+      await runMigration139Mysql(presentPool as any);
+
+      // existence check only for createTableIfMissing; createIndexIfMissing may still query
+      expect(presentConn.release).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/migrations/139_automation_home_anchors.ts
+++ b/src/server/migrations/139_automation_home_anchors.ts
@@ -1,0 +1,91 @@
+/**
+ * Migration 139: create `automation_home_anchors` for trigger.leftHome.
+ *
+ * Persists per-(automation, node) home/anchor coordinates so left-home
+ * automations survive restarts without re-homing a moved (stolen) node.
+ * GLOBAL — no sourceId, matching the automations table.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+import { createTableIfMissingMysql, createIndexIfMissingMysql } from './helpers.js';
+
+const LABEL = 'Migration 139';
+const TABLE = 'automation_home_anchors';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): creating ${TABLE}...`);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS ${TABLE} (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        automationId TEXT NOT NULL,
+        nodeNum INTEGER NOT NULL,
+        latitude REAL NOT NULL,
+        longitude REAL NOT NULL,
+        setAt INTEGER NOT NULL
+      )
+    `);
+    db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS aha_automation_node_idx ON ${TABLE}(automationId, nodeNum)`);
+
+    logger.info(`${LABEL} complete (SQLite)`);
+  },
+
+  down: (db: Database): void => {
+    logger.info(`${LABEL} down (SQLite): dropping ${TABLE}`);
+    db.exec(`DROP TABLE IF EXISTS ${TABLE}`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration139Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): creating ${TABLE}...`);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS ${TABLE} (
+      id SERIAL PRIMARY KEY,
+      "automationId" TEXT NOT NULL,
+      "nodeNum" BIGINT NOT NULL,
+      latitude DOUBLE PRECISION NOT NULL,
+      longitude DOUBLE PRECISION NOT NULL,
+      "setAt" BIGINT NOT NULL
+    )
+  `);
+  await client.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS aha_automation_node_idx
+    ON ${TABLE}("automationId", "nodeNum")
+  `);
+
+  logger.info(`${LABEL} complete (PostgreSQL)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration139Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): creating ${TABLE}...`);
+
+  await createTableIfMissingMysql(pool, TABLE, `
+    CREATE TABLE ${TABLE} (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      automationId VARCHAR(36) NOT NULL,
+      nodeNum BIGINT NOT NULL,
+      latitude DOUBLE NOT NULL,
+      longitude DOUBLE NOT NULL,
+      setAt BIGINT NOT NULL,
+      UNIQUE KEY aha_automation_node_idx (automationId, nodeNum)
+    )
+  `);
+  await createIndexIfMissingMysql(
+    pool,
+    TABLE,
+    'aha_automation_node_idx',
+    `CREATE UNIQUE INDEX aha_automation_node_idx ON ${TABLE}(automationId, nodeNum)`,
+  );
+
+  logger.info(`${LABEL} complete (MySQL)`);
+}

--- a/src/server/routes/automationRoutes.ts
+++ b/src/server/routes/automationRoutes.ts
@@ -427,8 +427,8 @@ router.delete('/:id', canWrite, async (req: Request, res: Response) => {
     // Drop any left-home anchors owned by this automation.
     try {
       await databaseService.automationHomeAnchorsRepo?.deleteByAutomation(req.params.id);
-    } catch (e: any) {
-      logger.warn(`Failed to clean home anchors for automation ${req.params.id}: ${e?.message}`);
+    } catch (e) {
+      logger.warn(`Failed to clean home anchors for automation ${req.params.id}: ${e instanceof Error ? e.message : String(e)}`);
     }
     await reloadAutomations();
     res.json({ success: true });

--- a/src/server/routes/automationRoutes.ts
+++ b/src/server/routes/automationRoutes.ts
@@ -341,6 +341,12 @@ router.delete('/:id', canWrite, async (req: Request, res: Response) => {
   try {
     const ok = await databaseService.automations.deleteAutomation(req.params.id);
     if (!ok) return res.status(404).json({ error: 'automation not found' });
+    // Drop any left-home anchors owned by this automation.
+    try {
+      await databaseService.automationHomeAnchorsRepo?.deleteByAutomation(req.params.id);
+    } catch (e: any) {
+      logger.warn(`Failed to clean home anchors for automation ${req.params.id}: ${e?.message}`);
+    }
     await reloadAutomations();
     res.json({ success: true });
   } catch (error) {

--- a/src/server/routes/automationRoutes.ts
+++ b/src/server/routes/automationRoutes.ts
@@ -21,10 +21,11 @@ import {
   COLLAPSE_MODES,
   NUMERIC_OPS,
 } from '../../types/automation.js';
-import { reloadAutomations } from '../services/automation/automationEngineSingleton.js';
+import { reloadAutomations, getAutomationEngine } from '../services/automation/automationEngineSingleton.js';
 import { simulateAutomation, type SimEventInput } from '../services/automation/automationSimulator.js';
 import { createMeshNodeDataProvider } from '../services/automation/meshNodeData.js';
 import { unifyChannels, sourceProtocol } from '../services/automation/channelUnify.js';
+import { estimateHomeFromNodeHistory } from '../services/automation/leftHomeFromHistory.js';
 
 const router = Router();
 
@@ -334,6 +335,88 @@ router.post('/:id/disable', canWrite, async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Error disabling automation:', error);
     res.status(500).json({ error: 'Failed to disable automation' });
+  }
+});
+
+/**
+ * Reset left-home anchors for a `trigger.leftHome` automation: delete stored
+ * homes and re-seed each watched node from position-history inliers (median
+ * cluster). Clears in-memory alarmed state so the rule can fire again.
+ */
+router.post('/:id/reset-homes', canWrite, async (req: Request, res: Response) => {
+  try {
+    const auto = await databaseService.automations.getAutomation(req.params.id);
+    if (!auto) return res.status(404).json({ error: 'automation not found' });
+
+    let graph: ReturnType<typeof validateAutomationGraph>['graph'];
+    try {
+      const parsed = JSON.parse(auto.config);
+      const v = validateAutomationGraph(parsed);
+      if (!v.valid || !v.graph) {
+        return res.status(400).json({ error: 'invalid automation config', details: v.errors });
+      }
+      graph = v.graph;
+    } catch {
+      return res.status(400).json({ error: 'automation config is not valid JSON' });
+    }
+
+    const trigger = graph!.nodes.find((n) => n.type === 'trigger.leftHome');
+    if (!trigger) {
+      return res.status(400).json({ error: 'automation is not a left-home trigger' });
+    }
+    const params = (trigger.params ?? {}) as Record<string, unknown>;
+    const nodeNums = Array.isArray(params.nodeNums)
+      ? (params.nodeNums as unknown[]).map(Number).filter((n) => Number.isInteger(n) && n > 0)
+      : [];
+    if (nodeNums.length === 0) {
+      return res.status(400).json({ error: 'no watched nodes configured' });
+    }
+    const thresholdMeters = Number(params.thresholdMeters ?? 300);
+    const thr = Number.isFinite(thresholdMeters) && thresholdMeters > 0 ? thresholdMeters : 300;
+
+    const repo = databaseService.automationHomeAnchorsRepo;
+    if (!repo) return res.status(503).json({ error: 'home anchors store not available' });
+
+    const results: Array<{
+      nodeNum: number;
+      seeded: boolean;
+      latitude?: number;
+      longitude?: number;
+      sampleCount?: number;
+      inlierCount?: number;
+    }> = [];
+
+    for (const nodeNum of nodeNums) {
+      await repo.deleteAnchor(auto.id, nodeNum);
+      const est = await estimateHomeFromNodeHistory(nodeNum, thr);
+      if (est) {
+        await repo.upsertAnchor(auto.id, nodeNum, est.latitude, est.longitude, Date.now());
+        results.push({
+          nodeNum,
+          seeded: true,
+          latitude: est.latitude,
+          longitude: est.longitude,
+          sampleCount: est.sampleCount,
+          inlierCount: est.inlierCount,
+        });
+      } else {
+        results.push({ nodeNum, seeded: false });
+      }
+    }
+
+    getAutomationEngine()?.clearLeftHomeRuntimeState(auto.id);
+    await reloadAutomations();
+
+    res.json({
+      success: true,
+      thresholdMeters: thr,
+      reset: nodeNums.length,
+      seeded: results.filter((r) => r.seeded).length,
+      results,
+    });
+  } catch (error) {
+    logger.error('Error resetting left-home anchors:', error);
+    res.status(500).json({ error: 'Failed to reset homes' });
   }
 });
 

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -1345,4 +1345,104 @@ describe('AutomationEngineService — becameMobile / leftHome', () => {
     expect(await engine2.checkLeftHome(3, 'default')).toBe(1);
     expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(1);
   });
+
+  it('leftHome: averages home while within threshold/2; does not pull home toward a far glitch', async () => {
+    const { deps } = recorder();
+    const created = await createEnabled('refine-home', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.leftHome', params: { nodeNums: [5], thresholdMeters: 200 } },
+        { id: 'a', type: 'action.notify', params: { body: 'away' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    });
+    // Start with a slightly-off "glitch" home, then walk toward the true site
+    // with fixes well inside threshold/2 (100 m) so EMA can pull the anchor.
+    const pos = { lat: 40.0, lon: -70.0 };
+    const data = {
+      getNode: async () => ({ nodeNum: 5, latitude: pos.lat, longitude: pos.lon }),
+      getTelemetry: async () => null,
+    };
+    const engine = new AutomationEngineService({
+      automationsRepo: autos, varResolver: resolver, deps, data, homeAnchorsRepo: homeAnchors, now: () => clock,
+    });
+    await engine.load();
+    expect(await engine.checkLeftHome(5, 'default')).toBe(0);
+    const home0 = await homeAnchors.getAnchor(created.id, 5);
+    expect(home0?.latitude).toBe(40.0);
+
+    // ~55 m north (≈ 0.0005°) — inside refine radius 100 m → average toward it.
+    pos.lat = 40.0005;
+    expect(await engine.checkLeftHome(5, 'default')).toBe(0);
+    const home1 = await homeAnchors.getAnchor(created.id, 5);
+    expect(home1).toBeTruthy();
+    expect(home1!.latitude).toBeGreaterThan(40.0);
+    expect(home1!.latitude).toBeLessThan(40.0005);
+
+    // Far glitch (~1.1 km) — beyond threshold → would fire, must NOT average into home.
+    const latBeforeGlitch = home1!.latitude;
+    pos.lat = 40.01;
+    expect(await engine.checkLeftHome(5, 'default')).toBe(1);
+    const homeAfterGlitch = await homeAnchors.getAnchor(created.id, 5);
+    expect(homeAfterGlitch!.latitude).toBe(latBeforeGlitch);
+  });
+
+  it('leftHome: seeds home from estimateHomeFromHistory when provided', async () => {
+    const { deps } = recorder();
+    const created = await createEnabled('hist-home', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.leftHome', params: { nodeNums: [8], thresholdMeters: 300 } },
+        { id: 'a', type: 'action.notify', params: { body: 'away' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    });
+    const data = {
+      getNode: async () => ({ nodeNum: 8, latitude: 1.0, longitude: 2.0 }), // live glitch
+      getTelemetry: async () => null,
+    };
+    const engine = new AutomationEngineService({
+      automationsRepo: autos,
+      varResolver: resolver,
+      deps,
+      data,
+      homeAnchorsRepo: homeAnchors,
+      now: () => clock,
+      estimateHomeFromHistory: async () => ({ latitude: 46.05, longitude: 14.5 }),
+    });
+    await engine.load();
+    expect(await engine.checkLeftHome(8, 'default')).toBe(0);
+    const anchor = await homeAnchors.getAnchor(created.id, 8);
+    expect(anchor?.latitude).toBe(46.05);
+    expect(anchor?.longitude).toBe(14.5);
+  });
+
+  it('clearLeftHomeRuntimeState drops alarmed so a beyond fix can fire again', async () => {
+    const { calls, deps } = recorder();
+    const created = await createEnabled('rearm-clear', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.leftHome', params: { nodeNums: [9], thresholdMeters: 100 } },
+        { id: 'a', type: 'action.notify', params: { body: 'away' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    });
+    const pos = { lat: 20.0, lon: 30.0 };
+    const data = {
+      getNode: async () => ({ nodeNum: 9, latitude: pos.lat, longitude: pos.lon }),
+      getTelemetry: async () => null,
+    };
+    const engine = new AutomationEngineService({
+      automationsRepo: autos, varResolver: resolver, deps, data, homeAnchorsRepo: homeAnchors, now: () => clock,
+    });
+    await engine.load();
+    expect(await engine.checkLeftHome(9, 'default')).toBe(0);
+    pos.lat = 20.002;
+    expect(await engine.checkLeftHome(9, 'default')).toBe(1);
+    expect(await engine.checkLeftHome(9, 'default')).toBe(0); // alarmed
+
+    engine.clearLeftHomeRuntimeState(created.id);
+    expect(await engine.checkLeftHome(9, 'default')).toBe(1);
+    expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(2);
+  });
 });

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -1223,3 +1223,126 @@ describe('#4594 MQTT-source hop glyph', () => {
     expect(await tapbackEmojiFor('meshtastic_tcp', { viaMqtt: true } as Partial<DbMessage>)).toBe('2️⃣');
   });
 });
+
+describe('AutomationEngineService — becameMobile / leftHome', () => {
+  let db: ReturnType<typeof createTestDb>['sqlite'];
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let autos: AutomationsRepository;
+  let varsRepo: AutomationVariablesRepository;
+  let resolver: VariableResolver;
+  let clock: number;
+  let homeAnchors: import('../../../db/repositories/automationHomeAnchors.js').AutomationHomeAnchorsRepository;
+
+  beforeEach(async () => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    autos = new AutomationsRepository(drizzleDb, 'sqlite');
+    varsRepo = new AutomationVariablesRepository(drizzleDb, 'sqlite');
+    resolver = new VariableResolver(varsRepo);
+    const { AutomationHomeAnchorsRepository } = await import('../../../db/repositories/automationHomeAnchors.js');
+    homeAnchors = new AutomationHomeAnchorsRepository(drizzleDb, 'sqlite');
+    clock = 1_000_000;
+  });
+  afterEach(() => { db.close(); automationTraceBus.reset(); automationTraceBus.setSink(null); });
+
+  async function createEnabled(name: string, graph: AutomationGraph) {
+    return autos.createAutomation({ name, enabled: true, config: JSON.stringify(graph) });
+  }
+
+  it('becameMobile: fires only on 0→1 for a watched node', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('mob', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.becameMobile', params: { nodeNums: [42] } },
+        { id: 'a', type: 'action.notify', params: { body: 'moved {{ trigger.nodeNum }}' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    });
+    const data = {
+      getNode: async () => ({ nodeNum: 42, latitude: 1, longitude: 2, longName: 'Site A' }),
+      getTelemetry: async () => null,
+    };
+    const engine = new AutomationEngineService({
+      automationsRepo: autos, varResolver: resolver, deps, data, homeAnchorsRepo: homeAnchors, now: () => clock,
+    });
+    await engine.load();
+
+    expect(await engine.checkBecameMobile(42, 0, 0, 'default')).toBe(0);
+    expect(await engine.checkBecameMobile(42, 1, 1, 'default')).toBe(0);
+    expect(await engine.checkBecameMobile(99, 0, 1, 'default')).toBe(0); // not watched
+    expect(await engine.checkBecameMobile(42, 0, 1, 'default')).toBe(1);
+    expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(1);
+    expect(calls[0].args.body).toBe('moved 42');
+  });
+
+  it('leftHome: establishes home without firing, then fires on exceed and re-arms on return', async () => {
+    const { calls, deps } = recorder();
+    const created = await createEnabled('home', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.leftHome', params: { nodeNums: [7], thresholdMeters: 100 } },
+        { id: 'a', type: 'action.notify', params: { body: 'away {{ trigger.distanceMeters }}' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    });
+    const pos = { lat: 30.0, lon: -90.0 };
+    const data = {
+      getNode: async () => ({ nodeNum: 7, latitude: pos.lat, longitude: pos.lon }),
+      getTelemetry: async () => null,
+    };
+    const engine = new AutomationEngineService({
+      automationsRepo: autos, varResolver: resolver, deps, data, homeAnchorsRepo: homeAnchors, now: () => clock,
+    });
+    await engine.load();
+
+    expect(await engine.checkLeftHome(7, 'default')).toBe(0); // establish home
+    const anchor = await homeAnchors.getAnchor(created.id, 7);
+    expect(anchor?.latitude).toBe(30.0);
+
+    // ~222 m north → beyond 100 m
+    pos.lat = 30.002;
+    expect(await engine.checkLeftHome(7, 'default')).toBe(1);
+    expect(await engine.checkLeftHome(7, 'default')).toBe(0); // still alarmed
+    expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(1);
+
+    // Return home → re-arm
+    pos.lat = 30.0;
+    expect(await engine.checkLeftHome(7, 'default')).toBe(0);
+    pos.lat = 30.002;
+    expect(await engine.checkLeftHome(7, 'default')).toBe(1);
+    expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(2);
+  });
+
+  it('leftHome: persists home across engine reload', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('persist-home', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.leftHome', params: { nodeNums: [3], thresholdMeters: 100 } },
+        { id: 'a', type: 'action.notify', params: { body: 'stolen' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    });
+    const pos = { lat: 10.0, lon: 20.0 };
+    const data = {
+      getNode: async () => ({ nodeNum: 3, latitude: pos.lat, longitude: pos.lon }),
+      getTelemetry: async () => null,
+    };
+    const engine1 = new AutomationEngineService({
+      automationsRepo: autos, varResolver: resolver, deps, data, homeAnchorsRepo: homeAnchors, now: () => clock,
+    });
+    await engine1.load();
+    expect(await engine1.checkLeftHome(3, 'default')).toBe(0); // home set
+
+    // New engine instance (simulates restart) — must NOT re-home at stolen coords
+    pos.lat = 10.002;
+    const engine2 = new AutomationEngineService({
+      automationsRepo: autos, varResolver: resolver, deps, data, homeAnchorsRepo: homeAnchors, now: () => clock,
+    });
+    await engine2.load();
+    expect(await engine2.checkLeftHome(3, 'default')).toBe(1);
+    expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(1);
+  });
+});

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -160,6 +160,15 @@ export interface EngineServiceOptions {
   data: NodeDataProvider;
   /** Persists left-home anchors. Optional in unit tests that don't cover leftHome. */
   homeAnchorsRepo?: AutomationHomeAnchorsRepository | null;
+  /**
+   * Optional: estimate a home lat/lon from stored position history (median +
+   * inlier mean). Used on first establish / reset so a glitched first packet
+   * does not become the anchor when history exists. Injected for testability.
+   */
+  estimateHomeFromHistory?: (
+    nodeNum: number,
+    thresholdMeters: number,
+  ) => Promise<{ latitude: number; longitude: number } | null>;
   /** Injectable clock (cooldown + flag TTL). Defaults to Date.now. */
   now?: () => number;
   /** Per-run action cap (loop/spam guard). Default 50. */
@@ -174,6 +183,7 @@ export class AutomationEngineService {
   private readonly deps: ActionDeps;
   private readonly data: NodeDataProvider;
   private readonly homeAnchorsRepo: AutomationHomeAnchorsRepository | null;
+  private readonly estimateHomeFromHistory: EngineServiceOptions['estimateHomeFromHistory'];
   private readonly now: () => number;
   private readonly maxActions: number;
   private readonly cron: CronScheduler;
@@ -195,6 +205,7 @@ export class AutomationEngineService {
     this.deps = opts.deps;
     this.data = opts.data;
     this.homeAnchorsRepo = opts.homeAnchorsRepo ?? null;
+    this.estimateHomeFromHistory = opts.estimateHomeFromHistory;
     this.now = opts.now ?? (() => Date.now());
     this.maxActions = opts.maxActions ?? 50;
     this.cron = opts.cron ?? REAL_CRON_SCHEDULER;
@@ -765,6 +776,11 @@ export class AutomationEngineService {
    * Fire `trigger.leftHome` automations when a watched node exceeds its home
    * distance. First sighting establishes (and persists) home without firing;
    * returning within threshold re-arms after an alert.
+   *
+   * While the node stays within threshold/2 of home, the anchor is refined with
+   * an exponential moving average so a glitched first fix can drift toward the
+   * true site without waiting for multi-packet confirmation (sparse ~3h beacons).
+   * Fixes beyond threshold/2 never pull home (and beyond threshold may fire).
    */
   async checkLeftHome(nodeNum: number, sourceId: string | null): Promise<number> {
     const entries = this.index.get('trigger.leftHome');
@@ -779,24 +795,46 @@ export class AutomationEngineService {
       const p = (a.triggerNode.params ?? {}) as Record<string, unknown>;
       if (!nodeNumsInclude(p.nodeNums, nodeNum)) continue;
 
-      const thresholdMeters = Number(p.thresholdMeters ?? 100);
+      const thresholdMeters = Number(p.thresholdMeters ?? 300);
       if (!Number.isFinite(thresholdMeters) || thresholdMeters <= 0) continue;
+      const refineRadius = thresholdMeters / 2;
 
       let home = this.homeAnchorsRepo
         ? await this.homeAnchorsRepo.getAnchor(a.id, nodeNum)
         : null;
 
       if (!home) {
-        // First sighting: establish home, do not fire.
+        // First sighting: prefer a history-derived cluster home when available
+        // (drops spider-line outliers), else the live fix.
+        let homeLat = node.latitude;
+        let homeLon = node.longitude;
+        let fromHistory = false;
+        if (this.estimateHomeFromHistory) {
+          try {
+            const est = await this.estimateHomeFromHistory(nodeNum, thresholdMeters);
+            if (est) {
+              homeLat = est.latitude;
+              homeLon = est.longitude;
+              fromHistory = true;
+            }
+          } catch (e: any) {
+            logger.warn(`[AutomationEngine] leftHome history seed failed for node ${nodeNum}: ${e?.message}`);
+          }
+        }
         if (this.homeAnchorsRepo) {
-          await this.homeAnchorsRepo.upsertAnchor(a.id, nodeNum, node.latitude, node.longitude, now);
+          await this.homeAnchorsRepo.upsertAnchor(a.id, nodeNum, homeLat, homeLon, now);
         }
         const ctx = buildLeftHomeContext(
           nodeNum, node.latitude, node.longitude,
-          node.latitude, node.longitude, 0, thresholdMeters, sourceId, now,
+          homeLat, homeLon, 0, thresholdMeters, sourceId, now,
         );
         const traced = automationTraceBus.activeCount() > 0 && automationTraceBus.isTracing(a.id, now);
-        if (traced) this.emitTrace(a, ctx, now, { outcome: 'prefiltered', reason: 'first sighting — home established' });
+        if (traced) {
+          this.emitTrace(a, ctx, now, {
+            outcome: 'prefiltered',
+            reason: fromHistory ? 'first sighting — home seeded from position history' : 'first sighting — home established',
+          });
+        }
         continue;
       }
 
@@ -817,7 +855,23 @@ export class AutomationEngineService {
           let inner = this.leftHomeAlarmed.get(a.id);
           if (inner) inner.set(nodeNum, false);
         }
-        if (traced) this.emitTrace(a, ctx, now, { outcome: 'prefiltered', reason: 'within home threshold' });
+        // Soft-refine home while the fix is in the inner half-radius so a
+        // glitched first anchor can crawl toward the real cluster. Outside
+        // refineRadius we leave home alone (noise / partial move).
+        if (distanceMeters <= refineRadius && this.homeAnchorsRepo) {
+          const alpha = LEFT_HOME_REFINE_ALPHA;
+          const newLat = home.latitude * (1 - alpha) + node.latitude * alpha;
+          const newLon = home.longitude * (1 - alpha) + node.longitude * alpha;
+          await this.homeAnchorsRepo.upsertAnchor(a.id, nodeNum, newLat, newLon, now);
+          if (traced) {
+            this.emitTrace(a, ctx, now, {
+              outcome: 'prefiltered',
+              reason: `within home refine radius — anchor averaged (α=${alpha})`,
+            });
+          }
+        } else if (traced) {
+          this.emitTrace(a, ctx, now, { outcome: 'prefiltered', reason: 'within home threshold' });
+        }
         continue;
       }
 
@@ -843,7 +897,18 @@ export class AutomationEngineService {
     }
     return fired;
   }
+
+  /**
+   * Drop in-memory left-home alarmed flags for one automation (e.g. after a
+   * homes reset). Persisted anchors are managed by the caller / repository.
+   */
+  clearLeftHomeRuntimeState(automationId: string): void {
+    this.leftHomeAlarmed.delete(automationId);
+  }
 }
+
+/** EMA weight for leftHome anchor refinement (new fix vs existing home). */
+const LEFT_HOME_REFINE_ALPHA = 0.25;
 
 /** True when `nodeNums` (trigger param) includes `nodeNum`. Empty/missing → no match (v1 requires hand-select). */
 function nodeNumsInclude(raw: unknown, nodeNum: number): boolean {

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -799,7 +799,7 @@ export class AutomationEngineService {
       if (!Number.isFinite(thresholdMeters) || thresholdMeters <= 0) continue;
       const refineRadius = thresholdMeters / 2;
 
-      let home = this.homeAnchorsRepo
+      const home = this.homeAnchorsRepo
         ? await this.homeAnchorsRepo.getAnchor(a.id, nodeNum)
         : null;
 
@@ -817,8 +817,8 @@ export class AutomationEngineService {
               homeLon = est.longitude;
               fromHistory = true;
             }
-          } catch (e: any) {
-            logger.warn(`[AutomationEngine] leftHome history seed failed for node ${nodeNum}: ${e?.message}`);
+          } catch (e) {
+            logger.warn(`[AutomationEngine] leftHome history seed failed for node ${nodeNum}: ${e instanceof Error ? e.message : String(e)}`);
           }
         }
         if (this.homeAnchorsRepo) {
@@ -852,7 +852,7 @@ export class AutomationEngineService {
       if (!beyond) {
         // Back within threshold → re-arm.
         if (alarmed) {
-          let inner = this.leftHomeAlarmed.get(a.id);
+          const inner = this.leftHomeAlarmed.get(a.id);
           if (inner) inner.set(nodeNum, false);
         }
         // Soft-refine home while the fix is in the inner half-radius so a

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -14,6 +14,7 @@
 import { logger } from '../../../utils/logger.js';
 import type { DbMessage } from '../../../services/database.js';
 import type { AutomationsRepository } from '../../../db/repositories/automations.js';
+import type { AutomationHomeAnchorsRepository } from '../../../db/repositories/automationHomeAnchors.js';
 import { isMqttSourceType } from '../../../db/repositories/sources.js';
 import {
   validateAutomationGraph,
@@ -32,6 +33,8 @@ import {
   buildTelemetryContext,
   buildSystemContext,
   buildGeofenceContext,
+  buildBecameMobileContext,
+  buildLeftHomeContext,
   buildScheduleContext,
   messageMatchesFilter,
   meshCoreMessageMatchesFilter,
@@ -155,6 +158,8 @@ export interface EngineServiceOptions {
   deps: ActionDeps;
   /** Hydrates the subject node + telemetry for conditions. */
   data: NodeDataProvider;
+  /** Persists left-home anchors. Optional in unit tests that don't cover leftHome. */
+  homeAnchorsRepo?: AutomationHomeAnchorsRepository | null;
   /** Injectable clock (cooldown + flag TTL). Defaults to Date.now. */
   now?: () => number;
   /** Per-run action cap (loop/spam guard). Default 50. */
@@ -168,6 +173,7 @@ export class AutomationEngineService {
   private readonly vars: VariableResolver;
   private readonly deps: ActionDeps;
   private readonly data: NodeDataProvider;
+  private readonly homeAnchorsRepo: AutomationHomeAnchorsRepository | null;
   private readonly now: () => number;
   private readonly maxActions: number;
   private readonly cron: CronScheduler;
@@ -178,6 +184,8 @@ export class AutomationEngineService {
   private lastFired = new Map<string, Map<string, number>>();
   /** automationId → nodeNum → { inside: was the node in the geofence at last check; ts: when last checked (eviction, #4399) }. */
   private geofenceState = new Map<string, Map<number, { inside: boolean; ts: number }>>();
+  /** automationId → nodeNum → alarmed (beyond threshold) for left-home re-arm. */
+  private leftHomeAlarmed = new Map<string, Map<number, boolean>>();
   /** automationId → live cron job, for `trigger.schedule` automations. */
   private cronJobs = new Map<string, { stop: () => void }>();
 
@@ -186,6 +194,7 @@ export class AutomationEngineService {
     this.vars = opts.varResolver;
     this.deps = opts.deps;
     this.data = opts.data;
+    this.homeAnchorsRepo = opts.homeAnchorsRepo ?? null;
     this.now = opts.now ?? (() => Date.now());
     this.maxActions = opts.maxActions ?? 50;
     this.cron = opts.cron ?? REAL_CRON_SCHEDULER;
@@ -238,6 +247,7 @@ export class AutomationEngineService {
     // dropping them is unobservable — unlike evicting a *live* automation's
     // per-node entries, which is the risky case GEOFENCE_STATE_MAX guards.
     for (const id of this.geofenceState.keys()) if (!liveIds.has(id)) this.geofenceState.delete(id);
+    for (const id of this.leftHomeAlarmed.keys()) if (!liveIds.has(id)) this.leftHomeAlarmed.delete(id);
     this.rescheduleCron();
     logger.info(`[AutomationEngine] loaded ${rows.length} enabled automation(s)`);
   }
@@ -705,4 +715,139 @@ export class AutomationEngineService {
     }
     return fired;
   }
+
+  /**
+   * Fire `trigger.becameMobile` automations when a watched node flips 0→1.
+   * Called after mobility recompute with the previous+current flags.
+   */
+  async checkBecameMobile(
+    nodeNum: number,
+    previousMobile: number,
+    currentMobile: number,
+    sourceId: string | null,
+  ): Promise<number> {
+    if (!(previousMobile === 0 && currentMobile === 1)) return 0;
+    const entries = this.index.get('trigger.becameMobile');
+    if (!entries || entries.length === 0) return 0;
+
+    const node = await this.data.getNode(sourceId, nodeNum);
+    const now = this.now();
+    let fired = 0;
+
+    for (const a of entries) {
+      const p = (a.triggerNode.params ?? {}) as Record<string, unknown>;
+      if (!nodeNumsInclude(p.nodeNums, nodeNum)) continue;
+
+      const ctx = buildBecameMobileContext(
+        nodeNum,
+        node?.latitude,
+        node?.longitude,
+        previousMobile,
+        currentMobile,
+        sourceId,
+        now,
+      );
+      const traced = automationTraceBus.activeCount() > 0 && automationTraceBus.isTracing(a.id, now);
+      const gate = this.cooldownGate(a, ctx, now);
+      if (!gate.ok) {
+        if (traced) this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: gate.reason });
+        continue;
+      }
+      this.markFired(a, gate.key, now);
+      fired++;
+      const fr = await this.fireAutomation(a, ctx, now);
+      if (traced) this.emitTrace(a, ctx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });
+    }
+    return fired;
+  }
+
+  /**
+   * Fire `trigger.leftHome` automations when a watched node exceeds its home
+   * distance. First sighting establishes (and persists) home without firing;
+   * returning within threshold re-arms after an alert.
+   */
+  async checkLeftHome(nodeNum: number, sourceId: string | null): Promise<number> {
+    const entries = this.index.get('trigger.leftHome');
+    if (!entries || entries.length === 0) return 0;
+    const node = await this.data.getNode(sourceId, nodeNum);
+    if (!node || node.latitude == null || node.longitude == null) return 0;
+
+    const now = this.now();
+    let fired = 0;
+
+    for (const a of entries) {
+      const p = (a.triggerNode.params ?? {}) as Record<string, unknown>;
+      if (!nodeNumsInclude(p.nodeNums, nodeNum)) continue;
+
+      const thresholdMeters = Number(p.thresholdMeters ?? 100);
+      if (!Number.isFinite(thresholdMeters) || thresholdMeters <= 0) continue;
+
+      let home = this.homeAnchorsRepo
+        ? await this.homeAnchorsRepo.getAnchor(a.id, nodeNum)
+        : null;
+
+      if (!home) {
+        // First sighting: establish home, do not fire.
+        if (this.homeAnchorsRepo) {
+          await this.homeAnchorsRepo.upsertAnchor(a.id, nodeNum, node.latitude, node.longitude, now);
+        }
+        const ctx = buildLeftHomeContext(
+          nodeNum, node.latitude, node.longitude,
+          node.latitude, node.longitude, 0, thresholdMeters, sourceId, now,
+        );
+        const traced = automationTraceBus.activeCount() > 0 && automationTraceBus.isTracing(a.id, now);
+        if (traced) this.emitTrace(a, ctx, now, { outcome: 'prefiltered', reason: 'first sighting — home established' });
+        continue;
+      }
+
+      const distanceKm = haversineKm(node.latitude, node.longitude, home.latitude, home.longitude);
+      const distanceMeters = distanceKm * 1000;
+      const beyond = distanceMeters > thresholdMeters;
+      const alarmed = this.leftHomeAlarmed.get(a.id)?.get(nodeNum) === true;
+
+      const ctx = buildLeftHomeContext(
+        nodeNum, node.latitude, node.longitude,
+        home.latitude, home.longitude, distanceMeters, thresholdMeters, sourceId, now,
+      );
+      const traced = automationTraceBus.activeCount() > 0 && automationTraceBus.isTracing(a.id, now);
+
+      if (!beyond) {
+        // Back within threshold → re-arm.
+        if (alarmed) {
+          let inner = this.leftHomeAlarmed.get(a.id);
+          if (inner) inner.set(nodeNum, false);
+        }
+        if (traced) this.emitTrace(a, ctx, now, { outcome: 'prefiltered', reason: 'within home threshold' });
+        continue;
+      }
+
+      if (alarmed) {
+        if (traced) this.emitTrace(a, ctx, now, { outcome: 'prefiltered', reason: 'already alarmed (awaiting return within threshold)' });
+        continue;
+      }
+
+      const gate = this.cooldownGate(a, ctx, now);
+      if (!gate.ok) {
+        if (traced) this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: gate.reason });
+        continue;
+      }
+
+      let inner = this.leftHomeAlarmed.get(a.id);
+      if (!inner) { inner = new Map(); this.leftHomeAlarmed.set(a.id, inner); }
+      inner.set(nodeNum, true);
+
+      this.markFired(a, gate.key, now);
+      fired++;
+      const fr = await this.fireAutomation(a, ctx, now);
+      if (traced) this.emitTrace(a, ctx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });
+    }
+    return fired;
+  }
+}
+
+/** True when `nodeNums` (trigger param) includes `nodeNum`. Empty/missing → no match (v1 requires hand-select). */
+function nodeNumsInclude(raw: unknown, nodeNum: number): boolean {
+  if (!Array.isArray(raw) || raw.length === 0) return false;
+  const want = Number(nodeNum);
+  return raw.some((x) => Number(x) === want);
 }

--- a/src/server/services/automation/automationEngineSingleton.ts
+++ b/src/server/services/automation/automationEngineSingleton.ts
@@ -15,6 +15,7 @@ import { AutomationEngineService } from './automationEngineService.js';
 import { VariableResolver } from './variableResolver.js';
 import { createMeshActionDeps } from './meshActionDeps.js';
 import { createMeshNodeDataProvider } from './meshNodeData.js';
+import { estimateHomeFromNodeHistory } from './leftHomeFromHistory.js';
 
 let engine: AutomationEngineService | null = null;
 let subscribed = false;
@@ -74,6 +75,10 @@ export async function startAutomationEngine(): Promise<void> {
     deps: createMeshActionDeps(),
     data: createMeshNodeDataProvider(),
     homeAnchorsRepo: databaseService.automationHomeAnchorsRepo,
+    estimateHomeFromHistory: async (nodeNum, thresholdMeters) => {
+      const est = await estimateHomeFromNodeHistory(nodeNum, thresholdMeters);
+      return est ? { latitude: est.latitude, longitude: est.longitude } : null;
+    },
   });
   await engine.load();
   subscribe();

--- a/src/server/services/automation/automationEngineSingleton.ts
+++ b/src/server/services/automation/automationEngineSingleton.ts
@@ -73,6 +73,7 @@ export async function startAutomationEngine(): Promise<void> {
     varResolver,
     deps: createMeshActionDeps(),
     data: createMeshNodeDataProvider(),
+    homeAnchorsRepo: databaseService.automationHomeAnchorsRepo,
   });
   await engine.load();
   subscribe();
@@ -112,10 +113,21 @@ async function handleEvent(event: DataEvent): Promise<void> {
       // Discovered vs updated detection (isNew) is deferred to a later phase; fire
       // as nodeUpdated with the changed field keys.
       await e.onNode('trigger.nodeUpdated', nodeNum, changed, sourceId);
-      // Geofence checks only matter when position changed.
+      // Geofence + left-home checks only matter when position changed.
       if (changed.includes('latitude') || changed.includes('longitude')) {
         await e.checkGeofences(nodeNum, sourceId);
+        await e.checkLeftHome(nodeNum, sourceId);
       }
+      break;
+    }
+
+    case 'node:mobility': {
+      const data = event.data as {
+        nodeNum: number;
+        previous: number;
+        current: number;
+      };
+      await e.checkBecameMobile(data.nodeNum, data.previous, data.current, sourceId);
       break;
     }
 

--- a/src/server/services/automation/automationSimulator.test.ts
+++ b/src/server/services/automation/automationSimulator.test.ts
@@ -277,4 +277,118 @@ describe('simulateAutomation', () => {
     expect(r.actions[0].type).toBe('action.runScript');
     expect((r.actions[0].resolvedParams as any).scriptPath).toBe('foo.sh');
   });
+
+  it('leftHome: dry-run matches only when watched node is beyond threshold', async () => {
+    const graph: AutomationGraph = {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.leftHome', params: { nodeNums: [7], thresholdMeters: 100 } },
+        { id: 'a', type: 'action.notify', params: { body: '{{ node.longName }} {{ trigger.distanceMeters }}' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    };
+
+    const beyond = await simulateAutomation({
+      graph, varsRepo,
+      event: { kind: 'leftHome', nodeNum: 7, distanceMeters: 250 },
+      node: { longName: 'Roof' },
+    });
+    expect(beyond.matched).toBe(true);
+    expect(beyond.actions).toHaveLength(1);
+    expect(beyond.fields.distanceMeters).toBe(250);
+    expect(beyond.fields.thresholdMeters).toBe(100);
+    expect(beyond.fields.distanceSource).toBe('distance');
+
+    const within = await simulateAutomation({
+      graph, varsRepo,
+      event: { kind: 'leftHome', nodeNum: 7, distanceMeters: 50 },
+    });
+    expect(within.matched).toBe(false);
+    expect(within.actions).toHaveLength(0);
+
+    const wrongNode = await simulateAutomation({
+      graph, varsRepo,
+      event: { kind: 'leftHome', nodeNum: 99, distanceMeters: 999 },
+    });
+    expect(wrongNode.matched).toBe(false);
+
+    // No distance and incomplete coords → 0 m / still at home.
+    const atHome = await simulateAutomation({
+      graph, varsRepo,
+      event: { kind: 'leftHome', nodeNum: 7 },
+      node: { latitude: 1, longitude: 2 },
+    });
+    expect(atHome.matched).toBe(false);
+    expect(atHome.fields.distanceMeters).toBe(0);
+    expect(atHome.fields.distanceSource).toBe('none');
+  });
+
+  it('leftHome: always uses automation threshold; coordinates beat distance', async () => {
+    const graph: AutomationGraph = {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.leftHome', params: { nodeNums: [7], thresholdMeters: 500 } },
+        { id: 'a', type: 'action.notify', params: { body: 'x' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    };
+
+    // Event thresholdMeters must be ignored — automation says 500.
+    const ignoreEvThr = await simulateAutomation({
+      graph, varsRepo,
+      event: { kind: 'leftHome', nodeNum: 7, distanceMeters: 250, thresholdMeters: 10 },
+    });
+    expect(ignoreEvThr.matched).toBe(false);
+    expect(ignoreEvThr.fields.thresholdMeters).toBe(500);
+
+    // Same home/current → ~0 m even if distanceMeters claims 9999.
+    const coordsWin = await simulateAutomation({
+      graph, varsRepo,
+      event: { kind: 'leftHome', nodeNum: 7, distanceMeters: 9999, homeLat: 48.0, homeLon: 16.0 },
+      node: { latitude: 48.0, longitude: 16.0 },
+    });
+    expect(coordsWin.matched).toBe(false);
+    expect(coordsWin.fields.distanceSource).toBe('coordinates');
+    expect(Number(coordsWin.fields.distanceMeters)).toBeLessThan(1);
+
+    // Far coordinates → fire against automation threshold 500.
+    const far = await simulateAutomation({
+      graph, varsRepo,
+      event: { kind: 'leftHome', nodeNum: 7, distanceMeters: 1, homeLat: 48.0, homeLon: 16.0 },
+      node: { latitude: 48.1, longitude: 16.0 }, // ~11 km north
+    });
+    expect(far.matched).toBe(true);
+    expect(far.fields.distanceSource).toBe('coordinates');
+    expect(Number(far.fields.distanceMeters)).toBeGreaterThan(500);
+  });
+
+  it('becameMobile: empty watch list does not match (same as live)', async () => {
+    const empty: AutomationGraph = {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.becameMobile', params: { nodeNums: [] } },
+        { id: 'a', type: 'action.notify', params: { body: 'x' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    };
+    const miss = await simulateAutomation({
+      graph: empty, varsRepo,
+      event: { kind: 'becameMobile', nodeNum: 1 },
+    });
+    expect(miss.matched).toBe(false);
+
+    const watched: AutomationGraph = {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.becameMobile', params: { nodeNums: [1] } },
+        { id: 'a', type: 'action.notify', params: { body: 'x' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    };
+    const hit = await simulateAutomation({
+      graph: watched, varsRepo,
+      event: { kind: 'becameMobile', nodeNum: 1 },
+    });
+    expect(hit.matched).toBe(true);
+  });
 });

--- a/src/server/services/automation/automationSimulator.ts
+++ b/src/server/services/automation/automationSimulator.ts
@@ -277,8 +277,9 @@ function buildContext(graph: AutomationGraph, ev: SimEventInput, node: Partial<N
     }
     case 'becameMobile': {
       const nodeNum = Number(ev.nodeNum ?? 0);
+      // Mirror live checkBecameMobile: empty/missing nodeNums never matches.
       const want = Array.isArray(params.nodeNums) ? (params.nodeNums as unknown[]).map(Number) : [];
-      const matched = want.length === 0 || want.includes(nodeNum);
+      const matched = want.length > 0 && want.includes(nodeNum);
       return {
         ctx: buildBecameMobileContext(
           nodeNum,
@@ -294,18 +295,63 @@ function buildContext(graph: AutomationGraph, ev: SimEventInput, node: Partial<N
     }
     case 'leftHome': {
       const nodeNum = Number(ev.nodeNum ?? 0);
+      // Mirror live checkLeftHome: must be on the watch list AND beyond the
+      // automation's threshold. Test events never override thresholdMeters —
+      // that always comes from the trigger params (default 300).
       const want = Array.isArray(params.nodeNums) ? (params.nodeNums as unknown[]).map(Number) : [];
-      const matched = want.length === 0 || want.includes(nodeNum);
-      const lat = Number(node?.latitude ?? 0);
-      const lon = Number(node?.longitude ?? 0);
-      const homeLat = Number(ev.homeLat ?? lat);
-      const homeLon = Number(ev.homeLon ?? lon);
-      const thresholdMeters = Number(ev.thresholdMeters ?? params.thresholdMeters ?? 100);
-      const distanceMeters = Number(ev.distanceMeters ?? (haversineKm(lat, lon, homeLat, homeLon) * 1000));
-      return {
-        ctx: buildLeftHomeContext(nodeNum, lat, lon, homeLat, homeLon, distanceMeters, thresholdMeters, sourceId, now),
-        matched,
-      };
+      const thresholdMeters = Number(params.thresholdMeters ?? 300);
+      const thrOk = Number.isFinite(thresholdMeters) && thresholdMeters > 0;
+
+      const curLat = node?.latitude;
+      const curLon = node?.longitude;
+      const homeLatRaw = ev.homeLat;
+      const homeLonRaw = ev.homeLon;
+      const hasCoordinates =
+        curLat != null && Number.isFinite(Number(curLat)) &&
+        curLon != null && Number.isFinite(Number(curLon)) &&
+        homeLatRaw != null && Number.isFinite(Number(homeLatRaw)) &&
+        homeLonRaw != null && Number.isFinite(Number(homeLonRaw));
+
+      let latitude: number;
+      let longitude: number;
+      let homeLat: number;
+      let homeLon: number;
+      let distanceMeters: number;
+      let distanceSource: 'coordinates' | 'distance' | 'none';
+
+      if (hasCoordinates) {
+        // Coordinates win over a typed distance (home + current position).
+        latitude = Number(curLat);
+        longitude = Number(curLon);
+        homeLat = Number(homeLatRaw);
+        homeLon = Number(homeLonRaw);
+        distanceMeters = haversineKm(latitude, longitude, homeLat, homeLon) * 1000;
+        distanceSource = 'coordinates';
+      } else if (ev.distanceMeters != null && Number.isFinite(Number(ev.distanceMeters))) {
+        distanceMeters = Number(ev.distanceMeters);
+        latitude = Number(curLat ?? 0);
+        longitude = Number(curLon ?? 0);
+        homeLat = Number(homeLatRaw ?? latitude);
+        homeLon = Number(homeLonRaw ?? longitude);
+        distanceSource = 'distance';
+      } else {
+        // Nothing usable → treat as still at home.
+        latitude = Number(curLat ?? 0);
+        longitude = Number(curLon ?? 0);
+        homeLat = Number(homeLatRaw ?? latitude);
+        homeLon = Number(homeLonRaw ?? longitude);
+        distanceMeters = 0;
+        distanceSource = 'none';
+      }
+
+      const onList = want.length > 0 && want.includes(nodeNum);
+      const beyond = thrOk && distanceMeters > thresholdMeters;
+      const ctx = buildLeftHomeContext(
+        nodeNum, latitude, longitude, homeLat, homeLon, distanceMeters, thresholdMeters, sourceId, now,
+      );
+      // Surface which input path won so the Test panel / result can explain it.
+      ctx.fields.distanceSource = distanceSource;
+      return { ctx, matched: onList && beyond };
     }
     case 'schedule':
       // No mesh payload — a cron tick. Assume it fires so the downstream

--- a/src/server/services/automation/automationSimulator.ts
+++ b/src/server/services/automation/automationSimulator.ts
@@ -33,6 +33,8 @@ import {
   buildTelemetryContext,
   buildSystemContext,
   buildGeofenceContext,
+  buildBecameMobileContext,
+  buildLeftHomeContext,
   messageMatchesFilter,
   BROADCAST_ADDR,
   type TriggerContext,
@@ -48,7 +50,7 @@ import {
 } from './engineContext.js';
 
 export type SimEventKind =
-  | 'message' | 'nodeUpdated' | 'nodeDiscovered' | 'telemetry' | 'system' | 'geofence' | 'schedule';
+  | 'message' | 'nodeUpdated' | 'nodeDiscovered' | 'telemetry' | 'system' | 'geofence' | 'becameMobile' | 'leftHome' | 'schedule';
 
 /** Synthetic trigger event the caller fills in (Test form / system test). */
 export interface SimEventInput {
@@ -79,6 +81,13 @@ export interface SimEventInput {
   reason?: string;
   latestVersion?: string;
   currentVersion?: string;
+  // becameMobile / leftHome
+  previousMobile?: number;
+  mobile?: number;
+  distanceMeters?: number;
+  thresholdMeters?: number;
+  homeLat?: number;
+  homeLon?: number;
 }
 
 export interface SimResult {
@@ -265,6 +274,38 @@ function buildContext(graph: AutomationGraph, ev: SimEventInput, node: Partial<N
       // Preview: assume the configured crossing occurred; conditions still run
       // against the supplied position. matched=true so the trace is informative.
       return { ctx: buildGeofenceContext(Number(ev.nodeNum ?? 0), mode, lat, lon, distanceKm, sourceId, now), matched: true };
+    }
+    case 'becameMobile': {
+      const nodeNum = Number(ev.nodeNum ?? 0);
+      const want = Array.isArray(params.nodeNums) ? (params.nodeNums as unknown[]).map(Number) : [];
+      const matched = want.length === 0 || want.includes(nodeNum);
+      return {
+        ctx: buildBecameMobileContext(
+          nodeNum,
+          node?.latitude,
+          node?.longitude,
+          Number(ev.previousMobile ?? 0),
+          Number(ev.mobile ?? 1),
+          sourceId,
+          now,
+        ),
+        matched,
+      };
+    }
+    case 'leftHome': {
+      const nodeNum = Number(ev.nodeNum ?? 0);
+      const want = Array.isArray(params.nodeNums) ? (params.nodeNums as unknown[]).map(Number) : [];
+      const matched = want.length === 0 || want.includes(nodeNum);
+      const lat = Number(node?.latitude ?? 0);
+      const lon = Number(node?.longitude ?? 0);
+      const homeLat = Number(ev.homeLat ?? lat);
+      const homeLon = Number(ev.homeLon ?? lon);
+      const thresholdMeters = Number(ev.thresholdMeters ?? params.thresholdMeters ?? 100);
+      const distanceMeters = Number(ev.distanceMeters ?? (haversineKm(lat, lon, homeLat, homeLon) * 1000));
+      return {
+        ctx: buildLeftHomeContext(nodeNum, lat, lon, homeLat, homeLon, distanceMeters, thresholdMeters, sourceId, now),
+        matched,
+      };
     }
     case 'schedule':
       // No mesh payload — a cron tick. Assume it fires so the downstream

--- a/src/server/services/automation/engineContext.test.ts
+++ b/src/server/services/automation/engineContext.test.ts
@@ -4,6 +4,7 @@ import {
   varContextFromTrigger,
   resolveFieldValue,
   getSubjectNode,
+  interpolateAsync,
   NODE_COMPLETENESS,
   type CooldownKeyResolution,
   type EngineEvalContext,
@@ -228,5 +229,61 @@ describe('resolveFieldValue: node.* (#4340 Phase 3)', () => {
     await resolveFieldValue(c, 'node.batteryLevel');
     await getSubjectNode(c);
     expect(spy.calls).toBe(1);
+  });
+});
+
+describe('interpolateAsync: node.* in message templates', () => {
+  const FAKE_VARS = { getValue: async () => null } as unknown as VariableResolver;
+
+  function evalCtx(opts: {
+    node?: NodeFacts | null;
+    subjectNodeNum?: number | null;
+    fields?: Record<string, unknown>;
+    triggerType?: string;
+  } = {}): EngineEvalContext {
+    const trigger: TriggerContext = {
+      triggerType: opts.triggerType ?? 'trigger.becameMobile',
+      sourceId: 'src-1',
+      subjectNodeNum: opts.subjectNodeNum === undefined ? 42 : opts.subjectNodeNum,
+      timestamp: 1_700_000_000_000,
+      fields: { nodeNum: 42, ...(opts.fields ?? {}) },
+    };
+    return {
+      trigger,
+      vars: FAKE_VARS,
+      data: {
+        getNode: async () => opts.node ?? null,
+        getTelemetry: async () => null,
+      },
+      varCtx: { sourceId: trigger.sourceId, nodeNum: trigger.subjectNodeNum },
+      now: 1_700_000_000_000,
+    };
+  }
+
+  it('substitutes {{ node.longName }} / {{ node.nodeId }} from the hydrated subject node', async () => {
+    const c = evalCtx({
+      node: { nodeNum: 42, longName: 'Roof Site', shortName: 'ROOF', nodeId: '!0000002a' },
+    });
+    expect(await interpolateAsync(
+      'A wild stationary node {{ node.longName }} ({{ node.nodeId }}) just uprooted itself!',
+      c,
+    )).toBe('A wild stationary node Roof Site (!0000002a) just uprooted itself!');
+  });
+
+  it('renders blank when the node row is missing', async () => {
+    const c = evalCtx({ node: null });
+    expect(await interpolateAsync('name=[{{ node.longName }}]', c)).toBe('name=[]');
+  });
+
+  it('still resolves trigger.* alongside node.*', async () => {
+    const c = evalCtx({
+      node: { nodeNum: 42, longName: 'Tower' },
+      fields: { distanceMeters: 250, thresholdMeters: 100 },
+      triggerType: 'trigger.leftHome',
+    });
+    expect(await interpolateAsync(
+      '{{ node.longName }} is {{ trigger.distanceMeters }}m from home (limit {{ trigger.thresholdMeters }}m)',
+      c,
+    )).toBe('Tower is 250m from home (limit 100m)');
   });
 });

--- a/src/server/services/automation/engineContext.ts
+++ b/src/server/services/automation/engineContext.ts
@@ -212,6 +212,13 @@ export async function resolvePath(ctx: EngineEvalContext, path: string): Promise
     // Render objects/arrays as JSON so {{ var.obj }} shows the blob; scalars pass through.
     return typeof v === 'object' ? JSON.stringify(v) : (v as InterpolationValue);
   }
+  // Same namespaces conditions use (`node.*` / `telemetry.*`) so message templates
+  // can say {{ node.longName }} on becameMobile / leftHome / nodeUpdated / …
+  if (path.startsWith('node.') || path.startsWith('telemetry.')) {
+    const v = await resolveFieldValue(ctx, path);
+    if (v == null) return undefined;
+    return typeof v === 'object' ? JSON.stringify(v) : (v as InterpolationValue);
+  }
   return resolveTriggerPath(ctx.trigger, path, ctx.now);
 }
 

--- a/src/server/services/automation/engineContext.ts
+++ b/src/server/services/automation/engineContext.ts
@@ -35,6 +35,8 @@ export interface NodeFacts {
   airUtilTx?: number;
   snr?: number;
   isFavorite?: boolean;
+  /** MeshMonitor-computed mobility: 0 = stationary, 1 = mobile (>100 m history span). */
+  mobile?: number;
 }
 
 /** Hydrates the subject node + latest telemetry during evaluation. Injected for testability. */

--- a/src/server/services/automation/leftHomeFromHistory.test.ts
+++ b/src/server/services/automation/leftHomeFromHistory.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { estimateHomeFromPositions } from './leftHomeFromHistory.js';
+
+describe('estimateHomeFromPositions', () => {
+  it('returns null for an empty list', () => {
+    expect(estimateHomeFromPositions([], 150)).toBeNull();
+  });
+
+  it('returns the single point when only one fix exists', () => {
+    const est = estimateHomeFromPositions([{ latitude: 46.1, longitude: 14.2 }], 150);
+    expect(est).toEqual({
+      latitude: 46.1,
+      longitude: 14.2,
+      sampleCount: 1,
+      inlierCount: 1,
+    });
+  });
+
+  it('drops spider-line outliers beyond the refine radius and averages the cluster', () => {
+    // Tight cluster around 46.05 / 14.50, plus a kilometre-scale glitch north.
+    const cluster = [
+      { latitude: 46.0500, longitude: 14.5000 },
+      { latitude: 46.0501, longitude: 14.5001 },
+      { latitude: 46.0499, longitude: 14.4999 },
+      { latitude: 46.0502, longitude: 14.5000 },
+      { latitude: 46.0500, longitude: 14.5002 },
+    ];
+    const glitch = { latitude: 46.06, longitude: 14.50 }; // ~1.1 km north
+    const est = estimateHomeFromPositions([...cluster, glitch], 150);
+    expect(est).toBeTruthy();
+    expect(est!.sampleCount).toBe(6);
+    expect(est!.inlierCount).toBe(5);
+    expect(est!.latitude).toBeGreaterThan(46.049);
+    expect(est!.latitude).toBeLessThan(46.051);
+    // Must not be pulled toward the glitch (~46.06).
+    expect(est!.latitude).toBeLessThan(46.052);
+  });
+});

--- a/src/server/services/automation/leftHomeFromHistory.ts
+++ b/src/server/services/automation/leftHomeFromHistory.ts
@@ -92,8 +92,8 @@ export async function estimateHomeFromNodeHistory(
       pivoted.map((p) => ({ latitude: p.latitude, longitude: p.longitude })),
       refineRadius,
     );
-  } catch (e: any) {
-    logger.warn(`[leftHome] history estimate failed for ${nodeId}: ${e?.message}`);
+  } catch (e) {
+    logger.warn(`[leftHome] history estimate failed for ${nodeId}: ${e instanceof Error ? e.message : String(e)}`);
     return null;
   }
 }

--- a/src/server/services/automation/leftHomeFromHistory.ts
+++ b/src/server/services/automation/leftHomeFromHistory.ts
@@ -1,0 +1,99 @@
+/**
+ * Estimate a leftHome anchor from stored position history.
+ *
+ * Takes pivoted lat/lon fixes, drops outliers farther than `refineRadiusMeters`
+ * from the median, and returns the mean of the inliers. Used when establishing
+ * or resetting a home so a single glitched "first fix" does not become the anchor
+ * when a dense cluster already exists in telemetry.
+ */
+import { haversineKm } from './geo.js';
+import { pivotPositionHistory, type PivotTelemetryRow } from '../../utils/positionHistoryPivot.js';
+import databaseService from '../../../services/database.js';
+import { ALL_SOURCES } from '../../../db/repositories/base.js';
+import { logger } from '../../../utils/logger.js';
+
+export interface LatLon {
+  latitude: number;
+  longitude: number;
+}
+
+export interface HomeEstimate extends LatLon {
+  /** Total complete lat/lon fixes considered. */
+  sampleCount: number;
+  /** Fixes kept after the median-radius filter. */
+  inlierCount: number;
+}
+
+function nodeIdOf(nodeNum: number): string {
+  return `!${(nodeNum >>> 0).toString(16).padStart(8, '0')}`;
+}
+
+function median(sorted: number[]): number {
+  const n = sorted.length;
+  if (n === 0) return NaN;
+  const mid = Math.floor(n / 2);
+  return n % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Pure estimator: median → keep points within refineRadius → mean of inliers.
+ * Returns null when fewer than 1 complete fix exists.
+ */
+export function estimateHomeFromPositions(
+  positions: Array<{ latitude: number; longitude: number }>,
+  refineRadiusMeters: number,
+): HomeEstimate | null {
+  const pts = positions.filter(
+    (p) => Number.isFinite(p.latitude) && Number.isFinite(p.longitude),
+  );
+  if (pts.length === 0) return null;
+
+  const latMed = median([...pts.map((p) => p.latitude)].sort((a, b) => a - b));
+  const lonMed = median([...pts.map((p) => p.longitude)].sort((a, b) => a - b));
+  const radius = Number.isFinite(refineRadiusMeters) && refineRadiusMeters > 0
+    ? refineRadiusMeters
+    : 150;
+
+  const inliers = pts.filter(
+    (p) => haversineKm(p.latitude, p.longitude, latMed, lonMed) * 1000 <= radius,
+  );
+  const use = inliers.length > 0 ? inliers : pts;
+  const latitude = use.reduce((s, p) => s + p.latitude, 0) / use.length;
+  const longitude = use.reduce((s, p) => s + p.longitude, 0) / use.length;
+  return {
+    latitude,
+    longitude,
+    sampleCount: pts.length,
+    inlierCount: use.length,
+  };
+}
+
+/**
+ * Load recent position telemetry for a node and estimate a home anchor.
+ * `thresholdMeters` sizes the outlier radius as threshold/2 (same as live refine).
+ */
+export async function estimateHomeFromNodeHistory(
+  nodeNum: number,
+  thresholdMeters: number,
+  opts?: { limit?: number },
+): Promise<HomeEstimate | null> {
+  const refineRadius = (Number.isFinite(thresholdMeters) && thresholdMeters > 0 ? thresholdMeters : 300) / 2;
+  const nodeId = nodeIdOf(nodeNum);
+  try {
+    // intentional cross-source: home is a property of the physical node
+    const rows = await databaseService.telemetry.getPositionTelemetryByNode(
+      nodeId,
+      opts?.limit ?? 500,
+      undefined,
+      ALL_SOURCES,
+    );
+    const pivoted = pivotPositionHistory(rows as PivotTelemetryRow[]);
+    return estimateHomeFromPositions(
+      pivoted.map((p) => ({ latitude: p.latitude, longitude: p.longitude })),
+      refineRadius,
+    );
+  } catch (e: any) {
+    logger.warn(`[leftHome] history estimate failed for ${nodeId}: ${e?.message}`);
+    return null;
+  }
+}

--- a/src/server/services/automation/triggerContext.test.ts
+++ b/src/server/services/automation/triggerContext.test.ts
@@ -7,6 +7,8 @@ import {
   buildSystemContext,
   buildScheduleContext,
   buildGeofenceContext,
+  buildBecameMobileContext,
+  buildLeftHomeContext,
   deriveHops,
   messageMatchesFilter,
   meshCoreMessageMatchesFilter,
@@ -216,6 +218,20 @@ describe('other trigger contexts', () => {
     expect(buildSystemContext('bootup', null, null, undefined, 5).subjectNodeKey).toBeUndefined();
     expect(buildScheduleContext(null, 1234).subjectNodeKey).toBeUndefined();
     expect(buildGeofenceContext(5, 'enter', 0, 0, 1, 'default', 5).subjectNodeKey).toBeUndefined();
+  });
+
+  it('buildBecameMobileContext / buildLeftHomeContext set subject and fields', () => {
+    const mob = buildBecameMobileContext(9, 1.5, 2.5, 0, 1, 'src', 10);
+    expect(mob.triggerType).toBe('trigger.becameMobile');
+    expect(mob.subjectNodeNum).toBe(9);
+    expect(mob.fields.previousMobile).toBe(0);
+    expect(mob.fields.mobile).toBe(1);
+
+    const left = buildLeftHomeContext(9, 1.5, 2.5, 1.0, 2.0, 250, 100, 'src', 10);
+    expect(left.triggerType).toBe('trigger.leftHome');
+    expect(left.fields.distanceMeters).toBe(250);
+    expect(left.fields.thresholdMeters).toBe(100);
+    expect(left.fields.homeLat).toBe(1.0);
   });
 });
 

--- a/src/server/services/automation/triggerContext.ts
+++ b/src/server/services/automation/triggerContext.ts
@@ -319,6 +319,64 @@ export function buildGeofenceContext(
   };
 }
 
+/** Build the trigger context when a watched node flips stationary → mobile. */
+export function buildBecameMobileContext(
+  nodeNum: number,
+  latitude: number | undefined,
+  longitude: number | undefined,
+  previousMobile: number,
+  mobile: number,
+  sourceId: string | null,
+  timestamp: number,
+): TriggerContext {
+  return {
+    triggerType: 'trigger.becameMobile',
+    sourceId,
+    subjectNodeNum: Number(nodeNum),
+    timestamp,
+    fields: {
+      nodeNum: Number(nodeNum),
+      latitude,
+      longitude,
+      previousMobile,
+      mobile,
+      sourceId,
+      timestamp,
+    },
+  };
+}
+
+/** Build the trigger context when a watched node exceeds its home-distance threshold. */
+export function buildLeftHomeContext(
+  nodeNum: number,
+  latitude: number,
+  longitude: number,
+  homeLat: number,
+  homeLon: number,
+  distanceMeters: number,
+  thresholdMeters: number,
+  sourceId: string | null,
+  timestamp: number,
+): TriggerContext {
+  return {
+    triggerType: 'trigger.leftHome',
+    sourceId,
+    subjectNodeNum: Number(nodeNum),
+    timestamp,
+    fields: {
+      nodeNum: Number(nodeNum),
+      latitude,
+      longitude,
+      homeLat,
+      homeLon,
+      distanceMeters,
+      thresholdMeters,
+      sourceId,
+      timestamp,
+    },
+  };
+}
+
 /** System events the engine can raise (param `event` on a `trigger.system` block). */
 export type SystemEvent = 'bootup' | 'source-connected' | 'source-disconnected' | 'upgrade-available';
 

--- a/src/server/services/dataEventEmitter.ts
+++ b/src/server/services/dataEventEmitter.ts
@@ -14,6 +14,7 @@ import { logger } from '../../utils/logger.js';
 
 export type DataEventType =
   | 'node:updated'
+  | 'node:mobility'
   | 'message:new'
   | 'channel:updated'
   | 'telemetry:batch'
@@ -113,6 +114,25 @@ class DataEventEmitter extends EventEmitter {
     };
     this.emit('data', event);
     logger.debug(`[DataEventEmitter] Node updated: ${nodeNum}`);
+  }
+
+  /**
+   * Emit a mobility flag transition (used by trigger.becameMobile).
+   */
+  emitNodeMobility(
+    nodeNum: number,
+    previous: number,
+    current: number,
+    sourceId?: string,
+  ): void {
+    const event: DataEvent = {
+      type: 'node:mobility',
+      data: { nodeNum, previous, current },
+      timestamp: Date.now(),
+      sourceId,
+    };
+    this.emit('data', event);
+    logger.debug(`[DataEventEmitter] Node mobility: ${nodeNum} ${previous}→${current}`);
   }
 
   /**

--- a/src/server/services/nodeMobilityService.test.ts
+++ b/src/server/services/nodeMobilityService.test.ts
@@ -23,16 +23,18 @@ const positionRows = (latSpanDeg: number) => [
 describe('nodeMobilityService.updateNodeMobility', () => {
   let deps: NodeMobilityDeps;
   let getPositionTelemetryByNode: ReturnType<typeof vi.fn>;
+  let getNodeByNodeId: ReturnType<typeof vi.fn>;
   let updateNodeMobilityRepo: ReturnType<typeof vi.fn>;
   let patchCache: ReturnType<typeof vi.fn<(nodeId: string, mobile: number) => void>>;
 
   beforeEach(() => {
     getPositionTelemetryByNode = vi.fn().mockResolvedValue([]);
+    getNodeByNodeId = vi.fn().mockResolvedValue({ nodeId: NODE_ID, mobile: 0 });
     updateNodeMobilityRepo = vi.fn().mockResolvedValue(undefined);
     patchCache = vi.fn<(nodeId: string, mobile: number) => void>();
     deps = {
       telemetryRepo: { getPositionTelemetryByNode } as any,
-      nodesRepo: { updateNodeMobility: updateNodeMobilityRepo } as any,
+      nodesRepo: { updateNodeMobility: updateNodeMobilityRepo, getNodeByNodeId } as any,
       patchCache,
     };
   });
@@ -42,7 +44,7 @@ describe('nodeMobilityService.updateNodeMobility', () => {
 
     const result = await updateNodeMobility(NODE_ID, deps);
 
-    expect(result).toBe(1);
+    expect(result).toEqual({ previous: 0, current: 1 });
     expect(updateNodeMobilityRepo).toHaveBeenCalledWith(NODE_ID, 1);
     expect(patchCache).toHaveBeenCalledWith(NODE_ID, 1);
   });
@@ -52,12 +54,21 @@ describe('nodeMobilityService.updateNodeMobility', () => {
 
     const result = await updateNodeMobility(NODE_ID, deps);
 
-    expect(result).toBe(0);
+    expect(result).toEqual({ previous: 0, current: 0 });
     expect(updateNodeMobilityRepo).toHaveBeenCalledWith(NODE_ID, 0);
     expect(patchCache).toHaveBeenCalledWith(NODE_ID, 0);
   });
 
-  it('returns 0 (and still persists) with fewer than 2 position pairs', async () => {
+  it('reports previous=1 when the node was already mobile', async () => {
+    getNodeByNodeId.mockResolvedValue({ nodeId: NODE_ID, mobile: 1 });
+    getPositionTelemetryByNode.mockResolvedValue(positionRows(0.002));
+
+    const result = await updateNodeMobility(NODE_ID, deps);
+
+    expect(result).toEqual({ previous: 1, current: 1 });
+  });
+
+  it('returns stationary (and still persists) with fewer than 2 position pairs', async () => {
     getPositionTelemetryByNode.mockResolvedValue([
       { telemetryType: 'latitude', value: 30.0, timestamp: 1 },
       { telemetryType: 'longitude', value: -90.0, timestamp: 1 },
@@ -65,7 +76,7 @@ describe('nodeMobilityService.updateNodeMobility', () => {
 
     const result = await updateNodeMobility(NODE_ID, deps);
 
-    expect(result).toBe(0);
+    expect(result).toEqual({ previous: 0, current: 0 });
     expect(updateNodeMobilityRepo).toHaveBeenCalledWith(NODE_ID, 0);
   });
 
@@ -79,7 +90,7 @@ describe('nodeMobilityService.updateNodeMobility', () => {
 
     const result = await updateNodeMobility(NODE_ID, deps);
 
-    expect(result).toBe(0);
+    expect(result).toEqual({ previous: 0, current: 0 });
     expect(patchCache).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/nodeMobilityService.ts
+++ b/src/server/services/nodeMobilityService.ts
@@ -22,14 +22,30 @@ export interface NodeMobilityDeps {
   patchCache: (nodeId: string, mobile: number) => void;
 }
 
+export interface MobilityUpdateResult {
+  /** Flag before this update (0/1). Defaults to 0 when the node was unknown. */
+  previous: number;
+  /** Flag after this update (0 = stationary, 1 = mobile). */
+  current: number;
+}
+
 /**
  * Detect whether a node has moved more than 100 meters based on its last 500
  * position telemetry records, update the persisted mobile flag, patch the
- * in-memory cache, and return the resulting mobility status (0 = stationary,
- * 1 = mobile). Errors are swallowed and reported as non-mobile (0).
+ * in-memory cache, and return previous+current mobility status. Errors are
+ * swallowed and reported as non-mobile (current=0) with previous preserved
+ * when readable.
  */
-export async function updateNodeMobility(nodeId: string, deps: NodeMobilityDeps): Promise<number> {
+export async function updateNodeMobility(nodeId: string, deps: NodeMobilityDeps): Promise<MobilityUpdateResult> {
+  let previous = 0;
   try {
+    // Read the current flag so callers (automation engine) can detect 0→1 flips.
+    // Cross-source: mobility is a property of the physical nodeId.
+    const existing = await deps.nodesRepo.getNodeByNodeId(nodeId);
+    if (existing && existing.mobile != null) {
+      previous = Number(existing.mobile) ? 1 : 0;
+    }
+
     // Get last 500 position telemetry records for this node. Using a larger
     // limit ensures we capture movement over a longer time period (50 was too
     // small — nodes parked for a while would show only recent stationary
@@ -84,9 +100,9 @@ export async function updateNodeMobility(nodeId: string, deps: NodeMobilityDeps)
     // Patch the in-memory cache so getAllNodes() returns the updated value
     deps.patchCache(nodeId, isMobile);
 
-    return isMobile;
+    return { previous, current: isMobile };
   } catch (error) {
     logger.error(`Failed to update mobility for node ${nodeId}:`, error);
-    return 0; // Default to non-mobile on error
+    return { previous, current: 0 }; // Default to non-mobile on error
   }
 }

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -59,6 +59,7 @@ import {
   DeadDropRepository,
   AutomationsRepository,
   AutomationVariablesRepository,
+  AutomationHomeAnchorsRepository,
   SavedRegionsRepository,
   SolarEstimatesRepository,
   NewsCacheRepository,
@@ -529,6 +530,7 @@ class DatabaseService {
   public deadDropRepo: DeadDropRepository | null = null;
   public automationsRepo: AutomationsRepository | null = null;
   public automationVariablesRepo: AutomationVariablesRepository | null = null;
+  public automationHomeAnchorsRepo: AutomationHomeAnchorsRepository | null = null;
   public savedRegionsRepo: SavedRegionsRepository | null = null;
   public solarEstimatesRepo: SolarEstimatesRepository | null = null;
   public newsCacheRepo: NewsCacheRepository | null = null;
@@ -612,6 +614,11 @@ class DatabaseService {
   get automationVariables(): AutomationVariablesRepository {
     if (!this.automationVariablesRepo) throw new Error('Database not initialized');
     return this.automationVariablesRepo;
+  }
+
+  get automationHomeAnchors(): AutomationHomeAnchorsRepository {
+    if (!this.automationHomeAnchorsRepo) throw new Error('Database not initialized');
+    return this.automationHomeAnchorsRepo;
   }
 
   get savedRegions(): SavedRegionsRepository {
@@ -990,6 +997,7 @@ class DatabaseService {
       this.deadDropRepo = new DeadDropRepository(drizzleDb, this.drizzleDbType);
       this.automationsRepo = new AutomationsRepository(drizzleDb, this.drizzleDbType);
       this.automationVariablesRepo = new AutomationVariablesRepository(drizzleDb, this.drizzleDbType);
+      this.automationHomeAnchorsRepo = new AutomationHomeAnchorsRepository(drizzleDb, this.drizzleDbType);
       this.savedRegionsRepo = new SavedRegionsRepository(drizzleDb, this.drizzleDbType);
       this.solarEstimatesRepo = new SolarEstimatesRepository(drizzleDb, this.drizzleDbType);
       this.newsCacheRepo = new NewsCacheRepository(drizzleDb, this.drizzleDbType);
@@ -1730,9 +1738,9 @@ class DatabaseService {
    * Async version of updateNodeMobility - works for all database backends
    * Detects if a node has moved more than 100 meters based on position history
    * @param nodeId The node ID to check
-   * @returns The updated mobility status (0 = stationary, 1 = mobile)
+   * @returns Previous and current mobility status (0 = stationary, 1 = mobile)
    */
-  async updateNodeMobilityAsync(nodeId: string): Promise<number> {
+  async updateNodeMobilityAsync(nodeId: string): Promise<{ previous: number; current: number }> {
     // Delegates the movement heuristic to NodeMobilityService; the cache patch
     // stays here so the service has no direct dependency on the facade's cache.
     return updateNodeMobility(nodeId, {

--- a/src/types/automation.test.ts
+++ b/src/types/automation.test.ts
@@ -163,6 +163,23 @@ describe('validateAutomationGraph', () => {
     expect(bad.errors.join(' ')).toMatch(/trigger\.telemetry .* requires params\.cooldownScope ∈ \{automation,node,sourceNode\}/);
   });
 
+  it('trigger.becameMobile / trigger.leftHome require a non-empty nodeNums list', () => {
+    const graph = (type: string, params: Record<string, unknown>): AutomationGraph => ({
+      version: 1,
+      nodes: [
+        { id: 't', type: type as any, params },
+        { id: 'a', type: 'action.notify', params: { body: 'x' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    });
+    expect(validateAutomationGraph(graph('trigger.becameMobile', {})).valid).toBe(false);
+    expect(validateAutomationGraph(graph('trigger.becameMobile', { nodeNums: [] })).valid).toBe(false);
+    expect(validateAutomationGraph(graph('trigger.becameMobile', { nodeNums: [1, 2] })).valid).toBe(true);
+    expect(validateAutomationGraph(graph('trigger.leftHome', { nodeNums: [1], thresholdMeters: 0 })).valid).toBe(false);
+    expect(validateAutomationGraph(graph('trigger.leftHome', { nodeNums: [1], thresholdMeters: 100 })).valid).toBe(true);
+    expect(validateAutomationGraph(graph('trigger.leftHome', { nodeNums: [1] })).valid).toBe(true); // default threshold
+  });
+
   // ── action.sendMessage maxAttempts (#4340 Phase 3) ──────────────────────
   it('action.sendMessage: maxAttempts validates when present, and absence still validates', () => {
     const withSendMessage = (params: Record<string, unknown>): AutomationGraph => ({

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -21,7 +21,9 @@ export type TriggerType =
   | 'trigger.telemetry'
   | 'trigger.schedule'
   | 'trigger.system'
-  | 'trigger.geofence';
+  | 'trigger.geofence'
+  | 'trigger.becameMobile'
+  | 'trigger.leftHome';
 
 export type ConditionType =
   | 'condition.always'
@@ -65,6 +67,8 @@ export const TRIGGER_TYPES: readonly TriggerType[] = [
   'trigger.schedule',
   'trigger.system',
   'trigger.geofence',
+  'trigger.becameMobile',
+  'trigger.leftHome',
 ];
 
 export const CONDITION_TYPES: readonly ConditionType[] = [
@@ -463,6 +467,23 @@ export function validateAutomationGraph(input: unknown): ValidationResult {
             }
           }
           break;
+        case 'trigger.becameMobile':
+        case 'trigger.leftHome': {
+          // Hand-selected node list is required for v1 (no "all nodes" mode).
+          const nums = Array.isArray(p.nodeNums) ? p.nodeNums : null;
+          if (!nums || nums.length === 0) {
+            errors.push(`${n.type} "${n.id}" requires params.nodeNums (non-empty array of node numbers)`);
+          } else if (!nums.every((x) => Number.isInteger(Number(x)))) {
+            errors.push(`${n.type} "${n.id}" requires params.nodeNums to be an array of integers`);
+          }
+          if (n.type === 'trigger.leftHome') {
+            const thr = p.thresholdMeters == null || p.thresholdMeters === '' ? 100 : Number(p.thresholdMeters);
+            if (!Number.isFinite(thr) || thr <= 0) {
+              errors.push(`trigger.leftHome "${n.id}" requires params.thresholdMeters > 0`);
+            }
+          }
+          break;
+        }
         case 'action.delay': {
           const secs = Number(p.seconds);
           if (!Number.isFinite(secs) || secs < 0 || secs > AUTOMATION_DELAY_MAX_SECONDS) {

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -477,7 +477,7 @@ export function validateAutomationGraph(input: unknown): ValidationResult {
             errors.push(`${n.type} "${n.id}" requires params.nodeNums to be an array of integers`);
           }
           if (n.type === 'trigger.leftHome') {
-            const thr = p.thresholdMeters == null || p.thresholdMeters === '' ? 100 : Number(p.thresholdMeters);
+            const thr = p.thresholdMeters == null || p.thresholdMeters === '' ? 300 : Number(p.thresholdMeters);
             if (!Number.isFinite(thr) || thr <= 0) {
               errors.push(`trigger.leftHome "${n.id}" requires params.thresholdMeters > 0`);
             }


### PR DESCRIPTION
## Summary
Adds two Automation Engine triggers aimed at **stationary GPS fleets** (tamper / theft watch), plus the supporting UI and hardening needed to make them usable with sparse Meshtastic beacons and noisy rooftop GPS.
### Triggers
- **`trigger.becameMobile`** — fires when MeshMonitor’s mobility flag flips **0→1** (position-history bbox diagonal &gt; 100 m) for a **hand-selected** node list.
- **`trigger.leftHome`** — fires when a watched node’s live position is farther than a configurable threshold from a **per-(automation, node) home anchor**.
### leftHome behaviour (important for operators)
| Concern | Behaviour |
|--------|-----------|
| Default threshold | **300 m** (was 100) — sized for rooftop GPS wander on ~hourly/3h beacons |
| First home | Prefer **position-history inliers** (median → drop points beyond threshold/2 → mean). If no history, use the first live fix |
| While near home | Fixes within **threshold/2** **EMA-refine** the anchor (α=0.25) so a slightly-wrong first home can settle |
| Beyond threshold | Alert on the **first** beyond-threshold packet (no multi-packet confirm — that would be ~6h with 3h beacons) |
| Reset | Saved automations get **Reset homes from history** (`POST /api/automations/:id/reset-homes`) — clears anchors + in-memory alarmed state and re-seeds from history |
### UX / interpolation
- Node multi-picker shows **human names** (`user.longName` / `shortName`), stationary-first, with Stationary/Mobile chips.
- Message templates can use **`{{ node.longName }}`** / `{{ node.nodeId }}` (wired into interpolation + token checker; these triggers have no `senderLabel`).
- Tolkien **placeholders** on Send message / Notify for these triggers.
- **Test panel** for leftHome: always uses the **automation** threshold; **coordinates beat distance**; clear “active input” hints so dry-runs aren’t stuck always-firing.
### Prefer leftHome for theft watch
`becameMobile` only fires on **0→1**. Many parked nodes already sit at `mobile=1` from GPS spider-lines / long history, so they won’t alert until they flip back to 0. **leftHome** is the primary theft detector; becameMobile is a coarse companion.
## Notes / follow-ups (out of scope)
- Does **not** change the global `mobile` bbox heuristic or ingest-time teleport filtering
- Operators should still enable **smart position** and slightly increase location TX rate for sparse fleets
- Draft until the above is smoke-tested on a real ~40-node stationary deployment
