### PR TITLE
chore(release): bump to 4.14.1-rc5

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.14.1-rc4",
+  "version": "4.14.1-rc5",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.14.1-rc4",
+  "version": "4.14.1-rc5",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.14.1-rc4
+version: 4.14.1-rc5
 appVersion: "4.14.1-rc3"
 home: https://github.com/Yeraze/meshmonitor
 sources:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.1-rc4",
+  "version": "4.14.1-rc5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.14.1-rc4",
+      "version": "4.14.1-rc5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.1-rc4",
+  "version": "4.14.1-rc5",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary
- Bumps all five version files (`package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`) from `4.14.1-rc4` → `4.14.1-rc5`.
- Cuts a fresh pre-release primarily to get the proxy-auth session-fixation fix out to Windows desktop users.

## Contents over rc4
- **fix(security): regenerate session on proxy-auth identity binding** (#4672) — closes a fixation vector present when `PROXY_AUTH_ENABLED=true`
- **fix(meshcore-vn): deliver MeshMonitor-originated channel messages to VN clients** (#4668) — external contribution from @pfmos

## Test plan
- [x] `npm run typecheck` — clean
- [x] All five version files consistent at `4.14.1-rc5`
- [ ] CI (full suite + Docker + Helm + Desktop + System Tests) green
- [ ] After merge: `gh release create v4.14.1-rc5 --prerelease`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX