### PR TITLE
fix: clear auto-favorite targets and assignments on node purge (#4633)

### DIFF
--- a/src/db/repositories/autoFavoriteTargets.ts
+++ b/src/db/repositories/autoFavoriteTargets.ts
@@ -109,6 +109,33 @@ export class AutoFavoriteTargetsRepository extends BaseRepository {
       .where(and(eq(autoFavoriteTargets.sourceId, sourceId), eq(autoFavoriteTargets.targetNodeNum, targetNodeNum)));
   }
 
+  /**
+   * Remove every target config and its assignment ledger, scoped to one source
+   * or (when `sourceId` is omitted) across all sources.
+   *
+   * Called from the node purge (#4633). The targets are keyed by
+   * `targetNodeNum` and the ledger by assigned `nodeNum` — neither derived from
+   * the `nodes` table — so both survive a purge unless cleared here, and once
+   * the same physical nodes reappear the automation silently resumes on them.
+   * Assignments are deleted first so the ledger never outlives its target row.
+   * The scoped/unscoped split matches the sibling allowlists (#4630): every
+   * production caller passes a sourceId, but a global purge clears every one.
+   */
+  async clearAllForSource(sourceId?: string): Promise<void> {
+    const { autoFavoriteTargets, autoFavoriteAssignments } = this.tables;
+    if (sourceId) {
+      await this.db
+        .delete(autoFavoriteAssignments)
+        .where(eq(autoFavoriteAssignments.sourceId, sourceId));
+      await this.db
+        .delete(autoFavoriteTargets)
+        .where(eq(autoFavoriteTargets.sourceId, sourceId));
+    } else {
+      await this.db.delete(autoFavoriteAssignments);
+      await this.db.delete(autoFavoriteTargets);
+    }
+  }
+
   /** Record that a cycle ran for a target (lastRunAt). */
   async touchLastRun(sourceId: string, targetNodeNum: number, ts: number): Promise<void> {
     const { autoFavoriteTargets } = this.tables;

--- a/src/services/database.purgeAllNodes.test.ts
+++ b/src/services/database.purgeAllNodes.test.ts
@@ -9,6 +9,7 @@
  * @vitest-environment node
  */
 import { describe, it, expect, beforeAll, vi } from 'vitest';
+import type { AutoFavoriteTargetInput } from '../db/repositories/autoFavoriteTargets.js';
 
 // ─── Mock environment to point at in-memory SQLite ────────────────────────────
 
@@ -159,6 +160,66 @@ describe('DatabaseService.purgeAllNodesAsync — auto-traceroute/time-sync allow
     // Cross-source isolation — purging A must not disturb B's selection.
     expect(await databaseService.autoTraceroute.getAutoTracerouteNodes('srcB')).toEqual([7002]);
     expect(await databaseService.timeSync.getAutoTimeSyncNodes('srcB')).toEqual([7002]);
+  });
+});
+
+describe('DatabaseService.purgeAllNodesAsync — auto-favorite targets + ledger (#4633)', () => {
+  const target = (sourceId: string, targetNodeNum: number): AutoFavoriteTargetInput => ({
+    sourceId,
+    targetNodeNum,
+    enabled: true,
+    useNeighborInfo: true,
+    useTraceroutes: false,
+    intervalHours: 6,
+    maxNewPerCycle: 3,
+    maxRefavoritePerCycle: 1,
+    maxNeighborAgeHours: 48,
+    eligibleRoles: 'CLIENT',
+  });
+
+  beforeAll(async () => {
+    await databaseService.waitForReady();
+    for (let i = 0; i < 50 && !databaseService.autoFavoriteTargetsRepo; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    // Same reasoning as the #4629 block above: the purge clear is guarded by
+    // `if (this.autoFavoriteTargetsRepo)`, so an uninitialised repo would make
+    // the fix a silent no-op. Fail here instead.
+    expect(databaseService.autoFavoriteTargetsRepo).toBeTruthy();
+  });
+
+  it('clears the target config AND the assignment ledger so a purge does not resume favoriting reappearing nodes', async () => {
+    const repo = databaseService.autoFavoriteTargets;
+    await repo.upsertTarget(target('default', 6001));
+    // A recorded assignment on that target — the stale ledger that otherwise
+    // keeps claiming a neighbour is "already favorited" on a purged node.
+    await repo.recordAssignment('default', 6001, 6002, 'neighbor', Date.now());
+
+    expect((await repo.getTargetsForSource('default')).map((t) => Number(t.targetNodeNum))).toEqual([6001]);
+    expect((await repo.getAssignments('default', 6001)).length).toBe(1);
+
+    await databaseService.purgeAllNodesAsync();
+
+    // Both tables empty — the #4633 regression assertion. targetNodeNum is not
+    // `nodeNum`, so these tables never showed up in a node-keyed purge scan.
+    expect(await repo.getTargetsForSource('default')).toEqual([]);
+    expect(await repo.getAssignments('default', 6001)).toEqual([]);
+  });
+
+  it('scoped to one source, clears only that source and leaves other sources configured', async () => {
+    const repo = databaseService.autoFavoriteTargets;
+    await repo.upsertTarget(target('srcA', 8001));
+    await repo.upsertTarget(target('srcB', 8002));
+    await repo.recordAssignment('srcA', 8001, 8010, 'neighbor', Date.now());
+    await repo.recordAssignment('srcB', 8002, 8020, 'neighbor', Date.now());
+
+    await databaseService.purgeAllNodesAsync('srcA');
+
+    expect(await repo.getTargetsForSource('srcA')).toEqual([]);
+    expect(await repo.getAssignments('srcA', 8001)).toEqual([]);
+    // Cross-source isolation — purging A must not disturb B's tuned config or ledger.
+    expect((await repo.getTargetsForSource('srcB')).map((t) => Number(t.targetNodeNum))).toEqual([8002]);
+    expect((await repo.getAssignments('srcB', 8002)).length).toBe(1);
   });
 });
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -3453,6 +3453,18 @@ class DatabaseService {
           logger.error('Failed to clear auto-time-sync node list during purge:', err);
         }
       }
