### PR TITLE
chore(ci): bump github/codeql-action to 4.37.6 across all steps, group future bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,14 @@ updates:
       # until the tooling ecosystem ships TS7-native support.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # maplibre-gl 6 is ESM-only (default import removed) and reorganises
+      # Map/Camera/events. Harder blocker: @maplibre/maplibre-gl-leaflet, which
+      # backs VectorTileLayer, has no v6-compatible release (peer range stops
+      # at ^5.0.0, last publish a year ago). Hold major bumps until that
+      # adapter ships v6 support or VectorTileLayer is rewritten. See #4650
+      # for the concrete unblock plan; closed #4646 shows the CI failure.
+      - dependency-name: "maplibre-gl"
+        update-types: ["version-update:semver-major"]
     groups:
       development-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,17 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      # github/codeql-action ships init/autobuild/analyze/upload-sarif as
+      # sibling actions in one repo, and they MUST run at the same version —
+      # init loads a config file that autobuild refuses to accept from a
+      # different release. Without this group Dependabot opens one PR per
+      # sibling, each broken in isolation; every one has to be closed and
+      # replaced by a single hand-batched bump (see #4519/#4521/#4531 and
+      # the batch that closed #4635/#4637/#4644).
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   # Enable security updates for Docker
   - package-ecosystem: "docker"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
         run: trivy fs --scanners vuln --format sarif --output trivy-results.sarif --severity HIGH,CRITICAL .
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,15 +22,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
         with:
           languages: javascript-typescript
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
         with:
           category: "/language:javascript-typescript"


### PR DESCRIPTION
Supersedes and closes #4635, #4637, #4644.

## Why the three PRs failed

Dependabot opens one PR per codeql-action sibling (init/autobuild/analyze/upload-sarif), but the actions MUST run at the same version — init loads a config file autobuild refuses to accept from a different release:

\`\`\`
##[error]We were unable to automatically build your code.
Loaded a configuration file for version '4.37.4', but running version '4.37.6'
\`\`\`

Every release ships as three broken PRs, each failing in isolation. This isn't the first time: #4519 / #4521 / #4531 needed the same hand-batching, and \`dependabot-auto-merge.yml\` already carries a load-bearing comment explaining why \`Analyze\` was added to the required-checks list ("Dependabot's codeql-action bumps are *patch* updates, so they qualify for auto-merge, and CodeQL is the one thing they can break").

## Fix

1. Bump 4.37.4 → 4.37.6 across \`codeql.yml\` (init/autobuild/analyze) and \`ci.yml\` (upload-sarif under Trivy) in one atomic change.
2. Add a \`groups:\` block to \`.github/dependabot.yml\` matching \`github/codeql-action*\`, so future releases arrive as one PR instead of N broken ones.

## Verification

- All three superseded PRs used the same target SHA (\`5595ccaf912efad79be6eef63a5619ff05969be3\`) — confirmed by reading their diffs.
- \`ci.yml\`'s \`upload-sarif\` step was also on 4.37.4; bumping only what dependabot opened would have left this one stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX