### PR TITLE
fix(build): guarantee server emits shared compile.js (#4655)

### DIFF
--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -18,7 +18,14 @@
     "src/utils/**/*",
     "src/types/**/*",
     "src/cli/**/*",
-    "src/db/**/*"
+    "src/db/**/*",
+    // Shared pure-logic module that lives in the frontend tree but is imported at
+    // runtime by the server (autoAckConverter.ts). It is NOT under any glob above,
+    // so before this entry it reached dist/ only via tsc's "emit reachable files"
+    // behaviour — which varies by tsc version and vanishes if the sole value import
+    // ever becomes type-only. Listing it explicitly guarantees the emit and stops
+    // the desktop server from crashing with ERR_MODULE_NOT_FOUND (#4655).
+    "src/components/automations/compile.ts"
   ],
   "exclude": [
     "src/**/*.test.ts",


### PR DESCRIPTION
## Problem

Issue #4655's stderr log shows the desktop server crashing on launch:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'…\dist\components\automations\compile.js' imported from
'…\dist\server\services\automation\autoAckConverter.js'
```

## Root cause

`autoAckConverter.ts` (server, in `src/server/**` — always compiled to `dist/`)
imports `compile()` from `src/components/automations/compile.ts`. `compile.ts`
is pure, shared graph-builder logic, but it lives under `src/components/**`,
which **`tsconfig.server.json` does not include**.

Its `.js` therefore reached `dist/` only via tsc's *emit-reachable-files*
behaviour — kept alive solely by `autoAckConverter`'s one remaining **value**
import. That is fragile:

- The behaviour varies across TypeScript versions (why a shipped desktop build
  lacked the file even though a clean local build emits it).
- It would disappear entirely if that import ever became type-only — the other
  two server importers (`autoAckConverterRoutes.ts`, and the round-trip test)
  are already `import type`, which is erased and forces no emit.

A clean build asymmetry confirms it: `autoAckConverter.js` (in the included
`src/server/**`) always ships, while `compile.js` (reachable-only) may not —
exactly the two files in the crash.

## Fix

Add `src/components/automations/compile.ts` to `tsconfig.server.json`'s
`include` set so its emit is **explicit and deterministic**, independent of tsc
version or import shape. Config-only: every existing import keeps resolving to
the same `dist/components/automations/compile.js` path, and vitest (which uses
`tsconfig.json`) is unaffected.

## Verification

- Wiped `dist/`, ran the exact desktop build sequence (`npm run build` → server
  tsc); `compile.js` emits deterministically and the runtime import path
  resolves.
- `npm run lint:ci` clean.
- Related suites green: `compile.test.ts`, `autoAckConverter.test.ts`,
  `autoAckConverter.roundTrip.test.ts` (58 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)