### PR TITLE
feat(automations): in-app Automation Template Gallery + Auto-Ack template (#4577 P3)

### DIFF
--- a/docs/internal/dev-notes/MT_MC_BRIDGE_AUTOMATION_EPIC.md
+++ b/docs/internal/dev-notes/MT_MC_BRIDGE_AUTOMATION_EPIC.md
@@ -86,7 +86,7 @@ Each phase ships as its own merged PR and leaves `main` green.
   *Exit:* multi-MC-source self-send is dropped; rate limit caps runaway sends; suite green.
   *Deps:* none (independent of Phase 1).
 
-- [ ] **Phase 3 — In-app Automation Template Gallery (infra + Auto-Ack template).**
+- [x] **Phase 3 — In-app Automation Template Gallery (infra + Auto-Ack template).** ✅ SHIPPED (PR pending merge)
   New gallery UI in the Automations area; a template catalog mechanism (static TS
   catalog of `{ id, name, description, icon, tags, build(params) → AutomationGraph }`);
   a "Use template" flow that (optionally via a small wizard) fills parameters and
@@ -121,6 +121,23 @@ Each phase ships as its own merged PR and leaves `main` green.
 
 - 2026-08-12: Epic created. Surveyed automation engine, script gallery, position flow.
   Interview complete (2 rounds). Plan drafted.
+- 2026-08-12: **Phase 3 implemented** (4 WPs). In-app Template Gallery:
+  - New `src/components/automations/templates/` dir: `types.ts` (`AutomationTemplate` with
+    `build() → BuiltAutomation | BuiltAutomation[]` — the array form is Phase 4's pair hook),
+    `index.ts` (`TEMPLATES` registry), `autoAck.ts` (seed template).
+  - `TemplateGallery.tsx` + `.module.css` — card grid + param wizard reusing the exported
+    `FieldInput` from `AutomationBuilder.tsx` (source/channel pickers), installing each built
+    automation via `POST /api/automations/import` (lands **disabled**), with per-automation
+    partial-failure reporting. Wired into `AutomationsPage` via a "Browse templates" button.
+  - **Key implementation decision:** Auto-Ack builds its graph via the project's `compile()`
+    emitter (NOT hand-rolled `port:'true'` edges) so the installed automation round-trips
+    through `decompile()` and stays editable in the visual builder. `graphEvaluator.portSatisfied`
+    treats an unported condition-outgoing edge as the `true` branch (verified `graphEvaluator.ts`),
+    so `zeroHop==1 → tapback` fires ONLY on direct/0-hop messages — no flood.
+  - Gate: typecheck clean, vitest `success: true` (741 passed / 0 failed / 0 failed suites),
+    lint clean. **Browser-validated** on the live dev instance: gallery card → wizard (real
+    source/channel pickers, MT/MC badges) → Install → disabled automation that decompiles into
+    the builder; no console errors; validation automation cleaned up afterward.
 - 2026-08-12: **Phase 1 shipped** — PR #4675 merged (`{{ trigger.protocolShort }}` → MT/MC).
 - 2026-08-12: **Phase 2 implemented** (2 commits). Two deliverables:
   - `isSelfMeshCore` cross-source fallback via new `getOwnPublicKeys()`/`isOwnPublicKey()`

--- a/src/components/automations/AutomationBuilder.tsx
+++ b/src/components/automations/AutomationBuilder.tsx
@@ -74,9 +74,11 @@ function defaultParams(type: string, triggerType: string): Record<string, unknow
   return params;
 }
 
-function FieldInput({ field, value, onChange, variables, sources, channels, scripts, regions, nodes, triggerType }: {
+export interface FieldInputProps {
   field: FieldDef; value: unknown; onChange: (v: unknown) => void; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; regions: string[]; nodes: NodeMultiOption[]; triggerType: string;
-}) {
+}
+
+export function FieldInput({ field, value, onChange, variables, sources, channels, scripts, regions, nodes, triggerType }: FieldInputProps) {
   const { t } = useTranslation();
   let control;
   const varNames = variables.map((v) => v.name);

--- a/src/components/automations/AutomationsPage.templateGallery.test.tsx
+++ b/src/components/automations/AutomationsPage.templateGallery.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * AutomationsPage (#4577 Phase 3 WP4) — "Browse templates" entry point tests.
+ *
+ * These are deliberately light: the deep install-flow behavior (wizard fields,
+ * partial-failure reporting, POST /api/automations/import) is already covered
+ * by TemplateGallery.test.tsx. This file only proves AutomationsPage wires the
+ * gallery in correctly — the button exists, clicking it swaps in the gallery
+ * (using the REAL template registry, unlike TemplateGallery's own suite which
+ * always injects fakes), and closing it returns to the automations list.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import AutomationsPage from './AutomationsPage';
+
+// AutomationBuilder statically imports GeofenceFieldInput → GeofenceMapEditor →
+// BaseMap → TilesetSelector → SettingsContext → config/i18n → init.ts, which
+// calls `api.setBaseUrl(...)` at MODULE SCOPE (before any component renders).
+// `setBaseUrl` must be on the mock even though this suite never uses it
+// directly — same pattern as TemplateGallery.test.tsx / AdminCommandsTab.txDisabled.test.tsx.
+vi.mock('../../services/api', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), setBaseUrl: vi.fn() },
+}));
+
+import apiService from '../../services/api';
+
+const mockedGet = apiService.get as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockedGet.mockReset();
+  // Catch-all: AutomationsList loads /api/automations; the gallery (once
+  // opened) loads /api/sources and /api/automations/channels. Everything
+  // else this suite doesn't care about resolves to an empty list too.
+  mockedGet.mockImplementation(() => Promise.resolve([]));
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AutomationsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('AutomationsPage — Browse templates', () => {
+  it('renders a "Browse templates" button next to "+ New automation"', async () => {
+    renderPage();
+    expect(await screen.findByRole('button', { name: '+ New automation' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Browse templates' })).toBeInTheDocument();
+  });
+
+  it('opens the Template Gallery (real registry) when clicked', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('button', { name: 'Browse templates' }));
+
+    expect(await screen.findByText('Template Gallery')).toBeInTheDocument();
+    // Real TEMPLATES registry (WP2's Auto-Ack), not an injected fake — proves
+    // AutomationsPage renders <TemplateGallery> without overriding `templates`.
+    expect(await screen.findByText('Auto-Ack')).toBeInTheDocument();
+
+    // The automations list underneath is no longer rendered while browsing.
+    expect(screen.queryByRole('button', { name: '+ New automation' })).not.toBeInTheDocument();
+  });
+
+  it('returns to the automations list when the gallery is closed', async () => {
+    renderPage();
+    await userEvent.click(await screen.findByRole('button', { name: 'Browse templates' }));
+    await screen.findByText('Template Gallery');
+
+    await userEvent.click(screen.getByRole('button', { name: /Close/ }));
+
+    expect(await screen.findByRole('button', { name: '+ New automation' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Browse templates' })).toBeInTheDocument();
+  });
+});

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -13,6 +13,7 @@ import apiService from '../../services/api';
 import AutomationBuilder, { type VariableOption, type SourceOption, type UnifiedChannelOption, type ScriptOption, type NodeMultiOption } from './AutomationBuilder';
 import AutomationTester from './AutomationTester';
 import LiveTracePanel from './LiveTracePanel';
+import TemplateGallery, { type InstalledAutomationRow } from './TemplateGallery';
 import { UiIcon } from '../icons';
 import { compile, decompile, type WorkflowForm } from './compile';
 import './AutomationsPage.css';
@@ -106,6 +107,7 @@ export default function AutomationsPage() {
 function AutomationsList() {
   const [items, setItems] = useState<Automation[]>([]);
   const [editing, setEditing] = useState<Automation | 'new' | null>(null);
+  const [browsing, setBrowsing] = useState(false);
   const [runsFor, setRunsFor] = useState<Automation | null>(null);
   const [traceFor, setTraceFor] = useState<Automation | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -125,6 +127,31 @@ function AutomationsList() {
   };
 
   if (editing) return <AutomationEditor automation={editing} onClose={() => { setEditing(null); void load(); }} />;
+  if (browsing) return (
+    <TemplateGallery
+      onClose={() => setBrowsing(false)}
+      onInstalled={(rows: InstalledAutomationRow[]) => {
+        setBrowsing(false);
+        void load();
+        // Installed automations always land disabled (see TemplateGallery) — open
+        // the first one so the user reviews it before flipping it on. `createdAt`/
+        // `updatedAt` aren't part of the /import response shape; the editor doesn't
+        // read them, so a Date.now() placeholder is fine.
+        if (rows.length > 0) {
+          const row = rows[0];
+          setEditing({
+            id: row.id,
+            name: row.name,
+            description: row.description,
+            enabled: row.enabled,
+            config: row.config,
+            createdAt: row.createdAt ?? Date.now(),
+            updatedAt: row.updatedAt ?? Date.now(),
+          });
+        }
+      }}
+    />
+  );
   if (runsFor) return <RunLog automation={runsFor} onClose={() => setRunsFor(null)} />;
   if (traceFor) return (
     <div>
@@ -137,6 +164,7 @@ function AutomationsList() {
     <div>
       <div className="ae-btn-row" style={{ marginBottom: '1rem' }}>
         <button className="ae-btn ae-btn--primary" onClick={() => setEditing('new')}>+ New automation</button>
+        <button className="ae-btn" onClick={() => setBrowsing(true)}>Browse templates</button>
       </div>
       {error && <div className="ae-error-list">{error}</div>}
       {items.length === 0 && <div className="ae-empty">No automations yet. Create one to get started.</div>}

--- a/src/components/automations/TemplateGallery.module.css
+++ b/src/components/automations/TemplateGallery.module.css
@@ -72,7 +72,7 @@
 }
 
 .outcomeOk {
-  color: var(--color-success, #2e7d32);
+  color: var(--color-success);
   font-size: 0.85rem;
 }
 

--- a/src/components/automations/TemplateGallery.module.css
+++ b/src/components/automations/TemplateGallery.module.css
@@ -1,0 +1,82 @@
+/* TemplateGallery (#4577 Phase 3 WP3) — card grid + param wizard layout.
+ * CSS module per CLAUDE.md's CSS containment rule; buttons/cards/chips/fields
+ * reuse the existing `ae-*` classes from AutomationsPage.css for visual
+ * consistency with the rest of the Automation Engine UI.
+ */
+
+.gallery {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.85rem;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.cardName {
+  font-weight: 600;
+}
+
+.cardDescription {
+  margin: 0;
+  color: var(--color-text-subtle);
+  font-size: 0.85rem;
+  flex-grow: 1;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.wizard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 640px;
+}
+
+.outcomes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin: 0.5rem 0;
+}
+
+.outcomeOk {
+  color: var(--color-success, #2e7d32);
+  font-size: 0.85rem;
+}
+
+.outcomeFail {
+  color: var(--color-error);
+  font-size: 0.85rem;
+}

--- a/src/components/automations/TemplateGallery.test.tsx
+++ b/src/components/automations/TemplateGallery.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * TemplateGallery (#4577 Phase 3 WP3) tests.
+ *
+ * These tests never rely on the real `TEMPLATES` registry — WP2 (Auto-Ack)
+ * populates it in parallel and its landing is not ordered relative to this
+ * file, so every test injects fake templates via the optional `templates`
+ * prop. That prop exists for exactly this reason (see TemplateGallery.tsx).
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TemplateGallery, { type InstalledAutomationRow } from './TemplateGallery';
+import type { AutomationTemplate, BuiltAutomation } from './templates/types';
+
+// AutomationBuilder statically imports GeofenceFieldInput → GeofenceMapEditor →
+// BaseMap → TilesetSelector → SettingsContext → config/i18n → init.ts, which
+// calls `api.setBaseUrl(...)` at MODULE SCOPE (before any component renders).
+// `setBaseUrl` must be on the mock even though this suite never uses it
+// directly — same pattern as AdminCommandsTab.txDisabled.test.tsx.
+vi.mock('../../services/api', () => ({
+  default: { get: vi.fn(), post: vi.fn(), setBaseUrl: vi.fn() },
+}));
+
+import apiService from '../../services/api';
+
+const mockedGet = apiService.get as unknown as ReturnType<typeof vi.fn>;
+const mockedPost = apiService.post as unknown as ReturnType<typeof vi.fn>;
+
+const SAMPLE_SOURCES = [
+  { id: 'src1', name: 'Home Node', type: 'meshtastic-tcp', enabled: true, radio: { txEnabled: true, canTransmit: true } },
+];
+const SAMPLE_CHANNELS = [
+  { name: 'gauntlet', protocol: 'meshtastic', encryption: 'AQ==' },
+];
+
+function minimalGraph(triggerId: string, actionId: string, actionParams: Record<string, unknown> = {}) {
+  return {
+    version: 1,
+    nodes: [
+      { id: triggerId, type: 'trigger.message', params: {} },
+      { id: actionId, type: 'action.sendMessage', params: actionParams },
+    ],
+    edges: [{ from: triggerId, to: actionId }],
+  };
+}
+
+/** A simple, single-automation template exercising sourceMulti + channelMulti fields. */
+function makeSingleTemplate(): AutomationTemplate {
+  return {
+    id: 'fake-single',
+    name: 'Fake Single',
+    description: 'A fake single-automation template for testing.',
+    icon: 'bot',
+    tags: ['test-tag'],
+    params: [
+      { name: 'sourceIds', label: 'Sources', kind: 'sourceMulti' },
+      { name: 'channels', label: 'Channels', kind: 'channelMulti' },
+    ],
+    build(values): BuiltAutomation {
+      return {
+        name: 'Fake Single Automation',
+        description: 'desc',
+        config: minimalGraph('trig', 'act', {
+          sourceIds: values.sourceIds ?? [],
+          channels: values.channels ?? [],
+        }),
+      };
+    },
+  };
+}
+
+/** A "bridge" template whose build() returns TWO automations, for partial-failure coverage. */
+function makeDualTemplate(): AutomationTemplate {
+  return {
+    id: 'fake-dual',
+    name: 'Fake Dual',
+    description: 'A fake bridge template producing two automations.',
+    icon: 'bot',
+    tags: ['bridge'],
+    params: [],
+    build(): BuiltAutomation[] {
+      return [
+        { name: 'Fake Dual A', description: 'first', config: minimalGraph('trigA', 'actA') },
+        { name: 'Fake Dual B', description: 'second', config: minimalGraph('trigB', 'actB') },
+      ];
+    },
+  };
+}
+
+beforeEach(() => {
+  mockedGet.mockReset();
+  mockedPost.mockReset();
+  mockedGet.mockImplementation((endpoint: string) => {
+    if (endpoint === '/api/sources') return Promise.resolve(SAMPLE_SOURCES);
+    if (endpoint === '/api/automations/channels') return Promise.resolve(SAMPLE_CHANNELS);
+    return Promise.resolve([]);
+  });
+});
+
+function renderGallery(templates: AutomationTemplate[], onInstalled = vi.fn(), onClose = vi.fn()) {
+  render(<TemplateGallery onClose={onClose} onInstalled={onInstalled} templates={templates} />);
+  return { onInstalled, onClose };
+}
+
+describe('TemplateGallery', () => {
+  it('renders a card for each injected template', async () => {
+    renderGallery([makeSingleTemplate(), makeDualTemplate()]);
+    expect(await screen.findByText('Fake Single')).toBeInTheDocument();
+    expect(screen.getByText('Fake Dual')).toBeInTheDocument();
+    expect(screen.getByText('test-tag')).toBeInTheDocument();
+    expect(screen.getByText('bridge')).toBeInTheDocument();
+  });
+
+  it('opens the wizard with the template\'s param fields, populated from injected sources/channels', async () => {
+    renderGallery([makeSingleTemplate()]);
+    await screen.findByText('Fake Single');
+    await waitFor(() => expect(mockedGet).toHaveBeenCalledWith('/api/sources'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Use template' }));
+
+    expect(screen.getByText('Sources')).toBeInTheDocument();
+    expect(screen.getByText('Channels')).toBeInTheDocument();
+    // The sourceMulti/channelMulti pickers render options from the props the
+    // gallery loaded via apiService — not hardcoded — proving the wiring.
+    expect(await screen.findByRole('checkbox', { name: /Home Node/ })).toBeInTheDocument();
+    expect(screen.getByText('gauntlet')).toBeInTheDocument();
+  });
+
+  it('installs a single-automation template and reports the created row', async () => {
+    const { onInstalled } = renderGallery([makeSingleTemplate()]);
+    await screen.findByText('Fake Single');
+    await waitFor(() => expect(mockedGet).toHaveBeenCalledWith('/api/sources'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Use template' }));
+
+    // Fill a minimal param: select the one available source.
+    const sourceCheckbox = await screen.findByRole('checkbox', { name: /Home Node/ });
+    await userEvent.click(sourceCheckbox);
+
+    const createdRow: InstalledAutomationRow = {
+      id: 'created-1', name: 'Fake Single Automation', description: 'desc', enabled: false, config: '{}',
+    };
+    mockedPost.mockResolvedValueOnce(createdRow);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Install' }));
+
+    await waitFor(() => expect(mockedPost).toHaveBeenCalled());
+    expect(mockedPost).toHaveBeenCalledWith('/api/automations/import', {
+      name: 'Fake Single Automation',
+      description: 'desc',
+      config: minimalGraph('trig', 'act', { sourceIds: ['src1'], channels: [] }),
+    });
+    await waitFor(() => expect(onInstalled).toHaveBeenCalledWith([createdRow]));
+  });
+
+  it('surfaces a partial failure across a multi-automation (bridge) template without rolling back', async () => {
+    const { onInstalled } = renderGallery([makeDualTemplate()]);
+    await screen.findByText('Fake Dual');
+    await waitFor(() => expect(mockedGet).toHaveBeenCalledWith('/api/sources'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Use template' }));
+
+    const firstRow: InstalledAutomationRow = {
+      id: 'created-a', name: 'Fake Dual A', description: 'first', enabled: false, config: '{}',
+    };
+    mockedPost
+      .mockResolvedValueOnce(firstRow)
+      .mockRejectedValueOnce(new Error('second automation rejected'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Install' }));
+
+    await waitFor(() => expect(mockedPost).toHaveBeenCalledTimes(2));
+
+    // First succeeded and is reported as installed…
+    expect(await screen.findByText(/Installed "Fake Dual A"/)).toBeInTheDocument();
+    // …second failed and its error is surfaced, verbatim.
+    expect(screen.getByText(/Failed to install "Fake Dual B": second automation rejected/)).toBeInTheDocument();
+
+    // Partial failure withholds onInstalled — the caller must not treat this as done.
+    expect(onInstalled).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a load error for the sources/channels picker data without crashing', async () => {
+    mockedGet.mockImplementation((endpoint: string) => {
+      if (endpoint === '/api/sources') return Promise.reject(new Error('sources down'));
+      return Promise.resolve([]);
+    });
+    renderGallery([makeSingleTemplate()]);
+    expect(await screen.findByText('sources down')).toBeInTheDocument();
+  });
+
+  it('calls onClose from the gallery close affordance', async () => {
+    const { onClose } = renderGallery([makeSingleTemplate()]);
+    await screen.findByText('Fake Single');
+    await userEvent.click(screen.getByRole('button', { name: /Close/ }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/automations/TemplateGallery.tsx
+++ b/src/components/automations/TemplateGallery.tsx
@@ -1,0 +1,301 @@
+/**
+ * TemplateGallery (#4577 Phase 3 WP3) — install-flow UI for prebuilt automation
+ * templates. Renders a card grid over the `TEMPLATES` registry (./templates),
+ * a per-template param wizard that reuses AutomationBuilder's exported
+ * `FieldInput` renderer, and installs the built automation(s) via
+ * `POST /api/automations/import` (which always lands them disabled, for
+ * review before the user turns them on).
+ *
+ * A template's `build()` may return ONE automation or an ARRAY — the latter
+ * is the Phase 4 "bridge" shape (a template that installs a matched pair,
+ * e.g. a MeshCore + Meshtastic half of the same behavior). Installs are
+ * sequential and NOT transactional: if automation N fails to import, N-1
+ * already exist in the database and are not rolled back. The wizard surfaces
+ * per-automation success/failure so the user knows exactly what landed.
+ */
+import { useEffect, useState } from 'react';
+import apiService from '../../services/api';
+import { FieldInput, type SourceOption, type UnifiedChannelOption } from './AutomationBuilder';
+import { fieldVisible } from './catalog';
+import { UiIcon, UI_ICON_DEFINITIONS, type UiIconName } from '../icons';
+import { validateAutomationGraph } from '../../types/automation';
+import { TEMPLATES } from './templates';
+import type { AutomationTemplate, BuiltAutomation } from './templates/types';
+import styles from './TemplateGallery.module.css';
+
+/** Minimal shape of a created automation row, as returned by POST /api/automations/import. */
+export interface InstalledAutomationRow {
+  id: string;
+  name: string;
+  description: string | null;
+  enabled: boolean;
+  config: string;
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+export interface TemplateGalleryProps {
+  onClose: () => void;
+  onInstalled: (createdRows: InstalledAutomationRow[]) => void;
+  /** Defaults to the real registry; overridable so tests can inject a fake template. */
+  templates?: AutomationTemplate[];
+}
+
+type SourcesResponse = Array<{
+  id: string;
+  name: string;
+  type?: string;
+  enabled?: boolean;
+  radio?: { txEnabled?: boolean; canTransmit?: boolean };
+}>;
+
+type InstallOutcome =
+  | { status: 'success'; name: string; row: InstalledAutomationRow }
+  | { status: 'error'; name: string; error: string };
+
+/** Icon name is data (WP2's catalog), not a literal — fall back rather than crash on a typo. */
+function TemplateIcon({ name, size = 28 }: { name: string; size?: number }) {
+  const resolved = (name in UI_ICON_DEFINITIONS ? name : 'bot') as UiIconName;
+  return <UiIcon name={resolved} size={size} />;
+}
+
+/** Seed the editable name/description from a first build() pass. Templates that need
+ * required params may throw on an empty `{}` — that's fine, we just fall back. */
+function seedFromBuild(template: AutomationTemplate): BuiltAutomation | null {
+  try {
+    const built = template.build({});
+    const first = Array.isArray(built) ? built[0] : built;
+    return first ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default function TemplateGallery({ onClose, onInstalled, templates = TEMPLATES }: TemplateGalleryProps) {
+  const [sources, setSources] = useState<SourceOption[]>([]);
+  const [channels, setChannels] = useState<UnifiedChannelOption[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<AutomationTemplate | null>(null);
+
+  // Mirrors AutomationEditor's picker-data load (AutomationsPage.tsx): plain
+  // GETs via apiService, independent try/catch per call so one endpoint
+  // failing doesn't blank the other's data.
+  useEffect(() => {
+    Promise.all([
+      apiService.get<SourcesResponse>('/api/sources'),
+      apiService.get<UnifiedChannelOption[]>('/api/automations/channels'),
+    ])
+      .then(([ss, cs]) => {
+        setSources((ss ?? []).map((s) => ({
+          id: s.id,
+          name: s.name,
+          type: s.type,
+          enabled: s.enabled,
+          txEnabled: s.radio?.txEnabled,
+          canTransmit: s.radio?.canTransmit,
+        })));
+        setChannels(cs ?? []);
+        setLoadError(null);
+      })
+      .catch((e: unknown) => {
+        setLoadError(e instanceof Error ? e.message : 'Failed to load sources/channels');
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (selected) {
+    return (
+      <TemplateWizard
+        template={selected}
+        sources={sources}
+        channels={channels}
+        onBack={() => setSelected(null)}
+        onClose={onClose}
+        onInstalled={onInstalled}
+      />
+    );
+  }
+
+  return (
+    <div className={styles.gallery}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>Template Gallery</h2>
+        <button className="ae-btn ae-btn--ghost" onClick={onClose}>
+          <UiIcon name="back" size={15} /> Close
+        </button>
+      </div>
+      {loading && <div className="ae-muted">Loading…</div>}
+      {loadError && <div className="ae-error-list">{loadError}</div>}
+      {!loading && templates.length === 0 && (
+        <div className="ae-empty">No templates available yet.</div>
+      )}
+      <div className={styles.grid}>
+        {templates.map((t) => (
+          <div className={`ae-card ${styles.card}`} key={t.id}>
+            <div className={styles.cardHeader}>
+              <TemplateIcon name={t.icon} />
+              <div className={styles.cardName}>{t.name}</div>
+            </div>
+            <p className={styles.cardDescription}>{t.description}</p>
+            <div className={styles.tags}>
+              {t.tags.map((tag) => (
+                <span className="ae-chip" key={tag}>{tag}</span>
+              ))}
+            </div>
+            <button className="ae-btn ae-btn--primary" onClick={() => setSelected(t)}>
+              Use template
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TemplateWizard({ template, sources, channels, onBack, onClose, onInstalled }: {
+  template: AutomationTemplate;
+  sources: SourceOption[];
+  channels: UnifiedChannelOption[];
+  onBack: () => void;
+  onClose: () => void;
+  onInstalled: (rows: InstalledAutomationRow[]) => void;
+}) {
+  const [values, setValues] = useState<Record<string, unknown>>({});
+  const [name, setName] = useState(() => seedFromBuild(template)?.name ?? template.name);
+  const [description, setDescription] = useState(() => seedFromBuild(template)?.description ?? template.description);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [installing, setInstalling] = useState(false);
+  const [outcomes, setOutcomes] = useState<InstallOutcome[] | null>(null);
+
+  const setParam = (fieldName: string, v: unknown) =>
+    setValues((prev) => ({ ...prev, [fieldName]: v }));
+
+  const install = async () => {
+    setErrors([]);
+    setOutcomes(null);
+
+    let built: BuiltAutomation | BuiltAutomation[];
+    try {
+      built = template.build(values);
+    } catch (e) {
+      setErrors([e instanceof Error ? e.message : 'Failed to build this template from the entered values.']);
+      return;
+    }
+    const list = Array.isArray(built) ? built.slice() : [built];
+    if (list.length === 0) {
+      setErrors(['This template produced no automations to install.']);
+      return;
+    }
+    // The wizard's editable Name/Description apply to the first automation only —
+    // a multi-automation (bridge) template's remaining rows keep their own
+    // build()-derived identity.
+    list[0] = { ...list[0], name, description };
+
+    const validationErrors: string[] = [];
+    for (const a of list) {
+      const v = validateAutomationGraph(a.config);
+      if (!v.valid) validationErrors.push(`"${a.name}": ${v.errors.join('; ')}`);
+    }
+    if (validationErrors.length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setInstalling(true);
+    const results: InstallOutcome[] = [];
+    // Sequential, not Promise.all — a later automation may depend on an earlier
+    // one existing (Phase 4 bridge pairs), and sequential installs make the
+    // partial-failure story ("which ones landed") deterministic to report.
+    for (const a of list) {
+      try {
+        const row = await apiService.post<InstalledAutomationRow>('/api/automations/import', {
+          name: a.name,
+          description: a.description,
+          config: a.config,
+        });
+        results.push({ status: 'success', name: a.name, row });
+      } catch (e) {
+        results.push({ status: 'error', name: a.name, error: e instanceof Error ? e.message : 'Install failed' });
+      }
+    }
+    setInstalling(false);
+    setOutcomes(results);
+
+    const failed = results.filter((r) => r.status === 'error');
+    if (failed.length === 0) {
+      onInstalled(results.map((r) => (r as { status: 'success'; row: InstalledAutomationRow }).row));
+    }
+    // On partial failure we deliberately do NOT roll back the ones that
+    // succeeded — they already exist (disabled) in the database. `outcomes`
+    // below reports exactly which name(s) installed and which failed, and
+    // `onInstalled` is withheld so the caller doesn't treat this as "done".
+  };
+
+  return (
+    <div className={styles.wizard}>
+      <div className={styles.header}>
+        <button className="ae-btn ae-btn--ghost" onClick={onBack}>
+          <UiIcon name="back" size={15} /> Back
+        </button>
+        <h2 className={styles.title}>
+          <TemplateIcon name={template.icon} size={20} /> {template.name}
+        </h2>
+      </div>
+      <p className={styles.cardDescription}>{template.description}</p>
+
+      <div className="ae-field">
+        <label className="ae-field-label">Name</label>
+        <input className="ae-input" value={name} onChange={(e) => setName(e.target.value)} />
+      </div>
+      <div className="ae-field">
+        <label className="ae-field-label">Description</label>
+        <textarea className="ae-textarea" value={description} onChange={(e) => setDescription(e.target.value)} />
+      </div>
+
+      {template.params.filter((p) => fieldVisible(p, values)).map((p) => (
+        <FieldInput
+          key={p.name}
+          field={p}
+          value={values[p.name]}
+          variables={[]}
+          sources={sources}
+          channels={channels}
+          scripts={[]}
+          regions={[]}
+          nodes={[]}
+          triggerType="trigger.message"
+          onChange={(v) => setParam(p.name, v)}
+        />
+      ))}
+
+      {errors.length > 0 && (
+        <ul className="ae-error-list">
+          {errors.map((e) => <li key={e}>{e}</li>)}
+        </ul>
+      )}
+
+      {outcomes && (
+        <div className={styles.outcomes}>
+          {outcomes.map((o) => (
+            <div
+              key={o.name}
+              className={o.status === 'success' ? styles.outcomeOk : styles.outcomeFail}
+            >
+              {o.status === 'success'
+                ? `Installed "${o.name}" (disabled — enable it from the automations list).`
+                : `Failed to install "${o.name}": ${o.error}`}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="ae-btn-row">
+        <button className="ae-btn ae-btn--primary" disabled={installing} onClick={() => void install()}>
+          {installing ? 'Installing…' : 'Install'}
+        </button>
+        <button className="ae-btn" onClick={onClose}>Cancel</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/automations/templates/autoAck.test.ts
+++ b/src/components/automations/templates/autoAck.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { autoAckTemplate } from './autoAck';
+import { validateAutomationGraph, type AutomationGraph } from '../../../types/automation';
+import type { BuiltAutomation } from './types';
+
+function buildOne(values: Record<string, unknown>): BuiltAutomation {
+  const built = autoAckTemplate.build(values);
+  const arr = Array.isArray(built) ? built : [built];
+  expect(arr).toHaveLength(1); // Auto-Ack never produces a pair (unlike a bridge template)
+  return arr[0];
+}
+
+function node(config: AutomationGraph, id: string) {
+  const n = config.nodes.find((x) => x.id === id);
+  expect(n, `node "${id}" not found in ${JSON.stringify(config.nodes)}`).toBeDefined();
+  return n!;
+}
+
+describe('autoAckTemplate', () => {
+  it('has the expected template metadata', () => {
+    expect(autoAckTemplate.id).toBe('auto-ack');
+    expect(autoAckTemplate.tags).toEqual(['Acknowledgement', 'Reply']);
+    expect(autoAckTemplate.params.map((p) => p.name)).toEqual(['sourceIds', 'channelFilter', 'ackStyle']);
+    // AutomationBuilder.tsx's defaultParams() seeds a select from options[0] —
+    // 'hop' must stay first so an un-configured template defaults sanely.
+    const ackStyleField = autoAckTemplate.params.find((p) => p.name === 'ackStyle')!;
+    expect(ackStyleField.options?.[0]?.value).toBe('hop');
+  });
+
+  it('defaults to ackStyle=hop with no source/channel filter', () => {
+    const { config } = buildOne({});
+    expect(config.nodes.map((n) => n.type)).toEqual(['trigger.message', 'condition.numeric', 'action.tapback']);
+    expect(node(config, 't').params).toEqual({ rateLimit: { maxActions: 30, windowSeconds: 60 } });
+    expect(node(config, 'c0').params).toEqual({ field: 'zeroHop', op: '==', value: '1' });
+    expect(node(config, 'a0').params).toEqual({ emojiMode: 'hopCount' });
+    expect(config.edges).toEqual([{ from: 't', to: 'c0' }, { from: 'c0', to: 'a0' }]);
+  });
+
+  it('ackStyle=fixed emits action.tapback with no explicit emoji (executor defaults to 👍)', () => {
+    const { config } = buildOne({ ackStyle: 'fixed' });
+    // No `emoji` key: actionExecutor.ts's action.tapback case already falls back
+    // to 👍 when it's absent (`String(p.emoji ?? '👍')`) — duplicating the glyph
+    // here would just be a second place for it to drift out of sync.
+    expect(node(config, 'a0')).toEqual({ id: 'a0', type: 'action.tapback', params: { emojiMode: 'fixed' } });
+  });
+
+  it('ackStyle=text emits action.sendMessage with a hopEmoji reply, threaded via replyToTrigger', () => {
+    const { config } = buildOne({ ackStyle: 'text' });
+    expect(node(config, 'a0')).toEqual({
+      id: 'a0',
+      type: 'action.sendMessage',
+      params: { text: 'Received ({{ trigger.hopEmoji }})', replyToTrigger: true },
+    });
+  });
+
+  it('an unrecognised ackStyle value falls back to hop (same as blank)', () => {
+    const { config } = buildOne({ ackStyle: 'bogus' });
+    expect(node(config, 'a0').params).toEqual({ emojiMode: 'hopCount' });
+  });
+
+  it('omits condition.sourceFilter when sourceIds is blank', () => {
+    const { config } = buildOne({});
+    expect(config.nodes.some((n) => n.type === 'condition.sourceFilter')).toBe(false);
+  });
+
+  it('inserts condition.sourceFilter between the trigger and the zeroHop check when sourceIds is set, threading the ids', () => {
+    const { config } = buildOne({ sourceIds: ['source-a', 'source-b'] });
+    expect(config.nodes.map((n) => n.type)).toEqual([
+      'trigger.message', 'condition.sourceFilter', 'condition.numeric', 'action.tapback',
+    ]);
+    expect(node(config, 'c0')).toEqual({
+      id: 'c0', type: 'condition.sourceFilter', params: { sourceIds: ['source-a', 'source-b'] },
+    });
+    expect(node(config, 'c1').params).toEqual({ field: 'zeroHop', op: '==', value: '1' });
+    expect(config.edges).toEqual([
+      { from: 't', to: 'c0' }, { from: 'c0', to: 'c1' }, { from: 'c1', to: 'a0' },
+    ]);
+  });
+
+  it('ignores a non-string/blank entries in sourceIds and still omits sourceFilter for an all-blank list', () => {
+    const { config } = buildOne({ sourceIds: ['', null, undefined, 42] });
+    expect(config.nodes.some((n) => n.type === 'condition.sourceFilter')).toBe(false);
+  });
+
+  it('omits the trigger channels param when channelFilter is blank', () => {
+    const { config } = buildOne({});
+    expect(node(config, 't').params).not.toHaveProperty('channels');
+  });
+
+  it('adds channels to the trigger only when channelFilter is set, leaving the condition chain untouched', () => {
+    const { config } = buildOne({ channelFilter: [{ name: 'general' }, { name: 'gauntlet', protocol: 'meshcore' }] });
+    expect(node(config, 't').params).toEqual({
+      rateLimit: { maxActions: 30, windowSeconds: 60 },
+      channels: [{ name: 'general' }, { name: 'gauntlet', protocol: 'meshcore' }],
+    });
+    // No sourceFilter inserted just because a channel filter was set.
+    expect(config.nodes.some((n) => n.type === 'condition.sourceFilter')).toBe(false);
+  });
+
+  it('combines a source filter, a channel filter, and a text ack together', () => {
+    const { config } = buildOne({
+      sourceIds: ['source-a'],
+      channelFilter: [{ name: 'general' }],
+      ackStyle: 'text',
+    });
+    expect(config.nodes.map((n) => n.type)).toEqual([
+      'trigger.message', 'condition.sourceFilter', 'condition.numeric', 'action.sendMessage',
+    ]);
+    expect(node(config, 't').params.channels).toEqual([{ name: 'general' }]);
+    expect(node(config, 'c0').params).toEqual({ sourceIds: ['source-a'] });
+    expect(node(config, 'a0').type).toBe('action.sendMessage');
+  });
+
+  it('never emits a portnum trigger param (would silently make the rule Meshtastic-only)', () => {
+    const { config } = buildOne({});
+    expect(node(config, 't').params).not.toHaveProperty('portnum');
+  });
+
+  it('always sets the default flood-guard rateLimit on the trigger', () => {
+    for (const values of [{}, { sourceIds: ['s1'] }, { ackStyle: 'text' as const }]) {
+      const { config } = buildOne(values);
+      expect(node(config, 't').params.rateLimit).toEqual({ maxActions: 30, windowSeconds: 60 });
+    }
+  });
+
+  it('every edge leaving a condition node is an implicit-true gate (no `port` field) — compile()\'s minimal linear chain never emits ports; graphEvaluator.ts treats an unported edge from a condition identically to an explicit port:\'true\' gate', () => {
+    for (const values of [{}, { sourceIds: ['s1'] }, { channelFilter: [{ name: 'general' }] }, { sourceIds: ['s1'], channelFilter: [{ name: 'general' }], ackStyle: 'text' as const }]) {
+      const { config } = buildOne(values);
+      for (const edge of config.edges) {
+        expect(edge).not.toHaveProperty('port');
+      }
+    }
+  });
+
+  it('always validates', () => {
+    for (const values of [
+      {},
+      { ackStyle: 'hop' },
+      { ackStyle: 'fixed' },
+      { ackStyle: 'text' },
+      { sourceIds: ['source-a'] },
+      { channelFilter: [{ name: 'general' }] },
+      { sourceIds: ['source-a'], channelFilter: [{ name: 'general' }], ackStyle: 'text' as const },
+    ]) {
+      const { config } = buildOne(values);
+      const result = validateAutomationGraph(config);
+      expect(result.valid, JSON.stringify(result.errors)).toBe(true);
+    }
+  });
+});

--- a/src/components/automations/templates/autoAck.ts
+++ b/src/components/automations/templates/autoAck.ts
@@ -1,0 +1,130 @@
+/**
+ * Auto-Ack template (Automation Template Gallery, Phase 3 WP2).
+ *
+ * Reproduces the common "acknowledge direct, zero-hop text messages" pattern
+ * as an installable automation: WHEN a text message arrives, IF it was heard
+ * direct (0 hops, over RF — {@link https://…|`zeroHop`} is the same derived,
+ * total field Auto-Acknowledge's own converter uses, see
+ * `src/server/services/automation/autoAckConverter.ts`), THEN react/reply.
+ *
+ * Graph shape is built via the shared `compile()` (`../compile.ts`) rather
+ * than hand-assembled nodes/edges — `compile()` is the project's only graph
+ * emitter (see `autoAckConverter.ts`'s header comment) and its plain
+ * AND-chain output carries no `port` fields, which keeps the installed
+ * automation `decompile()`-able back into the friendly builder UI. An
+ * unported edge leaving a condition node behaves as an implicit "true" gate
+ * (`graphEvaluator.ts`'s `portSatisfied`), so this is also behaviourally
+ * identical to an explicit `port: 'true'` edge — just editable afterwards.
+ */
+import { compile, type WorkflowForm, type FormBlock } from '../compile';
+import type { AutomationTemplate, BuiltAutomation, ParamSpec } from './types';
+
+type AckStyle = 'hop' | 'fixed' | 'text';
+
+function normalizeAckStyle(v: unknown): AckStyle {
+  return v === 'fixed' || v === 'text' ? v : 'hop';
+}
+
+/** `sourceMulti`/`sendSourceMulti` fields store a plain array of source ids. */
+function asSourceIds(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === 'string' && x.length > 0);
+}
+
+/** `channelMulti` fields store `{ name, protocol? }` objects (AutomationBuilder.tsx). */
+function asChannelSelection(v: unknown): Array<{ name: string; protocol?: string }> {
+  if (!Array.isArray(v)) return [];
+  return v.filter((c): c is { name: string; protocol?: string } =>
+    !!c && typeof c === 'object' && typeof (c as Record<string, unknown>).name === 'string');
+}
+
+const PARAMS: ParamSpec[] = [
+  {
+    name: 'sourceIds', label: 'Only acknowledge messages from these sources', kind: 'sourceMulti',
+    help: 'Leave none selected to acknowledge messages from any source.',
+  },
+  {
+    name: 'channelFilter', label: 'Only on these channels', kind: 'channelMulti',
+    help: 'Leave none selected to acknowledge on any channel (DMs are always included).',
+  },
+  {
+    // 'hop' MUST stay first — AutomationBuilder.tsx's defaultParams() seeds a
+    // select field from options[0] when a template's chosen values are absent.
+    name: 'ackStyle', label: 'Acknowledgement style', kind: 'select',
+    options: [
+      { value: 'hop', label: 'Tapback: hop-count emoji' },
+      { value: 'fixed', label: 'Tapback: thumbs up' },
+      { value: 'text', label: 'Reply message' },
+    ],
+    help: 'The hop-count and thumbs-up tapbacks react to the triggering message (Meshtastic only — MeshCore has no tapback). '
+      + 'Reply message sends a short reply and works on both protocols.',
+  },
+];
+
+function buildAckAction(ackStyle: AckStyle): FormBlock {
+  // 'emoji' is deliberately OMITTED for the 'fixed' style rather than hardcoded
+  // here as a literal: actionExecutor.ts's action.tapback case already applies
+  // the exact same thumbs-up fallback (`String(p.emoji ?? '👍')`) when the param
+  // is absent, so leaving it unset reuses that single source of truth instead of
+  // duplicating the glyph. (It also keeps this file free of a raw content-emoji
+  // literal, which meshmonitor-ui/no-hardcoded-ui-glyph would otherwise flag —
+  // correctly, since that rule can't distinguish "duplicated app default" from
+  // "hardcoded UI icon" by looking at the literal alone.)
+  if (ackStyle === 'fixed') return { type: 'action.tapback', params: { emojiMode: 'fixed' } };
+  if (ackStyle === 'text') {
+    // No literal emoji in the template text either — {{ trigger.hopEmoji }} is
+    // a plain-ASCII token that renders the protocol glyph at send time.
+    return { type: 'action.sendMessage', params: { text: 'Received ({{ trigger.hopEmoji }})', replyToTrigger: true } };
+  }
+  return { type: 'action.tapback', params: { emojiMode: 'hopCount' } };
+}
+
+function build(values: Record<string, unknown>): BuiltAutomation {
+  const sourceIds = asSourceIds(values.sourceIds);
+  const channelFilter = asChannelSelection(values.channelFilter);
+  const ackStyle = normalizeAckStyle(values.ackStyle);
+
+  // portnum is deliberately OMITTED: trigger.message has no portnum field in
+  // the catalog, and messageMatchesFilter/meshCoreMessageMatchesFilter treat
+  // ANY portnum param as Meshtastic-only — meshCoreMessageMatchesFilter (and
+  // describeMeshCoreFilterMiss) force a non-match whenever params.portnum is
+  // set at all (triggerContext.ts). Setting it would silently make this
+  // cross-protocol template Meshtastic-only.
+  const triggerParams: Record<string, unknown> = {
+    // Flood guard: caps this automation at 30 fires/minute regardless of subject —
+    // see RATE_LIMIT_MAX_ACTIONS_MIN/MAX in src/types/automation.ts.
+    rateLimit: { maxActions: 30, windowSeconds: 60 },
+  };
+  if (channelFilter.length > 0) triggerParams.channels = channelFilter;
+
+  const conditions: FormBlock[] = [];
+  // Mirrors autoAckConverter.ts's own S1 ordering (source filter first).
+  if (sourceIds.length > 0) conditions.push({ type: 'condition.sourceFilter', params: { sourceIds } });
+  // zeroHop (#4340 Phase 4): the derived, TOTAL (never NaN) "direct RF, 0 hops"
+  // field — 1 when the message arrived direct over RF, 0 when relayed or via
+  // MQTT. Verified present in EVENT_NUMERIC['trigger.message'] (catalog.ts)
+  // and computed in buildMessageContext (triggerContext.ts).
+  conditions.push({ type: 'condition.numeric', params: { field: 'zeroHop', op: '==', value: '1' } });
+
+  const form: WorkflowForm = {
+    trigger: { type: 'trigger.message', params: triggerParams },
+    rules: [{ conditions, actions: [buildAckAction(ackStyle)] }],
+    combine: null,
+  };
+
+  return {
+    name: 'Auto-Ack',
+    description: 'Automatically acknowledges direct (zero-hop) text messages with a tapback or a short reply.',
+    config: compile(form),
+  };
+}
+
+export const autoAckTemplate: AutomationTemplate = {
+  id: 'auto-ack',
+  name: 'Auto-Ack',
+  description: 'Acknowledge direct, zero-hop text messages with a tapback (hop-count emoji or a fixed emoji) or a short reply — a lightweight range-test responder.',
+  icon: 'check',
+  tags: ['Acknowledgement', 'Reply'],
+  params: PARAMS,
+  build,
+};

--- a/src/components/automations/templates/catalog.integrity.test.ts
+++ b/src/components/automations/templates/catalog.integrity.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Cross-template hard guarantee (Automation Template Gallery, Phase 3): every
+ * template in TEMPLATES must produce a `validateAutomationGraph`-valid graph
+ * for EVERY reachable combination of its own param values — not just the
+ * defaults. Generic over `AutomationTemplate.params` (declarative FieldDef[])
+ * so a future template is covered automatically without editing this file.
+ */
+import { describe, it, expect } from 'vitest';
+import { TEMPLATES } from './index';
+import { validateAutomationGraph } from '../../../types/automation';
+import type { BuiltAutomation } from './types';
+import type { FieldDef } from '../catalog';
+
+// A representative value per FieldKind — the shapes AutomationBuilder.tsx's
+// FieldInput actually stores (see AutomationBuilder.tsx's onChange calls per
+// `case` in the field-kind switch). Each list always includes the "blank"
+// value first so "nothing configured" is always part of the matrix.
+const SAMPLE_SOURCE_IDS: unknown[] = [[], ['source-a'], ['source-a', 'source-b']];
+const SAMPLE_CHANNEL_SELECTIONS: unknown[] = [
+  [],
+  [{ name: 'general' }],
+  [{ name: 'gauntlet', protocol: 'meshtastic' }, { name: 'gauntlet', protocol: 'meshcore' }],
+];
+const SAMPLE_NODE_MULTI: unknown[] = [[], [1234567890]];
+const SAMPLE_TEXT: unknown[] = ['', 'sample'];
+const SAMPLE_NUMBER: unknown[] = ['', '5'];
+const SAMPLE_CHECKBOX: unknown[] = [false, true];
+
+function candidatesFor(field: FieldDef): unknown[] {
+  switch (field.kind) {
+    case 'select':
+    case 'fieldselect':
+      // Every declared option, so each branch a template keys off of is exercised.
+      return (field.options ?? field.groups?.flatMap((g) => g.options) ?? ['']).map((o) => o.value);
+    case 'checkbox':
+      return SAMPLE_CHECKBOX;
+    case 'sourceMulti':
+    case 'sendSourceMulti':
+      return SAMPLE_SOURCE_IDS;
+    case 'channelMulti':
+      return SAMPLE_CHANNEL_SELECTIONS;
+    case 'nodeMulti':
+      return SAMPLE_NODE_MULTI;
+    case 'number':
+      return SAMPLE_NUMBER;
+    // text / textarea / variable / emoji / geofence / scriptselect / regionSelect:
+    // free-form strings are the common denominator every one of these can accept.
+    default:
+      return SAMPLE_TEXT;
+  }
+}
+
+/**
+ * Cartesian product of every param's candidate values, one settings object per
+ * row. Capped so a future template with many multi-valued fields can't make
+ * the suite explode — still thorough for the handful of params any one
+ * template declares today.
+ */
+function paramMatrix(params: FieldDef[], cap = 500): Array<Record<string, unknown>> {
+  let rows: Array<Record<string, unknown>> = [{}];
+  for (const field of params) {
+    const values = candidatesFor(field);
+    const next: Array<Record<string, unknown>> = [];
+    outer: for (const row of rows) {
+      for (const v of values) {
+        next.push({ ...row, [field.name]: v });
+        if (next.length >= cap) break outer;
+      }
+    }
+    rows = next;
+  }
+  return rows;
+}
+
+function toArray(built: BuiltAutomation | BuiltAutomation[]): BuiltAutomation[] {
+  return Array.isArray(built) ? built : [built];
+}
+
+describe('template catalog integrity', () => {
+  it('TEMPLATES is non-empty', () => {
+    expect(TEMPLATES.length).toBeGreaterThan(0);
+  });
+
+  for (const template of TEMPLATES) {
+    describe(`template "${template.id}"`, () => {
+      it('has well-formed metadata', () => {
+        expect(template.id).toBeTruthy();
+        expect(template.name).toBeTruthy();
+        expect(template.description).toBeTruthy();
+        expect(template.icon).toBeTruthy();
+        expect(Array.isArray(template.tags)).toBe(true);
+        expect(Array.isArray(template.params)).toBe(true);
+      });
+
+      const matrix = paramMatrix(template.params);
+
+      it('the param permutation matrix is non-empty', () => {
+        expect(matrix.length).toBeGreaterThan(0);
+      });
+
+      matrix.forEach((values, i) => {
+        it(`build() output validates for permutation #${i} (${JSON.stringify(values)})`, () => {
+          const built = toArray(template.build(values));
+          expect(built.length).toBeGreaterThan(0);
+          for (const automation of built) {
+            expect(automation.name, 'BuiltAutomation.name must be non-empty').toBeTruthy();
+            expect(automation.description, 'BuiltAutomation.description must be non-empty').toBeTruthy();
+            const result = validateAutomationGraph(automation.config);
+            expect(result.valid, `values=${JSON.stringify(values)} errors=${JSON.stringify(result.errors)}`).toBe(true);
+          }
+        });
+      });
+    });
+  }
+});

--- a/src/components/automations/templates/index.ts
+++ b/src/components/automations/templates/index.ts
@@ -1,4 +1,5 @@
 import type { AutomationTemplate } from './types';
+import { autoAckTemplate } from './autoAck';
 
 /** Registry of installable automation templates. Populated per template file. */
-export const TEMPLATES: AutomationTemplate[] = [];
+export const TEMPLATES: AutomationTemplate[] = [autoAckTemplate];

--- a/src/components/automations/templates/index.ts
+++ b/src/components/automations/templates/index.ts
@@ -1,0 +1,4 @@
+import type { AutomationTemplate } from './types';
+
+/** Registry of installable automation templates. Populated per template file. */
+export const TEMPLATES: AutomationTemplate[] = [];

--- a/src/components/automations/templates/types.ts
+++ b/src/components/automations/templates/types.ts
@@ -1,0 +1,22 @@
+import type { FieldDef } from '../catalog';
+import type { AutomationGraph } from '../../../types/automation';
+
+/** A template parameter reuses the automation builder's field model. */
+export type ParamSpec = FieldDef;
+
+export interface BuiltAutomation {
+  name: string;
+  description: string;
+  config: AutomationGraph;
+}
+
+export interface AutomationTemplate {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;            // UiIcon name
+  tags: string[];
+  params: ParamSpec[];
+  /** May return ONE automation or an ARRAY (a bridge template produces a pair). */
+  build(values: Record<string, unknown>): BuiltAutomation | BuiltAutomation[];
+}


### PR DESCRIPTION
## Summary

Phase 3 of the **Meshtastic ↔ MeshCore automation-bridge epic** (#4577). Adds an in-app **Automation Template Gallery** — a click-to-install catalog of ready-made automations — seeded with an **Auto-Ack** template to prove the mechanism end-to-end. This is the surface Phase 4's MT↔MC Bridge template plugs into.

## What's new

- **Template catalog mechanism** (`src/components/automations/templates/`): `AutomationTemplate` descriptors with `build(values) → BuiltAutomation | BuiltAutomation[]`. The **array form is the Phase 4 hook** — a bridge template returns a *pair* of automations; the install loop already iterates.
- **`TemplateGallery.tsx`** — card grid + parameter wizard. The wizard reuses the existing `FieldInput` (now exported from `AutomationBuilder.tsx`) so template params render with the real source/channel pickers. Installs each built automation via `POST /api/automations/import`, which lands them **disabled for review**. Per-automation partial-failure reporting (Phase-4-ready).
- **"Browse templates"** button wired into `AutomationsPage`; on install the new disabled automation opens in the editor.
- **Auto-Ack template** — acknowledges direct (0-hop) text messages with a hop-count/fixed tapback or a short reply. Restricted to `zeroHop==1` (direct RF only — never amplifies relayed/MQTT traffic) with a default rate limit (Phase 2).

## Key implementation decision

Auto-Ack builds its graph via the project's `compile()` emitter rather than hand-rolling `port:'true'` edges, so the installed automation **round-trips through `decompile()` and stays editable in the visual builder**. `graphEvaluator.portSatisfied` treats an unported condition-outgoing edge as the `true` branch (verified in `graphEvaluator.ts`), so the ack fires **only** on the true path — no flood risk.

## Verification

- `npm run typecheck` — clean
- vitest (automations + types + server/automation), JSON reporter — **`success: true`, 741 passed, 0 failed, 0 failed suites**
- `npm run lint:ci` — clean
- Catalog-integrity test asserts every template's `build()` output passes `validateAutomationGraph` across a param permutation matrix
- **Browser-validated** on a live dev instance: gallery card → wizard (real source/channel pickers with MT/MC protocol badges) → Install → disabled automation appears and decompiles into the visual builder; zero console errors; test automation cleaned up afterward.

Frontend-only (no new route, no DB/schema). Reuses `ApiService` (no raw fetch), CSS modules, `UiIcon`, `validateAutomationGraph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)