### PR TITLE
fix(traceroute): reduce edge overlap in statistical route view (#4566)

### DIFF
--- a/src/components/traceroute/TracerouteStrip.module.css
+++ b/src/components/traceroute/TracerouteStrip.module.css
@@ -51,10 +51,13 @@
 }
 
 /* Statistical mode (SR_PHASE2_SPEC.md D16): one neutral lane — solid, no dash,
- * no arrowhead. Occurrence share arrives as `--stat-opacity`, already floored at
- * MIN_STAT_OPACITY by `statOpacity()`; this file never computes it. */
+ * no arrowhead. Occurrence share arrives as `--stat-opacity`, already floored
+ * at MIN_STAT_OPACITY by `statOpacity()`; this file never computes it. Stroke
+ * width comes from `--stat-weight` (issue #4566), a linear ramp precomputed
+ * by `statEdgeWeight()` — again this file maps nothing. */
 .statEdge {
   stroke-opacity: var(--stat-opacity, 1);
+  stroke-width: var(--stat-weight, 2);
 }
 
 .arrowHead {

--- a/src/components/traceroute/TracerouteStrip.statistical.test.tsx
+++ b/src/components/traceroute/TracerouteStrip.statistical.test.tsx
@@ -302,6 +302,26 @@ describe('TracerouteStrip — statistical mode (SR_PHASE2_SPEC.md §4.2)', () =>
       hits.forEach((h) => expect((h as HTMLElement).style.getPropertyValue('--stat-opacity')).toBe(''));
     });
 
+    it('every visible edge carries --stat-weight equal to `${UnionStripEdge.weight}px` (#4566)', () => {
+      const { graph } = buildFixture5();
+      const { container } = render(<TracerouteStrip graph={graph} meta={META} {...FMT} />);
+
+      const visible = Array.from(container.querySelectorAll(`polyline.${styles.statEdge}`)) as HTMLElement[];
+      expect(visible).toHaveLength(graph.edges.length);
+      const weights = new Set(graph.edges.map((e) => `${e.weight}px`));
+      visible.forEach((p) => {
+        expect(weights.has(p.style.getPropertyValue('--stat-weight'))).toBe(true);
+      });
+    });
+
+    it('.edgeHit targets carry no --stat-weight (hit-target width stays constant)', () => {
+      const { graph } = buildFixture5();
+      const { container } = render(<TracerouteStrip graph={graph} meta={META} {...FMT} />);
+
+      const hits = container.querySelectorAll(`.${styles.edgeHit}`);
+      hits.forEach((h) => expect((h as HTMLElement).style.getPropertyValue('--stat-weight')).toBe(''));
+    });
+
     it('a single-route render carries no .statNode class and no --stat-opacity', () => {
       const input: TracerouteStripInput = { fromNodeNum: LOCAL, toNodeNum: PEER, route: '[]', routeBack: null };
       const graph = buildTracerouteStripGraph(input);

--- a/src/components/traceroute/TracerouteStrip.tsx
+++ b/src/components/traceroute/TracerouteStrip.tsx
@@ -140,6 +140,12 @@ function statStyle(opacity: number, base: CSSProperties): CSSProperties {
   return { ...base, '--stat-opacity': opacity } as CSSProperties;
 }
 
+/** Edge variant of `statStyle` — sets `--stat-opacity` AND `--stat-weight` in
+ *  one shot so a UnionStripEdge only ever needs one style object. */
+function statEdgeStyle(opacity: number, weight: number): CSSProperties {
+  return { '--stat-opacity': opacity, '--stat-weight': `${weight}px` } as CSSProperties;
+}
+
 /** Maps a StripNode's semantic band to its CSS lane hook (spec §4.3/§4.4).
  * Deliberately empty rules today — an assertable class name and a home for
  * any future visual differentiation, not a styling switch. Do not branch
@@ -692,7 +698,7 @@ export function TracerouteStrip({
                   // D8: no arrowhead in statistical mode — the edge makes no
                   // direction claim.
                   markerEnd={stat ? undefined : `url(#${arrowId})`}
-                  style={stat ? statStyle(stat.opacity, {}) : undefined}
+                  style={stat ? statEdgeStyle(stat.opacity, stat.weight) : undefined}
                 />
               );
             })}

--- a/src/utils/tracerouteAggregate.test.ts
+++ b/src/utils/tracerouteAggregate.test.ts
@@ -7,9 +7,12 @@ import { describe, it, expect } from 'vitest';
 import {
   buildTracerouteUnion,
   statOpacity,
+  statEdgeWeight,
   REAL_NODE_ID_PREFIX,
   UNKNOWN_HOP_ID_PREFIX,
   MIN_STAT_OPACITY,
+  MIN_STAT_EDGE_WEIGHT,
+  MAX_STAT_EDGE_WEIGHT,
   type AggregateTracerouteRow,
 } from './tracerouteAggregate';
 import { BROADCAST_ADDR } from './tracerouteSegments';
@@ -470,5 +473,26 @@ describe('tracerouteAggregate — statOpacity', () => {
   it('44. out-of-range input (-1, 2) clamps to MIN_STAT_OPACITY / 1', () => {
     expect(statOpacity(-1)).toBe(MIN_STAT_OPACITY);
     expect(statOpacity(2)).toBe(1);
+  });
+});
+
+describe('tracerouteAggregate — statEdgeWeight (#4566)', () => {
+  it('45. statEdgeWeight(0) === MIN_STAT_EDGE_WEIGHT and statEdgeWeight(1) === MAX_STAT_EDGE_WEIGHT', () => {
+    expect(statEdgeWeight(0)).toBe(MIN_STAT_EDGE_WEIGHT);
+    expect(statEdgeWeight(1)).toBe(MAX_STAT_EDGE_WEIGHT);
+  });
+
+  it('46. statEdgeWeight is monotone non-decreasing across a swept range', () => {
+    let prev = -Infinity;
+    for (let i = 0; i <= 20; i++) {
+      const w = statEdgeWeight(i / 20);
+      expect(w).toBeGreaterThanOrEqual(prev);
+      prev = w;
+    }
+  });
+
+  it('47. out-of-range input (-1, 2) clamps to MIN / MAX weight', () => {
+    expect(statEdgeWeight(-1)).toBe(MIN_STAT_EDGE_WEIGHT);
+    expect(statEdgeWeight(2)).toBe(MAX_STAT_EDGE_WEIGHT);
   });
 });

--- a/src/utils/tracerouteAggregate.ts
+++ b/src/utils/tracerouteAggregate.ts
@@ -74,6 +74,16 @@ export const UNKNOWN_HOP_ID_PREFIX = 'u';
  *  constant serves both nodes and edges so the two floors cannot drift apart. */
 export const MIN_STAT_OPACITY = 0.28;
 
+/** Baseline stroke-width (px) an edge with `share -> 0` renders at. Matches the
+ *  non-statistical `.forwardEdge`/`.returnEdge` weight so a single-route union
+ *  reads identical to the classic strip. */
+export const MIN_STAT_EDGE_WEIGHT = 2;
+
+/** Peak stroke-width (px) an edge with `share === 1` renders at. Kept modest
+ *  so a highly-repeated edge stays legible next to node glyphs (glyphSize/2 is
+ *  16px by default). */
+export const MAX_STAT_EDGE_WEIGHT = 5;
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -401,4 +411,22 @@ function round3(x: number): number {
 export function statOpacity(share: number): number {
   const clamped = Math.min(1, Math.max(0, share));
   return round3(MIN_STAT_OPACITY + (1 - MIN_STAT_OPACITY) * clamped);
+}
+
+/**
+ * Linear ramp from `MIN_STAT_EDGE_WEIGHT` at `share -> 0` to `MAX_STAT_EDGE_WEIGHT`
+ * at `share === 1`, rounded to two decimals. Clamps out-of-range input.
+ *
+ * This is what tells the reader "this A-B adjacency showed up in most of the
+ * routes I stored" — a merged StatEdge with share=1 renders as the thickest
+ * stroke, share≈1/N as the thinnest. Kept in this module (not the layout
+ * module) so the counting model owns every scalar mapping off `share`.
+ */
+export function statEdgeWeight(share: number): number {
+  const clamped = Math.min(1, Math.max(0, share));
+  return round2(MIN_STAT_EDGE_WEIGHT + (MAX_STAT_EDGE_WEIGHT - MIN_STAT_EDGE_WEIGHT) * clamped);
+}
+
+function round2(x: number): number {
+  return Math.round(x * 100) / 100;
 }

--- a/src/utils/tracerouteUnionLayout.test.ts
+++ b/src/utils/tracerouteUnionLayout.test.ts
@@ -9,7 +9,12 @@ import {
   layoutTracerouteUnion,
   buildStatisticalStrip,
 } from './tracerouteUnionLayout';
-import { buildTracerouteUnion, statOpacity, type AggregateTracerouteRow } from './tracerouteAggregate';
+import {
+  buildTracerouteUnion,
+  statOpacity,
+  statEdgeWeight,
+  type AggregateTracerouteRow,
+} from './tracerouteAggregate';
 import {
   DEFAULT_LAYOUT_OPTIONS,
   minBand,
@@ -400,6 +405,19 @@ describe('tracerouteUnionLayout — graph shape', () => {
     const graph = buildGraph(rows);
     for (const nd of graph.nodes) expect(nd.opacity).toBe(statOpacity(nd.share));
     for (const e of graph.edges) expect(e.opacity).toBe(statOpacity(e.share));
+  });
+
+  it('24a. weight === statEdgeWeight(share) on every edge (#4566)', () => {
+    const rows = [
+      row({ route: JSON.stringify([300, 400]) }),
+      row({ route: JSON.stringify([300, 400]) }),
+      row({ route: JSON.stringify([300]) }),
+    ];
+    const graph = buildGraph(rows);
+    for (const e of graph.edges) expect(e.weight).toBe(statEdgeWeight(e.share));
+    // A more-repeated edge (higher share) reads visually heavier than a rare one.
+    const weights = graph.edges.map((e) => e.weight);
+    expect(Math.max(...weights)).toBeGreaterThan(Math.min(...weights));
   });
 
   it('25. node ids are carried over verbatim from the aggregate', () => {

--- a/src/utils/tracerouteUnionLayout.test.ts
+++ b/src/utils/tracerouteUnionLayout.test.ts
@@ -8,6 +8,8 @@ import {
   buildUnionStripGraph,
   layoutTracerouteUnion,
   buildStatisticalStrip,
+  nudgeOverlappingEdgePaths,
+  EDGE_OVERLAP_OFFSET_PX,
 } from './tracerouteUnionLayout';
 import {
   buildTracerouteUnion,
@@ -21,6 +23,7 @@ import {
   minRowHeight,
   labelOffset,
   edgeClearance,
+  EDGE_RIM_MARGIN,
   GEOM_EPS,
   type StripPoint,
 } from './tracerouteStrip';
@@ -528,14 +531,106 @@ describe('tracerouteUnionLayout — integration with fixtures', () => {
     expect(layout.width).toBe(graph.columns * o.colWidth);
 
     // Every clearance assertion: no path (of any edge) passes closer than
-    // edgeClearance(o) - GEOM_EPS to any node it doesn't terminate at.
-    const clearance = edgeClearance(o);
+    // the glyph rim (glyphSize/2 + EDGE_RIM_MARGIN) to any node it doesn't
+    // terminate at. The router itself gives edges the fuller `edgeClearance`
+    // (glyph rim + LANE_OFFSET), but #4566 spends up to LANE_OFFSET of that
+    // slack on lateral nudging, so the invariant that actually still holds
+    // post-nudge is the rim distance, not the full clearance.
+    const glyphRim = o.glyphSize / 2 + EDGE_RIM_MARGIN;
     for (const e of graph.edges) {
       const path = layout.edgePaths.get(e.id)!;
       const obstacles = graph.nodes
         .filter((nd) => nd.id !== e.fromId && nd.id !== e.toId)
         .map((nd) => layout.centers.get(nd.id)!);
-      expect(minDistanceToObstacles(path, obstacles)).toBeGreaterThanOrEqual(clearance - GEOM_EPS);
+      expect(minDistanceToObstacles(path, obstacles)).toBeGreaterThanOrEqual(glyphRim - GEOM_EPS);
     }
+  });
+});
+
+describe('tracerouteUnionLayout — edge-to-edge overlap nudge (#4566)', () => {
+  /** Deep-copy a Map<string, StripPoint[]> so the two calls under test see
+   *  independent inputs. */
+  function clonePaths(m: Map<string, StripPoint[]>): Map<string, StripPoint[]> {
+    return new Map([...m.entries()].map(([k, v]) => [k, v.map((p) => ({ ...p }))]));
+  }
+
+  it('31. two collinear paths get pushed apart by EDGE_OVERLAP_OFFSET_PX along their perpendicular', () => {
+    // A and B are exactly the same horizontal chord, so every sample coincides.
+    const paths = new Map<string, StripPoint[]>([
+      ['a', [{ x: 0, y: 50 }, { x: 100, y: 50 }]],
+      ['b', [{ x: 0, y: 50 }, { x: 100, y: 50 }]],
+    ]);
+    // maxNudgePx defaults to EDGE_OVERLAP_OFFSET_PX, so the +δ member stays uncapped.
+    nudgeOverlappingEdgePaths(paths);
+
+    const a = paths.get('a')!;
+    const b = paths.get('b')!;
+    // The first edge (id 'a') keeps its position; the second is nudged by +δ.
+    expect(a).toEqual([{ x: 0, y: 50 }, { x: 100, y: 50 }]);
+    // Perpendicular of a horizontal chord (dx>0) is (0, -1) — canonical "up".
+    expect(b[0].x).toBeCloseTo(0);
+    expect(b[0].y).toBeCloseTo(50 - EDGE_OVERLAP_OFFSET_PX);
+    expect(b[1].x).toBeCloseTo(100);
+    expect(b[1].y).toBeCloseTo(50 - EDGE_OVERLAP_OFFSET_PX);
+  });
+
+  it('32. non-overlapping paths are left byte-identical', () => {
+    const paths = new Map<string, StripPoint[]>([
+      ['a', [{ x: 0, y: 0 }, { x: 100, y: 0 }]],
+      ['b', [{ x: 0, y: 200 }, { x: 100, y: 200 }]], // 200px apart -> never coincident
+    ]);
+    const before = clonePaths(paths);
+    nudgeOverlappingEdgePaths(paths);
+    expect([...paths.entries()]).toEqual([...before.entries()]);
+  });
+
+  it('33. a single path is left untouched (no possible overlap)', () => {
+    const paths = new Map<string, StripPoint[]>([
+      ['solo', [{ x: 0, y: 0 }, { x: 100, y: 100 }]],
+    ]);
+    const before = clonePaths(paths);
+    nudgeOverlappingEdgePaths(paths);
+    expect([...paths.entries()]).toEqual([...before.entries()]);
+  });
+
+  it('34. three collinear paths -> offsets [0, +δ, -δ] (deterministic by id)', () => {
+    const chord: StripPoint[] = [{ x: 0, y: 100 }, { x: 200, y: 100 }];
+    // Key order: 'a' < 'b' < 'c' (already sorted); the algorithm sorts by id.
+    const paths = new Map<string, StripPoint[]>([
+      ['a', chord.map((p) => ({ ...p }))],
+      ['b', chord.map((p) => ({ ...p }))],
+      ['c', chord.map((p) => ({ ...p }))],
+    ]);
+    nudgeOverlappingEdgePaths(paths);
+    expect(paths.get('a')![0].y).toBeCloseTo(100);
+    expect(paths.get('b')![0].y).toBeCloseTo(100 - EDGE_OVERLAP_OFFSET_PX);
+    expect(paths.get('c')![0].y).toBeCloseTo(100 + EDGE_OVERLAP_OFFSET_PX);
+  });
+
+  it('35. nudge is capped so no member exceeds maxNudgePx', () => {
+    // Six collinear paths at δ=4 -> raw offsets [0, +4, -4, +8, -8, +12].
+    // With maxNudgePx=5, the +8/-8/+12 members clamp to ±5.
+    const chord: StripPoint[] = [{ x: 0, y: 100 }, { x: 200, y: 100 }];
+    const paths = new Map<string, StripPoint[]>();
+    for (const id of ['a', 'b', 'c', 'd', 'e', 'f']) {
+      paths.set(id, chord.map((p) => ({ ...p })));
+    }
+    nudgeOverlappingEdgePaths(paths, 5);
+    for (const [, path] of paths) {
+      for (const p of path) {
+        expect(Math.abs(p.y - 100)).toBeLessThanOrEqual(5 + GEOM_EPS);
+      }
+    }
+  });
+
+  it('36. running the nudge twice on the same map is idempotent (the second call finds no overlap)', () => {
+    const paths = new Map<string, StripPoint[]>([
+      ['a', [{ x: 0, y: 50 }, { x: 100, y: 50 }]],
+      ['b', [{ x: 0, y: 50 }, { x: 100, y: 50 }]],
+    ]);
+    nudgeOverlappingEdgePaths(paths);
+    const afterFirst = clonePaths(paths);
+    nudgeOverlappingEdgePaths(paths);
+    expect([...paths.entries()]).toEqual([...afterFirst.entries()]);
   });
 });

--- a/src/utils/tracerouteUnionLayout.ts
+++ b/src/utils/tracerouteUnionLayout.ts
@@ -64,6 +64,20 @@
  * `graph.mode === 'statistical'` to suppress arrowheads/SNR labels, never
  * read `leg` as a direction claim here.
  *
+ * EDGE-TO-EDGE LANE NUDGE (#4566). D8 rules out the forward/return
+ * LANE_OFFSET, but distinct edges in the union can still lay out with
+ * paths through the same screen region — dense unions collapse into a
+ * single visual line under D8 alone. After routing, edges whose sampled
+ * paths coincide within EDGE_OVERLAP_THRESHOLD_PX at ≥ MIN_MATCHES points
+ * are grouped by connected component and translated perpendicular to each
+ * edge's own overall chord by ±EDGE_OVERLAP_OFFSET_PX. Deterministic
+ * (edges ordered by id, every constant fixed), and singletons — the
+ * common case — are left untouched. The max nudge is clamped to the
+ * LANE_OFFSET slack the router already reserved on top of the glyph rim,
+ * so no nudged edge crosses into a nearby glyph — the very reason the
+ * post-routing clearance was inflated in the first place is what makes
+ * this legal.
+ *
  * DETERMINISM (D11). `depthKey` is an index into a sorted array. Group
  * order is sorted distinct integers, walked column-by-column (not via `Map`
  * iteration order) so nothing depends on insertion order. Within-group
@@ -378,7 +392,192 @@ export function layoutTracerouteUnion(
     labelAnchors.set(e.id, { x: anchorX, y: anchorY });
   }
 
+  // Issue #4566: distinct edges (different endpoints) whose independently-
+  // routed paths pass through the same screen region are pushed apart along
+  // their own perpendicular by a small lateral step, so a dense union no
+  // longer collapses into a single visual line. Pure, bounded, deterministic
+  // — see `nudgeOverlappingEdgePaths` for the algorithm. The max nudge is
+  // the "spare" clearance the router already reserved on top of the glyph
+  // rim (edgeClearance = glyph half + rim + LANE_OFFSET; the statistical
+  // union doesn't use LANE_OFFSET per D8, so it's free for #4566 to spend
+  // without violating glyph safety).
+  const maxNudgePx = clearance - (o.glyphSize / 2 + EDGE_RIM_MARGIN);
+  nudgeOverlappingEdgePaths(edgePaths, maxNudgePx);
+
   return { width, height, centers, edgePaths, labelAnchors };
+}
+
+// ---------------------------------------------------------------------------
+// Edge-to-edge overlap nudge (#4566)
+// ---------------------------------------------------------------------------
+
+/** Perpendicular lateral step (px) applied to each edge in an overlap group.
+ *  Edges in a group of size N get signed offsets `[0, +1, -1, +2, -2, …] × δ`.
+ *  Kept small — roughly one rim margin — so a nudged edge still visually
+ *  connects to its endpoint glyph rather than looking detached. Must be
+ *  strictly greater than `EDGE_OVERLAP_THRESHOLD_PX` so a nudged pair is
+ *  no longer flagged as overlapping on a subsequent pass — idempotence. */
+export const EDGE_OVERLAP_OFFSET_PX = 4;
+
+/** Sample count per polyline for overlap detection. Even spacing along
+ *  arc length; higher counts catch shorter shared spans at O(edges² × count). */
+const EDGE_OVERLAP_SAMPLE_COUNT = 8;
+
+/** Distance (px) at which two samples on distinct edges count as coincident.
+ *  Must sit BELOW `EDGE_OVERLAP_OFFSET_PX` (idempotence) but above the
+ *  default 2-px stroke width so parallel-but-adjacent strokes still
+ *  register as overlapping. */
+const EDGE_OVERLAP_THRESHOLD_PX = 3;
+
+/** Min sample matches to call two edges "overlapping." One crossing hits a
+ *  single sample by chance; requiring two means a shared span, not a crossing. */
+const EDGE_OVERLAP_MIN_MATCHES = 2;
+
+/** Arc length of a polyline as a running sum of segment distances. */
+function pathLength(path: readonly StripPoint[]): number {
+  let total = 0;
+  for (let i = 1; i < path.length; i++) {
+    total += Math.hypot(path[i].x - path[i - 1].x, path[i].y - path[i - 1].y);
+  }
+  return total;
+}
+
+/** Point at arc distance `s` along `path`, clamped to the polyline's extent. */
+function pointAtArc(path: readonly StripPoint[], s: number): StripPoint {
+  if (s <= 0) return path[0];
+  let remaining = s;
+  for (let i = 1; i < path.length; i++) {
+    const dx = path[i].x - path[i - 1].x;
+    const dy = path[i].y - path[i - 1].y;
+    const segLen = Math.hypot(dx, dy);
+    if (segLen === 0) continue;
+    if (remaining <= segLen) {
+      const t = remaining / segLen;
+      return { x: path[i - 1].x + dx * t, y: path[i - 1].y + dy * t };
+    }
+    remaining -= segLen;
+  }
+  return path[path.length - 1];
+}
+
+/** N evenly-spaced samples along a polyline's arc length, at segment midpoints. */
+function samplePath(path: readonly StripPoint[], count: number): StripPoint[] {
+  const total = pathLength(path);
+  if (total === 0) return Array.from({ length: count }, () => path[0]);
+  const samples: StripPoint[] = [];
+  for (let i = 0; i < count; i++) {
+    samples.push(pointAtArc(path, ((i + 0.5) / count) * total));
+  }
+  return samples;
+}
+
+/** Count how many of `a[i]` land within `threshold` of `b[i]` (same index —
+ *  arc-length-aligned samples, not nearest-neighbor). A shared parallel span
+ *  produces contiguous matches; a single crossing produces at most one. */
+function coincidentSampleCount(a: readonly StripPoint[], b: readonly StripPoint[], threshold: number): number {
+  let matches = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    if (Math.hypot(a[i].x - b[i].x, a[i].y - b[i].y) <= threshold) matches++;
+  }
+  return matches;
+}
+
+/** Signed offset for a member's index within a sorted overlap group:
+ *  `0, +1, -1, +2, -2, …`. Same shape as `offsetForIndex` (D6) but expressed
+ *  as a unit multiplier for `EDGE_OVERLAP_OFFSET_PX`. */
+function laneOffsetForIndex(i: number): number {
+  if (i === 0) return 0;
+  return i % 2 === 1 ? (i + 1) / 2 : -(i / 2);
+}
+
+/**
+ * In-place: detect distinct-endpoint edges whose paths pass through the same
+ * screen region and translate each entire polyline by a small perpendicular
+ * offset so they read as separate lines. Deterministic — edges are ordered by
+ * id, and every constant is fixed above.
+ *
+ * Two-pass: sample all paths once, pairwise overlap into an adjacency map,
+ * BFS the connected components, then translate. Edges with no overlap are
+ * left untouched. Same-endpoint edges cannot exist in a union graph (the
+ * counting model merges them, D3), so "distinct endpoints" is guaranteed by
+ * the input shape rather than checked here.
+ *
+ * `maxNudgePx` caps the largest offset a member of a big overlap group may
+ * receive so no nudged edge crosses into a nearby glyph — see the caller.
+ *
+ * @internal exported for tracerouteUnionLayout.test.ts.
+ */
+export function nudgeOverlappingEdgePaths(
+  edgePaths: Map<string, StripPoint[]>,
+  maxNudgePx: number = EDGE_OVERLAP_OFFSET_PX,
+): void {
+  const ids = [...edgePaths.keys()].sort();
+  if (ids.length < 2) return;
+
+  const paths = ids.map((id) => edgePaths.get(id)!);
+  const samples = paths.map((p) => samplePath(p, EDGE_OVERLAP_SAMPLE_COUNT));
+
+  // Adjacency: which edges overlap which. O(n²) sample compares; n is the
+  // number of union edges (bounded by unique adjacencies), always modest.
+  const neighbors: number[][] = ids.map(() => []);
+  for (let i = 0; i < ids.length; i++) {
+    for (let j = i + 1; j < ids.length; j++) {
+      if (coincidentSampleCount(samples[i], samples[j], EDGE_OVERLAP_THRESHOLD_PX) >= EDGE_OVERLAP_MIN_MATCHES) {
+        neighbors[i].push(j);
+        neighbors[j].push(i);
+      }
+    }
+  }
+
+  // Connected components via BFS. `component[k] === -1` means "no overlaps,
+  // no offset needed."
+  const component = new Array<number>(ids.length).fill(-1);
+  let nextComp = 0;
+  for (let i = 0; i < ids.length; i++) {
+    if (component[i] !== -1 || neighbors[i].length === 0) continue;
+    const queue: number[] = [i];
+    component[i] = nextComp;
+    while (queue.length > 0) {
+      const k = queue.shift()!;
+      for (const nb of neighbors[k]) {
+        if (component[nb] === -1) {
+          component[nb] = nextComp;
+          queue.push(nb);
+        }
+      }
+    }
+    nextComp++;
+  }
+
+  // Bucket members per component. `ids` is already sorted, so `members` is
+  // sorted by edge id — offset assignment is deterministic.
+  const componentMembers: number[][] = Array.from({ length: nextComp }, () => []);
+  for (let i = 0; i < ids.length; i++) {
+    if (component[i] >= 0) componentMembers[component[i]].push(i);
+  }
+
+  for (const members of componentMembers) {
+    if (members.length < 2) continue; // singleton components shouldn't exist here, but be safe.
+    members.forEach((idx, order) => {
+      const rawOffset = laneOffsetForIndex(order) * EDGE_OVERLAP_OFFSET_PX;
+      // Clamp to maxNudgePx so a big overlap group's outermost members can
+      // never push into a nearby glyph. Two lanes may end up at the same
+      // clamped offset (large N); the residual is a small on-the-rim overlap,
+      // strictly better than the pre-nudge single-line collapse.
+      const nudge = Math.max(-maxNudgePx, Math.min(maxNudgePx, rawOffset));
+      if (nudge === 0) return;
+      const path = paths[idx];
+      // Perpendicular of the OVERALL start->end chord; canonicalized so a
+      // path traversed either way picks the same "up" side (this module
+      // already relies on canonicalPerpendicular for glyph-routing tie-break).
+      const perp = canonicalPerpendicular(path[0], path[path.length - 1]);
+      const dx = perp.x * nudge;
+      const dy = perp.y * nudge;
+      const translated = path.map((p) => ({ x: p.x + dx, y: p.y + dy }));
+      edgePaths.set(ids[idx], translated);
+    });
+  }
 }
 
 /** One-shot seam for Phase 2: rows -> counting model -> cells -> pixels. */

--- a/src/utils/tracerouteUnionLayout.ts
+++ b/src/utils/tracerouteUnionLayout.ts
@@ -96,7 +96,7 @@ import {
   pickLabelX,
 } from './tracerouteStrip.js';
 import type { AggregateTracerouteRow, StatNode, TracerouteUnionGraph } from './tracerouteAggregate.js';
-import { statOpacity, buildTracerouteUnion } from './tracerouteAggregate.js';
+import { statOpacity, statEdgeWeight, buildTracerouteUnion } from './tracerouteAggregate.js';
 
 // ---------------------------------------------------------------------------
 // Public types (D10)
@@ -120,6 +120,9 @@ export interface UnionStripEdge extends StripEdge {
   count: number;
   share: number;
   opacity: number;
+  /** `statEdgeWeight(share)` — stroke-width in px. Repeated adjacencies read
+   *  heavier; the counting model owns this scalar (issue #4566). */
+  weight: number;
 }
 
 export interface UnionStripGraph extends TracerouteStripGraph {
@@ -259,6 +262,7 @@ export function buildUnionStripGraph(union: TracerouteUnionGraph): UnionStripGra
       count: e.count,
       share: e.share,
       opacity: statOpacity(e.share),
+      weight: statEdgeWeight(e.share),
     }),
   );
 


### PR DESCRIPTION
## Summary
In the Statistical Route view, dense unions of many stored routes collapse into a single visual line: edges are drawn 2 px thick regardless of how many routes contained them, and distinct edges whose independently-routed paths pass through the same screen region are never separated. This PR gives edges visual weight proportional to how often the adjacency occurred, and pushes overlapping edges apart along their perpendicular so each line is individually hoverable.

## Changes
- **Commit 1** — `feat(traceroute): scale statistical edge thickness by share`. A merged `StatEdge`'s `share` now drives `stroke-width` via a new pure `statEdgeWeight` (2 px at share→0, 5 px at share===1) exposed as a `--stat-weight` CSS var alongside the existing `--stat-opacity`. Hit-target width unchanged.
- **Commit 2** — `fix(traceroute): nudge overlapping statistical edges apart`. After routing, `layoutTracerouteUnion` samples each polyline at 8 arc-length points, groups distinct edges whose samples coincide within 3 px via BFS-connected components, and translates each polyline perpendicular to its own overall chord by ±4 px (deterministic by edge id). Max nudge is clamped to the LANE_OFFSET slack the router already reserves on top of the glyph rim, so no nudged edge crosses into a nearby glyph.

## Issues Resolved
Fixes #4566

## Documentation Updates
No documentation changes needed — the module banner in tracerouteUnionLayout.ts records the deviation from D8 (previously "no lane translation") with a new EDGE-TO-EDGE LANE NUDGE section; SR_PHASE1_SPEC.md's design decisions remain internally consistent.

## Testing
- [x] Unit tests pass (14,724 tests, 0 failures — full suite)
- [x] TypeScript compiles cleanly (tsc --noEmit)
- [x] Six new tests in tracerouteUnionLayout.test.ts (31–36) cover: collinear paths get pushed apart, non-overlapping paths are byte-identical, single-path input untouched, three-way group gets [0, +δ, -δ], big-group offsets clamp to maxNudgePx, and the nudge is idempotent on a second pass (δ > threshold).
- [x] Three new tests in tracerouteAggregate.test.ts (45–47) cover statEdgeWeight monotonicity, endpoints, and out-of-range clamping.
- [x] Two new tests in TracerouteStrip.statistical.test.tsx assert every visible edge carries --stat-weight equal to \`\${e.weight}px\` and .edgeHit targets carry none.
- [x] Test 30's clearance invariant relaxed from >= edgeClearance to >= glyphSize/2 + EDGE_RIM_MARGIN (glyph rim, not full clearance ring) to reflect the LANE_OFFSET slack being spent on #4566 nudging.
- [ ] Reviewer: eyeball a dense Statistical Route (a node with 15+ traceroutes to the same peer) and verify heavier lines correspond to more-frequent adjacencies, and that previously indistinguishable overlapping edges are now individually hoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mCe21XL2jVcmg9QiqrJbX