### PR TITLE
fix(map): render one card shell for node popups (#4677)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- **Map node popups render one card, not a card inside a card** — Leaflet's popup wrapper and the app's own node card both drew a background, border, radius and shadow, so a popup showed a double border with an uneven inset. The wrapper is now the only shell. Long popups also scroll their body under a pinned header instead of clipping the card, and are capped by the viewport on phones. (#4677)
+
 ## [4.14.1-rc3] - 2026-08-10
 
 ### Added

--- a/src/styles/mapPopupChrome.test.ts
+++ b/src/styles/mapPopupChrome.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression tests for the map popup's duplicate card chrome (#4677).
+ *
+ * A map node popup is two nested boxes: Leaflet's `.leaflet-popup-content-wrapper`
+ * and, inside it, the app's `.node-popup` (rendered by `NodeCard` for every map
+ * surface). Both used to paint a full card — background + border + radius +
+ * shadow — so the popup showed a visible card-inside-a-card: double border,
+ * double corner radius, uneven inset.
+ *
+ * The wrapper is the single card shell; `.node-popup` keeps its own chrome
+ * (TracerouteStrip's portalled hover popup and DashboardNeighborPopup render it
+ * with no shell of their own) but drops it when nested inside a Leaflet popup.
+ *
+ * jsdom does no layout and no cascade, so these read the stylesheet source, in
+ * the same style as the other stylesheet assertions under src/ (see
+ * bottomBarClearance.test.ts and NodesTab.test.tsx).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const nodesCss = readFileSync(resolve('src/styles/nodes.css'), 'utf-8');
+
+/** Body of a rule, searched by exact selector text at any indent. */
+function ruleBody(css: string, selector: string): string | null {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = css.match(new RegExp(escaped + '\\s*\\{([^}]*)\\}'));
+  return m ? m[1] : null;
+}
+
+describe('map popup card chrome (#4677)', () => {
+  it('strips the inner card chrome from a .node-popup nested in a Leaflet popup', () => {
+    const body = ruleBody(nodesCss, '.leaflet-popup-content .node-popup');
+    expect(body).not.toBeNull();
+
+    // Each of these is also declared by .leaflet-popup-content-wrapper; leaving
+    // any one of them on the inner card is what draws the second card.
+    expect(body).toMatch(/(?:^|;)\s*background:\s*none/);
+    expect(body).toMatch(/(?:^|;)\s*border:\s*none/);
+    expect(body).toMatch(/(?:^|;)\s*border-radius:\s*0/);
+    expect(body).toMatch(/(?:^|;)\s*box-shadow:\s*none/);
+  });
+
+  it('keeps the standalone .node-popup chrome for consumers with no shell', () => {
+    // TracerouteStrip's `.hoverPopup` is a bare portalled div and
+    // DashboardNeighborPopup renders inline — both rely on this base rule, so
+    // the fix must stay scoped rather than stripping the base.
+    const body = ruleBody(nodesCss, '.node-popup');
+    expect(body).not.toBeNull();
+    expect(body).toMatch(/background:\s*var\(--color-surface\)/);
+    expect(body).toMatch(/border:\s*1px solid/);
+  });
+
+  it('hands the popup inset to the inner card so it is even on all sides', () => {
+    // Leaflet's defaults (wrapper padding 1px + content margin 13/24/13/20)
+    // stacked with .node-popup's own 12px padding for the uneven inset.
+    const wrapper = ruleBody(nodesCss, '.leaflet-popup-content-wrapper:has(.node-popup)');
+    expect(wrapper).toMatch(/padding:\s*0/);
+    expect(ruleBody(nodesCss, '.leaflet-popup-content:has(> .node-popup)')).toMatch(/margin:\s*0/);
+
+    // Zeroing the content margin removes the gap Leaflet's absolutely
+    // positioned close button used to sit in, so the header reserves it.
+    const header = nodesCss.match(
+      /\.leaflet-popup-content \.node-popup > \.node-popup-header,[^{]*\{([^}]*)\}/,
+    )?.[1];
+    expect(header).toMatch(/padding-right:\s*\d+px/);
+  });
+
+  it('clips the inner card to the wrapper radius', () => {
+    // Without this the inner card's square corners poke through the wrapper's
+    // rounded ones. The close button is a child of `.leaflet-popup`, not of the
+    // wrapper, so it is not clipped by this.
+    expect(ruleBody(nodesCss, '.leaflet-popup-content-wrapper:has(.node-popup)')).toMatch(
+      /overflow:\s*hidden/,
+    );
+  });
+
+  it('leaves popups that are not a .node-popup on Leaflet defaults', () => {
+    // `.route-popup` (NodesTab position segments / neighbor links) declares no
+    // padding of its own, so zeroing the content margin for every popup would
+    // push its text flush against the card edge. Every override is `:has()`-gated.
+    const base = ruleBody(nodesCss, '.leaflet-popup-content-wrapper');
+    expect(base).not.toMatch(/padding:/);
+    expect(base).not.toMatch(/overflow:/);
+    expect(ruleBody(nodesCss, '.route-popup')).not.toBeNull();
+  });
+});
+
+describe('map popup overflow (#4677)', () => {
+  it('scrolls the body rather than the whole card, keeping the header pinned', () => {
+    const card = ruleBody(nodesCss, '.leaflet-popup-content .node-popup:has(> .node-popup-content)');
+    expect(card).not.toBeNull();
+    expect(card).toMatch(/display:\s*flex/);
+    expect(card).toMatch(/flex-direction:\s*column/);
+
+    const content = ruleBody(nodesCss, '.leaflet-popup-content .node-popup > .node-popup-content');
+    expect(content).not.toBeNull();
+    expect(content).toMatch(/overflow-y:\s*auto/);
+    // Without min-height:0 the flex child refuses to shrink below its content
+    // height and nothing scrolls at all.
+    expect(content).toMatch(/min-height:\s*0/);
+  });
+
+  it('keeps a styled scrollbar on the element that actually scrolls', () => {
+    // The card-level `.node-popup::-webkit-scrollbar` rules no longer apply
+    // once the scroll box moves to the body. An explicit width is also what
+    // opts Chromium out of overlay scrollbars, so the thumb stays on screen.
+    const track = ruleBody(
+      nodesCss,
+      '.leaflet-popup-content .node-popup > .node-popup-content::-webkit-scrollbar',
+    );
+    expect(track).toMatch(/width:\s*6px/);
+    expect(
+      ruleBody(
+        nodesCss,
+        '.leaflet-popup-content .node-popup > .node-popup-content::-webkit-scrollbar-thumb',
+      ),
+    ).toMatch(/background:/);
+    expect(
+      ruleBody(nodesCss, '.leaflet-popup-content .node-popup > .node-popup-content'),
+    ).toMatch(/scrollbar-width:\s*thin/);
+  });
+
+  it('bounds a tall popup by the viewport and does not pan the map at the end of a scroll', () => {
+    const body = ruleBody(nodesCss, '.leaflet-popup-content .node-popup');
+    expect(body).toMatch(/max-height:\s*min\(400px,\s*60vh\)/);
+    expect(body).toMatch(/overscroll-behavior:\s*contain/);
+  });
+});

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1139,6 +1139,30 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
+/* A popup holding a `.node-popup` card (#4677). The wrapper is the ONE card
+   shell: the card inside drops its own background/border/radius/shadow (see
+   the scoped rule near "Node popup INSIDE a Leaflet popup" below), or the two
+   chromes stack into a visible card-inside-a-card.
+
+   `padding: 0` here + `margin: 0` on the content hand the inset to the card's
+   own padding, so it is even on all four sides instead of Leaflet's default
+   13/24/13/20 stacked with the card's 12px. `overflow: hidden` clips the card
+   to this radius — Leaflet's close button is a child of `.leaflet-popup`, not
+   of this wrapper, so it is not clipped by it.
+
+   Scoped with `:has()` rather than applied to every popup: `.route-popup`
+   (NodesTab position segments / neighbor links) has no padding of its own and
+   still needs Leaflet's content margin as its inset. */
+.leaflet-popup-content-wrapper:has(.node-popup) {
+  border: 1px solid var(--color-surface-active);
+  padding: 0;
+  overflow: hidden;
+}
+
+.leaflet-popup-content:has(> .node-popup) {
+  margin: 0;
+}
+
 .leaflet-popup-tip {
   background: var(--color-surface);
 }
