### PR TITLE
feat(automation): loop & flood safety hardening for MT↔MC bridge (#4577 P2)

### DIFF
--- a/docs/internal/dev-notes/MT_MC_BRIDGE_AUTOMATION_EPIC.md
+++ b/docs/internal/dev-notes/MT_MC_BRIDGE_AUTOMATION_EPIC.md
@@ -76,7 +76,7 @@ Each phase ships as its own merged PR and leaves `main` green.
   *Exit:* token resolves to `MT`/`MC` on each protocol; documented; tests green.
   *Deps:* none.
 
-- [ ] **Phase 2 — Loop & flood safety hardening.**
+- [x] **Phase 2 — Loop & flood safety hardening.** ✅ SHIPPED (PR pending merge)
   (a) Give `isSelfMeshCore` a cross-source fallback (mirror `isOwnNodeNum`/#4593 for
   MeshCore self public keys across all MeshCore sources).
   (b) Add a per-automation rate limit primitive (config + enforcement), distinct from
@@ -121,6 +121,23 @@ Each phase ships as its own merged PR and leaves `main` green.
 
 - 2026-08-12: Epic created. Surveyed automation engine, script gallery, position flow.
   Interview complete (2 rounds). Plan drafted.
+- 2026-08-12: **Phase 1 shipped** — PR #4675 merged (`{{ trigger.protocolShort }}` → MT/MC).
+- 2026-08-12: **Phase 2 implemented** (2 commits). Two deliverables:
+  - `isSelfMeshCore` cross-source fallback via new `getOwnPublicKeys()`/`isOwnPublicKey()`
+    in `src/server/utils/ownNodes.ts` + `NodeDataProvider.isOwnPublicKey?` — mirrors the
+    Meshtastic `isOwnNodeNum`/#4593 path so a self-sent MeshCore message re-entering via a
+    different MC source is recognized as self and dropped.
+  - Per-automation **rate-limit primitive**, keyed by automation id only (flood ceiling,
+    NOT per-subject). Config surface: **`params.rateLimit = { maxActions, windowSeconds }`
+    on the trigger node** (absent = no limit; `maxActions` clamped to 1000). Parsed by
+    `parseRateLimit()` (`src/types/automation.ts`, runtime-lenient / save-strict like
+    `cooldownScope`), enforced at all 5 engine dispatch sites via `rateLimitGate()` using the
+    injectable clock. Precedence: cooldown checked first (a debounced event spends no rate
+    budget); a rate-limited event does not advance cooldown. New trace outcome `'ratelimited'`.
+  - **This is the shape Phase 4's bridge template writes for its safe defaults**, and what
+    Phase 5 documents for users.
+  - Gate: typecheck clean, vitest `success: true` (1234 passed / 0 failed / 0 failed suites),
+    lint clean. No UI beyond the trace-badge enum (typecheck-covered) → no browser pass.
 
 ## Key file references (from survey)
 

--- a/src/components/automations/LiveTracePanel.tsx
+++ b/src/components/automations/LiveTracePanel.tsx
@@ -21,7 +21,7 @@ interface TraceEntry {
   triggerType: string;
   sourceId: string | null;
   event: Record<string, unknown>;
-  outcome: 'fired' | 'prefiltered' | 'cooldown';
+  outcome: 'fired' | 'prefiltered' | 'cooldown' | 'ratelimited';
   reason?: string;
   status?: 'completed' | 'failed';
   conditionResults?: Record<string, boolean>;
@@ -64,6 +64,7 @@ function summarizeEvent(triggerType: string, event: Record<string, unknown>): st
 const OUTCOME_BADGE: Record<string, { label: string; cls: string }> = {
   prefiltered: { label: 'filtered out', cls: 'no' },
   cooldown: { label: 'cooldown', cls: 'muted' },
+  ratelimited: { label: 'rate limited', cls: 'muted' },
 };
 
 export default function LiveTracePanel({ automationId, automationName, enabled, onClose }: LiveTracePanelProps) {

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -1182,6 +1182,93 @@ describe('AutomationEngineService', () => {
     await engine.onMessage(message({ text: 'hello' }), 'default');
     expect(got).toHaveLength(0);
   });
+
+  // ── rate limit (#4577 Phase 2, RATE-LIMIT) ─────────────────────────────────
+  //
+  // Distinct from cooldownScope above: rateLimit is keyed by automation id
+  // ONLY, so it bounds total fires across every subject, not one subject's
+  // debounce window.
+  describe('rate limit (#4577 Phase 2, RATE-LIMIT)', () => {
+    it('caps total fires across ALL subjects within the window, then replenishes once it elapses', async () => {
+      const { calls, deps } = recorder();
+      await createEnabled('ping', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping', rateLimit: { maxActions: 2, windowSeconds: 60 } } },
+          { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+        ],
+        edges: [{ from: 't', to: 'tap' }],
+      });
+      const engine = engineWith(deps);
+      await engine.load();
+
+      // Three DISTINCT senders inside the same 60s window — only the first two
+      // may fire; the rate ceiling is per-automation, not per-sender.
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(1);
+      clock += 1_000;
+      expect(await engine.onMessage(message({ fromNodeNum: 222 }), 'default')).toBe(1);
+      clock += 1_000;
+      expect(await engine.onMessage(message({ fromNodeNum: 333 }), 'default')).toBe(0); // budget spent
+      expect(calls).toHaveLength(2);
+
+      // Advance the injected clock past the window: the two prior fires age
+      // out and the budget replenishes.
+      clock += 60_000;
+      expect(await engine.onMessage(message({ fromNodeNum: 444 }), 'default')).toBe(1);
+      expect(calls).toHaveLength(3);
+    });
+
+    it('trace: emits outcome "ratelimited" with the max/window in the reason', async () => {
+      const got: any[] = [];
+      automationTraceBus.setSink((_id, payload) => got.push(payload));
+      const a = await createEnabled('ping', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.message', params: { textContains: 'ping', rateLimit: { maxActions: 1, windowSeconds: 60 } } },
+          { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+        ],
+        edges: [{ from: 't', to: 'tap' }],
+      });
+      const engine = engineWith(recorder().deps);
+      await engine.load();
+      automationTraceBus.arm(a.id, 'sock1', FAR_FUTURE);
+
+      await engine.onMessage(message({ fromNodeNum: 111 }), 'default'); // fires, spends the one slot
+      await engine.onMessage(message({ fromNodeNum: 222 }), 'default'); // rate-limited
+      const rlEvent = got.find((g) => g.outcome === 'ratelimited');
+      expect(rlEvent).toBeDefined();
+      expect(rlEvent.reason).toMatch(/rate limit reached — 1\/60s/);
+    });
+
+    it('a cooldown-suppressed event does not consume rate budget (precedence: cooldown before rate limit)', async () => {
+      const { calls, deps } = recorder();
+      await createEnabled('ping', {
+        version: 1,
+        nodes: [
+          {
+            id: 't',
+            type: 'trigger.message',
+            params: { textContains: 'ping', cooldownSeconds: 60, cooldownScope: 'node', rateLimit: { maxActions: 2, windowSeconds: 60 } },
+          },
+          { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+        ],
+        edges: [{ from: 't', to: 'tap' }],
+      });
+      const engine = engineWith(deps);
+      await engine.load();
+
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(1); // fires — rate budget 1/2
+      clock += 1_000;
+      // Same node, still inside its own node-scoped cooldown → suppressed by
+      // cooldownGate BEFORE the rate gate is ever consulted. If this wrongly
+      // consumed budget, the ceiling would already read 2/2 and the distinct
+      // sender below would be dropped too.
+      expect(await engine.onMessage(message({ fromNodeNum: 111 }), 'default')).toBe(0);
+      clock += 1_000;
+      expect(await engine.onMessage(message({ fromNodeNum: 222 }), 'default')).toBe(1); // budget still available
+      expect(calls).toHaveLength(2);
+    });
+  });
 });
 
 // ── MQTT-source tapback glyph (#4594) ─────────────────────────────────────

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -290,6 +290,32 @@ describe('AutomationEngineService', () => {
     expect(await engine.onMeshCoreMessage(mcMessage({ fromPublicKey: 'channel-0', text: 'ping' }), 'default')).toBe(1);
   });
 
+  it('self-origin (#4577 P2): ignores our own key on a MeshCore source with no self key yet (cross-source fallback)', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('mc-ping', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping' } },
+        { id: 's', type: 'action.sendMessage', params: { text: 'pong' } },
+      ],
+      edges: [{ from: 't', to: 's' }],
+    });
+    // This source's own key hasn't resolved (getSelfPublicKey → null); only the
+    // cross-source owned-pubkey set (another MeshCore source) can recognise us.
+    const selfData = {
+      ...data,
+      getSelfPublicKey: async () => null,
+      isOwnPublicKey: async (k: string) => k.toLowerCase() === 'abcd',
+    };
+    const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data: selfData, now: () => clock });
+    await engine.load();
+    // Our own key, relayed back via a different MeshCore source → dropped.
+    expect(await engine.onMeshCoreMessage(mcMessage({ fromPublicKey: 'ABCD', text: 'ping' }), 'default')).toBe(0);
+    expect(calls).toHaveLength(0);
+    // A different sender → fires.
+    expect(await engine.onMeshCoreMessage(mcMessage({ fromPublicKey: 'channel-0', text: 'ping' }), 'default')).toBe(1);
+  });
+
   it('self-origin (#3914): ignores our own node telemetry', async () => {
     const { deps } = recorder();
     await createEnabled('batt', {

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -20,6 +20,7 @@ import {
   validateAutomationGraph,
   categoryOf,
   parseCooldownScope,
+  parseRateLimit,
   type AutomationGraph,
   type AutomationNode,
   type TriggerType,
@@ -67,6 +68,8 @@ interface LoadedAutomation {
   triggerType: TriggerType;
   cooldownSeconds: number;
   cooldownScope: CooldownScope;
+  /** Per-automation flood ceiling (#4577 Phase 2, RATE-LIMIT). Absent = no cap. */
+  rateLimit?: { maxActions: number; windowSeconds: number };
 }
 
 /**
@@ -192,6 +195,8 @@ export class AutomationEngineService {
   private index = new Map<TriggerType, LoadedAutomation[]>();
   /** automationId → cooldown key → last fired ms. Inner key shape: cooldownKeyFor(). */
   private lastFired = new Map<string, Map<string, number>>();
+  /** automationId → fire timestamps (ms) within the current rate-limit window (#4577 Phase 2). */
+  private rateLimitEvents = new Map<string, number[]>();
   /** automationId → nodeNum → { inside: was the node in the geofence at last check; ts: when last checked (eviction, #4399) }. */
   private geofenceState = new Map<string, Map<number, { inside: boolean; ts: number }>>();
   /** automationId → nodeNum → alarmed (beyond threshold) for left-home re-arm. */
@@ -235,8 +240,11 @@ export class AutomationEngineService {
       // No `as any` needed: params is Record<string, unknown> and parseCooldownScope
       // takes unknown. (The cooldownSeconds line above predates the lint ratchet.)
       const cooldownScope = parseCooldownScope(triggerNode.params?.cooldownScope);
+      // No `as any` needed: params is Record<string, unknown> and parseRateLimit
+      // takes unknown (same reasoning as the parseCooldownScope line above).
+      const rateLimit = parseRateLimit(triggerNode.params?.rateLimit);
       const entry: LoadedAutomation = {
-        id: row.id, name: row.name, graph: result.graph, triggerNode, triggerType, cooldownSeconds, cooldownScope,
+        id: row.id, name: row.name, graph: result.graph, triggerNode, triggerType, cooldownSeconds, cooldownScope, rateLimit,
       };
       if (!index.has(triggerType)) index.set(triggerType, []);
       index.get(triggerType)!.push(entry);
@@ -253,6 +261,10 @@ export class AutomationEngineService {
     const liveIds = new Set<string>();
     for (const list of index.values()) for (const a of list) liveIds.add(a.id);
     for (const id of this.lastFired.keys()) if (!liveIds.has(id)) this.lastFired.delete(id);
+    // Same prune for rate-limit event history (#4577 Phase 2): unreachable once
+    // out of the index, so dropping it is unobservable — identical reasoning to
+    // the lastFired prune immediately above.
+    for (const id of this.rateLimitEvents.keys()) if (!liveIds.has(id)) this.rateLimitEvents.delete(id);
     // Same prune for geofence baselines (#4399): a deleted/disabled automation's
     // entries are unreachable (checkGeofences only iterates `this.index`), so
     // dropping them is unobservable — unlike evicting a *live* automation's
@@ -305,7 +317,13 @@ export class AutomationEngineService {
       if (traced) this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: gate.reason });
       return 0;
     }
+    const rateGate = this.rateLimitGate(a, now);
+    if (!rateGate.ok) {
+      if (traced) this.emitTrace(a, ctx, now, { outcome: 'ratelimited', reason: rateGate.reason });
+      return 0;
+    }
     this.markFired(a, gate.key, now);
+    this.markRateLimited(a, now);
     const fr = await this.fireAutomation(a, ctx, now);
     if (traced) this.emitTrace(a, ctx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });
     return 1;
@@ -391,6 +409,36 @@ export class AutomationEngineService {
     logger.debug(`[AutomationEngine] "${a.name}" cooldown keys trimmed to ${inner.size} (scope=${a.cooldownScope})`);
   }
 
+  /**
+   * Rate-limit verdict for one automation (#4577 Phase 2, RATE-LIMIT). Distinct
+   * from {@link cooldownGate}: keyed by automation id ONLY (never per-subject),
+   * so it bounds total fires of the whole rule inside a rolling window rather
+   * than debouncing a single subject. No `a.rateLimit` ⇒ always ok (pre-Phase-2
+   * behaviour). Precedence with cooldownGate is enforced by call order at each
+   * dispatch site: cooldown is checked first, and a cooldown-suppressed event
+   * never reaches this gate, so it never consumes rate budget.
+   */
+  private rateLimitGate(a: LoadedAutomation, now: number): { ok: true } | { ok: false; reason: string } {
+    if (!a.rateLimit) return { ok: true };
+    const { maxActions, windowSeconds } = a.rateLimit;
+    const windowMs = windowSeconds * 1000;
+    const prior = this.rateLimitEvents.get(a.id) ?? [];
+    const events = prior.filter((ts) => now - ts < windowMs);
+    this.rateLimitEvents.set(a.id, events);
+    if (events.length >= maxActions) {
+      return { ok: false, reason: `rate limit reached — ${maxActions}/${windowSeconds}s (flood guard)` };
+    }
+    return { ok: true };
+  }
+
+  /** Stamp a fire against its rate-limit window (#4577 Phase 2). No-op if the automation has no rateLimit. */
+  private markRateLimited(a: LoadedAutomation, now: number): void {
+    if (!a.rateLimit) return;
+    const events = this.rateLimitEvents.get(a.id) ?? [];
+    events.push(now);
+    this.rateLimitEvents.set(a.id, events);
+  }
+
   /** Prior inside/outside geofence state for (automation, node), or undefined on first sighting. */
   private getGeofenceBaseline(a: LoadedAutomation, nodeNum: number): boolean | undefined {
     return this.geofenceState.get(a.id)?.get(nodeNum)?.inside;
@@ -451,7 +499,13 @@ export class AutomationEngineService {
         if (traced) this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: gate.reason });
         continue;
       }
+      const rateGate = this.rateLimitGate(a, now);
+      if (!rateGate.ok) {
+        if (traced) this.emitTrace(a, ctx, now, { outcome: 'ratelimited', reason: rateGate.reason });
+        continue;
+      }
       this.markFired(a, gate.key, now);
+      this.markRateLimited(a, now);
       fired++;
       const fr = await this.fireAutomation(a, ctx, now);
       if (traced) this.emitTrace(a, ctx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });
@@ -733,7 +787,13 @@ export class AutomationEngineService {
         if (traced) this.emitTrace(a, geoCtx, now, { outcome: 'cooldown', reason: gate.reason });
         continue;
       }
+      const rateGate = this.rateLimitGate(a, now);
+      if (!rateGate.ok) {
+        if (traced) this.emitTrace(a, geoCtx, now, { outcome: 'ratelimited', reason: rateGate.reason });
+        continue;
+      }
       this.markFired(a, gate.key, now);
+      this.markRateLimited(a, now);
       fired++;
       const fr = await this.fireAutomation(a, geoCtx, now);
       if (traced) this.emitTrace(a, geoCtx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });
@@ -778,7 +838,13 @@ export class AutomationEngineService {
         if (traced) this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: gate.reason });
         continue;
       }
