### PR TITLE
fix(automation): let MT↔MC bridge relay the operator's own messages

### DIFF
--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -126,6 +126,13 @@ export const TRIGGERS: BlockDef[] = [
       { name: 'from', label: 'From node #', kind: 'number', placeholder: 'any', advanced: true, help: 'Only fire for messages from this node number.' },
       COOLDOWN,
       COOLDOWN_SCOPE,
+      // `includeSelf` (bypasses the engine's #3914 self-origin guard, #4694) is
+      // deliberately NOT a field here, same as `rateLimit` (also trigger.message-
+      // only and also absent from this list) — both are template-internal params
+      // set directly by bridge.ts, not general builder options. Exposing
+      // `includeSelf` as a checkbox would let a user re-create the self-reply
+      // loop #3914 exists to prevent; don't add one without a loop-safety story
+      // for whatever automation would use it.
     ],
   },
   {

--- a/src/components/automations/templates/bridge.test.ts
+++ b/src/components/automations/templates/bridge.test.ts
@@ -135,6 +135,12 @@ describe('bridgeTemplate', () => {
     }
   });
 
+  it('sets includeSelf:true on both triggers so the operator\'s own outgoing messages still relay (#4694)', () => {
+    for (const a of buildPair(FULL_PARAMS)) {
+      expect(node(a.config, 't').params.includeSelf).toBe(true);
+    }
+  });
+
   it('never emits a portnum trigger param on either direction (would silently go Meshtastic-only)', () => {
     for (const a of buildPair(FULL_PARAMS)) {
       expect(node(a.config, 't').params).not.toHaveProperty('portnum');

--- a/src/components/automations/templates/bridge.ts
+++ b/src/components/automations/templates/bridge.ts
@@ -106,6 +106,14 @@ interface DirectionSpec {
 function buildDirectionForm(spec: DirectionSpec): WorkflowForm {
   const triggerParams: Record<string, unknown> = {
     rateLimit: { maxActions: spec.rateLimitMax ?? DEFAULT_RATE_LIMIT_MAX_ACTIONS, windowSeconds: 60 },
+    // Opt out of the engine's #3914 self-origin guard (automationEngineService.ts
+    // includesSelfOrigin()): without this, a message the OPERATOR types directly
+    // on the bridged Meshtastic/MeshCore node never crosses to the other side —
+    // it's dropped before any trigger.message automation (including this one)
+    // ever sees it, since the guard exists to stop an automation's own reply
+    // from re-triggering itself. This bridge doesn't need that protection —
+    // its own loop guard is the `notContains 'MT@'/'MC@'` conditions below (#4694).
+    includeSelf: true,
   };
   if (spec.triggerChannel) triggerParams.channels = [spec.triggerChannel];
 

--- a/src/components/automations/templates/bridge.ts
+++ b/src/components/automations/templates/bridge.ts
@@ -107,12 +107,9 @@ function buildDirectionForm(spec: DirectionSpec): WorkflowForm {
   const triggerParams: Record<string, unknown> = {
     rateLimit: { maxActions: spec.rateLimitMax ?? DEFAULT_RATE_LIMIT_MAX_ACTIONS, windowSeconds: 60 },
     // Opt out of the engine's #3914 self-origin guard (automationEngineService.ts
-    // includesSelfOrigin()): without this, a message the OPERATOR types directly
-    // on the bridged Meshtastic/MeshCore node never crosses to the other side —
-    // it's dropped before any trigger.message automation (including this one)
-    // ever sees it, since the guard exists to stop an automation's own reply
-    // from re-triggering itself. This bridge doesn't need that protection —
-    // its own loop guard is the `notContains 'MT@'/'MC@'` conditions below (#4694).
+    // includesSelfOrigin()) — otherwise a message the operator types directly on
+    // the bridged node never reaches this trigger at all. Safe here because the
+    // `notContains 'MT@'/'MC@'` conditions below are this bridge's own loop guard (#4694).
     includeSelf: true,
   };
   if (spec.triggerChannel) triggerParams.channels = [spec.triggerChannel];

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -316,6 +316,52 @@ describe('AutomationEngineService', () => {
     expect(await engine.onMeshCoreMessage(mcMessage({ fromPublicKey: 'channel-0', text: 'ping' }), 'default')).toBe(1);
   });
 
+  it('self-origin opt-out (#4694): a trigger.message automation with includeSelf:true still fires on our own Meshtastic node', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('bridge-like', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping', includeSelf: true } },
+        { id: 's', type: 'action.sendMessage', params: { text: 'relayed' } },
+      ],
+      edges: [{ from: 't', to: 's' }],
+    });
+    const selfData = { ...data, getLocalNodeNum: async () => 111 };
+    const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data: selfData, now: () => clock });
+    await engine.load();
+    // Our own message → still fires because this automation opted back in.
+    expect(await engine.onMessage(message({ fromNodeNum: 111, text: 'ping' }), 'default')).toBe(1);
+    expect(calls).toHaveLength(1);
+    // A different automation on the same event WITHOUT includeSelf keeps dropping self-origin.
+    await createEnabled('normal', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping' } },
+        { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+      ],
+      edges: [{ from: 't', to: 'tap' }],
+    });
+    await engine.load();
+    expect(await engine.onMessage(message({ fromNodeNum: 111, text: 'ping' }), 'default')).toBe(1); // only the includeSelf one fires
+  });
+
+  it('self-origin opt-out (#4694): a trigger.message automation with includeSelf:true still fires on our own MeshCore key', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('bridge-like', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping', includeSelf: true } },
+        { id: 's', type: 'action.sendMessage', params: { text: 'relayed' } },
+      ],
+      edges: [{ from: 't', to: 's' }],
+    });
+    const selfData = { ...data, getSelfPublicKey: async () => 'ABCD' };
+    const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data: selfData, now: () => clock });
+    await engine.load();
+    expect(await engine.onMeshCoreMessage(mcMessage({ fromPublicKey: 'abcd', text: 'ping' }), 'default')).toBe(1);
+    expect(calls).toHaveLength(1);
+  });
+
   it('self-origin (#3914): ignores our own node telemetry', async () => {
     const { deps } = recorder();
     await createEnabled('batt', {

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -345,6 +345,23 @@ describe('AutomationEngineService', () => {
     expect(await engine.onMessage(message({ fromNodeNum: 111, text: 'ping' }), 'default')).toBe(1); // only the includeSelf one fires
   });
 
+  it('self-origin opt-out (#4694): includeSelf:false behaves identically to includeSelf absent (still dropped)', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('explicit-false', {
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.message', params: { textContains: 'ping', includeSelf: false } },
+        { id: 'tap', type: 'action.tapback', params: { emoji: '👍' } },
+      ],
+      edges: [{ from: 't', to: 'tap' }],
+    });
+    const selfData = { ...data, getLocalNodeNum: async () => 111 };
+    const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data: selfData, now: () => clock });
+    await engine.load();
+    expect(await engine.onMessage(message({ fromNodeNum: 111, text: 'ping' }), 'default')).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+
   it('self-origin opt-out (#4694): a trigger.message automation with includeSelf:true still fires on our own MeshCore key', async () => {
     const { calls, deps } = recorder();
     await createEnabled('bridge-like', {

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -627,10 +627,27 @@ export class AutomationEngineService {
     return false;
   }
 
+  /**
+   * True when a loaded `trigger.message` automation explicitly opts back into
+   * self-originated events (#4694). The #3914 self-origin guard above exists
+   * to stop an `action.sendMessage` reply from re-triggering the very rule
+   * that sent it, but that same guard silently made the MT↔MC bridge template
+   * (`bridge.ts`) blind to messages the operator typed on their OWN connected
+   * node — those never crossed to the other protocol at all. The bridge
+   * already has its own independent loop guard (the `notContains 'MT@'/'MC@'`
+   * tag conditions), so it sets `includeSelf: true` on its trigger to skip
+   * this guard rather than needing it disabled globally.
+   */
+  private includesSelfOrigin(a: LoadedAutomation): boolean {
+    return (a.triggerNode.params as Record<string, unknown> | undefined)?.includeSelf === true;
+  }
+
   // ─── event entry points ─────────────────────────────────────────────────
 
   async onMessage(msg: DbMessage, sourceId: string | null): Promise<number> {
-    if (await this.isSelfMeshtastic(sourceId, msg.fromNodeNum)) return 0; // #3914: ignore our own sends
+    // #3914: ignore our own sends, UNLESS the matching automation opted back in
+    // via `includeSelf` (#4694 — see includesSelfOrigin()'s doc comment).
+    const isSelf = await this.isSelfMeshtastic(sourceId, msg.fromNodeNum);
     // Resolve the per-source channel name + sender node name once. We resolve when
     // EITHER a channelName/`channels` filter needs it (#3974) OR the universal
     // channelName/fromName/senderLabel tokens need populating — and since ANY loaded
@@ -662,7 +679,7 @@ export class AutomationEngineService {
     const ctx = buildMessageContext(msg, sourceId, this.now(), { channelName, fromName, viaMqttSource });
     return this.runTrigger(
       ctx,
-      (a) => messageMatchesFilter(msg, a.triggerNode.params ?? {}, channelName),
+      (a) => (!isSelf || this.includesSelfOrigin(a)) && messageMatchesFilter(msg, a.triggerNode.params ?? {}, channelName),
       (a) => describeMessageFilterMiss(msg, a.triggerNode.params ?? {}, channelName),
     );
   }
@@ -674,7 +691,9 @@ export class AutomationEngineService {
    * engine previously ignored entirely).
    */
   async onMeshCoreMessage(msg: MeshCoreMessage, sourceId: string | null): Promise<number> {
-    if (await this.isSelfMeshCore(sourceId, msg.fromPublicKey)) return 0; // #3914: ignore our own sends
+    // #3914: ignore our own sends, UNLESS the matching automation opted back in
+    // via `includeSelf` (#4694 — see includesSelfOrigin()'s doc comment).
+    const isSelf = await this.isSelfMeshCore(sourceId, msg.fromPublicKey);
     // Same reconciliation as onMessage: resolve the channel name when any message
     // automation is loaded (subsumes #3974's channelName/`channels` filter gate),
     // feeding both the universal channelName/senderLabel tokens and the matcher's
@@ -689,7 +708,7 @@ export class AutomationEngineService {
     const ctx = buildMeshCoreMessageContext(msg, sourceId, this.now(), { channelName });
     return this.runTrigger(
       ctx,
-      (a) => meshCoreMessageMatchesFilter(msg, a.triggerNode.params ?? {}, channelName),
+      (a) => (!isSelf || this.includesSelfOrigin(a)) && meshCoreMessageMatchesFilter(msg, a.triggerNode.params ?? {}, channelName),
       (a) => describeMeshCoreFilterMiss(msg, a.triggerNode.params ?? {}, channelName),
     );
   }


### PR DESCRIPTION
## Summary

Fixes #4694 — "Bridge does not include own messages".

- The Automation Engine's self-origin guard (#3914) unconditionally drops any `trigger.message` event that originated from MeshMonitor's own connected node, before any automation — including the MT↔MC Bridge template — ever sees it. That guard exists so an auto-responder's own `action.sendMessage` reply can't re-trigger the very rule that sent it, but it also meant a message the operator typed directly on the bridged Meshtastic or MeshCore node never crossed the bridge to the other protocol.
- Added an opt-in `includeSelf` param on `trigger.message` (`automationEngineService.ts`'s `includesSelfOrigin()`) that lets a specific automation bypass the self-origin guard.
- Set `includeSelf: true` on both directions of the bridge template (`bridge.ts`). The bridge already carries its own independent loop guard (the `MT@`/`MC@` `notContains` tag conditions), so it doesn't need the self-origin guard and can safely skip it. All other automations keep today's default behavior (self-origin still dropped).

## Test plan

- [x] `automationEngineService.test.ts` — new tests proving an `includeSelf: true` automation still fires on our own Meshtastic node / MeshCore key, while a sibling automation without the flag continues to drop self-origin events (regression coverage for #3914's existing behavior).
- [x] `bridge.test.ts` — new test asserting both compiled bridge directions carry `includeSelf: true` on their trigger.
- [x] Full `src/server/services/automation` + `src/components/automations` suites (904 tests) pass locally.
- [x] `npm run lint:ci` gate passes (no new baseline violations).
- [x] `tsc --noEmit` clean for both `tsconfig.server.json` and `tsconfig.json`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y7FuPBBnJVJhFBxfy7nKgM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7FuPBBnJVJhFBxfy7nKgM)_