### PR TITLE
fix(tcp): propagate asynchronous socket write failures

### DIFF
--- a/src/server/tcpTransport.send.test.ts
+++ b/src/server/tcpTransport.send.test.ts
@@ -1,0 +1,100 @@
+import { EventEmitter } from 'events';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TcpTransport } from './tcpTransport.js';
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+type WriteCallback = (error?: Error | null) => void;
+
+class FakeSocket extends EventEmitter {
+  write = vi.fn<(data: Uint8Array, callback: WriteCallback) => boolean>();
+}
+
+describe('TcpTransport.send write completion', () => {
+  let transport: TcpTransport;
+  let socket: FakeSocket;
+
+  beforeEach(() => {
+    transport = new TcpTransport();
+    socket = new FakeSocket();
+    (transport as any).isConnected = true;
+    (transport as any).socket = socket;
+  });
+
+  it('rejects an asynchronous EPIPE even when socket.write() returned true', async () => {
+    let writeCallback: WriteCallback | undefined;
+    socket.write.mockImplementation((_data, callback) => {
+      writeCallback = callback;
+      return true;
+    });
+
+    const sendPromise = transport.send(new Uint8Array([0x01]));
+    let fulfilled = false;
+    void sendPromise.then(() => { fulfilled = true; }, () => undefined);
+
+    await Promise.resolve();
+    expect(fulfilled).toBe(false);
+
+    const error = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+    const rejection = expect(sendPromise).rejects.toMatchObject({ code: 'EPIPE' });
+    writeCallback?.(error);
+    await rejection;
+  });
+
+  it('does not resolve a buffered write before its completion callback', async () => {
+    let writeCallback: WriteCallback | undefined;
+    socket.write.mockImplementation((_data, callback) => {
+      writeCallback = callback;
+      return true;
+    });
+
+    const sendPromise = transport.send(new Uint8Array([0x02]));
+    let fulfilled = false;
+    void sendPromise.then(() => { fulfilled = true; });
+
+    await Promise.resolve();
+    expect(fulfilled).toBe(false);
+
+    writeCallback?.();
+    await expect(sendPromise).resolves.toBeUndefined();
+  });
+
+  it('waits for both write completion and drain when backpressure is reported', async () => {
+    let writeCallback: WriteCallback | undefined;
+    socket.write.mockImplementation((_data, callback) => {
+      writeCallback = callback;
+      return false;
+    });
+
+    const sendPromise = transport.send(new Uint8Array([0x03]));
+    let fulfilled = false;
+    void sendPromise.then(() => { fulfilled = true; });
+
+    writeCallback?.();
+    await Promise.resolve();
+    expect(fulfilled).toBe(false);
+
+    socket.emit('drain');
+    await expect(sendPromise).resolves.toBeUndefined();
+  });
+
+  it('removes the pending drain listener when a backpressured write fails', async () => {
+    let writeCallback: WriteCallback | undefined;
+    socket.write.mockImplementation((_data, callback) => {
+      writeCallback = callback;
+      return false;
+    });
+
+    const sendPromise = transport.send(new Uint8Array([0x04]));
+    expect(socket.listenerCount('drain')).toBe(1);
+
+    const error = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+    const rejection = expect(sendPromise).rejects.toMatchObject({ code: 'EPIPE' });
+    writeCallback?.(error);
+    await rejection;
+
+    expect(socket.listenerCount('drain')).toBe(0);
+  });
+});

