### PR TITLE
feat: add Ko-fi Support link to the sidebar footer

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4816,6 +4816,7 @@
   "source.sidebar.github": "GitHub",
   "source.sidebar.website": "Website",
   "source.sidebar.discord": "Discord",
+  "source.sidebar.support": "Support on Ko-fi",
   "source.sidebar.unified_messages": "Unified Messages",
   "source.sidebar.unified_telemetry": "Unified Telemetry",
   "source.sidebar.unified_packets": "Unified Packets",

--- a/src/components/SidebarFooter.test.tsx
+++ b/src/components/SidebarFooter.test.tsx
@@ -11,6 +11,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import SidebarFooter, {
   MESHMONITOR_DISCORD_URL,
   MESHMONITOR_GITHUB_URL,
+  MESHMONITOR_KOFI_URL,
   MESHMONITOR_WEBSITE_URL,
 } from './SidebarFooter';
 import packageJson from '../../package.json';
@@ -28,13 +29,14 @@ beforeEach(() => {
 });
 
 describe('SidebarFooter', () => {
-  it('renders the full link set: Users, Settings, News, GitHub, Discord, Website', () => {
+  it('renders the full link set: Users, Settings, News, GitHub, Discord, Support, Website', () => {
     render(<SidebarFooter {...baseProps} />);
     expect(screen.getByTitle('source.sidebar.users')).toBeInTheDocument();
     expect(screen.getByTitle('source.sidebar.settings')).toBeInTheDocument();
     expect(screen.getByTitle('source.sidebar.news')).toBeInTheDocument();
     expect(screen.getByTitle('source.sidebar.github')).toBeInTheDocument();
     expect(screen.getByTitle('source.sidebar.discord')).toBeInTheDocument();
+    expect(screen.getByTitle('source.sidebar.support')).toBeInTheDocument();
     expect(screen.getByTitle('source.sidebar.website')).toBeInTheDocument();
   });
 
@@ -57,7 +59,7 @@ describe('SidebarFooter', () => {
     expect(discord).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
-  it('links GitHub and Website externally in new tabs', () => {
+  it('links GitHub, Website, and Support externally in new tabs', () => {
     render(<SidebarFooter {...baseProps} />);
     const github = screen.getByTitle('source.sidebar.github');
     expect(github).toHaveAttribute('href', MESHMONITOR_GITHUB_URL);
@@ -65,6 +67,11 @@ describe('SidebarFooter', () => {
     const website = screen.getByTitle('source.sidebar.website');
     expect(website).toHaveAttribute('href', MESHMONITOR_WEBSITE_URL);
     expect(website).toHaveAttribute('target', '_blank');
+    const support = screen.getByTitle('source.sidebar.support');
+    expect(support).toHaveAttribute('href', MESHMONITOR_KOFI_URL);
+    expect(MESHMONITOR_KOFI_URL).toBe('https://ko-fi.com/yeraze');
+    expect(support).toHaveAttribute('target', '_blank');
+    expect(support).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('hides Users when the viewer is not an admin', () => {

--- a/src/components/SidebarFooter.tsx
+++ b/src/components/SidebarFooter.tsx
@@ -17,6 +17,7 @@ import styles from './SidebarFooter.module.css';
 export const MESHMONITOR_GITHUB_URL = 'https://github.com/Yeraze/meshmonitor';
 export const MESHMONITOR_DISCORD_URL = 'https://discord.gg/JVR3VBETQE';
 export const MESHMONITOR_WEBSITE_URL = 'https://meshmonitor.org';
+export const MESHMONITOR_KOFI_URL = 'https://ko-fi.com/yeraze';
 
 export interface SidebarFooterProps {
   /** Shows the Users link. */
@@ -112,6 +113,15 @@ const SidebarFooter: React.FC<SidebarFooterProps> = ({
           title={t('source.sidebar.discord', 'Discord')}
         >
           <BrandIcon brand="discord" size={18} />
+        </a>
+        <a
+          className={styles.btn}
+          href={MESHMONITOR_KOFI_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={t('source.sidebar.support', 'Support on Ko-fi')}
+        >
+          <UiIcon name="heart" size={18} />
         </a>
         <a
           className={styles.btn}


### PR DESCRIPTION
## Summary
- Adds a heart-icon Ko-fi Support link to the shared `SidebarFooter`, placed between Discord and Website. Both the unified dashboard sidebar and each per-source sidebar surface it.
- Links to https://ko-fi.com/yeraze — the same handle as `.github/FUNDING.yml`, the in-app Settings Support button, and the new site-nav link (PR #4665).
- Exports `MESHMONITOR_KOFI_URL` so the test file asserts against the same constant as the other external links.
- New i18n key: `source.sidebar.support` = "Support on Ko-fi".

## Test plan
- [x] `npm run typecheck` — clean
- [x] `SidebarFooter.test.tsx` — 10/10 pass (full-link-set assertion updated, new href/target/rel assertion for the Ko-fi link)
- [x] `DashboardSidebar.test.tsx` — 44/44 pass
- [ ] Manual: heart icon visible in the collapsed rail (60px `narrowIcons`) and expanded modes; click opens Ko-fi in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX