### PR TITLE
fix(security): regenerate session on proxy-auth identity binding

### DIFF
--- a/src/server/auth/authMiddleware.proxyAuthFixation.test.ts
+++ b/src/server/auth/authMiddleware.proxyAuthFixation.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Regression: proxy-auth must regenerate the session ID when it binds a user
+ * to the request, or an attacker who planted a `meshmonitor.sid` cookie on
+ * the victim's browser can ride the post-authentication session (the
+ * reverse-proxy's X-Forwarded-User headers are added ON TOP OF the client's
+ * cookie, so a naive write of `req.session.userId = user.id` writes into the
+ * attacker's session).
+ *
+ * The fix mirrors what `authRoutes.ts` already does for local / MFA / OIDC
+ * login. This file exists purely to lock that behavior in.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import databaseService from '../../services/database.js';
+import { optionalAuth } from './authMiddleware.js';
+import { extractProxyUser, isAdminUser, isNormalProxyUserAllowed } from './proxyAuth.js';
+import { getEnvironmentConfig } from '../config/environment.js';
+
+vi.mock('../../services/database.js', () => ({
+  default: {
+    findUserByIdAsync: vi.fn(),
+    findUserByEmailAsync: vi.fn(),
+    findUserByUsernameAsync: vi.fn(),
+    checkPermissionAsync: vi.fn(),
+    getUserPermissionSetAsync: vi.fn(),
+    auditLogAsync: vi.fn().mockResolvedValue(undefined),
+    auth: {
+      createUser: vi.fn(),
+      createPermission: vi.fn(),
+      updateUser: vi.fn().mockResolvedValue(undefined),
+    },
+  },
+}));
+
+vi.mock('./proxyAuth.js', () => ({
+  extractProxyUser: vi.fn(),
+  isAdminUser: vi.fn(() => false),
+  isNormalProxyUserAllowed: vi.fn(() => true),
+}));
+
+vi.mock('../config/environment.js', () => ({
+  getEnvironmentConfig: vi.fn(() => ({
+    proxyAuthEnabled: true,
+    proxyAuthAutoProvision: false,
+    proxyAuthAuditLogging: false,
+  })),
+}));
+
+const mockDb = databaseService as any;
+const mockExtract = extractProxyUser as unknown as ReturnType<typeof vi.fn>;
+const mockIsAdmin = isAdminUser as unknown as ReturnType<typeof vi.fn>;
+const mockGroupAllowed = isNormalProxyUserAllowed as unknown as ReturnType<typeof vi.fn>;
+const mockEnv = getEnvironmentConfig as unknown as ReturnType<typeof vi.fn>;
+
+const alice = { id: 42, username: 'alice', email: 'alice@example.com', isActive: true, isAdmin: false, authProvider: 'proxy' };
+const bob   = { id: 43, username: 'bob',   email: 'bob@example.com',   isActive: true, isAdmin: false, authProvider: 'proxy' };
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(session({
+    secret: 'test-secret',
+    resave: false,
+    saveUninitialized: true, // set session cookie even if nothing written yet
+    cookie: { secure: false },
+    name: 'meshmonitor.sid',
+  }));
+  app.get('/whoami', optionalAuth(), (req: any, res) => {
+    res.json({ userId: req.user?.id ?? null, sid: req.sessionID });
+  });
+  return app;
+}
+
+/** Pull the meshmonitor.sid cookie value out of a supertest response. */
+function extractSid(headers: any): string | undefined {
+  const setCookie = headers['set-cookie'];
+  if (!Array.isArray(setCookie)) return undefined;
+  const line = setCookie.find((c: string) => c.startsWith('meshmonitor.sid='));
+  return line?.split(';')[0].split('=')[1];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGroupAllowed.mockReturnValue(true);
+  mockIsAdmin.mockReturnValue(false);
+  mockEnv.mockReturnValue({
+    proxyAuthEnabled: true,
+    proxyAuthAutoProvision: false,
+    proxyAuthAuditLogging: false,
+  });
+});
+
+describe('optionalAuth() — proxy-auth session-fixation defense', () => {
+  it('rotates the session ID when binding a user to a pre-existing session (the fixation case)', async () => {
+    const app = buildApp();
+
+    // Step 1: attacker plants a cookie by hitting an unauthenticated endpoint.
+    // No proxy-auth headers, no user — but the session ID is now issued.
+    mockExtract.mockReturnValue(null);
+    const planted = await request(app).get('/whoami');
+    const plantedSid = extractSid(planted.headers);
+    expect(plantedSid).toBeTruthy();
+    expect(planted.body.userId).toBeNull();
+
+    // Step 2: victim reuses that same cookie, this time with proxy-auth
+    // headers set by the reverse proxy. The middleware MUST bind alice to a
+    // FRESH session id, not the planted one.
+    mockExtract.mockReturnValue({ email: alice.email, groups: [], source: 'proxy' });
+    mockDb.findUserByEmailAsync.mockResolvedValue(alice);
+    mockDb.findUserByIdAsync.mockResolvedValue(alice);
+
+    const authed = await request(app)
+      .get('/whoami')
+      .set('Cookie', `meshmonitor.sid=${plantedSid}`);
+
+    expect(authed.status).toBe(200);
+    expect(authed.body.userId).toBe(alice.id);
+    // The proof: sessionID (server-side) has rotated away from the attacker's.
+    expect(authed.body.sid).not.toBe(plantedSid);
+    // And the Set-Cookie carries the new id, so the browser will swap over.
+    const rotatedSid = extractSid(authed.headers);
+    expect(rotatedSid).toBeTruthy();
+    expect(rotatedSid).not.toBe(plantedSid);
+  });
+
+  it('does NOT rotate on subsequent hops that carry the already-bound identity', async () => {
+    const app = buildApp();
+
+    // First bind: force one rotation.
+    mockExtract.mockReturnValue({ email: alice.email, groups: [], source: 'proxy' });
+    mockDb.findUserByEmailAsync.mockResolvedValue(alice);
+    mockDb.findUserByIdAsync.mockResolvedValue(alice);
+    const first = await request(app).get('/whoami');
+    const boundSid = first.body.sid;
+    expect(boundSid).toBeTruthy();
+
+    // Second hop with the SAME cookie AND the same headers — must keep sid.
+    const second = await request(app)
+      .get('/whoami')
+      .set('Cookie', `meshmonitor.sid=${extractSid(first.headers)}`);
+
+    expect(second.body.userId).toBe(alice.id);
+    expect(second.body.sid).toBe(boundSid);
+  });
+
+  it('rotates again when a DIFFERENT proxy user arrives on the same cookie', async () => {
+    const app = buildApp();
+
+    mockExtract.mockReturnValue({ email: alice.email, groups: [], source: 'proxy' });
+    mockDb.findUserByEmailAsync.mockResolvedValue(alice);
+    mockDb.findUserByIdAsync.mockResolvedValue(alice);
+    const asAlice = await request(app).get('/whoami');
+    const aliceSid = extractSid(asAlice.headers);
+
+    // Same session cookie, but the reverse proxy now identifies a different user.
+    mockExtract.mockReturnValue({ email: bob.email, groups: [], source: 'proxy' });
+    mockDb.findUserByEmailAsync.mockResolvedValue(bob);
+    mockDb.findUserByIdAsync.mockResolvedValue(bob);
+    const asBob = await request(app)
+      .get('/whoami')
+      .set('Cookie', `meshmonitor.sid=${aliceSid}`);
+
+    expect(asBob.body.userId).toBe(bob.id);
+    expect(asBob.body.sid).not.toBe(asAlice.body.sid);
+  });
+
+  it('preserves csrfToken across regeneration', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(session({
+      secret: 'test-secret',
+      resave: false,
+      saveUninitialized: true,
+      cookie: { secure: false },
+      name: 'meshmonitor.sid',
+    }));
+    // Prime a csrfToken on the session before the proxy-auth hop, then run
+    // optionalAuth and check the token still sits on req.session afterward.
+    app.get('/prime', (req: any, res) => { req.session.csrfToken = 'csrf-abc'; res.json({ sid: req.sessionID }); });
+    app.get('/whoami', optionalAuth(), (req: any, res) => {
+      res.json({ userId: req.user?.id ?? null, sid: req.sessionID, csrf: req.session.csrfToken ?? null });
+    });
+
+    mockExtract.mockReturnValue(null);
+    const primed = await request(app).get('/prime');
+    const primedSid = extractSid(primed.headers);
+
+    mockExtract.mockReturnValue({ email: alice.email, groups: [], source: 'proxy' });
+    mockDb.findUserByEmailAsync.mockResolvedValue(alice);
+    mockDb.findUserByIdAsync.mockResolvedValue(alice);
+
+    const authed = await request(app)
+      .get('/whoami')
+      .set('Cookie', `meshmonitor.sid=${primedSid}`);
+
+    expect(authed.body.userId).toBe(alice.id);
+    expect(authed.body.sid).not.toBe(primedSid);
+    expect(authed.body.csrf).toBe('csrf-abc');
+  });
+});

--- a/src/server/auth/authMiddleware.ts
+++ b/src/server/auth/authMiddleware.ts
@@ -13,6 +13,32 @@ import { extractProxyUser, isAdminUser, isNormalProxyUserAllowed } from './proxy
 import { getEnvironmentConfig } from '../config/environment.js';
 
 /**
+ * Bind a proxy-auth-authenticated user to a fresh session ID, mirroring the
+ * pattern in `authRoutes.ts` for local/MFA/OIDC login. Regenerating the
+ * session on identity binding is what defends against session fixation: an
+ * attacker who planted a cookie on the victim's browser cannot ride the
+ * post-authentication session, because that cookie's session ID is discarded
+ * before the user's identity is written.
+ *
+ * Preserves the CSRF token across regeneration so the frontend's cached token
+ * remains valid — same reasoning as `authRoutes.regenerateSession`.
+ */
+function regenerateProxyAuthSession(req: Request, user: User): Promise<void> {
+  const csrfToken = req.session.csrfToken;
+  return new Promise((resolve, reject) => {
+    req.session.regenerate((err) => {
+      if (err) return reject(err);
+      req.session.userId = user.id;
+      req.session.username = user.username;
+      req.session.authProvider = 'proxy';
+      req.session.isAdmin = user.isAdmin;
+      if (csrfToken) req.session.csrfToken = csrfToken;
+      resolve();
+    });
+  });
+}
+
+/**
  * Attach user to request if authenticated (optional auth)
  * If not authenticated, attaches anonymous user for permission checks
  *
@@ -163,11 +189,36 @@ export function optionalAuth() {
           if (user && user.isActive) {
             req.user = user;
 
-            // Update session to match (creates session if not exists)
-            req.session.userId = user.id;
-            req.session.username = user.username;
-            req.session.authProvider = 'proxy';
-            req.session.isAdmin = user.isAdmin;
+            // Bind user to the session, defending against session fixation.
+            //
+            // The naive form here — writing userId/username/isAdmin directly
+            // into whatever session came in with the request — let an
+            // attacker who planted a `meshmonitor.sid` cookie on the victim's
+            // browser ride the post-authentication session, because the
+            // reverse-proxy's X-Forwarded-User headers are added on top of
+            // the client's cookie. Regenerating the session ID at the moment
+            // of identity binding discards the attacker's cookie. This
+            // parallels the pattern in authRoutes.ts for local/MFA/OIDC login.
+            //
+            // Only regenerate when this session isn't already bound to this
+            // user — proxy-auth runs on every request that carries the
+            // headers, and rotating the SID each hop would thrash cookies
+            // and (worse) create a regeneration storm under concurrent hits.
+            if (req.session.userId !== user.id) {
+              try {
+                await regenerateProxyAuthSession(req, user);
+              } catch (err) {
+                logger.error('Proxy-auth session regeneration failed:', err);
+                return _res.status(500).json({ error: 'Internal server error' });
+              }
+            } else {
+              // Already bound to this identity — keep the metadata current
+              // (username/isAdmin can change between requests) but do not
+              // rotate the SID.
+              req.session.username = user.username;
+              req.session.authProvider = 'proxy';
+              req.session.isAdmin = user.isAdmin;
+            }
 
             // Audit log successful auth (if enabled)
             if (config.proxyAuthAuditLogging) {


### PR DESCRIPTION
## Summary

Fixes a session-fixation exposure in `authMiddleware.optionalAuth()`'s proxy-auth path. Every other MeshMonitor login handler (local, MFA, OIDC in `authRoutes.ts`) already regenerates the session ID on identity binding; the proxy-auth path was the outlier.

**Not a CodeQL finding** — CodeQL flagged four MeshCore route endpoints for `js/session-fixation` on the naive "URL contains /login" heuristic, but those routes don't touch `req.session` (they log into a remote MeshCore device, not MeshMonitor). Investigating those false positives is what surfaced this real issue in the middleware. The four route-level alerts will be dismissed as false positives with pointers to this fix.

## Exposure

With `PROXY_AUTH_ENABLED=true` (SSO deployments — Authelia, oauth2-proxy, Cloudflare Access, Authentik, etc.):

1. Attacker plants a `meshmonitor.sid` cookie on the victim's browser (same-origin XSS, subdomain cookie shadowing on the same eTLD+1, or a compromised sibling app).
2. Victim's browser sends that cookie with a subsequent request. The reverse proxy adds `X-Forwarded-User: victim@example.com` **on top of** the cookie.
3. `authMiddleware.ts:167-170` writes `userId/username/isAdmin` into **the attacker's session**.
4. Attacker holds an authenticated session as the victim.

**Severity:** Medium. Not exploitable on default deployments (`PROXY_AUTH_ENABLED=false`), but a real risk in the common SSO configuration.

## Fix

Mirror `authRoutes.regenerateSession()`:

- On the **first** proxy-auth hop that binds a user (`req.session.userId !== user.id`) → `req.session.regenerate()` before writing identity fields.
- On **subsequent** hops with the already-bound identity → keep the SID, refresh metadata (username/isAdmin can change between requests).
- **CSRF token is preserved** across regeneration so the frontend's cached token stays valid.
- Why the guard: proxy-auth fires on every request that carries the headers; rotating on each hop would thrash cookies and create a regeneration storm under concurrent load.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `authMiddleware.test.ts` + new `authMiddleware.proxyAuthFixation.test.ts` — 14/14 pass
- [x] New tests lock in: rotation on first bind, no-rotation on identity-matched hops, rotation on user change, CSRF-token preservation
- [ ] Manual verify on an Authelia deployment: `Set-Cookie: meshmonitor.sid=...` on the initial authenticated hit shows a fresh SID
- [ ] After merge: dismiss CodeQL alerts 168–171 with pointers here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX