### PR TITLE
feat(automations): scope MT↔MC Bridge wizard pickers to their own protocol (#4577)

### DIFF
--- a/src/components/automations/AutomationBuilder.protocolFilter.test.tsx
+++ b/src/components/automations/AutomationBuilder.protocolFilter.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * FieldInput — `protocolFilter` on source/channel pickers (#4577 follow-up).
+ * A `sourceMulti` / `sendSourceMulti` / `channelMulti` field with
+ * `protocolFilter: 'meshtastic' | 'meshcore'` must list ONLY that protocol's
+ * options. MeshCore is the explicit side (`type === 'meshcore'` /
+ * `protocol === 'meshcore'`); everything else — native Meshtastic AND MQTT
+ * bridge/broker sources — counts as Meshtastic. Used by the MT↔MC Bridge
+ * template so the "Meshtastic" pickers don't list MeshCore options and
+ * vice-versa. No filter set = every option shown (unchanged behavior).
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FieldInput, type SourceOption, type UnifiedChannelOption } from './AutomationBuilder';
+import type { FieldDef } from './catalog';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string | Record<string, unknown>) =>
+      typeof defaultValue === 'string' ? defaultValue : key,
+    i18n: { changeLanguage: vi.fn(), language: 'en' },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+}));
+
+const sources: SourceOption[] = [
+  { id: 'mt-tcp', name: 'Radio TCP', type: 'meshtastic_tcp', enabled: true, txEnabled: true },
+  { id: 'mqtt', name: 'MQTT Bridge', type: 'mqtt_bridge', enabled: true, txEnabled: true },
+  { id: 'mc', name: 'MeshCore Node', type: 'meshcore', enabled: true, txEnabled: true },
+];
+
+const channels: UnifiedChannelOption[] = [
+  { name: 'Primary', protocol: 'meshtastic' },
+  { name: 'gauntlet', protocol: 'meshtastic' },
+  { name: 'Public', protocol: 'meshcore' },
+];
+
+function renderField(field: FieldDef) {
+  return render(
+    <FieldInput
+      field={field}
+      value={[]}
+      onChange={() => {}}
+      variables={[]}
+      sources={sources}
+      channels={channels}
+      scripts={[]}
+      regions={[]}
+      nodes={[]}
+      triggerType="trigger.message"
+    />,
+  );
+}
+
+describe('FieldInput protocolFilter — sources', () => {
+  it("'meshtastic' shows native + MQTT sources, hides MeshCore", () => {
+    renderField({ name: 's', label: 'MT source', kind: 'sourceMulti', protocolFilter: 'meshtastic' });
+    expect(screen.getByText('Radio TCP')).toBeTruthy();
+    expect(screen.getByText('MQTT Bridge')).toBeTruthy(); // MQTT is Meshtastic-protocol
+    expect(screen.queryByText('MeshCore Node')).toBeNull();
+  });
+
+  it("'meshcore' shows only MeshCore sources", () => {
+    renderField({ name: 's', label: 'MC source', kind: 'sourceMulti', protocolFilter: 'meshcore' });
+    expect(screen.getByText('MeshCore Node')).toBeTruthy();
+    expect(screen.queryByText('Radio TCP')).toBeNull();
+    expect(screen.queryByText('MQTT Bridge')).toBeNull();
+  });
+
+  it('no filter shows every source (unchanged behavior)', () => {
+    renderField({ name: 's', label: 'Any source', kind: 'sourceMulti' });
+    expect(screen.getByText('Radio TCP')).toBeTruthy();
+    expect(screen.getByText('MQTT Bridge')).toBeTruthy();
+    expect(screen.getByText('MeshCore Node')).toBeTruthy();
+  });
+});
+
+describe('FieldInput protocolFilter — channels', () => {
+  it("'meshtastic' shows only Meshtastic channels", () => {
+    renderField({ name: 'c', label: 'MT channel', kind: 'channelMulti', protocolFilter: 'meshtastic' });
+    expect(screen.getByText('Primary')).toBeTruthy();
+    expect(screen.getByText('gauntlet')).toBeTruthy();
+    expect(screen.queryByText('Public')).toBeNull();
+  });
+
+  it("'meshcore' shows only MeshCore channels", () => {
+    renderField({ name: 'c', label: 'MC channel', kind: 'channelMulti', protocolFilter: 'meshcore' });
+    expect(screen.getByText('Public')).toBeTruthy();
+    expect(screen.queryByText('Primary')).toBeNull();
+    expect(screen.queryByText('gauntlet')).toBeNull();
+  });
+});

