### PR TITLE
fix(meshcore-vn): deliver MeshMonitor-originated channel messages to Virtual Node clients (#4535)

### DIFF
--- a/docs/configuration/virtual-node.md
+++ b/docs/configuration/virtual-node.md
@@ -455,6 +455,16 @@ MeshCore App 3 ┘
 - **Contacts** — served from the durable per-source contact list (so the app sees the full set even when the live companion read is flaky).
 - **Channels & battery** — channel info (including PSK) and the local node's battery level.
 - **Messaging** — incoming channel and direct messages are pushed to the app; outgoing **direct** and **channel** text messages are forwarded to the real node, unless the source is in [receive-only mode](#safety-receive-only-mode).
+- **Channel messages MeshMonitor sends are mirrored to every connected app.** A channel message you send from the MeshMonitor web UI — or that another connected client sends — is pushed to all the *other* connected clients, so each one shows the same conversation. The client that actually sent the message is skipped, because its app already displayed it locally when you hit send.
+
+::: info Direct messages you send are not mirrored
+This mirroring covers **channel** messages only. The companion protocol has no
+frame for "a DM this node sent" — `CONTACT_MSG_RECV` means *received from* a
+contact — so a DM sent from the web UI (or from another connected client) cannot
+be represented to the app without either attributing it to yourself, which no
+real companion ever does, or fabricating a reply from its recipient. Those DMs
+stay visible in MeshMonitor's own message history.
+:::
 
 ### Enabling MeshCore Virtual Node on a Source
 

--- a/src/server/meshcoreVirtualNodeServer.test.ts
+++ b/src/server/meshcoreVirtualNodeServer.test.ts
@@ -204,6 +204,16 @@ class TestClient {
   private socket = new Socket();
   private buffer = Buffer.alloc(0);
   private waiters: Array<(payload: Buffer) => void> = [];
+  /**
+   * Frames that arrived before anything asked for them. Without this queue a
+   * frame decoded while no waiter was registered was DROPPED, so any test whose
+   * waiter lost the race to an unsolicited push (MsgWaiting/LogRxData, which the
+   * server emits whenever it likes) waited forever and failed on the 10s
+   * timeout. That made this file intermittently red regardless of the code under
+   * test. Buffering preserves arrival order and makes frame delivery
+   * order-independent rather than scheduling-dependent.
+   */
+  private queued: Buffer[] = [];
 
   async connect(port: number): Promise<void> {
     await new Promise<void>((resolve, reject) => {
@@ -224,20 +234,29 @@ class TestClient {
       if (this.buffer.length < 3 + len) break;
       const payload = Buffer.from(this.buffer.subarray(3, 3 + len));
       this.buffer = this.buffer.subarray(3 + len);
-      this.waiters.shift()?.(payload);
+      const waiter = this.waiters.shift();
+      if (waiter) waiter(payload);
+      else this.queued.push(payload);
     }
+  }
+
+  /** Next frame in arrival order — already-buffered one first, else the next to arrive. */
+  next(): Promise<Buffer> {
+    const alreadyHere = this.queued.shift();
+    if (alreadyHere) return Promise.resolve(alreadyHere);
+    return new Promise<Buffer>((resolve) => this.waiters.push(resolve));
   }
 
   /** Send a command and await the next response payload. */
   request(payload: number[]): Promise<Buffer> {
-    const p = new Promise<Buffer>((resolve) => this.waiters.push(resolve));
+    const p = this.next();
     this.socket.write(frameCommand(payload));
     return p;
   }
 
   /** Await the next N response payloads (for commands that reply with several frames). */
   expectFrames(n: number): Promise<Buffer[]> {
-    return Promise.all(Array.from({ length: n }, () => new Promise<Buffer>((resolve) => this.waiters.push(resolve))));
+    return Promise.all(Array.from({ length: n }, () => this.next()));
   }
 
   send(payload: number[]): void {
@@ -246,6 +265,26 @@ class TestClient {
 
   close(): void {
     this.socket.destroy();
+  }
+}
+
+/**
+ * Wait until the SERVER has registered `n` clients.
+ *
+ * `TestClient.connect()` resolves on the client side of the handshake, which can
+ * land a tick before the server's own `connection` handler adds the socket to
+ * its client map. A test that emitted straight after connecting could therefore
+ * fan out to zero clients, and its `await push` then sat there until the 10s
+ * timeout — the file's long-standing intermittent failures. Waiting on the
+ * server's own count removes the guesswork.
+ */
+async function waitForClients(server: MeshCoreVirtualNodeServer, n: number): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (server.getClientCount() < n) {
+    if (Date.now() >= deadline) {
+      throw new Error(`server registered ${server.getClientCount()} of ${n} clients within 2s`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
   }
 }
 
@@ -260,6 +299,7 @@ describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
   });
 
   afterEach(async () => {
@@ -365,7 +405,7 @@ describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
   });
 
   it('pushes MsgWaiting on a live incoming message and delivers it via SyncNextMessage', async () => {
-    const push = new Promise<Buffer>((resolve) => (client as any).waiters.push(resolve));
+    const push = client.next();
     manager.emitMessage({
       id: 'm1',
       fromPublicKey: 'b1'.repeat(32),
@@ -382,7 +422,7 @@ describe('MeshCoreVirtualNodeServer — Phase 0 handshake', () => {
   });
 
   it('delivers an incoming CHANNEL message as ChannelMsgRecv (marker in fromPublicKey)', async () => {
-    const push = new Promise<Buffer>((resolve) => (client as any).waiters.push(resolve));
+    const push = client.next();
     // Incoming channel messages carry the channel marker in fromPublicKey, with
     // toPublicKey unset, and the sender name in fromName.
     manager.emitMessage({
@@ -544,6 +584,7 @@ describe('MeshCoreVirtualNodeServer — local node not ready', () => {
     await server.start();
     const client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
 
     const payload = await client.request([CommandCodes.AppStart, 1, 0, 0, 0, 0, 0, 0]);
     expect(payload[0]).toBe(ResponseCodes.Err);
@@ -601,6 +642,7 @@ describe('MeshCoreVirtualNodeServer — config-command forwarding (#3904)', () =
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
   }
 
   afterEach(async () => {
@@ -711,6 +753,7 @@ describe('MeshCoreVirtualNodeServer — SendSelfAdvert forwarding (#3904)', () =
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
   }
 
   afterEach(async () => {
@@ -773,6 +816,7 @@ describe('MeshCoreVirtualNodeServer — SendLogin relay (#3904)', () => {
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
   }
 
   afterEach(async () => {
@@ -887,6 +931,7 @@ describe('MeshCoreVirtualNodeServer — SendTracePath relay (#3904)', () => {
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
   }
   afterEach(async () => { client?.close(); await server?.stop(); });
 
@@ -954,6 +999,7 @@ describe('MeshCoreVirtualNodeServer — SendTelemetryReq relay (#3904)', () => {
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
   }
   afterEach(async () => { client?.close(); await server?.stop(); });
 
@@ -1014,6 +1060,7 @@ describe('MeshCoreVirtualNodeServer — SendStatusReq relay (#3904)', () => {
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
   }
   afterEach(async () => { client?.close(); await server?.stop(); });
 
@@ -1115,6 +1162,7 @@ describe('MeshCoreVirtualNodeServer — SendBinaryReq/GetNeighbours relay (#3904
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
   }
   afterEach(async () => { client?.close(); await server?.stop(); });
 
@@ -1279,6 +1327,7 @@ describe('MeshCoreVirtualNodeServer — SendTxtMsg CLI relay (#4106)', () => {
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
   }
   afterEach(async () => { client?.close(); await server?.stop(); });
 
@@ -1413,6 +1462,7 @@ describe('MeshCoreVirtualNodeServer — ExportPrivateKey (allowPkiExport gate)',
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
   }
 
   afterEach(async () => {
@@ -1514,6 +1564,7 @@ describe('MeshCoreVirtualNodeServer — getClientDetails (status endpoint contra
 
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
     await vi.waitFor(() => expect(server.getClientCount()).toBe(1));
 
     const details = server.getClientDetails();
@@ -1570,6 +1621,7 @@ describe('MeshCoreVirtualNodeServer — receive-only mode (#4547)', () => {
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
   }
 
   afterEach(async () => {
@@ -1776,7 +1828,7 @@ describe('MeshCoreVirtualNodeServer — receive-only mode (#4547)', () => {
   it('keeps the live OTA packet feed and MsgWaiting push flowing while receive-only is ON', async () => {
     await startReceiveOnly();
 
-    const msgPush = new Promise<Buffer>((resolve) => (client as unknown as { waiters: Array<(p: Buffer) => void> }).waiters.push(resolve));
+    const msgPush = client.next();
     manager.emitMessage({
       id: 'ro-1',
       fromPublicKey: 'b1'.repeat(32),
@@ -1848,6 +1900,7 @@ describe('MeshCoreVirtualNodeServer — receive-only mode (#4547)', () => {
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
 
     manager.receiveOnlyMock.mockReturnValue(true);
     const refused = await client.request(advertFrame);
@@ -1872,6 +1925,7 @@ describe('MeshCoreVirtualNodeServer — receive-only mode (#4547)', () => {
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
 
     const payload = await client.request(advertFrame);
     expect(payload[0]).toBe(ResponseCodes.Err);
@@ -1892,6 +1946,7 @@ describe('MeshCoreVirtualNodeServer — receive-only mode (#4547)', () => {
     await server.start();
     client = new TestClient();
     await client.connect(server.getListeningPort()!);
+    await waitForClients(server, 1);
 
     manager.sendMessageMock.mockResolvedValueOnce(false);
     const channelRes = await client.request(channelFrame('nope'));
@@ -1907,5 +1962,322 @@ describe('MeshCoreVirtualNodeServer — receive-only mode (#4547)', () => {
     const advertRes = await client.request(advertFrame);
     expect(advertRes[0]).toBe(ResponseCodes.Err);
     expect(advertRes[1]).toBe(ErrorCodes.BadState);
+  });
+});
+
+// ── Per-client message attribution (#4535) ──
+//
+// The manager stamps every outbound message with our own identity, so before
+// this the server dropped ALL self-originated messages and nothing MeshMonitor
+// sent ever reached a connected app. Delivery is now per-client: everyone gets
+// the message except whichever client asked us to transmit it.
+//
+// Two clients throughout, because the interesting failures (one client's send
+// hiding a message from another, one client's sync draining another's queue)
+// are invisible with a single connection.
+describe('MeshCoreVirtualNodeServer — per-client message delivery (#4535)', () => {
+  let server: MeshCoreVirtualNodeServer;
+  let manager: FakeManager;
+  let clientA: TestClient;
+  let clientB: TestClient;
+
+  const CHANNEL_IDX = 1;
+  const REMOTE_KEY = 'b1'.repeat(32); // matches SAMPLE_CONTACTS
+
+  const channelFrame = (text: string, channelIdx = CHANNEL_IDX): number[] => [
+    CommandCodes.SendChannelTxtMsg, 0, channelIdx, 0, 0, 0, 0, ...Buffer.from(text, 'utf8'),
+  ];
+
+  /** Resolve on the next frame this client receives (push or response). */
+  const nextFrame = (c: TestClient): Promise<Buffer> => c.next();
+
+  /** A message as the manager emits it when MeshMonitor transmits on a channel. */
+  const selfChannelMessage = (
+    text: string,
+    id = `ui-${text}`,
+    channelIdx = CHANNEL_IDX,
+  ): MeshCoreMessage => ({
+    id,
+    fromPublicKey: LOCAL_NODE.publicKey,
+    fromName: LOCAL_NODE.name,
+    toPublicKey: `channel-${channelIdx}`,
+    text,
+    timestamp: 1_750_000_000_000,
+  });
+
+  /** Drain one message for a client, asserting something actually arrived. */
+  async function syncOne(c: TestClient): Promise<Buffer> {
+    const frame = await c.request([CommandCodes.SyncNextMessage]);
+    expect(frame[0]).not.toBe(ResponseCodes.NoMoreMessages);
+    return frame;
+  }
+
+  /** Assert this client's queue is empty (nothing was pushed to it). */
+  async function expectEmpty(c: TestClient): Promise<void> {
+    const frame = await c.request([CommandCodes.SyncNextMessage]);
+    expect(frame[0]).toBe(ResponseCodes.NoMoreMessages);
+  }
+
+  /** Wait until the server has observed a socket close and is down to `n` clients. */
+  async function settleTo(n: number): Promise<void> {
+    const deadline = Date.now() + 2000;
+    while (server.getClientCount() > n) {
+      if (Date.now() >= deadline) {
+        throw new Error(`server still has ${server.getClientCount()} clients, expected ${n}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  }
+
+  beforeEach(async () => {
+    manager = new FakeManager();
+    server = new MeshCoreVirtualNodeServer({ port: 0, manager, databaseService: CHANNELS_DB });
+    await server.start();
+    clientA = new TestClient();
+    clientB = new TestClient();
+    await clientA.connect(server.getListeningPort()!);
+    await clientB.connect(server.getListeningPort()!);
+    await waitForClients(server, 2);
+  });
+
+  afterEach(async () => {
+    clientA.close();
+    clientB.close();
+    await server.stop();
+  });
+
+  it('delivers an incoming RF DM to BOTH connected clients', async () => {
+    const pushA = nextFrame(clientA);
+    const pushB = nextFrame(clientB);
+    manager.emitMessage({
+      id: 'rf-dm',
+      fromPublicKey: REMOTE_KEY,
+      text: 'rf direct message',
+      timestamp: 1_750_000_000_000,
+    });
+    expect((await pushA)[0]).toBe(PushCodes.MsgWaiting);
+    expect((await pushB)[0]).toBe(PushCodes.MsgWaiting);
+
+    for (const c of [clientA, clientB]) {
+      const recv = await syncOne(c);
+      expect(recv[0]).toBe(ResponseCodes.ContactMsgRecv);
+      expect(recv.subarray(-'rf direct message'.length).toString('utf8')).toBe('rf direct message');
+    }
+  });
+
+  it('delivers an incoming RF channel message to BOTH connected clients', async () => {
+    const pushA = nextFrame(clientA);
+    const pushB = nextFrame(clientB);
+    manager.emitMessage({
+      id: 'rf-ch',
+      fromPublicKey: `channel-${CHANNEL_IDX}`,
+      fromName: 'Distant Node',
+      text: 'rf channel message',
+      timestamp: 1_750_000_000_000,
+    });
+    expect((await pushA)[0]).toBe(PushCodes.MsgWaiting);
+    expect((await pushB)[0]).toBe(PushCodes.MsgWaiting);
+
+    for (const c of [clientA, clientB]) {
+      const recv = await syncOne(c);
+      expect(recv[0]).toBe(ResponseCodes.ChannelMsgRecv);
+      expect(recv.subarray(8).toString('utf8')).toBe('Distant Node: rf channel message');
+    }
+  });
+
+  // The headline bug: MeshMonitor's own web-UI send reached nobody.
+  it('delivers a channel message MeshMonitor originated to every connected client', async () => {
+    const pushA = nextFrame(clientA);
+    const pushB = nextFrame(clientB);
+    manager.emitMessage(selfChannelMessage('from the web UI'));
+    expect((await pushA)[0]).toBe(PushCodes.MsgWaiting);
+    expect((await pushB)[0]).toBe(PushCodes.MsgWaiting);
+
+    for (const c of [clientA, clientB]) {
+      const recv = await syncOne(c);
+      expect(recv[0]).toBe(ResponseCodes.ChannelMsgRecv);
+      expect(recv.readInt8(1)).toBe(CHANNEL_IDX);
+      // Rendered exactly as a peer node would have heard it over the air.
+      expect(recv.subarray(8).toString('utf8')).toBe(`${LOCAL_NODE.name}: from the web UI`);
+    }
+  });
+
+  it('relays one client channel send to the OTHER client, but not back to the sender', async () => {
+    const ack = await clientA.request(channelFrame('hello from A'));
+    expect(ack[0]).toBe(ResponseCodes.Ok);
+
+    const pushB = nextFrame(clientB);
+    manager.emitMessage(selfChannelMessage('hello from A', 'a-1'));
+    expect((await pushB)[0]).toBe(PushCodes.MsgWaiting);
+
+    const recv = await syncOne(clientB);
+    expect(recv[0]).toBe(ResponseCodes.ChannelMsgRecv);
+    expect(recv.subarray(8).toString('utf8')).toBe(`${LOCAL_NODE.name}: hello from A`);
+
+    // A already rendered it optimistically — a copy back would double it.
+    await expectEmpty(clientA);
+  });
+
+  it('relays a client B send to client A symmetrically', async () => {
+    await clientB.request(channelFrame('hello from B'));
+
+    const pushA = nextFrame(clientA);
+    manager.emitMessage(selfChannelMessage('hello from B', 'b-1'));
+    expect((await pushA)[0]).toBe(PushCodes.MsgWaiting);
+
+    expect((await syncOne(clientA))[0]).toBe(ResponseCodes.ChannelMsgRecv);
+    await expectEmpty(clientB);
+  });
+
+  // The companion protocol has no outbound-DM frame (ContactMsgRecv means
+  // "received FROM"), so a self-sent DM stays undeliverable by design.
+  it('does not deliver a DM MeshMonitor sent (no representable companion frame)', async () => {
+    manager.emitMessage({
+      id: 'ui-dm',
+      fromPublicKey: LOCAL_NODE.publicKey,
+      fromName: LOCAL_NODE.name,
+      toPublicKey: REMOTE_KEY,
+      text: 'outbound dm',
+      timestamp: 1_750_000_000_000,
+    });
+    await expectEmpty(clientA);
+    await expectEmpty(clientB);
+  });
+
+  it('still suppresses our own channel transmission heard back over the air, for every client', async () => {
+    manager.emitMessage({
+      id: 'ota-echo',
+      fromPublicKey: `channel-${CHANNEL_IDX}`, // received-side marker
+      fromName: LOCAL_NODE.name,
+      text: 'heard my own flood',
+      timestamp: 1_750_000_000_000,
+    });
+    await expectEmpty(clientA);
+    await expectEmpty(clientB);
+  });
+
+  it('preserves ordering across a burst and keeps each queue independent', async () => {
+    // Waiters registered up front: a frame that arrives with none pending is
+    // dropped by TestClient, and an unconsumed push would otherwise be handed
+    // to the next SyncNextMessage in place of its response.
+    const pushesA = clientA.expectFrames(3);
+    const pushesB = clientB.expectFrames(3);
+    for (const text of ['first', 'second', 'third']) {
+      manager.emitMessage({
+        id: `ord-${text}`,
+        fromPublicKey: REMOTE_KEY,
+        text,
+        timestamp: 1_750_000_000_000,
+      });
+    }
+    for (const frame of [...(await pushesA), ...(await pushesB)]) {
+      expect(frame[0]).toBe(PushCodes.MsgWaiting);
+    }
+
+    // Client A draining its queue must not consume client B's copies.
+    for (const expected of ['first', 'second', 'third']) {
+      const recv = await syncOne(clientA);
+      expect(recv.subarray(-expected.length).toString('utf8')).toBe(expected);
+    }
+    await expectEmpty(clientA);
+
+    for (const expected of ['first', 'second', 'third']) {
+      const recv = await syncOne(clientB);
+      expect(recv.subarray(-expected.length).toString('utf8')).toBe(expected);
+    }
+    await expectEmpty(clientB);
+  });
+
+  it('attributes only ONE message per send, so an identical later message still reaches the sender', async () => {
+    await clientA.request(channelFrame('duplicate text'));
+
+    // The echo of A's own send: suppressed for A, delivered to B.
+    const pushB1 = nextFrame(clientB);
+    manager.emitMessage(selfChannelMessage('duplicate text', 'dup-1'));
+    expect((await pushB1)[0]).toBe(PushCodes.MsgWaiting);
+    expect((await syncOne(clientB))[0]).toBe(ResponseCodes.ChannelMsgRecv);
+    await expectEmpty(clientA);
+
+    // A second, unrelated message with the same text (e.g. typed in the web UI)
+    // has no attribution left to claim, so A must receive it.
+    const pushA2 = nextFrame(clientA);
+    const pushB2 = nextFrame(clientB);
+    manager.emitMessage(selfChannelMessage('duplicate text', 'dup-2'));
+    expect((await pushA2)[0]).toBe(PushCodes.MsgWaiting);
+    expect((await pushB2)[0]).toBe(PushCodes.MsgWaiting);
+    expect((await syncOne(clientA))[0]).toBe(ResponseCodes.ChannelMsgRecv);
+    expect((await syncOne(clientB))[0]).toBe(ResponseCodes.ChannelMsgRecv);
+  });
+
+  it('does not suppress anything when the forwarded send failed at the node', async () => {
+    manager.sendMessageMock.mockResolvedValueOnce(false);
+    const res = await clientA.request(channelFrame('never left the radio'));
+    expect(res[0]).toBe(ResponseCodes.Err);
+
+    // Nothing was transmitted, so a later identical message is unrelated and
+    // must still reach A rather than matching the dead attribution.
+    const pushA = nextFrame(clientA);
+    manager.emitMessage(selfChannelMessage('never left the radio', 'retry-1'));
+    expect((await pushA)[0]).toBe(PushCodes.MsgWaiting);
+    expect((await syncOne(clientA))[0]).toBe(ResponseCodes.ChannelMsgRecv);
+  });
+
+  it('keeps delivering to the remaining client while the other is disconnected', async () => {
+    clientB.close();
+    await settleTo(1);
+
+    const pushA = nextFrame(clientA);
+    manager.emitMessage({
+      id: 'while-b-away',
+      fromPublicKey: REMOTE_KEY,
+      text: 'B is offline',
+      timestamp: 1_750_000_000_000,
+    });
+    expect((await pushA)[0]).toBe(PushCodes.MsgWaiting);
+    expect((await syncOne(clientA))[0]).toBe(ResponseCodes.ContactMsgRecv);
+    expect(server.getClientCount()).toBe(1);
+  });
+
+  // Documents CURRENT reconnect semantics: a reconnecting client starts from an
+  // empty mailbox (the server seeds `pendingMessages` empty so the app's own
+  // local history isn't re-delivered on every reconnect). Real firmware queues
+  // while the app is away, so this is a known parity gap tracked separately —
+  // deliberately NOT changed here.
+  it('gives a reconnecting client an empty mailbox even after the other client saw a message', async () => {
+    clientB.close();
+    await settleTo(1);
+
+    const pushA = nextFrame(clientA);
+    manager.emitMessage({
+      id: 'missed-by-b',
+      fromPublicKey: REMOTE_KEY,
+      text: 'B missed this',
+      timestamp: 1_750_000_000_000,
+    });
+    // A, still connected, receives it — B's absence consumed nothing.
+    expect((await pushA)[0]).toBe(PushCodes.MsgWaiting);
+    expect((await syncOne(clientA))[0]).toBe(ResponseCodes.ContactMsgRecv);
+
+    const reconnected = new TestClient();
+    await reconnected.connect(server.getListeningPort()!);
+    await waitForClients(server, 2); // clientA plus the reconnected one
+    try {
+      await expectEmpty(reconnected);
+    } finally {
+      reconnected.close();
+    }
+  });
+
+  it('drops a departed client pending attribution instead of leaking it', async () => {
+    await clientA.request(channelFrame('A sent then left'));
+    clientA.close();
+    await settleTo(1);
+
+    // With A gone its attribution is discarded, so the message is simply
+    // delivered to everyone still connected.
+    const pushB = nextFrame(clientB);
+    manager.emitMessage(selfChannelMessage('A sent then left', 'gone-1'));
+    expect((await pushB)[0]).toBe(PushCodes.MsgWaiting);
+    expect((await syncOne(clientB))[0]).toBe(ResponseCodes.ChannelMsgRecv);
   });
 });

--- a/src/server/meshcoreVirtualNodeServer.ts
+++ b/src/server/meshcoreVirtualNodeServer.ts
@@ -305,6 +305,39 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
    */
   private readonly pendingAcks = new Map<number, string>();
 
+  /**
+   * Channel sends this server forwarded on behalf of a specific client, so the
+   * manager's resulting self-originated `message` event can be attributed back
+   * to its originator (#4535).
+   *
+   * The manager stamps EVERY outbound message with our own identity, whether it
+   * came from MeshMonitor's web UI or was relayed here from a companion. That
+   * makes "the app's own send, echoed back" and "a message the app has never
+   * seen" byte-identical at the event boundary — which is why the old blanket
+   * self-origin skip silently dropped UI-originated messages.
+   *
+   * Correlation is by content rather than message id because the manager mints
+   * the id internally and emits DURING the `sendMessage()` call, so the id does
+   * not exist on our side until after the event has already fired. An entry is
+   * registered immediately BEFORE that call and consumed by the first matching
+   * event; unmatched entries expire so a send that never round-trips (node
+   * offline, message dropped) cannot suppress an unrelated later message.
+   */
+  private readonly recentClientChannelSends: Array<{
+    key: string;
+    clientId: string;
+    expiresAt: number;
+  }> = [];
+
+  /**
+   * How long a forwarded channel send stays attributable to its originating
+   * client. The manager emits synchronously inside `sendMessage()`, so this only
+   * needs to cover that round-trip; it is generous purely so a slow serial write
+   * cannot mis-attribute. Kept short so a repeat of the same text in the same
+   * channel gets its own attribution rather than matching a stale entry.
+   */
+  private readonly SEND_ATTRIBUTION_TTL_MS = 30000;
+
   private readonly MAX_FRAME_BYTES = 4096;
   private readonly CLIENT_TIMEOUT_MS = 300000; // 5 min inactivity
   private readonly CLEANUP_INTERVAL_MS = 60000;
@@ -364,6 +397,7 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     this.options.manager.off('send_confirmed', this.onManagerSendConfirmed);
     this.options.manager.off('ota_packet', this.onManagerOtaPacket);
     this.pendingAcks.clear();
+    this.recentClientChannelSends.length = 0;
 
     for (const client of this.clients.values()) {
       client.socket.destroy();
@@ -464,6 +498,14 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     // leak entries for acks that will never be claimed (#3869).
     for (const [crc, owner] of this.pendingAcks) {
       if (owner === clientId) this.pendingAcks.delete(crc);
+    }
+    // Same for its in-flight send attributions (#4535). Leaving them would only
+    // cost memory until they expire — the id is never reused — but a departing
+    // client should take all of its state with it.
+    for (let i = this.recentClientChannelSends.length - 1; i >= 0; i--) {
+      if (this.recentClientChannelSends[i].clientId === clientId) {
+        this.recentClientChannelSends.splice(i, 1);
+      }
     }
     logger.info(`📱 [MeshCore VN ${this.sourceId}] client disconnected: ${clientId} (${this.clients.size} remaining)`);
 
@@ -1205,6 +1247,10 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     const text = cmd.text ?? '';
     const channelIdx = cmd.channelIdx ?? 0;
     try {
+      // Registered BEFORE the send: the manager emits its self-originated
+      // `message` event from inside this call, and the attribution has to exist
+      // by then or this client sees its own message echoed back (#4535).
+      this.rememberClientChannelSend(clientId, channelIdx, text);
       const ok = await this.options.manager.sendMessage(text, undefined, channelIdx);
       if (ok) {
         logger.debug(`[MeshCore VN ${this.sourceId}] ▶ forwarded channel ${channelIdx} msg from ${clientId} (${text.length} chars)`);
@@ -1214,10 +1260,12 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
         // promise pending forever (the message never shows as sent).
         this.send(clientId, encodeOk());
       } else {
+        this.forgetClientChannelSend(clientId, channelIdx, text);
         logger.warn(`[MeshCore VN ${this.sourceId}] channel send from ${clientId} failed at the node`);
         this.send(clientId, encodeErr(ErrorCodes.BadState));
       }
     } catch (err) {
+      this.forgetClientChannelSend(clientId, channelIdx, text);
       logger.error(`[MeshCore VN ${this.sourceId}] channel send from ${clientId} threw: ${(err as Error).message}`);
       this.send(clientId, encodeErr(ErrorCodes.BadState));
     }
@@ -1401,27 +1449,126 @@ export class MeshCoreVirtualNodeServer extends EventEmitter {
     return this.options.manager.getContacts().find((c) => c.publicKey?.toLowerCase().startsWith(lc))?.publicKey;
   }
 
+  /** Attribution key for a channel send — the fields the manager echoes back. */
+  private channelSendKey(channelIdx: number, text: string): string {
+    return `${channelIdx} ${text}`;
+  }
+
   /**
-   * Fan a newly-arrived incoming mesh message out to every connected app
-   * client: enqueue it and nudge the app with a MsgWaiting push so it drains
-   * via SyncNextMessage. Messages our own node originated are skipped so the
-   * app doesn't see its/our own sends echoed back.
+   * Remember that `clientId` asked us to transmit `text` on `channelIdx`, so the
+   * self-originated event it produces can be suppressed for that client only
+   * (#4535). Called before the manager send so the entry is in place when the
+   * event fires.
+   */
+  private rememberClientChannelSend(clientId: string, channelIdx: number, text: string): void {
+    this.pruneSendAttributions();
+    this.recentClientChannelSends.push({
+      key: this.channelSendKey(channelIdx, text),
+      clientId,
+      expiresAt: Date.now() + this.SEND_ATTRIBUTION_TTL_MS,
+    });
+  }
+
+  /**
+   * Drop an attribution whose send never happened (node refused, or the write
+   * threw). The manager emits nothing in that case, so leaving the entry would
+   * let it match an unrelated later message with the same text on the same
+   * channel and wrongly hide it from this client.
+   */
+  private forgetClientChannelSend(clientId: string, channelIdx: number, text: string): void {
+    const key = this.channelSendKey(channelIdx, text);
+    const idx = this.recentClientChannelSends.findIndex((e) => e.key === key && e.clientId === clientId);
+    if (idx !== -1) this.recentClientChannelSends.splice(idx, 1);
+  }
+
+  /** Drop attribution entries that have aged out (see SEND_ATTRIBUTION_TTL_MS). */
+  private pruneSendAttributions(now = Date.now()): void {
+    for (let i = this.recentClientChannelSends.length - 1; i >= 0; i--) {
+      if (this.recentClientChannelSends[i].expiresAt <= now) {
+        this.recentClientChannelSends.splice(i, 1);
+      }
+    }
+  }
+
+  /**
+   * Consume the attribution for a self-originated channel message and return the
+   * originating client id, or undefined when MeshMonitor itself originated it
+   * (web UI, automation, auto-responder — nothing on the VN port sent it).
+   *
+   * Consuming on match keeps repeats honest: sending the same text twice
+   * registers two entries, and each event claims exactly one.
+   */
+  private claimChannelSendOrigin(channelIdx: number, text: string): string | undefined {
+    this.pruneSendAttributions();
+    const key = this.channelSendKey(channelIdx, text);
+    const idx = this.recentClientChannelSends.findIndex((e) => e.key === key);
+    if (idx === -1) return undefined;
+    return this.recentClientChannelSends.splice(idx, 1)[0].clientId;
+  }
+
+  /**
+   * Fan a newly-arrived mesh message out to connected app clients: enqueue it
+   * and nudge the app with a MsgWaiting push so it drains via SyncNextMessage.
+   *
+   * "Newly-arrived" covers both directions. A message MeshMonitor sent is just
+   * as new to a companion that didn't send it as one that arrived over RF — the
+   * app has no other way to learn about it, since the physical node's companion
+   * slot is held by MeshMonitor. Delivery is therefore per-client: everyone gets
+   * it except the one client that asked us to transmit it (which already shows
+   * it optimistically and would otherwise render it twice) — issue #4535.
+   *
+   * Direct messages we sent are the one case that stays undeliverable. The
+   * companion protocol has no outbound-message frame: ContactMsgRecv(7) means
+   * "received FROM this contact", so a self-sent DM could only be encoded as
+   * either from ourselves (which no real node ever emits) or from its recipient
+   * (which would fabricate a reply they never sent). Neither is honest, so we
+   * keep skipping those and document the gap rather than push a misleading
+   * frame. Channel messages have no such problem — ChannelMsgRecv(8) carries the
+   * originator inline in the body, exactly as a peer node would have heard it.
    */
   private handleIncomingMessage(msg: MeshCoreMessage): void {
     const local = this.options.manager.getLocalNode();
     const selfKey = local?.publicKey?.toLowerCase();
-    // Skip DMs our own node originated (echoed back through the manager).
-    if (selfKey && msg.fromPublicKey?.toLowerCase() === selfKey) return;
-    // Skip our own channel transmissions heard back over the air: channel
-    // packets carry no sender key (fromPublicKey is the synthetic `channel-N`),
-    // so identify them by the name prefix. The app already shows these
-    // optimistically on send — re-delivering would duplicate them.
-    if (this.isChannelMessage(msg) && local?.name && msg.fromName === local.name) return;
+    const selfOriginated = !!selfKey && msg.fromPublicKey?.toLowerCase() === selfKey;
+    // Our own channel transmission heard back over the air. A received channel
+    // packet carries the synthetic `channel-N` marker in fromPublicKey (not our
+    // key), so it is identified by name — and it is a genuine duplicate of
+    // something every client has already been given, so it is dropped outright.
+    if (this.isChannelMessage(msg) && !selfOriginated && local?.name && msg.fromName === local.name) return;
 
+    let skipClientId: string | undefined;
+    if (selfOriginated) {
+      const channelIdx = this.sentChannelIndex(msg);
+      // A self-sent DM (no channel marker) has no representable frame — see above.
+      if (channelIdx === undefined) return;
+      skipClientId = this.claimChannelSendOrigin(channelIdx, msg.text);
+    }
+
+    let delivered = 0;
     for (const [clientId, client] of this.clients.entries()) {
+      if (clientId === skipClientId) continue;
       client.pendingMessages.push(msg);
       this.send(clientId, encodeMsgWaitingPush());
+      delivered++;
     }
+    if (selfOriginated) {
+      // Says who originated it and who it reached — the two facts you need to
+      // tell "correctly suppressed for the sender" from "wrongly dropped".
+      logger.debug(
+        `[MeshCore VN ${this.sourceId}] ◀ self-originated channel msg → ${delivered} client(s)` +
+          `${skipClientId ? `, skipped originator ${skipClientId}` : ' (originated in MeshMonitor)'}`,
+      );
+    }
+  }
+
+  /**
+   * Channel index of a message WE sent, or undefined when it isn't one. Outgoing
+   * channel messages carry the `channel-N` marker in toPublicKey (incoming ones
+   * carry it in fromPublicKey) — the same split `encodeIncomingMessage` relies on.
+   */
+  private sentChannelIndex(msg: MeshCoreMessage): number | undefined {
+    const match = /^channel-(\d+)$/.exec(msg.toPublicKey ?? '');
+    return match ? Number(match[1]) : undefined;
   }
 
   /** True when the message belongs to a channel (marker in either key field). */


### PR DESCRIPTION
Fixes #4535.

## The user-visible bug

With a MeshCore Virtual Node running, message sync only worked in one direction. A message sent from the **MeshCore app** showed up in MeshMonitor, but a message sent from **MeshMonitor's own web UI** never reached the app — silently dropped, no error.

Testing with two apps connected at once surfaces a second half of the same bug that the issue doesn't mention: a message sent by **one connected client never reached any other connected client** either. Since MeshMonitor holds the physical node's companion slot, the Virtual Node is the only way those clients can learn about each other's traffic, so each app saw a different conversation.

## Root cause

`MeshCoreManager` stamps every outbound message with the local node's identity (`fromPublicKey = localNode.publicKey`, `fromName = localNode.name`) before emitting `message`. `handleIncomingMessage` then skipped anything matching that identity.

That filter conflates two different things:

- **the app's own send, echoed back** — must be suppressed, or the app renders the message twice (it already showed it optimistically on send)
- **a message this app has never seen** — must be delivered

Both look identical at the event boundary, so it suppressed both.

## Protocol behaviour, before and after

| Message | Before | After |
|---|---|---|
| Channel msg from MeshMonitor web UI | dropped for everyone | `ChannelMsgRecv(8)` to every connected client |
| Channel msg from client A | dropped for everyone | `ChannelMsgRecv(8)` to all clients **except A** |
| Channel msg heard back over the air (self-echo) | dropped | dropped (unchanged) |
| Incoming RF DM / channel msg | delivered to all | delivered to all (unchanged) |
| DM sent by MeshMonitor | dropped | dropped — see below |

Delivery is now attributed per client. `handleSendChannelTxtMsg` records `(channelIdx, text) -> clientId` **before** calling the manager, because the manager emits from inside that call, so the message id doesn't exist on our side yet. The resulting self-originated event claims that attribution and is delivered to everyone else. A self-originated message with no attribution came from MeshMonitor itself and goes to all clients.

Attributions are consumed on match (so sending the same text twice registers two entries and each event claims exactly one), expire after 30s, are dropped when a send fails at the node, and are cleared when their client disconnects or the server stops.

## Why sent DMs are still not delivered

The companion protocol has no outbound-message frame. `CONTACT_MSG_RECV(7)` means *received from* a contact, and `TxtType` has no "sent" variant. A DM MeshMonitor sent could therefore only be encoded as:

- from **ourselves** — which no real companion ever emits, and there is no self contact to thread it against, or
- from its **recipient** — which fabricates a reply they never sent

Neither is honest, so those stay suppressed. This is now documented in `docs/configuration/virtual-node.md` and in the handler, rather than being a silent drop. Channel messages have no such problem: `CHANNEL_MSG_RECV(8)` carries the originator inline in the body, so a MeshMonitor-sent channel message renders in the app exactly as a peer node would have heard it (`"<node name>: <text>"`). The existing `encodeIncomingMessage` already handled the `toPublicKey = channel-N` form used by messages we send — that path just wasn't reachable.

Happy to revisit if there's an app-side convention for this I've missed.

## Explicitly unchanged

- our own channel transmission heard back over the air is still dropped for every client
- the `LogRxData(0x88)` OTA packet feed still fans out unconditionally with no self-origin filtering (Analyzer Observer / packet-cracker tools)
- receive-only gating (#4547) and the admin / PKI-export gates are untouched
- reconnecting clients still start from an empty mailbox — deliberately not changed here, see follow-ups

## Tests

13 new tests in a `per-client message delivery (#4535)` block, all using **two simultaneous clients**, since the interesting failures are invisible with one connection: RF DM and RF channel fan-out to both clients; UI-originated channel delivery; A to B and B to A relay with sender suppression; sent-DM suppression; OTA self-echo suppression; per-queue independence and ordering across a burst; consume-once attribution; failed-send cleanup; delivery while a client is disconnected; reconnect mailbox semantics; departed-client attribution cleanup.

The two pre-existing self-origin tests still pass unmodified.

## Test-harness deflake (also in this PR)

The new multi-client tests couldn't be trusted until two latent races in `TestClient` were fixed — this file was already intermittently red regardless of the code under test:

1. a decoded frame arriving while no waiter was registered was **dropped**, so any test whose waiter lost the race to an unsolicited push waited out the 10s timeout. Frames are now queued in arrival order.
2. `connect()` resolves on the client side of the handshake, which can precede the server registering the socket — so a test that emitted immediately could fan out to **zero** clients. Connect sites now wait on the server's own client count, as do the disconnect assertions (replacing a fixed 50ms sleep).

Measured on Windows / Node 22, before this change: **1 of 5 runs failed on the pre-existing tests alone**. After: **10 of 10 runs green**, with 13 more tests. This is the only part of the diff touching pre-existing tests — happy to split it into its own PR if you'd prefer.

## Validation

- `npm run typecheck` — clean
- `eslint` on both changed files — clean
- `meshcoreVirtualNodeServer.test.ts` — 117/117, ten consecutive runs
- `tsc -p tsconfig.tests.json` — 435 errors, identical with and without this change (all pre-existing, unrelated files)

**I could not run the full suite locally**: no MSVC build tools on this machine, so `better-sqlite3` / `zstd-napi` can't compile and any file importing them fails to collect. Relying on CI for the full run — please flag anything it catches and I'll fix it.

## Follow-ups (not in this PR)

- **Reconnect mailbox.** `pendingMessages` is deliberately seeded empty at connect so an app's local history isn't re-delivered on every reconnect. The protocol wiki notes real firmware queues messages *"even while the app is disconnected"*, so there's a parity gap — but reversing a documented decision belongs in its own issue with your input rather than inside a bugfix. Happy to open one.
- `AddUpdateContact(9)` and `RemoveContact(15)` are unimplemented and `GetContacts` reports `flags: 0`, so a connected app can't favourite / unfavourite a contact. Working on that separately.