+      const rateGate = this.rateLimitGate(a, now);
+      if (!rateGate.ok) {
+        if (traced) this.emitTrace(a, ctx, now, { outcome: 'ratelimited', reason: rateGate.reason });
+        continue;
+      }
       this.markFired(a, gate.key, now);
+      this.markRateLimited(a, now);
       fired++;
       const fr = await this.fireAutomation(a, ctx, now);
       if (traced) this.emitTrace(a, ctx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });
@@ -899,12 +965,18 @@ export class AutomationEngineService {
         if (traced) this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: gate.reason });
         continue;
       }
+      const rateGate = this.rateLimitGate(a, now);
+      if (!rateGate.ok) {
+        if (traced) this.emitTrace(a, ctx, now, { outcome: 'ratelimited', reason: rateGate.reason });
+        continue;
+      }
 
       let inner = this.leftHomeAlarmed.get(a.id);
       if (!inner) { inner = new Map(); this.leftHomeAlarmed.set(a.id, inner); }
       inner.set(nodeNum, true);
 
       this.markFired(a, gate.key, now);
+      this.markRateLimited(a, now);
       fired++;
       const fr = await this.fireAutomation(a, ctx, now);
       if (traced) this.emitTrace(a, ctx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -551,11 +551,25 @@ export class AutomationEngineService {
     return false;
   }
 
-  /** True if `fromPublicKey` is this MeshCore source's own local node key. */
+  /**
+   * True if `fromPublicKey` is one of MeshMonitor's own MeshCore nodes.
+   *
+   * Checks the event's own source first (the #3914 behaviour), then falls back
+   * to the cross-source owned-pubkey set. The fallback exists for multi-MeshCore
+   * -source / bridge setups where the event's source hasn't resolved its own
+   * key yet (or the key belongs to a different MeshCore source we also own),
+   * mirroring the Meshtastic `isOwnNodeNum` fallback above (#4577 P2).
+   */
   private async isSelfMeshCore(sourceId: string | null, fromPublicKey: string | null | undefined): Promise<boolean> {
-    if (!this.data.getSelfPublicKey || !fromPublicKey) return false;
-    const key = await this.data.getSelfPublicKey(sourceId);
-    return key != null && key.toLowerCase() === fromPublicKey.toLowerCase();
+    if (!fromPublicKey) return false;
+    if (this.data.getSelfPublicKey) {
+      const key = await this.data.getSelfPublicKey(sourceId);
+      if (key != null && key.toLowerCase() === fromPublicKey.toLowerCase()) return true;
+    }
+    if (this.data.isOwnPublicKey) {
+      return await this.data.isOwnPublicKey(fromPublicKey);
+    }
+    return false;
   }
 
   // ─── event entry points ─────────────────────────────────────────────────

--- a/src/server/services/automation/engineContext.ts
+++ b/src/server/services/automation/engineContext.ts
@@ -87,6 +87,9 @@ export interface NodeDataProvider {
    * received messages (#3914). Optional; absent → no drop.
    */
   getSelfPublicKey?(sourceId: string | null): Promise<string | null>;
+  /** True when a MeshCore public key belongs to ANY MeshCore source MeshMonitor owns —
+   *  cross-source fallback for the self-guard on multi-MC-source / bridge setups (#4577 P2). */
+  isOwnPublicKey?(pubkey: string): Promise<boolean>;
 }
 
 export interface EngineEvalContext {

--- a/src/server/services/automation/meshNodeData.ts
+++ b/src/server/services/automation/meshNodeData.ts
@@ -9,7 +9,7 @@ import type { NodeDataProvider, NodeFacts } from './engineContext.js';
 import { sourceProtocol } from './channelUnify.js';
 import { sourceManagerRegistry } from '../../sourceManagerRegistry.js';
 import { isMeshCoreManager } from '../../sourceManagerTypes.js';
-import { isOwnNodeNum as isOwnedByAnySource } from '../../utils/ownNodes.js';
+import { isOwnNodeNum as isOwnedByAnySource, isOwnPublicKey as isOwnedPubkeyByAnySource } from '../../utils/ownNodes.js';
 
 function nodeIdOf(nodeNum: number): string {
   return `!${(nodeNum >>> 0).toString(16).padStart(8, '0')}`;
@@ -105,6 +105,19 @@ export function createMeshNodeDataProvider(): NodeDataProvider {
         return (m && isMeshCoreManager(m) ? m.getLocalNode()?.publicKey : null) ?? null;
       } catch {
         return null;
+      }
+    },
+
+    // Cross-source owned-pubkey check (#4577 P2) — the fallback the engine uses
+    // when the event's own MeshCore source has no self key (not yet connected)
+    // or a different MeshCore source owns the key (multi-MC-source bridge
+    // safety). Reads the registry live; an empty registry means "nothing is
+    // ours" → no drop.
+    async isOwnPublicKey(pubkey) {
+      try {
+        return isOwnedPubkeyByAnySource(pubkey);
+      } catch {
+        return false;
       }
     },
   };

--- a/src/server/utils/ownNodes.test.ts
+++ b/src/server/utils/ownNodes.test.ts
@@ -4,10 +4,15 @@
  * self-origin guard (#3914) cannot recognise our own traffic arriving there.
  */
 import { describe, it, expect, afterEach } from 'vitest';
-import { getOwnNodeNums, isOwnNodeNum } from './ownNodes.js';
+import { getOwnNodeNums, isOwnNodeNum, getOwnPublicKeys, isOwnPublicKey } from './ownNodes.js';
 import { sourceManagerRegistry, type ISourceManager } from '../sourceManagerRegistry.js';
 
-function fakeManager(sourceId: string, sourceType: any, nodeNum: number | null): ISourceManager {
+function fakeManager(
+  sourceId: string,
+  sourceType: any,
+  nodeNum: number | null,
+  publicKey: string | null = null,
+): ISourceManager {
   return {
     sourceId,
     sourceType,
@@ -16,6 +21,7 @@ function fakeManager(sourceId: string, sourceType: any, nodeNum: number | null):
     getStatus: () => ({ sourceId, sourceName: sourceId, sourceType, connected: true }),
     getLocalNodeInfo: () =>
       nodeNum == null ? null : { nodeNum, nodeId: `!${nodeNum.toString(16)}`, longName: 'n', shortName: 'n' },
+    getLocalNode: () => (publicKey == null ? null : { publicKey, name: 'n', advType: 1 }),
     startDistanceDeleteScheduler: async () => undefined,
     stopDistanceDeleteScheduler: () => undefined,
   } as ISourceManager;
@@ -71,5 +77,65 @@ describe('ownNodes', () => {
     expect(isOwnNodeNum(null)).toBe(false);
     expect(isOwnNodeNum(undefined)).toBe(false);
     expect(isOwnNodeNum(Number.NaN)).toBe(false);
+  });
+
+  describe('MeshCore public keys (#4577 P2)', () => {
+    it('is empty (and drops nothing) when no source is registered', () => {
+      expect(getOwnPublicKeys()).toEqual([]);
+      expect(isOwnPublicKey('abcd')).toBe(false);
+    });
+
+    it('collects the local public key of every MeshCore source that has one', async () => {
+      await add(fakeManager('mc-a', 'meshcore', null, 'AABBCC'));
+      await add(fakeManager('mc-b', 'meshcore', null, 'DDEEFF'));
+
+      expect(getOwnPublicKeys().sort()).toEqual(['aabbcc', 'ddeeff'].sort());
+      expect(isOwnPublicKey('AABBCC')).toBe(true);
+      expect(isOwnPublicKey('ddeeff')).toBe(true);
+      expect(isOwnPublicKey('112233')).toBe(false);
+    });
+
+    it('ignores non-MeshCore sources (meshtastic/mqtt contribute nothing)', async () => {
+      await add(fakeManager('tcp-a', 'meshtastic_tcp', 0x11223344));
+      await add(fakeManager('bridge-1', 'mqtt_bridge', null));
+      expect(getOwnPublicKeys()).toEqual([]);
+      expect(isOwnPublicKey('anything')).toBe(false);
+    });
+
+    it('matches case-insensitively', async () => {
+      await add(fakeManager('mc-a', 'meshcore', null, 'AaBbCc'));
+      expect(isOwnPublicKey('aabbcc')).toBe(true);
+      expect(isOwnPublicKey('AABBCC')).toBe(true);
+    });
+
+    it('recognises a key owned by ANY MeshCore source, not just the one asking', async () => {
+      await add(fakeManager('mc-a', 'meshcore', null, 'AABBCC'));
+      await add(fakeManager('mc-b', 'meshcore', null, 'DDEEFF'));
+
+      // A message that arrived via mc-b but carries mc-a's own key is still ours.
+      expect(isOwnPublicKey('aabbcc')).toBe(true);
+    });
+
+    it('dedupes when two sources report the same key', async () => {
+      await add(fakeManager('mc-a', 'meshcore', null, 'AABBCC'));
+      await add(fakeManager('mc-b', 'meshcore', null, 'aabbcc'));
+      expect(getOwnPublicKeys()).toEqual(['aabbcc']);
+    });
+
+    it('survives a manager that throws while reporting its local node', async () => {
+      const broken = fakeManager('broken', 'meshcore', null, 'AABBCC');
+      (broken as any).getLocalNode = () => { throw new Error('mid-connect'); };
+      await add(broken);
+      await add(fakeManager('mc-a', 'meshcore', null, 'DDEEFF'));
+
+      expect(getOwnPublicKeys()).toEqual(['ddeeff']);
+    });
+
+    it('treats null/undefined/empty pubkeys as not ours', async () => {
+      await add(fakeManager('mc-a', 'meshcore', null, 'AABBCC'));
+      expect(isOwnPublicKey(null)).toBe(false);
+      expect(isOwnPublicKey(undefined)).toBe(false);
+      expect(isOwnPublicKey('')).toBe(false);
+    });
   });
 });

--- a/src/server/utils/ownNodes.ts
+++ b/src/server/utils/ownNodes.ts
@@ -22,6 +22,7 @@
  */
 
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+import { isMeshCoreManager } from '../sourceManagerTypes.js';
 
 /**
  * Every local node number MeshMonitor currently owns, across all registered
@@ -49,4 +50,33 @@ export function isOwnNodeNum(nodeNum: number | null | undefined): boolean {
   const n = Number(nodeNum);
   if (!Number.isFinite(n)) return false;
   return getOwnNodeNums().includes(n);
+}
+
+/**
+ * Every local MeshCore public key MeshMonitor currently owns, across all
+ * registered MeshCore sources. Meshtastic/MQTT managers contribute nothing.
+ * Keys are lowercased for case-insensitive comparison, matching the #3914
+ * per-source `getSelfPublicKey` convention.
+ */
+export function getOwnPublicKeys(): string[] {
+  const keys: string[] = [];
+  for (const manager of sourceManagerRegistry.getAllManagers()) {
+    if (!isMeshCoreManager(manager)) continue;
+    let k: unknown;
+    try {
+      k = manager.getLocalNode()?.publicKey;
+    } catch {
+      continue; // a manager mid-connect must never break the caller
+    }
+    if (typeof k !== 'string' || !k) continue;
+    const lower = k.toLowerCase();
+    if (!keys.includes(lower)) keys.push(lower);
+  }
+  return keys;
+}
+
+/** True when `pubkey` is the local node public key of ANY registered MeshCore source. */
+export function isOwnPublicKey(pubkey: string | null | undefined): boolean {
+  if (!pubkey) return false;
+  return getOwnPublicKeys().includes(pubkey.toLowerCase());
 }

--- a/src/types/automation.test.ts
+++ b/src/types/automation.test.ts
@@ -4,8 +4,10 @@ import {
   categoryOf,
   parseCooldownScope,
   parseSendMaxAttempts,
+  parseRateLimit,
   SEND_MAX_ATTEMPTS_MIN,
   SEND_MAX_ATTEMPTS_MAX,
+  RATE_LIMIT_MAX_ACTIONS_MAX,
   AUTOMATION_CONFIG_VERSION,
   type AutomationGraph,
 } from './automation.js';
@@ -161,6 +163,35 @@ describe('validateAutomationGraph', () => {
     const bad = validateAutomationGraph(withTelemetryTrigger({ cooldownScope: 'bogus' }));
     expect(bad.valid).toBe(false);
     expect(bad.errors.join(' ')).toMatch(/trigger\.telemetry .* requires params\.cooldownScope ∈ \{automation,node,sourceNode\}/);
+  });
+
+  // ── trigger.* rateLimit (#4577 Phase 2, RATE-LIMIT) ─────────────────────
+  it('trigger.message: rateLimit validates when present, and absence still validates', () => {
+    const withTrigger = (params: Record<string, unknown>): AutomationGraph => ({
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params },
+        { id: 'a', type: 'action.tapback', params: { emoji: '👍' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    });
+    // absent → valid (pre-Phase-2 stored automations keep validating unchanged)
+    expect(validateAutomationGraph(withTrigger({})).valid).toBe(true);
+    expect(validateAutomationGraph(withTrigger({ textContains: 'ping' })).valid).toBe(true);
+    // valid rateLimit
+    expect(validateAutomationGraph(withTrigger({ rateLimit: { maxActions: 5, windowSeconds: 60 } })).valid).toBe(true);
+    expect(validateAutomationGraph(withTrigger({ rateLimit: { maxActions: 1, windowSeconds: 1 } })).valid).toBe(true);
+    // maxActions 0 → error
+    const zeroMax = validateAutomationGraph(withTrigger({ rateLimit: { maxActions: 0, windowSeconds: 60 } }));
+    expect(zeroMax.valid).toBe(false);
+    expect(zeroMax.errors.join(' ')).toMatch(/requires params\.rateLimit = \{ maxActions >= 1, windowSeconds >= 1 \}/);
+    // non-integer maxActions → error
+    expect(validateAutomationGraph(withTrigger({ rateLimit: { maxActions: 2.5, windowSeconds: 60 } })).valid).toBe(false);
+    // windowSeconds 0 → error
+    expect(validateAutomationGraph(withTrigger({ rateLimit: { maxActions: 5, windowSeconds: 0 } })).valid).toBe(false);
+    // non-object rateLimit → error
+    expect(validateAutomationGraph(withTrigger({ rateLimit: 'often' })).valid).toBe(false);
+    expect(validateAutomationGraph(withTrigger({ rateLimit: [5, 60] })).valid).toBe(false);
   });
 
   it('trigger.becameMobile / trigger.leftHome require a non-empty nodeNums list', () => {
@@ -382,5 +413,31 @@ describe('parseSendMaxAttempts', () => {
   it('clamps out-of-range values instead of rejecting them (lenient at runtime)', () => {
     expect(parseSendMaxAttempts(0)).toBe(1);
     expect(parseSendMaxAttempts(9)).toBe(3);
+  });
+});
+
+describe('parseRateLimit', () => {
+  it('round-trips a valid shape', () => {
+    expect(parseRateLimit({ maxActions: 5, windowSeconds: 60 })).toEqual({ maxActions: 5, windowSeconds: 60 });
+    expect(parseRateLimit({ maxActions: 1, windowSeconds: 1 })).toEqual({ maxActions: 1, windowSeconds: 1 });
+  });
+
+  it('returns undefined for absent/blank/garbage values', () => {
+    expect(parseRateLimit(undefined)).toBeUndefined();
+    expect(parseRateLimit(null)).toBeUndefined();
+    expect(parseRateLimit('')).toBeUndefined();
+    expect(parseRateLimit('bogus')).toBeUndefined();
+    expect(parseRateLimit(42)).toBeUndefined();
+    expect(parseRateLimit([5, 60])).toBeUndefined();
+    expect(parseRateLimit({})).toBeUndefined();
+    expect(parseRateLimit({ maxActions: 0, windowSeconds: 60 })).toBeUndefined();
+    expect(parseRateLimit({ maxActions: 2.5, windowSeconds: 60 })).toBeUndefined();
+    expect(parseRateLimit({ maxActions: 5, windowSeconds: 0 })).toBeUndefined();
+    expect(parseRateLimit({ maxActions: 5 })).toBeUndefined();
+  });
+
+  it('clamps maxActions above RATE_LIMIT_MAX_ACTIONS_MAX instead of rejecting it (lenient at runtime)', () => {
+    expect(parseRateLimit({ maxActions: RATE_LIMIT_MAX_ACTIONS_MAX + 500, windowSeconds: 60 }))
+      .toEqual({ maxActions: RATE_LIMIT_MAX_ACTIONS_MAX, windowSeconds: 60 });
   });
 });

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -182,6 +182,36 @@ export function parseSendMaxAttempts(raw: unknown): number | undefined {
 }
 
 /**
+ * Per-automation flood ceiling (#4577 Phase 2, work package RATE-LIMIT).
+ *
+ * Distinct from the per-subject `cooldownGate` debounce above: this bounds
+ * how many times a SINGLE automation may FIRE inside a rolling window, keyed
+ * by automation id ONLY (never per-subject) — a flood guard, not a debounce.
+ * It composes with cooldownScope: cooldown decides IF/WHEN a given subject
+ * may re-fire; rate limit decides how many fires the whole automation may
+ * spend across ALL subjects in the window.
+ */
+export const RATE_LIMIT_MAX_ACTIONS_MIN = 1;
+export const RATE_LIMIT_MAX_ACTIONS_MAX = 1000;
+
+/**
+ * Coerce a stored `params.rateLimit` to `{ maxActions, windowSeconds }`, or
+ * `undefined` for absent / blank / malformed input — `undefined` means "no
+ * rate limit", the pre-Phase-2 behaviour every stored automation depends on.
+ * Lenient at RUNTIME (graphs written before this existed must still run)
+ * while validateAutomationGraph rejects a malformed value at SAVE time — the
+ * same split used above for cooldownScope and maxAttempts.
+ */
+export function parseRateLimit(raw: unknown): { maxActions: number; windowSeconds: number } | undefined {
+  if (!isPlainObject(raw)) return undefined;
+  const maxActions = Number(raw.maxActions);
+  const windowSeconds = Number(raw.windowSeconds);
+  if (!Number.isInteger(maxActions) || maxActions < RATE_LIMIT_MAX_ACTIONS_MIN) return undefined;
+  if (!Number.isInteger(windowSeconds) || windowSeconds < 1) return undefined;
+  return { maxActions: Math.min(RATE_LIMIT_MAX_ACTIONS_MAX, maxActions), windowSeconds };
+}
+
+/**
  * Match modes for `condition.meshcoreScope` (#3914). A MeshCore text message
  * carries a region "scope" (`scopeCode` 0 = unscoped, >0 = a region; `scopeName`
  * = the resolved region). This condition matches:
@@ -400,6 +430,22 @@ export function validateAutomationGraph(input: unknown): ValidationResult {
           && p.cooldownScope != null
           && !COOLDOWN_SCOPES.includes(p.cooldownScope as CooldownScope)) {
         errors.push(`${n.type} "${n.id}" requires params.cooldownScope ∈ {automation,node,sourceNode}`);
+      }
+      // Rate limit (#4577 Phase 2, RATE-LIMIT) is likewise a trigger-level param
+      // shared by every trigger type, checked once here for the same reason.
+      // Optional: absent/null = no rate limit, the pre-Phase-2 behaviour every
+      // stored automation depends on. Save-time strict; runtime lenient via
+      // parseRateLimit (same split as cooldownScope above).
+      if (categoryOf(n.type) === 'trigger' && p.rateLimit != null) {
+        const rl = p.rateLimit;
+        const maxActions = isPlainObject(rl) ? Number((rl as Record<string, unknown>).maxActions) : NaN;
+        const windowSeconds = isPlainObject(rl) ? Number((rl as Record<string, unknown>).windowSeconds) : NaN;
+        const validShape = isPlainObject(rl)
+          && Number.isInteger(maxActions) && maxActions >= RATE_LIMIT_MAX_ACTIONS_MIN && maxActions <= RATE_LIMIT_MAX_ACTIONS_MAX
+          && Number.isInteger(windowSeconds) && windowSeconds >= 1;
+        if (!validShape) {
+          errors.push(`${n.type} "${n.id}" requires params.rateLimit = { maxActions >= 1, windowSeconds >= 1 }`);
+        }
       }
       switch (n.type) {
         case 'flow.collapse':


### PR DESCRIPTION
## Summary

Phase 2 of the **Meshtastic ↔ MeshCore automation-bridge epic** (#4577). Hardens the Automation Engine against message loops and mesh flooding — the safety foundation the bridge template (Phase 4) ships on top of. Motivated by the owner's OverMesh concern (a prior tool flooded the MeshCore mesh with unwanted Meshtastic traffic).

Two deliverables:

### (a) MeshCore self-guard cross-source fallback
The Meshtastic self-origin guard already recognizes MeshMonitor's own traffic across sources (`isOwnNodeNum`/#4593). The MeshCore guard `isSelfMeshCore` only checked the event's own source key — so in a multi-MeshCore-source setup (which a bridge can create), a self-sent message re-entering via a *different* MC source wasn't recognized as self and could re-trigger automations and loop.

- New `getOwnPublicKeys()` / `isOwnPublicKey()` in `src/server/utils/ownNodes.ts`, mirroring the Meshtastic pair (enumerates all MeshCore sources via `isMeshCoreManager`, lowercased, deduped, fail-open per manager).
- New optional `NodeDataProvider.isOwnPublicKey?` wired into `isSelfMeshCore` as a fallback after the per-source key check.

### (b) Per-automation rate-limit primitive (flood ceiling)
A rolling-window cap on how many times a single automation may **fire**, keyed by automation id only — distinct from the per-subject `cooldownGate` debounce.

- Config surface: **`params.rateLimit = { maxActions, windowSeconds }`** on the trigger node (absent = no limit; `maxActions` clamped to 1000). Parsed by `parseRateLimit()` (runtime-lenient / save-strict, mirroring `cooldownScope`); validated in `validateAutomationGraph`.
- Enforced at **all 5** engine dispatch sites via `rateLimitGate()`, using the engine's injectable clock (no `Date.now()` — deterministic tests, respects the known fake-timer flake). Prune-on-read keeps the event array bounded by `maxActions`.
- **Precedence:** cooldown checked first (a debounced event spends no rate budget); a rate-limited event does not advance cooldown. New trace outcome `ratelimited` (+ frontend badge).

## Why per-fire, id-keyed
The engine already caps *actions within one fire* (`maxActions`, default 50). The rolling limit bounds *fires per window*, composing into a full ceiling. Keying by automation id (not subject) is deliberate — a loop cycles through many subjects, so a per-subject key would be trivially defeated; the per-subject dimension is already `cooldownGate`'s job.

## Verification
- `npm run typecheck` — clean
- vitest (automation + types + utils + components/automations + bus regression), JSON reporter — **`success: true`, 1234 passed, 0 failed, 0 failed suites**
- `src/server/mqttIngestion.automationBus.test.ts` self-origin regression — green
- `npm run lint:ci` — clean

New tests: `getOwnPublicKeys`/`isOwnPublicKey` (incl. cross-source recognition), multi-MC-source self-guard drop, rate-limit enforcement + window reset + cooldown-interaction, `parseRateLimit` + graph validation.

No DB/schema/migration, no raw SQL, no new global settings — both deliverables are in-memory engine state + per-automation graph config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)