### PR TITLE
chore(release): 4.14.1-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.14.1-rc3] - 2026-08-10
+
+### Added
+- **Movement automation triggers for stationary fleets** — two Automation Engine triggers aimed at tamper / theft watch on fixed GPS nodes. **Became mobile** fires when a hand-selected node's mobility flag flips stationary → mobile (MeshMonitor's >100 m position-history heuristic). **Left home** fires when a watched node moves farther than a configurable threshold (default 300 m) from a per-(automation, node) home anchor; the home is seeded from position-history inliers when available (else the first live fix), gently averaged while the node stays within half the threshold, and persisted (migration 139) so a restart never silently re-homes a moved node. Saved automations gain a **Reset homes from history** action, the node picker lists stationary nodes first, and message/notify templates can use `{{ node.longName }}` / `{{ node.nodeId }}`. (#4648)
+- **Set a node's private key from Device Configuration** — the Security section can now write the **local** node's X25519 private key (previously copy-only), for restoring a node's identity from a backup or migrating it onto replacement hardware. On a genuine key change the handler derives the matching public key and sends both, so the node can't be left advertising a key that no longer matches its secret. Local device only — never remote admin — and saving a changed key requires confirming a dialog spelling out the impersonation / duplicate-key risk. (#4632, #4654)
+
+### Fixed
+- **Node purge now clears its automation bookkeeping** — purging a node also clears its auto-favorite targets and assignments (#4633), and its auto-traceroute and auto-time-sync allowlist entries (#4630), so a re-added node no longer inherits stale automation state.
+- **MeshCore: a lost `out_path` acknowledgement is treated as success, not failure** — route establishment no longer reports a spurious failure when the ack is dropped in flight. (#4625)
+
+## [4.14.1-rc2] - 2026-08-09
+
+### Added
+- **Unread divider and jump-to-first-unread** in the message view, for both Meshtastic and MeshCore conversations. (#4607)
+- **Position-estimation anchors** — the estimator now records and exposes the traceroute/neighbor observations behind each estimated position, so Node Details can show *why* a position was inferred. (#4609)
+- **MeshCore Analyzer Observer: static MQTT username/password auth** — an alternative to the signed Ed25519 token for brokers that don't verify it, stored encrypted per source. (#4595)
+- **Theme color scales** — a **sequential** scale for magnitude ramps and a **categorical** scale for chart series, both distinct from the role-color tokens and consistent across every theme. (#4611, #4605)
+- **Automations: a distinct reaction emoji for MQTT-sourced pings**, so a ping that arrived over MQTT is visually separable from an RF one. (#4594)
+
+### Changed
+- **Theme colors are named by role, not by swatch** — the palette moved to semantic role tokens (read from a script rather than raw palette vars), and the whole stylesheet set — CSS modules, global sheets, `nodes.css`, and inline component styles — was migrated onto those tokens. No behavior change beyond consistent, theme-following colors everywhere; the theme gallery was refreshed to match. (#4579, #4622, #4623)
+
+### Fixed
+- **Themes: tinted backgrounds ignored the active theme** and reverted to hardcoded palette swatches; both are fixed and now follow the selected theme. (#4617, #4620)
+- **Themes: chart slots now stay visually distinct in every theme** instead of collapsing to similar colors in some. (#4606)
+- **ESM: explicit `.js` extensions added to relative specifiers in server-compiled code**, and the build now fails on unresolvable runtime imports so a missing extension can't reach a `dist/`-only deployment again. (#4596, #4598)
+- **MQTT: message events and alerts now fire for MQTT-sourced messages** that previously arrived silently. (#4593)
+- **MeshtasticManager: stopped auto-acknowledging tapbacks** — a reaction is not a message that needs an ack — and the auto-ack tapback guard now keys on the emoji flag rather than its mere presence. (#4569, #4589)
+- **Unified views no longer drop nodes with a non-numeric `nodeNum`.** (#4573)
+- **Map: pending-traceroute nodes are no longer shaded as 0-hop/local** while their route is still being resolved. (#4570)
+- **UI: surfaces why a Neighbor Info request was rejected** instead of failing opaquely. (#4575)
+- **Position estimation: `replaceAnchors` is now atomic**, with its empty-`nodeNums` contract documented. (#4614)
+- **Removed a dead `hopsAway` write** in `processNodeInfoMessageProtobuf`. (#4604)
+- **Desktop: `dist/components` is now bundled into the packaged app.** (#4592)
+- **Analysis: the hop-counts scan is bounded**, and telemetry-request failures are surfaced in the UI. (#4580)
+
+### Docs
+- **Link quality: corrected where `hopsAway` comes from.** (#4590)
+
 ## [4.14.1-rc1] - 2026-08-05
 
 ### Added

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.14.1-rc2",
+  "version": "4.14.1-rc3",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.14.1-rc2",
+  "version": "4.14.1-rc3",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/docs/features/custom-themes.md
+++ b/docs/features/custom-themes.md
@@ -207,6 +207,15 @@ To create a variation of an existing theme:
 - `flamingo`: Decorative elements
 - `rosewater`: Decorative elements
 
+### Chart & Data Colors
+
+::: tip Added in 4.14.1 (#4605, #4611)
+Charts draw from two dedicated scales, separate from the role/accent tokens above, so data colors stay meaningful and distinct in every theme.
+:::
+
+- **Categorical scale** — `chart1`…`chart8` (CSS `--chart-1`…`--chart-8`): eight hues for unordered series (e.g. per-node or per-channel lines) that only need to be tellable apart. They do not have to match the accent palette.
+- **Sequential scale** — `--seq-1`…`--seq-5`: a five-step magnitude ramp for ordered/quantitative data (heatmaps, distance distributions), from low to high.
+
 ## Accessibility Validation
 
 The theme editor includes real-time accessibility checking based on WCAG 2.1 guidelines:

--- a/docs/features/device.md
+++ b/docs/features/device.md
@@ -1389,6 +1389,26 @@ Configure the store-and-forward module to cache and replay messages for nodes th
 
 - [Meshtastic Store and Forward Module](https://meshtastic.org/docs/configuration/module/store-and-forward/)
 
+## Security Configuration
+
+The **Security** section of Device Configuration shows the local node's public key and its private key (masked). The public key is what other nodes use to send you PKI-encrypted direct messages.
+
+### Set Private Key
+
+::: tip Added in 4.14.1 (#4632)
+The private key is copy-only until you click **Set private key**, which clears the field for a paste.
+:::
+
+Setting the private key lets you **restore a node's identity from a backup** or **migrate it onto replacement hardware**, matching the official Meshtastic apps. When you save a changed key, MeshMonitor derives the matching public key from it and writes both together, so the node can never be left advertising a public key that no longer matches its secret (which would silently break PKI DMs to it).
+
+- **Local device only.** The private key can only be set on the directly-connected node, never through remote admin.
+- **Validated before it reaches the device.** The key must be base64 of a 32-byte X25519 scalar; anything else is rejected on both the client and the server.
+- **Confirmation required.** Saving a changed key requires acknowledging a dialog that spells out the identity change and the impersonation / duplicate-key risk. **Cancel** restores the loaded key.
+
+::: warning
+Whoever holds a node's private key can impersonate it. Only paste a private key you own, on a trusted machine, and never share it.
+:::
+
 ## Applying Changes
 
 All configuration changes require clicking the "Save" button in each section. Most changes also require a device reboot to take effect. MeshMonitor will notify you when a reboot is required.

--- a/docs/features/meshcore-analyzer-observer.md
+++ b/docs/features/meshcore-analyzer-observer.md
@@ -40,7 +40,7 @@ Check the enable box, fill in the fields, and save. Saving an Analyzer Observer 
 
 ### Which authentication mode?
 
-::: tip Added in 4.15 (#4595)
+::: tip Added in 4.14.1 (#4595)
 The **Username / password** mode exists for regional brokers that don't verify a signature.
 :::
 

--- a/docs/features/position-estimation.md
+++ b/docs/features/position-estimation.md
@@ -74,6 +74,13 @@ on, so a circle never appears without its marker. The circle radius is the
 node's computed `uncertaintyKm` — a small circle means a confident,
 multi-anchor estimate; a large one means the node could only be placed loosely.
 
+::: tip Added in 4.14.1 (#4609)
+Each estimate now records the **anchors** behind it — the traceroute and
+neighbor observations that placed the node — along with the **radius method**
+used (`single_anchor`, `blended`, or `convergence`). This exposes *why* a node
+was placed where it was, rather than just the result.
+:::
+
 ## Permissions & API
 
 The estimator's status and controls map to the global `settings` resource:

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.14.1-rc2
-appVersion: "4.14.1-rc2"
+version: 4.14.1-rc3
+appVersion: "4.14.1-rc3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.1-rc2",
+  "version": "4.14.1-rc3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.14.1-rc2",
+      "version": "4.14.1-rc3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -15,7 +15,6 @@
         "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#c5900ecfe66d076d044fbcec331c0bcfbfac9e9e",
         "@maplibre/maplibre-gl-leaflet": "^0.1.3",
         "@michaelhart/meshcore-decoder": "^0.3.0",
-        "@rollup/rollup-linux-arm64-musl": "4.62.4",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-virtual": "^3.14.9",
         "@tmcw/togeojson": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.1-rc2",
+  "version": "4.14.1-rc3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Bumps to **4.14.1-rc3** and reconciles the docs with everything that shipped across the 4.14.1 release candidates.

### Version bump
All five version files + lockfile → `4.14.1-rc3`: `package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml` (version + appVersion), `desktop/src-tauri/tauri.conf.json`, `desktop/package.json`.

### CHANGELOG backfill
The changelog had `[4.14.1-rc1]` but nothing for rc2 or rc3. Added both, attributing every substantive change to its PR (dependency bumps excluded, per the file's convention):
- **rc2 (2026-08-09):** unread divider + jump-to-first-unread, position-estimation anchors, Analyzer Observer static MQTT auth, theme role-token system + sequential/categorical color scales, MQTT ping reaction emoji, plus theme/ESM/MQTT/map/auto-ack fixes.
- **rc3 (2026-08-10):** became-mobile & left-home automation triggers (#4648), set node private key from Device Configuration (#4632/#4654), node-purge automation cleanup (#4633/#4630), MeshCore `out_path` ack fix (#4625).

### Doc accuracy fixes
A full pass over the feature docs against shipped rc1–rc3 behavior:
- **meshcore-analyzer-observer.md** — static MQTT auth was mis-tagged "Added in 4.15"; it shipped in 4.14.1-rc2 (#4595). Corrected.
- **device.md** — added a **Security Configuration** section for the new "set a node's private key" feature (#4632/#4654): local-only, X25519, derives the matching public key, with the impersonation warning.
- **position-estimation.md** — documented that estimates now expose their anchors + radius method (#4609).
- **custom-themes.md** — documented the categorical (`chart1..8`) and sequential (`--seq-1..5`) chart color scales (#4605/#4611).

Docs verified accurate (no change needed): MeshCore strict receive-only, Analyzer Observer battery/uptime/noise, Map Click Zoom Gate, per-source `canViewOnMap`, MQTT reaction emoji, semantic role tokens, and the became-mobile/left-home trigger docs.

### Known follow-up (not in this PR)
The rc2 **unread divider / jump-to-first-unread** (#4607) has no user-facing feature doc — there's no messages/chat page to extend, and adding one is beyond a release bump. Worth a dedicated docs issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)