--- a/src/components/automations/AutomationBuilder.tsx
+++ b/src/components/automations/AutomationBuilder.tsx
@@ -46,6 +46,26 @@ const protoBadge = (proto?: string): 'MC' | 'MT' | null => {
   return null;
 };
 
+/**
+ * Does a source match a field's `protocolFilter`? MeshCore is the explicit side
+ * (`type === 'meshcore'`); everything else — native Meshtastic AND MQTT
+ * bridge/broker sources — is Meshtastic-protocol. So `'meshtastic'` means "not
+ * MeshCore" rather than a `startsWith('meshtastic')` check, which would wrongly
+ * drop MQTT sources.
+ */
+const sourceMatchesProtocol = (s: SourceOption, filter?: 'meshtastic' | 'meshcore'): boolean => {
+  if (!filter) return true;
+  const isMeshCore = String(s.type ?? '') === 'meshcore';
+  return filter === 'meshcore' ? isMeshCore : !isMeshCore;
+};
+
+/** Channel counterpart of {@link sourceMatchesProtocol}, keyed off `UnifiedChannelOption.protocol`. */
+const channelMatchesProtocol = (c: UnifiedChannelOption, filter?: 'meshtastic' | 'meshcore'): boolean => {
+  if (!filter) return true;
+  const isMeshCore = String(c.protocol ?? '') === 'meshcore';
+  return filter === 'meshcore' ? isMeshCore : !isMeshCore;
+};
+
 interface Props {
   form: WorkflowForm;
   variables: VariableOption[];
@@ -114,10 +134,11 @@ export function FieldInput({ field, value, onChange, variables, sources, channel
       break;
     case 'sourceMulti': {
       const sel = Array.isArray(value) ? (value as string[]) : [];
+      const visible = sources.filter((s) => sourceMatchesProtocol(s, field.protocolFilter));
       control = (
         <div>
-          {sources.length === 0 && <div className="ae-muted">No sources available.</div>}
-          {sources.map((s) => (
+          {visible.length === 0 && <div className="ae-muted">No sources available.</div>}
+          {visible.map((s) => (
             <label key={s.id} className="ae-switch" style={{ display: 'block', marginBottom: '0.2rem' }}>
               <input type="checkbox" checked={sel.includes(s.id)} onChange={(e) =>
                 onChange(e.target.checked ? [...sel, s.id] : sel.filter((x) => x !== s.id))} /> {s.name}
@@ -169,7 +190,9 @@ export function FieldInput({ field, value, onChange, variables, sources, channel
       break;
     case 'sendSourceMulti': {
       const sel = Array.isArray(value) ? (value as string[]) : [];
-      const sendable = sources.filter(isSendableSource);
+      const sendable = sources
+        .filter(isSendableSource)
+        .filter((s) => sourceMatchesProtocol(s, field.protocolFilter));
       control = (
         <div>
           {sendable.length === 0 && <div className="ae-muted">No sendable (non-MQTT) sources.</div>}
@@ -204,10 +227,11 @@ export function FieldInput({ field, value, onChange, variables, sources, channel
       const same = (a: { name: string; protocol?: string }, c: UnifiedChannelOption) =>
         a.name === c.name && (a.protocol ?? '') === (c.protocol ?? '');
       const isSel = (c: UnifiedChannelOption) => sel.some((x) => same(x, c));
+      const visible = channels.filter((c) => channelMatchesProtocol(c, field.protocolFilter));
       control = (
         <div>
-          {channels.length === 0 && <div className="ae-muted">No channels found on sendable sources.</div>}
-          {channels.map((c) => (
+          {visible.length === 0 && <div className="ae-muted">No channels found on sendable sources.</div>}
+          {visible.map((c) => (
             <label key={`${c.protocol}/${c.name}`} className="ae-switch" style={{ display: 'block', marginBottom: '0.2rem' }}>
               <input type="checkbox" checked={isSel(c)} onChange={(e) =>
                 onChange(e.target.checked

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -30,6 +30,15 @@ export interface FieldDef {
   /** This `text`/`textarea` field accepts `{{ }}` tokens → highlight + typo-check. */
   tokens?: boolean;
   /**
+   * Restrict a source/channel picker (`sourceMulti` / `sendSourceMulti` /
+   * `channelMulti`) to one protocol's options. `'meshcore'` shows only MeshCore
+   * sources/channels; `'meshtastic'` shows everything that is NOT MeshCore
+   * (native Meshtastic + MQTT bridge/broker, which are Meshtastic-protocol).
+   * Omitted = show all. Used by the MT↔MC Bridge template so the "Meshtastic"
+   * pickers don't list MeshCore options and vice-versa.
+   */
+  protocolFilter?: 'meshtastic' | 'meshcore';
+  /**
    * Render this field only when a sibling param matches. Omitted = always shown.
    * Declarative (not a predicate function) so the catalog stays serialisable data.
    */

--- a/src/components/automations/templates/bridge.test.ts
+++ b/src/components/automations/templates/bridge.test.ts
@@ -41,6 +41,15 @@ describe('bridgeTemplate', () => {
     ]);
   });
 
+  it('scopes each side’s source/channel pickers to its own protocol', () => {
+    const byName = Object.fromEntries(bridgeTemplate.params.map((p) => [p.name, p]));
+    // The Meshtastic pickers must not offer MeshCore options, and vice-versa.
+    expect(byName.mtSource.protocolFilter).toBe('meshtastic');
+    expect(byName.mtChannel.protocolFilter).toBe('meshtastic');
+    expect(byName.mcSource.protocolFilter).toBe('meshcore');
+    expect(byName.mcChannel.protocolFilter).toBe('meshcore');
+  });
+
   it('build({}) does not throw and produces a valid pair with no filters', () => {
     const [mtToMc, mcToMt] = buildPair({});
     for (const a of [mtToMc, mcToMt]) {

--- a/src/components/automations/templates/bridge.ts
+++ b/src/components/automations/templates/bridge.ts
@@ -59,19 +59,19 @@ const DEFAULT_RATE_LIMIT_MAX_ACTIONS = 20;
 
 const PARAMS: ParamSpec[] = [
   {
-    name: 'mtSource', label: 'Meshtastic source', kind: 'sourceMulti',
+    name: 'mtSource', label: 'Meshtastic source', kind: 'sourceMulti', protocolFilter: 'meshtastic',
     help: 'The Meshtastic connection to bridge. Leave none selected to relay from/to any Meshtastic source.',
   },
   {
-    name: 'mtChannel', label: 'Meshtastic channel', kind: 'channelMulti',
+    name: 'mtChannel', label: 'Meshtastic channel', kind: 'channelMulti', protocolFilter: 'meshtastic',
     help: 'The Meshtastic channel to bridge. Leave none selected to relay on any channel.',
   },
   {
-    name: 'mcSource', label: 'MeshCore source', kind: 'sourceMulti',
+    name: 'mcSource', label: 'MeshCore source', kind: 'sourceMulti', protocolFilter: 'meshcore',
     help: 'The MeshCore connection to bridge. Leave none selected to relay from/to any MeshCore source.',
   },
   {
-    name: 'mcChannel', label: 'MeshCore channel', kind: 'channelMulti',
+    name: 'mcChannel', label: 'MeshCore channel', kind: 'channelMulti', protocolFilter: 'meshcore',
     help: 'The MeshCore channel to bridge. Leave none selected to relay on any channel.',
   },
   {


### PR DESCRIPTION
## Summary

Follow-up UX fix to the MT↔MC Bridge template (#4577). The bridge wizard's **Meshtastic source/channel** pickers listed *every* source and channel — including MeshCore ones — and the MeshCore pickers likewise listed Meshtastic options. Confusing to see MT sources offered on the MC side.

Now each side's pickers show only that protocol's options.

## How

- Adds an opt-in **`protocolFilter?: 'meshtastic' | 'meshcore'`** to `FieldDef`.
- `FieldInput` filters `sourceMulti` / `sendSourceMulti` / `channelMulti` options by it. Rule: **MeshCore is the explicit side** (`type`/`protocol === 'meshcore'`); everything else — native Meshtastic **and** MQTT bridge/broker — counts as Meshtastic, so MQTT sources correctly stay on the MT side.
- The Bridge template's four pickers set the filter (`meshtastic` on the MT pair, `meshcore` on the MC pair). All other builder fields omit it, so the main Automation Builder is unchanged.

## Verification

- `npm run typecheck` — clean
- **Full** vitest suite, JSON reporter — **`success: true`, 14210 passed, 0 failed, 0 failed suites**
- `npm run lint:ci` — clean
- New `AutomationBuilder.protocolFilter.test.tsx` renders `FieldInput` and asserts: `'meshtastic'` shows native + MQTT sources but hides MeshCore; `'meshcore'` shows only MeshCore; no filter shows all; channels filtered symmetrically. `bridge.test.ts` asserts the four params carry the right filter.
- **Browser-validated** on the live deploy: the MT source picker lists only native/MQTT sources, the MC source picker only the two MeshCore sources; channels MT-only vs MC-only.

Frontend-only. Opt-in field → no behavior change anywhere the filter isn't set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)