### PR TITLE
chore(release): bump to 4.14.2-rc1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.14.1",
+  "version": "4.14.2-rc1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.14.1",
+  "version": "4.14.2-rc1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.14.1
-appVersion: "4.14.1"
+version: 4.14.2-rc1
+appVersion: "4.14.2-rc1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.1",
+  "version": "4.14.2-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.14.1",
+      "version": "4.14.2-rc1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.1",
+  "version": "4.14.2-rc1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
First release candidate of the 4.14.2 cycle.

## What this line carries

Since v4.14.1, one PR has landed: **#4689**, which closed the last three `mt-2.8`
tracking issues (#3854, #3923, #3548).

- **MeshBeacon is configurable, not just decodable.** A `MeshBeaconConfig` editor
  on both surfaces that edit module configs, the Configuration page and the
  Admin Commands tab. Gated at firmware 2.8.0, so older devices show the section
  greyed out rather than accepting a save the device silently drops.
- **`trigger.meshBeacon` automation trigger.** Beacons are never stored as
  messages, so they were previously invisible to the engine. Filters on beacon
  text, or narrows to beacons that actually advertise a network.
- **XEdDSA signing status on messages** (migration 140), completing the
  packet-level shield that shipped in 4.14.1.

## Version bump

All five files per the release checklist:

| File | 4.14.1 → 4.14.2-rc1 |
| --- | --- |
| `package.json` | ✔ |
| `package-lock.json` | ✔ (regenerated via `npm install --package-lock-only`) |
| `helm/meshmonitor/Chart.yaml` | ✔ `version` **and** `appVersion` |
| `desktop/package.json` | ✔ |
| `desktop/src-tauri/tauri.conf.json` | ✔ |

One thing worth a look: Chart.yaml's `appVersion` drifted behind `version` during
the 4.14.1 RCs (ended at `4.14.1-rc3` while `version` was `4.14.1-rc5`). They were
back in sync at `4.14.1`, and this PR sets both together.

## Testing

Version-only change, no source touched. The four JSON files parse, the diff is
7 lines across the 5 expected files and nothing else, and the full suite was run
green on this content when #4689 merged (14,894 passed / 0 failed, with the
PostgreSQL and MySQL containers up).

Carries the `system-test` label: release version-bump chores always run the
hardware suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G
