### PR TITLE
feat(channels): add bell icon to the channel-list unread badge (#4660)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -527,6 +527,7 @@
   "channels.select_channel": "Select Channel",
   "channels.show_channel_info": "Show channel info",
   "channels.info_link": "info",
+  "channels.unread_badge_tooltip": "Unread messages",
   "channels.show_mqtt_messages": "Show MQTT/Bridge Messages",
   "channels.encrypted_secure": "Encrypted with unique key",
   "channels.encrypted_default": "Encrypted with default key (not secure)",

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -916,7 +916,12 @@ export default function ChannelsTab({
                         </div>
                       </div>
                       <div className="channel-button-right">
-                        {unreadCounts[channelId] > 0 && <span className="unread-badge">{unreadCounts[channelId]}</span>}
+                        {unreadCounts[channelId] > 0 && (
+                          <span className="unread-badge" title={t('channels.unread_badge_tooltip', 'Unread messages')}>
+                            <UiIcon name="notifications" size={12} />
+                            {unreadCounts[channelId]}
+                          </span>
+                        )}
                         <div className="channel-button-status">
                           <span
                             className={`arrow-icon uplink ${channelConfig?.uplinkEnabled ? 'enabled' : 'disabled'}`}

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1714,7 +1714,11 @@
   font-size: 11px;
   font-weight: 600;
   margin-left: 8px;
+  /* Bell glyph (#4660) sits before the count — keep a small gap so it doesn't
+     touch the number, and let the icon inherit the badge's text color. */
+  gap: 3px;
 }
+.unread-badge svg { color: inherit; }
 
 .unread-badge-inline {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- Adds a bell (`UiIcon name="notifications"`) inside `.unread-badge` on the ChannelsTab channel list, so a channel with unread traffic reads as "🔔 3" instead of just "3" — the change requested in [issue #4660 comment](https://github.com/Yeraze/meshmonitor/issues/4660#issuecomment-…).
- Small `gap: 3px` on `.unread-badge` keeps the glyph off the number; the icon inherits the badge's text color so it renders cleanly in both light and dark themes.
- New locale key `channels.unread_badge_tooltip` = "Unread messages" on the badge's `title=` for accessibility.
- Follows CLAUDE.md: UiIcon, not a hardcoded emoji.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `ChannelsTab.*.test.tsx` — 16/16 pass
- [ ] Manual: send messages on a non-active channel, confirm the bell + count appears on the channel-list row; open the channel and confirm badge clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX