### PR TITLE
fix(sidebar): keep footer icons on one line after Ko-fi link (#4666)

### DIFF
--- a/src/components/SidebarFooter.module.css
+++ b/src/components/SidebarFooter.module.css
@@ -29,7 +29,10 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 6px;
+  /* Tight enough that the full seven-icon set (Users, Settings, News, GitHub,
+     Discord, Ko-fi, Website) stays on one line at the 240px default sidebar
+     width. flex-wrap remains as a fallback if the sidebar is resized narrower. */
+  gap: 4px;
 }
 
 /* Narrow rail (the 60px collapsed per-source sidebar): a two-column grid keeps
@@ -51,7 +54,7 @@
 .btn {
   background: none;
   border: none;
-  padding: 4px 6px;
+  padding: 4px 4px;
   font-size: 14px;
   cursor: pointer;
   border-radius: 4px;


### PR DESCRIPTION
## Summary

The Ko-fi Support link added in #4666 made the sidebar footer a **seven-icon** row (Users, Settings, News, GitHub, Discord, Ko-fi, Website). At the default 240px sidebar width the old spacing overflowed and the seventh icon wrapped onto a second line.

## Fix

In `SidebarFooter.module.css`:
- `.icons` gap `6px` → `4px`
- `.btn` padding `4px 6px` → `4px 4px`

Row total drops from ~246px to ~206px, comfortably inside the ~216px usable width at the 240px default.

- Vertical padding (tap height) unchanged.
- `flex-wrap` kept as a fallback for narrower resized widths.
- Narrow collapsed rail unaffected — it overrides both values with its own 2-column grid.

## Verification

- Built + deployed the dev container; confirmed all seven icons sit on one line and the served bundle carries the new rule (`._icons_… { gap: 4px }`).
- CSS-only change; `tsc` / `lint:ci` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