+      // Clear the Automated Remote Favorites config and its assignment ledger
+      // for the same reason (issue #4633). Unlike the two allowlists above these
+      // rows carry tuned settings, not just a node selection — clearing them on
+      // purge is the deliberate choice for #4633, matching #4630's "a purge is a
+      // clean slate" behavior rather than silently resuming on reappearing nodes.
+      if (this.autoFavoriteTargetsRepo) {
+        try {
+          await this.autoFavoriteTargetsRepo.clearAllForSource(sourceId);
+        } catch (err) {
+          logger.error('Failed to clear auto-favorite targets during purge:', err);
+        }
+      }
 
       // Finally delete the nodes themselves
       if (this.nodesRepo) {


### PR DESCRIPTION
Follow-up to #4630, which fixed the same defect for the auto-traceroute and auto-time-sync allowlists (#4629).

## The bug

`auto_favorite_targets` (the Automated Remote Favorites config, #2608) and `auto_favorite_assignments` (its ledger) are keyed by node but live in their own tables, decoupled from `nodes`. Nothing in the purge path touched either. After a full node purge the config survived, and once the same physical nodes reappeared the automation silently resumed favoriting them. The ledger also kept claiming neighbours were "already favorited" on a target whose node record no longer existed.

Easy to miss because the column is `targetNodeNum`, not `nodeNum` — these tables don't surface in a node-keyed schema scan.

## The decision

Per the issue, this carries a real product choice the traceroute/time-sync fix didn't: those allowlists were *just* node numbers, but `auto_favorite_targets` rows carry tuned settings (`intervalHours`, `maxNewPerCycle`, `maxRefavoritePerCycle`, `maxNeighborAgeHours`, `eligibleRoles`). **Clearing on purge discards that configuration.**

Chosen: **clear everything** (issue option 1), matching #4630 — a purge is a clean slate, and consistency with the sibling automations wins. The disable-but-keep and filter-at-read alternatives were the runners-up; this was an explicit call, not a default.

## Change

- `clearAllForSource(sourceId?)` on `AutoFavoriteTargetsRepository`: deletes assignments before targets (ledger never outlives its config row), scoped by source when given or all sources on a global purge — same scoped/unscoped split as the sibling allowlists.
- Wired into `purgeAllNodesAsync` beside the #4630 clears, guarded by `if (this.autoFavoriteTargetsRepo)` so an uninitialised repo fails loud at test setup rather than no-opping silently.

## Tests

`database.purgeAllNodes.test.ts` — global purge and per-source purge, asserting **both** the config table and the ledger are cleared, plus cross-source isolation (purging A leaves B's tuned config and ledger intact). Verified by reverting the clear: both new tests fail.

- Full suite green locally (SQLite). This is a schema-touching change, so PG/MySQL matter — CI runs both as service containers; I note it because a local run skips them silently.
- `npm run lint:ci`: 0 in-repo failures.

## Not included

The issue also flagged `auto_traceroute_log` retaining rows for purged nodes (cosmetic) and left it out of scope. Not touched here either — worth its own cleanup if desired.

Closes #4633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtJnjbUgYwJfNU6XXACbFf