### PR TITLE
fix(unified): gate telemetry on nodes:read, fetch MeshCore nodes by publicKey

### DIFF
--- a/src/server/routes/unifiedRoutes.test.ts
+++ b/src/server/routes/unifiedRoutes.test.ts
@@ -27,6 +27,7 @@ vi.mock('../../services/database.js', () => ({
     meshcore: {
       getRecentMessages: vi.fn().mockResolvedValue([]),
       getChannelMessages: vi.fn().mockResolvedValue([]),
+      getNodesBySource: vi.fn().mockResolvedValue([]),
     },
     nodes: {
       getAllNodes: vi.fn(),
@@ -95,6 +96,7 @@ const createApp = (user: any = null): Express => {
 
 const SOURCE_A = { id: 'src-a', name: 'Source A', type: 'meshtastic_tcp', enabled: true };
 const SOURCE_B = { id: 'src-b', name: 'Source B', type: 'meshtastic_tcp', enabled: true };
+const SOURCE_MC = { id: 'src-mc', name: 'Source MC', type: 'meshcore', enabled: true };
 
 // Channel list fixtures — same name "Primary" lives at slot 0 on both sources.
 const CHANNELS_A = [
@@ -1082,6 +1084,44 @@ describe('Unified Routes', () => {
       expect(res.body).toHaveLength(1);
       expect(res.body[0].nodeLongName).toBe('Node Two');
       expect(mockDb.telemetry.getLatestTelemetryByNode).toHaveBeenCalledTimes(2);
+    });
+
+    it('gates on the nodes:read permission, not a nonexistent telemetry resource (#4700)', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_A]);
+      mockDb.nodes.getAllNodes.mockResolvedValue([
+        { nodeId: '!aabbccdd', nodeNum: 0xaabbccdd, longName: 'Node One', shortName: 'N1' },
+      ]);
+      mockDb.telemetry.getLatestTelemetryByNode.mockResolvedValue([
+        { nodeId: '!aabbccdd', nodeNum: 0xaabbccdd, telemetryType: 'battery_level', value: 85, timestamp: recentTs },
+      ]);
+
+      const app = createApp(regularUser);
+      const res = await request(app).get('/telemetry');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(mockDb.checkPermissionAsync).toHaveBeenCalledWith(regularUser.id, 'nodes', 'read', 'src-a');
+    });
+
+    it('enumerates MeshCore nodes by publicKey rather than the Meshtastic nodes table (#4700)', async () => {
+      mockDb.sources.getAllSources.mockResolvedValue([SOURCE_MC]);
+      const publicKey = 'a'.repeat(64);
+      mockDb.meshcore.getNodesBySource.mockResolvedValue([
+        { publicKey, name: 'MC Node One', sourceId: 'src-mc' },
+      ]);
+      mockDb.telemetry.getLatestTelemetryByNode.mockResolvedValue([
+        { nodeId: publicKey, telemetryType: 'battery_level', value: 77, timestamp: recentTs },
+      ]);
+
+      const app = createApp(adminUser);
+      const res = await request(app).get('/telemetry');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].nodeLongName).toBe('MC Node One');
+      expect(mockDb.telemetry.getLatestTelemetryByNode).toHaveBeenCalledWith(publicKey, 'src-mc');
+      // Meshtastic node table must not be consulted for a MeshCore source.
+      expect(mockDb.nodes.getAllNodes).not.toHaveBeenCalledWith('src-mc');
     });
   });
 

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -844,12 +844,34 @@ router.get('/telemetry', async (req: Request, res: Response) => {
 
     const sourceResults = await Promise.allSettled(
       sources.map(async (source) => {
+        // 'telemetry' is not a real permission resource (#4700) — gate on
+        // 'nodes:read' like the v1 telemetry route does.
         const canRead = isAdmin || (user
-          ? await databaseService.checkPermissionAsync(user.id, 'telemetry', 'read', source.id)
+          ? await databaseService.checkPermissionAsync(user.id, 'nodes', 'read', source.id)
           : false);
         if (!canRead) return [];
 
-        const nodes = await databaseService.nodes.getAllNodes(source.id);
+        // MeshCore nodes live in a separate table keyed by publicKey, not
+        // the Meshtastic `nodes` table's nodeId — enumerate from the right
+        // table per source type so MeshCore telemetry rows (also keyed by
+        // publicKey) actually get looked up (#4700).
+        const nodeList: Array<{
+          telemetryNodeId: string;
+          longName?: string | null;
+          shortName?: string | null;
+        }> =
+          source.type === 'meshcore'
+            ? (await databaseService.meshcore.getNodesBySource(source.id)).map((n) => ({
+                telemetryNodeId: n.publicKey,
+                longName: n.name,
+                shortName: null,
+              }))
+            : (await databaseService.nodes.getAllNodes(source.id)).map((n) => ({
+                telemetryNodeId: n.nodeId,
+                longName: n.longName,
+                shortName: n.shortName,
+              }));
+
         const entries: Array<Record<string, unknown>> = [];
 
         // Fan out per-node telemetry lookups in parallel rather than awaiting
@@ -857,13 +879,13 @@ router.get('/telemetry', async (req: Request, res: Response) => {
         // form was the dominant cost of /api/unified/telemetry — O(sources *
         // nodes) serial round trips through Drizzle.
         const perNodeLatest = await Promise.all(
-          nodes.map((node) =>
+          nodeList.map((node) =>
             databaseService.telemetry
-              .getLatestTelemetryByNode(node.nodeId, source.id)
+              .getLatestTelemetryByNode(node.telemetryNodeId, source.id)
               .then((latest) => ({ node, latest }))
               .catch((err) => {
                 logger.warn(
-                  `Failed to load telemetry for node ${node.nodeId} (source ${source.id}):`,
+                  `Failed to load telemetry for node ${node.telemetryNodeId} (source ${source.id}):`,
                   err
                 );
                 return { node, latest: [] as Array<{ timestamp: number }> };


### PR DESCRIPTION
## Summary

`GET /api/unified/telemetry` was unconditionally empty for MeshCore sources, and empty for every non-admin/anonymous user regardless of source type. Two independent bugs in the same handler (`src/server/routes/unifiedRoutes.ts`), both flagged in #4700 with a precise root-cause analysis:

- **Bug 1**: the permission check called `checkPermissionAsync(user.id, 'telemetry', 'read', source.id)`. `'telemetry'` is not a registered permission resource anywhere in the app (not in `/api/auth/status`'s resource list, not in the `permissions` table, not grantable via the Users UI) — an orphaned/typo'd string that no user could ever satisfy. The v1 `/api/v1/sources/:sourceId/telemetry` route correctly gates on `'nodes'`.
- **Bug 2**: node enumeration for the per-node telemetry fan-out went through `databaseService.nodes.getAllNodes(source.id)` — the Meshtastic-only `nodes` table — for every source unconditionally. MeshCore nodes live in `meshcore_nodes`, keyed by `publicKey` (no `nodeId` column), and MeshCore telemetry rows store that same 64-char publicKey in `telemetry.nodeId`. So the per-node lookup never touched a single MeshCore row, even for `admin` (who bypasses Bug 1 entirely).

## Fix

- Gate on `nodes:read` instead of the nonexistent `telemetry:read`, matching the v1 route's behavior.
- Branch node enumeration by `source.type`: MeshCore sources now enumerate via `databaseService.meshcore.getNodesBySource()` and look up telemetry by `publicKey`; Meshtastic sources keep the existing `databaseService.nodes.getAllNodes()` / `nodeId` path unchanged.

## Test plan

- [x] Added regression test asserting the permission check uses `nodes:read` (not `telemetry:read`) for a non-admin user.
- [x] Added regression test asserting a MeshCore source enumerates nodes via `getNodesBySource()` (by `publicKey`), not `nodes.getAllNodes()`, and that the returned entry's `nodeLongName` comes from the MeshCore node's `name`.
- [x] Full `src/server/routes/unifiedRoutes.test.ts` suite passes (58 → 60 tests, all green).
- [x] `src/pages/UnifiedTelemetryPage.test.tsx` still green (frontend already falls back `nodeLongName → nodeShortName → nodeId` so no frontend changes needed).
- [x] `npx tsc --noEmit -p tsconfig.server.json` clean.
- [x] `npm run lint:ci` ratchet gate passes (no new violations).

Fixes #4700

---

-- Authored by Roger 🤓


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5gN12XrkcUfRiYSBsMrm4)_