### PR TITLE
Add Border Wait Times to User Scripts Gallery

### DIFF
--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -715,7 +715,7 @@
     "icon": "🛂",
     "description": "Reports live wait times for U.S. land ports of entry on the Mexico and Canada borders, using CBP's public Border Wait Time RSS feed. Config-driven — register any number of crossings and query a specific one by name, or get a short default report for your nearest port(s).",
     "language": "Python",
-    "tags": ["border", "cbp", "wait-times", "travel", "mexico", "canada", "api"],
+    "tags": ["Border", "CBP", "Wait Times", "Travel", "Mexico", "Canada", "API"],
     "githubPath": "KF7R/meshmonitor-nogales-bwt/border_wait.py",
     "exampleTrigger": "border, crossing, line, garita, bwt",
     "requirements": [

--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -708,5 +708,27 @@
       "Links straight to the triggering packet's detail page on Meshview",
       "No external dependencies — POSIX shell only"
     ]
+  },
+  {
+    "name": "Border Wait Times",
+    "filename": "border_wait.py",
+    "icon": "🛂",
+    "description": "Reports live wait times for U.S. land ports of entry on the Mexico and Canada borders, using CBP's public Border Wait Time RSS feed. Config-driven — register any number of crossings and query a specific one by name, or get a short default report for your nearest port(s).",
+    "language": "Python",
+    "tags": ["border", "cbp", "wait-times", "travel", "mexico", "canada", "api"],
+    "githubPath": "KF7R/meshmonitor-nogales-bwt/border_wait.py",
+    "exampleTrigger": "border, crossing, line, garita, bwt",
+    "requirements": [
+      "Python 3 standard library only (no pip dependencies)",
+      "Outbound internet access from the container to bwt.cbp.gov",
+      "No API key needed"
+    ],
+    "author": "KF7R",
+    "features": [
+      "Multi-port config — register any number of crossings by CBP port code",
+      "Query a specific port by name/alias (e.g. \"/bwt mariposa\") or get a default summary",
+      "Reports per-lane wait times (General, SENTRI, NEXUS, Pedestrian, etc.)",
+      "No API key or external Python packages required"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- Adds a User Scripts Gallery entry for **Border Wait Times**, a Python Auto Responder script submitted by @KF7R that reports live CBP wait times for configured U.S. land ports of entry on the Mexico/Canada borders, using CBP's public Border Wait Time RSS feed.
- The script is hosted externally at [`KF7R/meshmonitor-nogales-bwt`](https://github.com/KF7R/meshmonitor-nogales-bwt/blob/main/border_wait.py), so this follows the established external-repo pattern (like the `Codename-11/meshmonitor_user-scripts` and `maxhayim/*` entries already in the gallery): only `docs/.vitepress/data/user-scripts.json` is touched, `githubPath` set to `KF7R/meshmonitor-nogales-bwt/border_wait.py` — no in-repo copy of the script.

## Review notes
- Outbound network calls are limited to `bwt.cbp.gov` via `urllib.request`, with an 8s timeout under the Auto Responder's 10s script budget.
- The requested URL is built entirely from the script's hardcoded `PORTS` config dict (port codes the operator registers), never from user-controlled `MESSAGE`/`PARAM_*` text — those are only used to pick which already-configured port to report, so there's no SSRF/URL-injection surface.
- No shell-out, `eval`, or arbitrary code execution. Reply text is capped to 195 chars (under Meshtastic's message-length ceiling) with a hard-truncate fallback.
- Network/parse failures are caught and degrade to a friendly "unavailable" reply instead of crashing.

## Test plan
- [x] `npx vitest run tests/unit/UserScriptsGallery.security.test.ts` — 52/52 passing (covers `githubPath` SSRF/path-traversal validation)
- [x] `python3 -c "import json; json.load(open('docs/.vitepress/data/user-scripts.json'))"` — valid JSON
- [x] `npx vitepress build docs` — docs site builds cleanly with the new gallery entry

Closes #4685

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdbbVsY93SUDBSaP6XZ5vx)_