--- a/src/server/tcpTransport.ts
+++ b/src/server/tcpTransport.ts
@@ -358,32 +358,70 @@ export class TcpTransport extends EventEmitter implements ITransport {
 
     const packet = Buffer.concat([header, Buffer.from(data)]);
 
+    const socket = this.socket;
     return new Promise((resolve, reject) => {
-      if (!this.socket) {
+      if (!socket) {
         reject(new Error('Socket is null'));
         return;
       }
 
-      // Handle TCP backpressure: if the kernel buffer is full, socket.write()
-      // returns false and we must wait for 'drain' before sending more data.
-      // Without this, rapid writes overwhelm WiFi-connected devices (#2474).
-      const canContinue = this.socket.write(packet, (error) => {
-        if (error) {
-          logger.error('❌ Failed to send data:', error.message);
-          reject(error);
-        }
-      });
+      // A true return from socket.write() only means that the writable buffer
+      // remains below its high-water mark. It does NOT mean that the write
+      // completed successfully. Resolving on that boolean caused an async
+      // EPIPE from the write callback to be ignored because the Promise had
+      // already fulfilled, so the manager could report a restarted
+      // meshtasticd as connected after its first protocol write had failed.
+      //
+      // Completion requires both the write callback and, when backpressure is
+      // reported, the drain event. Capturing the socket also prevents a later
+      // reconnect from moving the drain listener onto a different generation.
+      let settled = false;
+      let writeReturned = false;
+      let writeCompleted = false;
+      let drainCompleted = false;
+      let waitingForDrain = false;
 
-      if (canContinue) {
+      const cleanup = () => {
+        if (waitingForDrain) socket.off('drain', onDrain);
+      };
+
+      const maybeResolve = () => {
+        if (settled || !writeReturned || !writeCompleted || !drainCompleted) return;
+        settled = true;
+        cleanup();
         logger.debug(`📤 Sent ${data.length} bytes`);
         resolve();
-      } else {
-        logger.debug(`📤 Sent ${data.length} bytes (waiting for drain)`);
-        this.socket.once('drain', () => {
-          logger.debug('📤 TCP drain — write buffer cleared');
-          resolve();
-        });
+      };
+
+      const onDrain = () => {
+        drainCompleted = true;
+        logger.debug('📤 TCP drain — write buffer cleared');
+        maybeResolve();
+      };
+
+      const canContinue = socket.write(packet, (error) => {
+        if (error) {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          logger.error('❌ Failed to send data:', error.message);
+          reject(error);
+          return;
+        }
+        writeCompleted = true;
+        maybeResolve();
+      });
+
+      writeReturned = true;
+      if (settled) return;
+
+      drainCompleted = canContinue;
+      if (!canContinue) {
+        waitingForDrain = true;
+        logger.debug(`📤 Queued ${data.length} bytes (waiting for drain)`);
+        socket.once('drain', onDrain);
       }
+      maybeResolve();
     });
   }
 


### PR DESCRIPTION
## Summary

Fix `TcpTransport.send()` so asynchronous socket write failures such as
`EPIPE` and `ERR_STREAM_DESTROYED` are propagated to the caller instead of
being silently ignored.

This prevents MeshMonitor from reporting a Meshtastic TCP source as connected
after the first protocol write to a restarting `meshtasticd` instance has
already failed.

## Root cause

`net.Socket.write()` returns a boolean indicating whether the writable buffer
is below its high-water mark. It does not indicate that the write completed
successfully.

`TcpTransport.send()` previously resolved its Promise immediately whenever
`socket.write()` returned `true`:

```ts
const canContinue = socket.write(packet, callback);

if (canContinue) {
  resolve();
}
```

For small protocol packets, including the initial `want_config_id`, `write()`
normally returns `true`. If the write callback later received `EPIPE`, its
attempt to reject the Promise had no effect because the Promise had already
been fulfilled.

The resulting sequence was:

1. The TCP socket emitted `connect`.
2. MeshMonitor entered `ConfigSync` and reported the source as connected.
3. The initial `want_config_id` write appeared to succeed.
4. Its callback later received `EPIPE`.
5. The error did not reach the existing `HANDSHAKE_SEND_FAILED` recovery path.
6. The source could remain incorrectly reported as connected until a later
   socket close or health check.

## Fix

`TcpTransport.send()` now waits for the socket write callback before resolving.

When `write()` reports backpressure, completion requires both:

- the write callback to complete successfully;
- the socket `drain` event.

The implementation also:

- captures the socket generation used for the write;
- propagates asynchronous write errors to the caller;
- removes a pending `drain` listener when the write fails;
- preserves the existing backpressure behavior introduced for Wi-Fi-connected
  nodes.

No connection-state-machine changes are required. The propagated error now
reaches the existing `HANDSHAKE_SEND_FAILED` transition, which marks the source
disconnected and initiates clean recovery.

## Tests

Added regression coverage for:

- `write() === true` followed asynchronously by `EPIPE`;
- successful writes not resolving before their callback;
- backpressured writes waiting for both callback and `drain`;
- pending `drain` listener cleanup after a write failure.

Validation performed:

- 23 targeted TCP transport tests passed;
- targeted TypeScript check passed;
- verified against a real MeshMonitor 4.14.0 deployment and a restarting
  `meshtasticd` instance:
  - `EPIPE` was propagated;
  - MeshMonitor emitted `connected: false`;
  - the transport subsequently reconnected and returned to
    `connected: true`, `nodeResponsive: true`.