@@ -1916,6 +1940,87 @@
 
 .node-popup::-webkit-scrollbar-thumb:hover {
   background: var(--color-surface-inactive);
+}
+
+/* Node popup INSIDE a Leaflet popup (#4677).
+
+   `.node-popup` carries its own card chrome because several consumers render
+   it with no shell of their own — TracerouteStrip's portalled `.hoverPopup`
+   is a bare positioned div, and DashboardNeighborPopup renders it inline.
+   Map-anchored cards are the opposite case: `.leaflet-popup-content-wrapper`
+   already IS the card, so here the inner chrome is stripped and only the
+   padding is kept as the (now even) inset.
+
+   Specificity 0,2,0 beats every unconditional `.node-popup` rule above AND
+   the mobile @media block, so this is order-independent — but it is still
+   declared last, per this file's cascade-order convention (#3532).
+
+   Scrolling: `min()` keeps a tall card off the phone viewport, and
+   `overscroll-behavior` stops a scroll that runs past the end of the list
+   from panning the map underneath. */
+.leaflet-popup-content .node-popup {
+  background: none;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  max-height: min(400px, 60vh);
+  overscroll-behavior: contain;
+}
+
+/* Move the scroll box from the whole card down to the body, so the header
+   (and tab bar) stay put instead of scrolling away — and so the scrolled
+   region reads as a bounded list rather than a card cut off at the bottom.
+   `:has()` guards the consumers that render `.node-popup` with no
+   `.node-popup-content` child (WaypointsLayer): those keep scrolling the
+   root, as before. `min-height: 0` is what lets the flex child actually
+   shrink below its content height. */
+.leaflet-popup-content .node-popup:has(> .node-popup-content) {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.leaflet-popup-content .node-popup > .node-popup-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+
+/* The `.node-popup::-webkit-scrollbar` block above styled the card, which is
+   no longer the scroll box inside a Leaflet popup — without these the body
+   would fall back to the platform scrollbar. Giving `::-webkit-scrollbar` an
+   explicit width is also what opts Chromium out of OVERLAY scrollbars, so the
+   thumb is on screen the whole time instead of fading in on touch. That fade
+   is why the reported screenshot's clipped last row looked like a layout bug
+   rather than a scroll region (#4677); platforms with overlay-only scrollbars
+   (iOS) still show nothing until the list is dragged. */
+.leaflet-popup-content .node-popup > .node-popup-content::-webkit-scrollbar {
+  width: 6px;
+}
+
+.leaflet-popup-content .node-popup > .node-popup-content::-webkit-scrollbar-track {
+  background: var(--color-surface);
+  border-radius: var(--radius-xs);
+}
+
+.leaflet-popup-content .node-popup > .node-popup-content::-webkit-scrollbar-thumb {
+  background: var(--color-surface-active);
+  border-radius: var(--radius-xs);
+}
+
+.leaflet-popup-content .node-popup > .node-popup-content::-webkit-scrollbar-thumb:hover {
+  background: var(--color-surface-inactive);
+}
+
+/* Leaflet's close button is absolutely positioned over the wrapper's
+   top-right corner. Zeroing `.leaflet-popup-content`'s margin removed the
+   gap it used to sit in, so the header row reserves it explicitly — the one
+   place the inset is deliberately uneven. */
+.leaflet-popup-content .node-popup > .node-popup-header,
+.leaflet-popup-content .node-popup > .popup-header {
+  padding-right: 18px;
 }
 
 .node-popup-header {


### PR DESCRIPTION
## Summary

Clicking a node marker opened a popup with a visible card inside a card: double border, double corner radius, uneven inset, and a bottom row that looked clipped rather than scrolled. Two elements were each painting a full card — Leaflet's `.leaflet-popup-content-wrapper` and the app's `.node-popup`, which `NodeCard` renders inside it for every map surface — and Leaflet's `13/24/13/20` content margin then stacked with the card's own `12px` padding.

Leaflet's wrapper is now the only shell. The card inside drops its chrome and supplies the (now even) inset from its own padding. While in there, the scroll box moved from the whole card down to the body, so a long popup scrolls under a pinned header instead of scrolling its own title away.

## Changes

- `.leaflet-popup-content-wrapper` takes the border and drops its padding, and clips the inner card to its radius; `.leaflet-popup-content` drops its margin. Leaflet's close button is a child of `.leaflet-popup`, not the wrapper, so it is not clipped.
- `.leaflet-popup-content .node-popup` drops `background` / `border` / `border-radius` / `box-shadow`. The base `.node-popup` chrome stays untouched — TracerouteStrip's portalled `.hoverPopup` and DashboardNeighborPopup render the card with no shell of their own and would otherwise become transparent.
- The header reserves `18px` on the right for the close button, which used to sit in the removed margin.
- Every wrapper override is `:has()`-gated: `.route-popup` (NodesTab position segments and neighbor links) declares no padding of its own and still needs Leaflet's content margin as its inset.
- Scroll box moved to `.node-popup-content` (`:has()`-guarded, since WaypointsLayer renders a `.node-popup` with no content child and keeps scrolling the root). Capped at `min(400px, 60vh)` so a tall card can't eat a phone viewport, with `overscroll-behavior: contain` so running off the end of the list no longer pans the map underneath.
- The `::-webkit-scrollbar` styling carries over to the new scroll box.

## Issues Resolved

Fixes #4677

## Documentation Updates

- `CHANGELOG.md` — entry under Unreleased → Fixed.
- No feature docs needed: `docs/features/maps.md` documents what a node popup *contains*, not its chrome.

## Testing

- [x] Unit tests pass (13,964 passed, 0 failed, `success: true`; the 763 skipped are the PostgreSQL/MySQL suites, irrelevant to a CSS change)
- [x] `npx tsc -p tsconfig.server.json --noEmit` clean
- [x] `npm run lint:ci` clean
- [x] New regression tests in `src/styles/mapPopupChrome.test.ts` (8), in the stylesheet-source style already used by `bottomBarClearance.test.ts` — jsdom does no layout or cascade
- [x] Driven in the dev container at 414×896 against real node popups: one chrome layer, header pinned, body scrolls through all five "SEEN BY N SOURCES" rows to the last one
- [x] A synthetic `.route-popup` still computes Leaflet's `1px` wrapper padding and `13px 24px 13px 20px` content margin, i.e. non-node popups are untouched

**Reviewer check:** open the map, click a node marker with several sources — expect a single border and even inset; scroll the body and confirm the title stays put.

**Note on the missing scrollbar** from the issue: the content *was* already scrollable. The browser uses overlay scrollbars, which stay invisible until touched, so a clipped last row read as a layout bug. Giving `::-webkit-scrollbar` an explicit width is also what opts Chromium out of overlay scrollbars, so desktop keeps a visible thumb; iOS will still show nothing until the list is dragged. The classic `local`/`scroll` scroll-shadow trick is not available here — `.node-popup-item` rows have an opaque background that paints over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G