### PR TITLE
fix: preserve newlines in MeshCore message body (#4659)

### DIFF
--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -726,7 +726,7 @@
 }
 .meshcore-purge-all-btn:hover:not(:disabled) { filter: brightness(1.1); }
 .meshcore-purge-all-btn:disabled { opacity: 0.6; cursor: default; }
-.mc-message-text { color: var(--color-text); font-size: 0.9rem; word-wrap: break-word; }
+.mc-message-text { color: var(--color-text); font-size: 0.9rem; word-wrap: break-word; white-space: pre-line; }
 /* Hop count + relay route for received messages (#3742). */
 .mc-message-route { color: var(--color-text-subtle); font-size: 0.75rem; margin-top: 0.15rem; font-family: var(--font-mono, monospace); }
 /* Signal quality on a directly-received message (#4504). Same muted treatment


### PR DESCRIPTION
## Summary
- MeshCore chat messages collapsed `\n` to a single space because `.mc-message-text` had no `white-space` rule.
- Added `white-space: pre-line` so newlines render as line breaks, matching the Meshtastic side (which already uses `whiteSpace: 'pre-line'` inline on `.message-text`).

Fixes #4659.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `vitest run` on the three MeshCoreMessageStream suites — 43/43 pass
- [ ] Manual: send a multi-line MeshCore message; each `\n` renders as a line break in the stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX