### PR TITLE
fix(docker): skip puppeteer's Chrome download in the main image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,23 @@ COPY package*.json ./
 # better-sqlite3 will download pre-built binaries for the target platform
 # Use cache mount to speed up repeated builds
 # --legacy-peer-deps needed for vitest peer dependency conflicts
+#
+# PUPPETEER_SKIP_DOWNLOAD=true: puppeteer's npm postinstall downloads a Chrome
+# binary. This image is built for linux/arm64 under QEMU emulation, where that
+# postinstall crashes with SIGILL ("qemu: uncaught target signal 4") and takes
+# the whole build with it. Puppeteer is a devDependency used only by two ad-hoc
+# screenshot helpers (scripts/capture-*-screenshots.js) — neither the runtime
+# image nor the build needs the browser binary.
+#
+# .npmrc already sets `puppeteer_skip_download=true`, but that is no longer
+# sufficient: npm now reports it as `Unknown project config` and stops
+# forwarding it as `npm_config_puppeteer_skip_download`, so puppeteer never
+# sees it and runs the download anyway. The environment variable is read
+# directly by puppeteer and does not depend on npm's config forwarding.
+# Dockerfile.armv7 has always set it this way — which is why the armv7 leg
+# kept building while this one broke (v4.14.2-rc1).
 RUN --mount=type=cache,target=/root/.npm \
+    PUPPETEER_SKIP_DOWNLOAD=true \
     npm install --legacy-peer-deps
 
 # Verify protobufs are present (fail fast if git submodule wasn't initialized)


### PR DESCRIPTION
Fixes the Docker release-build failure seen on **v4.14.2-rc1**.

## What happened

The `build-main` job (linux/amd64 + linux/arm64) died during `npm install`, when
puppeteer's postinstall ran under QEMU emulation for arm64:

```
npm error path /app/node_modules/puppeteer
npm error command sh -c node install.mjs
npm error signal SIGILL
qemu: uncaught target signal 4 (Illegal instruction) - core dumped
```

`create-manifest` is gated on that job, so it was skipped and **no multi-arch
`:4.14.2-rc1` tag was ever published**, Docker users could not pull the RC.
A plain rerun of the same commit passed, so today this is a latent flake that
will bite again rather than a fixed problem.

## Root cause

`.npmrc` has set `puppeteer_skip_download=true` since #3096/#3097, but **npm no
longer honours it**. It now reports:

```
npm warn Unknown project config "puppeteer_skip_download"
```

and stops forwarding the key as `npm_config_puppeteer_skip_download`, so
puppeteer never sees the setting and downloads Chrome regardless. The
environment variable is read directly by puppeteer and does not depend on npm's
config forwarding.

`Dockerfile.armv7` has always set the env var explicitly, which is precisely
why the armv7 leg kept building while this one broke. This change brings the
main `Dockerfile` in line with it.

Puppeteer is a devDependency used only by two ad-hoc screenshot helpers
(`scripts/capture-doc-screenshots.js`, `scripts/capture-theme-screenshots.js`).
Neither the runtime image nor the build needs the browser binary.

## Verification

Reproduced and fixed under **real linux/arm64 emulation** (`docker buildx
--platform linux/arm64`), installing the same `puppeteer@25.5.0` on the same
`node:24.15.0-alpine3.22` base:

| | Result |
| --- | --- |
| without the flag | puppeteer runs `downloadBrowser` → install errors out |
| with the flag | `added 27 packages in 13s`, no download attempted |

## ⚠️ CI cannot prove this one

**A green PR here does not validate the fix.** The `Build Check` job in `ci.yml`
builds with `push: false` and no `platforms:`, so it is **amd64 only**, the
arm64 path that actually broke is built solely by `docker-publish.yml`, which
triggers on `release`. The local arm64 reproduction above is the real evidence;
the next release build is the first time CI exercises it.

## Not included

Two related things I deliberately left out of this PR:

- **The broader `.npmrc` breakage.** That silent config key also backs local
  clones, `npm ci`, and NixOS installs per its own comment, and the LXC build
  and system-tests workflow already set the env var explicitly. Worth a
  follow-up to decide whether `.npmrc` should keep a key npm ignores.
- **An unrelated `linux-headers` change** sitting uncommitted in the working
  copy, not mine to sweep in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G
