### PR TITLE
docs(add-ons): list CardMesh and document the REST API integration path

### DIFF
--- a/docs/add-ons/index.md
+++ b/docs/add-ons/index.md
@@ -1,12 +1,15 @@
 # Community Add-ons
 
-Community add-ons are third-party sidecar containers that extend MeshMonitor's capabilities. They connect to MeshMonitor's [Virtual Node](/configuration/virtual-node) (TCP port 4404) to interact with your Meshtastic mesh network.
+Community add-ons are third-party projects that extend MeshMonitor's capabilities. They integrate in one of two ways:
+
+- **Virtual Node sidecars** connect to MeshMonitor's [Virtual Node](/configuration/virtual-node) (TCP port 4404) and speak the Meshtastic protobuf protocol, acting like another client of your mesh.
+- **REST API clients** call MeshMonitor's [v1 REST API](/development/api-reference) with an API token, reading and sending through the data MeshMonitor already collects.
 
 ::: warning Third-Party Projects
 These add-ons are developed and maintained by outside contributors, not the MeshMonitor team. While we've tested them and include them in our documentation, please direct bug reports and feature requests to each project's own repository.
 :::
 
-## Available Add-ons
+## Virtual Node Sidecars
 
 ### [MQTT Client Proxy](/add-ons/mqtt-proxy)
 Route MQTT traffic through MeshMonitor instead of relying on your node's WiFi connection. Ideal for nodes with unreliable WiFi, serial/BLE-connected devices, or when you want server-grade MQTT reliability.
@@ -17,6 +20,17 @@ Route MQTT traffic through MeshMonitor instead of relying on your node's WiFi co
 Transform your Meshtastic node into an AI-powered assistant. Users on the mesh can ask questions, have conversations, and get intelligent responses through multiple AI providers (Ollama, Gemini, OpenAI, Anthropic).
 
 **By [LN4CY](https://github.com/LN4CY/ai-responder)**
+
+## REST API Clients
+
+### [CardMesh](https://github.com/maxhayim/cardmeshformeshmonitor)
+A keyboard-first pocket client for the [M5Stack CardputerZero](https://shop.m5stack.com/), turning it into a handheld console for your mesh. CardMesh talks to MeshMonitor's REST API rather than to a radio directly, so MeshMonitor keeps handling the connections, storage, and history while the CardputerZero is a compact field terminal.
+
+::: tip Early preview
+CardMesh is at **v0.1.0** and under active development. The dashboard is implemented; messaging, node browsing, and the remaining screens are still in progress. Treat it as a preview rather than a finished client.
+:::
+
+**By [maxhayim](https://github.com/maxhayim/cardmeshformeshmonitor)**
 
 ## How Add-ons Work
 
@@ -58,11 +72,29 @@ The easiest way to deploy add-ons is with the [Docker Compose Configurator](/con
 
 ## Building Your Own Add-on
 
-If you're interested in building a sidecar that integrates with MeshMonitor:
+Pick the integration style that matches what you're building.
+
+### As a Virtual Node sidecar
+
+Best when your add-on needs to behave like another node on the mesh, sending and receiving packets directly.
 
 1. **Connect via TCP** to the Virtual Node port (default 4404)
-2. **Use the Meshtastic protobuf protocol** — the same protocol used by official Meshtastic mobile apps
+2. **Use the Meshtastic protobuf protocol**, the same protocol used by official Meshtastic mobile apps
 3. **Libraries**: Use the official [meshtastic Python library](https://github.com/meshtastic/python) or any client that speaks the Meshtastic TCP protocol
 4. **Reference**: See the [official protobuf definitions](https://github.com/meshtastic/protobufs/) for message formats
+
+### As a REST API client
+
+Best when your add-on wants the data MeshMonitor has already collected, nodes, messages, telemetry, traceroutes, without re-implementing any protocol handling. This also works across every source type, not just Meshtastic.
+
+1. **Create an API token** in MeshMonitor and send it as `Authorization: Bearer <token>`
+2. **Discover sources** with `GET /api/v1/sources`, then use the source-scoped routes:
+   `/api/v1/sources/{sourceId}/` + `nodes`, `messages`, `channels`, `telemetry`, `traceroutes`, `network`, `packets`, `status`, `actions`
+3. **`default` works as a sourceId alias** for the primary source, so single-source setups don't have to look one up first
+4. **Reference**: the [API reference](/development/api-reference), the endpoint-by-endpoint [REST_API.md](https://github.com/Yeraze/meshmonitor/blob/main/docs/api/REST_API.md), and the OpenAPI spec served at `/api/v1/docs`
+
+::: warning API tokens inherit their owner's permissions
+A token is not independently scoped, it can do whatever the user who created it can do. For a device that leaves the house, create a dedicated user with only the permissions the add-on needs rather than issuing a token from an admin account.
+:::
 
 Want your add-on listed here? Open a [discussion on GitHub](https://github.com/yeraze/meshmonitor/discussions)!


### PR DESCRIPTION
Processes the community add-on submission in #4702.

## What CardMesh is

[CardMesh](https://github.com/maxhayim/cardmeshformeshmonitor) by @maxhayim is a
keyboard-first pocket client for the M5Stack CardputerZero. It talks to
MeshMonitor's v1 REST API rather than to a radio, so MeshMonitor keeps doing the
connection handling, storage, and history while the CardputerZero acts as a
handheld console.

## Why this touches more than one line

The Community Add-ons page assumed **every** add-on is a Virtual Node sidecar
container speaking the Meshtastic protobuf protocol — that is how both existing
entries work. CardMesh is neither a sidecar nor a container, so listing it under
that framing would have been wrong.

The page now describes the two integration styles and groups entries under them:

- **Virtual Node sidecars** — MQTT Client Proxy, AI Responder
- **REST API clients** — CardMesh

"Building Your Own Add-on" gains a matching REST-client section: token auth,
source discovery, the `default` sourceId alias, and the source-scoped route list.

## Verified rather than assumed

I checked the submission's technical claims against the code before listing it:

- All nine endpoints it cites exist and are mounted source-scoped in
  `src/server/routes/v1/index.ts` (`nodes`, `messages`, `channels`, `telemetry`,
  `traceroutes`, `network`, `packets`, `status`, plus `actions`).
- `Authorization: Bearer <token>` is supported (`authMiddleware.ts`
  `resolveBearerUser`).
- The `default` sourceId alias resolves to the primary source.

One thing that came out of that reading is worth documenting for **all** REST
clients, not just this one: API tokens are **not** independently scoped — they
inherit the permissions of the user who created them. For a device that leaves
the house, that argues for a dedicated limited user rather than a token minted
from an admin account. Added as a warning callout.

## Editorial call worth a second opinion

CardMesh is **v0.1.0** — the dashboard is implemented and everything else is
planned. I listed it with an explicit early-preview note so readers are not led
to expect a finished client. If you would rather hold the listing until it does
more, drop the CardMesh block and the rest of the restructure still stands on
its own.

## Testing

`npm run docs:build` passes. This caught two dead links on the first attempt:
`docs/api/REST_API.md` is not part of the VitePress site, so the in-site
reference is `/development/api-reference` with the GitHub blob URL alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G