### PR TITLE
feat(admin): warn when position precision exceeds the public-channel clamp (#4705)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3792,6 +3792,7 @@
   "admin_commands.downlink_enabled_description": "Allow this channel to receive messages from MQTT",
   "admin_commands.position_precision": "Location Precision (bits)",
   "admin_commands.position_precision_description": "Number of bits for position data (0-32). Higher = more precise. 32 = full precision.",
+  "admin_commands.position_precision_public_clamp_warning": "This is a public channel (no encryption or the default {{psk}} key). Firmware 2.8+ reduces position precision to {{bits}} bits (~{{meters}} m) on public channels, so a higher value here will be silently ignored by the radio. Use a custom PSK if you need finer precision.",
   "admin_commands.edit_channel": "Edit Channel {{slot}}",
   "admin_commands.save_channel": "Save Channel",
   "admin_commands.please_select_node_export": "Please select a node",

--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -3932,8 +3932,14 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                 bits on known-public channels. Warn rather than cap the input —
                 2.7.x honours higher values, so capping would break the setting
                 for everyone not yet on 2.8.
+
+                Skipped for role 0 (disabled): a disabled channel transmits no
+                position at all, so there is nothing to clamp. This also keeps
+                a freshly-opened, never-configured slot quiet, since the state
+                defaults (precision 32, empty PSK) would otherwise trip the
+                warning before the user has touched anything.
               */}
-              {exceedsPublicChannelPrecisionClamp(channelPsk, channelPositionPrecision) && (
+              {channelRole !== 0 && exceedsPublicChannelPrecisionClamp(channelPsk, channelPositionPrecision) && (
                 <span
                   className="setting-description"
                   role="alert"

--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -3937,7 +3937,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                 <span
                   className="setting-description"
                   role="alert"
-                  style={{ color: 'var(--color-warning, #d97706)' }}
+                  style={{ color: 'var(--color-warning)' }}
                 >
                   {t(
                     'admin_commands.position_precision_public_clamp_warning',

--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -18,6 +18,12 @@ import { DeviceConfigurationSection } from './admin-commands/DeviceConfiguration
 import AutoFavoriteManagementSection from './admin-commands/AutoFavoriteManagementSection';
 import { ModuleConfigurationSection } from './admin-commands/ModuleConfigurationSection';
 import { useAdminCommandsState, packMeshBeaconFlags, unpackMeshBeaconFlags, pskToBase64 } from './admin-commands/useAdminCommandsState';
+import {
+  DEFAULT_PUBLIC_PSK,
+  PUBLIC_CHANNEL_PRECISION_MAX_BITS,
+  PUBLIC_CHANNEL_PRECISION_MAX_METERS,
+  exceedsPublicChannelPrecisionClamp,
+} from '../utils/publicChannel';
 import { buildNodeOptions, filterNodes, sortNodeOptionsForRemoteAdmin, type NodeOption } from './admin-commands/nodeOptionsUtils';
 import { createEmptyChannelSlot, createChannelFromResponse, isRetryableChannelError, countLoadedChannels } from './admin-commands/channelLoadingUtils';
 import { UiIcon } from './icons';
@@ -3921,6 +3927,29 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                 className="setting-input"
                 style={{ width: '100%' }}
               />
+              {/*
+                #4705: firmware 2.8+ silently clamps position precision to 15
+                bits on known-public channels. Warn rather than cap the input —
+                2.7.x honours higher values, so capping would break the setting
+                for everyone not yet on 2.8.
+              */}
+              {exceedsPublicChannelPrecisionClamp(channelPsk, channelPositionPrecision) && (
+                <span
+                  className="setting-description"
+                  role="alert"
+                  style={{ color: 'var(--color-warning, #d97706)' }}
+                >
+                  {t(
+                    'admin_commands.position_precision_public_clamp_warning',
+                    'This is a public channel (no encryption or the default {{psk}} key). Firmware 2.8+ reduces position precision to {{bits}} bits (~{{meters}} m) on public channels, so a higher value here will be silently ignored by the radio. Use a custom PSK if you need finer precision.',
+                    {
+                      psk: DEFAULT_PUBLIC_PSK,
+                      bits: PUBLIC_CHANNEL_PRECISION_MAX_BITS,
+                      meters: PUBLIC_CHANNEL_PRECISION_MAX_METERS,
+                    },
+                  )}
+                </span>
+              )}
             </div>
 
             <div style={{ display: 'flex', gap: '1rem', marginTop: '1.5rem' }}>

--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -32,9 +32,9 @@ import { UiIcon } from './icons';
 import UnreadDivider from './messages/UnreadDivider';
 import { resolveUnreadAnchorId, shouldSuppressDivider } from '../utils/unreadAnchor';
 import { useUnreadDividerAnchors } from '../contexts/MessagingContext';
-
-// Default PSK value (publicly known key - not truly secure)
-const DEFAULT_PUBLIC_PSK = 'AQ==';
+// Default PSK value (publicly known key - not truly secure) — shared
+// definition lives in utils/publicChannel.ts (#4705).
+import { DEFAULT_PUBLIC_PSK } from '../utils/publicChannel';
 
 // Offset for Channel Database channels
 // IMPORTANT: This value must match CHANNEL_DB_OFFSET in src/server/constants/meshtastic.ts

--- a/src/components/NodeFilterPopup.tsx
+++ b/src/components/NodeFilterPopup.tsx
@@ -6,9 +6,9 @@ import { useUI } from '../contexts/UIContext';
 import { useSettings } from '../contexts/SettingsContext';
 import { useChannels } from '../hooks/useServerData';
 import { UiIcon } from './icons';
-
 // Meshtastic default PSK (base64 encoded single byte 0x01 = default/unencrypted)
-const DEFAULT_UNENCRYPTED_PSK = 'AQ==';
+// — shared definition lives in utils/publicChannel.ts (#4705).
+import { DEFAULT_PUBLIC_PSK as DEFAULT_UNENCRYPTED_PSK } from '../utils/publicChannel';
 
 interface NodeFilterPopupProps {
   isOpen: boolean;

--- a/src/components/configuration/ChannelsConfigSection.tsx
+++ b/src/components/configuration/ChannelsConfigSection.tsx
@@ -27,9 +27,9 @@ import { logger } from '../../utils/logger';
 import { useSettings } from '../../contexts/SettingsContext';
 import { useResolvedSourceId } from '../../hooks/useResolvedSourceId';
 import { formatPrecisionAccuracy } from '../../utils/distance';
-
-// Default public PSK (base64 encoded value of single byte 0x01)
-const DEFAULT_PUBLIC_PSK = 'AQ==';
+// Default public PSK (base64 encoded value of single byte 0x01) — shared
+// definition lives in utils/publicChannel.ts (#4705).
+import { DEFAULT_PUBLIC_PSK } from '../../utils/publicChannel';
 
 /** A device channel sharing its key with a differently-named Channel Database
  *  (server-decryption) entry (#3644). */

--- a/src/utils/publicChannel.test.ts
+++ b/src/utils/publicChannel.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_PUBLIC_PSK,
+  PUBLIC_CHANNEL_PRECISION_MAX_BITS,
+  isKnownPublicChannel,
+  exceedsPublicChannelPrecisionClamp,
+} from './publicChannel';
+
+/**
+ * #4705 — firmware 2.8 clamps position precision to 15 bits on known-public
+ * channels. Getting "public" wrong in either direction is a real problem:
+ * too broad and we nag users on private channels that are never clamped;
+ * too narrow and we stay silent while the radio quietly discards their setting.
+ */
+describe('isKnownPublicChannel', () => {
+  it('treats the default PSK as public', () => {
+    expect(isKnownPublicChannel(DEFAULT_PUBLIC_PSK)).toBe(true);
+    expect(DEFAULT_PUBLIC_PSK).toBe('AQ==');
+  });
+
+  it('treats an absent or empty PSK as public (no encryption at all)', () => {
+    expect(isKnownPublicChannel('')).toBe(true);
+    expect(isKnownPublicChannel(null)).toBe(true);
+    expect(isKnownPublicChannel(undefined)).toBe(true);
+  });
+
+  it('treats any custom PSK as private', () => {
+    expect(isKnownPublicChannel('AQAAAAAAAAAAAAAAAAAAAA==')).toBe(false);
+    expect(isKnownPublicChannel('c2VjcmV0LWtleS1oZXJl')).toBe(false);
+  });
+
+  it('is case-sensitive — base64 is, and a differing case is a different key', () => {
+    expect(isKnownPublicChannel('aq==')).toBe(false);
+  });
+});
+
+describe('exceedsPublicChannelPrecisionClamp', () => {
+  it('warns above the clamp on a public channel', () => {
+    expect(exceedsPublicChannelPrecisionClamp(DEFAULT_PUBLIC_PSK, 32)).toBe(true);
+    expect(exceedsPublicChannelPrecisionClamp('', 16)).toBe(true);
+  });
+
+  it('does not warn at or below the clamp', () => {
+    expect(exceedsPublicChannelPrecisionClamp(DEFAULT_PUBLIC_PSK, PUBLIC_CHANNEL_PRECISION_MAX_BITS)).toBe(false);
+    expect(exceedsPublicChannelPrecisionClamp(DEFAULT_PUBLIC_PSK, 10)).toBe(false);
+    expect(exceedsPublicChannelPrecisionClamp(DEFAULT_PUBLIC_PSK, 0)).toBe(false);
+  });
+
+  it('never warns on a private channel, even at full precision', () => {
+    // Private channels are not clamped by the firmware, so 32 is legitimate.
+    expect(exceedsPublicChannelPrecisionClamp('c2VjcmV0LWtleS1oZXJl', 32)).toBe(false);
+  });
+
+  it('pins the clamp at 15 bits', () => {
+    // Matches meshtastic/firmware#10665; if firmware changes this, the
+    // warning text's "~564 m" figure has to move with it.
+    expect(PUBLIC_CHANNEL_PRECISION_MAX_BITS).toBe(15);
+  });
+});

--- a/src/utils/publicChannel.test.ts
+++ b/src/utils/publicChannel.test.ts
@@ -40,6 +40,13 @@ describe('exceedsPublicChannelPrecisionClamp', () => {
     expect(exceedsPublicChannelPrecisionClamp('', 16)).toBe(true);
   });
 
+  it('warns for an absent PSK, not just an empty string', () => {
+    // A channel object may carry `psk: null` or omit it entirely; both mean
+    // unencrypted, and both are clamped by the firmware.
+    expect(exceedsPublicChannelPrecisionClamp(null, 32)).toBe(true);
+    expect(exceedsPublicChannelPrecisionClamp(undefined, 32)).toBe(true);
+  });
+
   it('does not warn at or below the clamp', () => {
     expect(exceedsPublicChannelPrecisionClamp(DEFAULT_PUBLIC_PSK, PUBLIC_CHANNEL_PRECISION_MAX_BITS)).toBe(false);
     expect(exceedsPublicChannelPrecisionClamp(DEFAULT_PUBLIC_PSK, 10)).toBe(false);

--- a/src/utils/publicChannel.ts
+++ b/src/utils/publicChannel.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared "is this a known public channel?" detection (#4705).
+ *
+ * The base64 `AQ==` PSK is Meshtastic's 1-byte default key — the one the stock
+ * LongFast/MediumFast presets ship with. A channel using it is readable by
+ * anyone running default firmware, so it is "public" in every sense that
+ * matters, despite technically being encrypted.
+ *
+ * The constant was previously copy-pasted into four files
+ * (`ChannelsConfigSection.tsx`, `ChannelsTab.tsx`, `NodeFilterPopup.tsx`, and
+ * server-side `channelView.ts`). This is the shared frontend definition; the
+ * server keeps its own copy so server code never imports from `src/components`.
+ */
+
+/** Meshtastic's default public PSK: base64 of the single byte 0x01. */
+export const DEFAULT_PUBLIC_PSK = 'AQ==';
+
+/**
+ * Firmware clamps `position_precision` to this many bits on known-public
+ * channels (~564 m accuracy).
+ *
+ * Introduced by meshtastic/firmware#10665 (merged to `develop` 2026-06-14, part
+ * of the 2.8 line — NOT in 2.7.x). The firmware enforces it twice: once in
+ * `AdminModule.cpp` when the config is saved, and again in `PositionModule.cpp`
+ * at transmit time. A client may still *request* a higher value; the radio
+ * silently reduces it either way.
+ */
+export const PUBLIC_CHANNEL_PRECISION_MAX_BITS = 15;
+
+/** Approximate ground accuracy of PUBLIC_CHANNEL_PRECISION_MAX_BITS, in metres. */
+export const PUBLIC_CHANNEL_PRECISION_MAX_METERS = 564;
+
+/**
+ * True when a channel counts as "known public" for the firmware's precision
+ * clamp: either unencrypted, or using the default public PSK.
+ *
+ * Mirrors the firmware's own definition. A custom PSK — of any length — is a
+ * private channel and is not clamped.
+ */
+export function isKnownPublicChannel(psk: string | null | undefined): boolean {
+  if (psk == null || psk === '') return true; // no encryption at all
+  return psk === DEFAULT_PUBLIC_PSK;
+}
+
+/**
+ * True when this precision setting will be silently reduced by 2.8+ firmware.
+ *
+ * Deliberately NOT firmware-version-gated: MeshMonitor generally cannot know
+ * the target node's firmware version when configuring a remote channel, and the
+ * warning is useful in both directions — it tells 2.7 users the constraint is
+ * coming, and explains to 2.8 users why their setting reduced itself.
+ */
+export function exceedsPublicChannelPrecisionClamp(
+  psk: string | null | undefined,
+  precisionBits: number,
+): boolean {
+  return isKnownPublicChannel(psk) && precisionBits > PUBLIC_CHANNEL_PRECISION_MAX_BITS;
+}


### PR DESCRIPTION
Closes #4705

## The problem

Firmware 2.8 ([meshtastic/firmware#10665](https://github.com/meshtastic/firmware/pull/10665)) clamps `position_precision` to **15 bits (~564 m)** on "known public" channels — unencrypted, or using the default `AQ==` PSK. It enforces this twice: in `AdminModule.cpp` on config save, and again in `PositionModule.cpp` at transmit.

The remote-admin channel editor accepted 0–32 with no awareness of that ceiling. A user could set 32 on LongFast, watch it save, and never learn the radio was sending 15.

## Warning, not a cap

The issue offered either. **A cap would be wrong**: the clamp is 2.8-only, and 2.7.x honours higher precision — capping the input would break the setting for every user not yet on 2.8.

The warning is also deliberately **not** firmware-version-gated. MeshMonitor generally can't know a remote node's firmware version when editing its channels, and the message earns its place either way: it tells 2.7 users the constraint is coming, and explains to 2.8 users why their setting silently reduced itself. That matches the issue's own stated goal.

It renders only when the channel is public **and** precision exceeds 15, so private channels — which are never clamped — stay quiet at full precision.

## Shared helper

The `AQ==` constant had been copy-pasted into four files. This adds `src/utils/publicChannel.ts` with the constant, `isKnownPublicChannel()`, the clamp values, and `exceedsPublicChannelPrecisionClamp()`.

The three frontend copies (`ChannelsConfigSection`, `ChannelsTab`, `NodeFilterPopup`) now import the shared constant. That part is a **pure constant dedup with no logic change** — their surrounding helpers have subtly different semantics (`'none' | 'default' | 'secure'` vs. a boolean "is encrypted"), so I deliberately did not unify those and risk a behaviour change in a UX-only PR.

`src/server/utils/channelView.ts` keeps its own copy on purpose, so server code never imports from `src/components`.

## Scope

This covers what MeshMonitor lets a user **set**. The issue's scope note flags a second concern — reflecting the precision a remote node is *actually broadcasting* after the clamp — as needing confirmation from the requester. That is **not** included here.

## Testing

- New `publicChannel.test.ts`: default PSK, empty/null/undefined, custom PSKs, base64 case-sensitivity, boundary at exactly 15, private-channel-at-32 stays silent, and a pin on the 15-bit constant so the "~564 m" figure can't drift away from it.
- 81 tests pass across the new util and all touched components.
- `tsc` clean, `lint:ci` clean, `en.json` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G