### PR TITLE
Fix traceroute channel resolution: 3 bypassing paths + PSK/name gaps

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -61,6 +61,7 @@ import { getEffectiveDbNodePosition } from './utils/nodeEnhancer.js';
 import { migrateAutomationChannels } from './utils/automationChannelMigration.js';
 import { detectChannelMoves } from './utils/channelMoveDetection.js';
 import { detectLocalNodeSpoof, SentPacketIdCache, type SpoofDetectionResult } from './utils/spoofDetection.js';
+import { resolveBroadcastChannel } from './utils/resolveDestinationChannel.js';
 import { applyHomoglyphOptimization } from '../utils/homoglyph.js';
 import { PortNum, RoutingError, isPkiError, getRoutingErrorName, CHANNEL_DB_OFFSET, TransportMechanism, resolveRadioPacketTransport, isViaMqtt, MIN_TRACEROUTE_INTERVAL_MS, StoreForwardRequestResponse, getStoreForwardRequestResponseName, isUdpBroadcastEnabled, resolveHopLimit } from './constants/meshtastic.js';
 import { normalizeChannelRole } from './constants/channelRole.js';
@@ -2317,7 +2318,10 @@ class MeshtasticManager implements ISourceManager {
           // Use async version which supports PostgreSQL/MySQL; scope to this source
           const targetNode = await databaseService.getNodeNeedingTracerouteAsync(this.localNodeInfo.nodeNum, this.sourceId);
           if (targetNode) {
-            const channel = targetNode.channel ?? 0; // Use node's channel, default to 0
+            // Resolve the well-known channel every intermediate node can
+            // decrypt and relay, rather than the target's raw stored channel
+            // (which may be a private secondary) — issues #3696, #4691.
+            const channel = await resolveBroadcastChannel(this, databaseService);
             const targetName = targetNode.longName || targetNode.nodeId;
             logger.debug(`🗺️ Auto-traceroute: Sending traceroute to ${targetName} (${targetNode.nodeId}) on channel ${channel}`);
 
@@ -11471,7 +11475,10 @@ class MeshtasticManager implements ISourceManager {
 
             // Send the actual traceroute packet
             try {
-              const channel = targetNode.channel ?? 0;
+              // Resolve the well-known channel every intermediate node can
+              // decrypt and relay, rather than the target's raw stored channel
+              // (which may be a private secondary) — issues #3696, #4691.
+              const channel = await resolveBroadcastChannel(this, databaseService);
               await this.sendTraceroute(targetNodeNum, channel);
               logger.debug(`🔍 Auto-responder traceroute to ${targetName} (${targetNode.nodeId}) initiated by ${nodeId}`);
 

--- a/src/server/routes/meshRequestRoutes.test.ts
+++ b/src/server/routes/meshRequestRoutes.test.ts
@@ -109,9 +109,10 @@ describe('POST /traceroute', () => {
   });
 
   it('honors an explicit channel override of 0 (guards the `?? ` vs `||` falsy trap)', async () => {
-    // The default-keyed resolution would also yield 0 here, so force the broadcast
-    // resolver toward a different slot — proving the explicit 0 is what wins.
-    (databaseService.channels.getAllChannels as any).mockResolvedValue([{ id: 3, psk: 'AQ==' }]);
+    // Make slot 3 genuinely well-known (mesh-readable PSK + matching preset
+    // name) so the broadcast resolver would pick it if consulted — proving
+    // the explicit 0 is what wins, not just an unresolvable fallback.
+    (databaseService.channels.getAllChannels as any).mockResolvedValue([{ id: 3, psk: 'AQ==', name: 'LongFast' }]);
     mockManager.sendTraceroute.mockResolvedValue(undefined);
     const res = await request(app).post('/traceroute').send({ destination: '!12345678', channel: 0 });
     expect(res.status).toBe(200);

--- a/src/server/routes/meshRequestRoutes.test.ts
+++ b/src/server/routes/meshRequestRoutes.test.ts
@@ -58,8 +58,8 @@ beforeEach(() => {
   // is mesh-readable; slot 2 is a private encrypted channel. resolveBroadcastChannel
   // should therefore pick slot 0 for traceroutes.
   (databaseService.channels.getAllChannels as any).mockResolvedValue([
-    { id: 0, psk: 'AQ==' },
-    { id: 2, psk: 'c29tZXByaXZhdGVrZXk=' },
+    { id: 0, psk: 'AQ==', name: 'LongFast' },
+    { id: 2, psk: 'c29tZXByaXZhdGVrZXk=', name: 'Private' },
   ]);
   mockManager.getLocalNodeInfo.mockReturnValue({ nodeNum: 1, nodeId: '!00000001' });
 });
@@ -92,8 +92,8 @@ describe('POST /traceroute', () => {
     // Slot 0 here has a PRIVATE key, slot 3 carries the default key, so a
     // traceroute must go out on slot 3 — not the encrypted slot 0.
     (databaseService.channels.getAllChannels as any).mockResolvedValue([
-      { id: 0, psk: 'cHJpdmF0ZWtleTAwMA==' },
-      { id: 3, psk: 'AQ==' },
+      { id: 0, psk: 'cHJpdmF0ZWtleTAwMA==', name: 'LongFast' },
+      { id: 3, psk: 'AQ==', name: 'LongFast' },
     ]);
     mockManager.sendTraceroute.mockResolvedValue(undefined);
     const res = await request(app).post('/traceroute').send({ destination: '!12345678' });

--- a/src/server/routes/v1/actions.test.ts
+++ b/src/server/routes/v1/actions.test.ts
@@ -50,6 +50,9 @@ vi.mock('../../../services/database.js', () => ({
     nodes: {
       getNode: vi.fn(),
     },
+    channels: {
+      getAllChannels: vi.fn(),
+    },
     messages: {
       insertMessage: vi.fn(),
     },
@@ -61,6 +64,7 @@ vi.mock('../../../services/database.js', () => ({
 // ──────────────────────────────────────────────────────────────────────────────
 
 const mockManager = {
+  sourceId:              SOURCE_A,
   sendTraceroute:        vi.fn(),
   sendPositionRequest:   vi.fn(),
   sendNodeInfoRequest:   vi.fn(),
@@ -136,6 +140,8 @@ beforeEach(() => {
   mockDb.sources.getAllSources.mockResolvedValue([]);
   // Default: no node found → channel 0
   mockDb.nodes.getNode.mockResolvedValue(null);
+  // Default: no channels configured → resolveBroadcastChannel falls back to 0
+  mockDb.channels.getAllChannels.mockResolvedValue([]);
   // Default: insertMessage succeeds
   mockDb.messages.insertMessage.mockResolvedValue(true);
   // Default: manager resolves to mockManager for any sourceId
@@ -169,14 +175,21 @@ describe('POST /traceroute', () => {
     expect(mockResolveSourceManager).toHaveBeenCalledWith(SOURCE_A);
   });
 
-  it('uses the node channel from the database', async () => {
+  it('resolves the well-known broadcast channel instead of the target\'s raw stored channel (#4691)', async () => {
+    // A target node last heard on a private secondary (channel 3) must NOT
+    // determine the traceroute channel — the mesh-readable/well-known
+    // channel (id 5 here) is what every intermediate node can decrypt.
     mockDb.nodes.getNode.mockResolvedValue({ channel: 3, hopsAway: 1 });
+    mockDb.channels.getAllChannels.mockResolvedValue([
+      { id: 3, psk: 'cHJpdmF0ZQ==', name: 'Private', role: 1 },
+      { id: 5, psk: 'AQ==', name: 'LongFast', role: 2 },
+    ]);
     const app = buildApp(normalUser);
     const res = await post(app, SOURCE_A, 'traceroute', { destination: `!${DEST_NUM.toString(16)}` });
 
     expect(res.status).toBe(200);
-    expect(mockManager.sendTraceroute).toHaveBeenCalledWith(DEST_NUM, 3);
-    expect(mockDb.nodes.getNode).toHaveBeenCalledWith(DEST_NUM, SOURCE_A);
+    expect(mockManager.sendTraceroute).toHaveBeenCalledWith(DEST_NUM, 5);
+    expect(mockDb.channels.getAllChannels).toHaveBeenCalledWith(SOURCE_A);
   });
 
   it('accepts channel override in request body', async () => {

--- a/src/server/routes/v1/actions.ts
+++ b/src/server/routes/v1/actions.ts
@@ -19,6 +19,7 @@ import { logger } from '../../../utils/logger.js';
 import { PortNum } from '../../constants/meshtastic.js';
 import { attachSource, resolvedSourceIdFromPath } from './sourceParam.js';
 import { isTxDisabledError } from '../../errors/txDisabledError.js';
+import { resolveBroadcastChannel, isValidChannelIndex } from '../../utils/resolveDestinationChannel.js';
 
 const router = express.Router({ mergeParams: true });
 
@@ -86,10 +87,14 @@ router.post('/traceroute', attachSource('traceroute', 'write'), async (req: Requ
     }
 
     const manager = resolveSourceManager(sourceId);
-    const node = await databaseService.nodes.getNode(destinationNum, sourceId);
-    const channel = (typeof req.body.channel === 'number' && req.body.channel >= 0 && req.body.channel <= 7)
+    // Traceroutes must traverse a channel every intermediate node can decrypt
+    // and relay, or those nodes can't append to the route and show up as
+    // "Unknown" (issue #3696, #4691). A valid explicit channel wins; otherwise
+    // resolve the well-known channel the whole mesh shares — never the
+    // target's raw stored channel, which may be a private secondary.
+    const channel = isValidChannelIndex(req.body.channel)
       ? req.body.channel
-      : (node?.channel ?? 0);
+      : await resolveBroadcastChannel(manager, databaseService);
 
     await manager.sendTraceroute(destinationNum, channel);
 

--- a/src/server/utils/resolveDestinationChannel.test.ts
+++ b/src/server/utils/resolveDestinationChannel.test.ts
@@ -83,9 +83,12 @@ describe('resolveDestinationChannel', () => {
 
 /**
  * `resolveBroadcastChannel` picks a channel every node in the mesh can decrypt
- * (the well-known default key "AQ==", or an unencrypted slot). This is what
- * traceroute needs so intermediate nodes can append to the route — and why
- * hardcoding slot 0 was wrong: slot 0 can carry a private key (issue #3696).
+ * AND relay: a mesh-readable PSK (any 1-byte shorthand, or unencrypted) whose
+ * name also matches a firmware ModemPreset display name (issue #4691's "well
+ * known channel" pairing — the on-wire hash is `hash(name) XOR hash(psk)`).
+ * This is what traceroute needs so intermediate nodes can append to the
+ * route — and why hardcoding slot 0 was wrong: slot 0 can carry a private key
+ * (issue #3696).
  */
 describe('resolveBroadcastChannel', () => {
   let getAllChannels: ReturnType<typeof vi.fn>;
@@ -97,49 +100,74 @@ describe('resolveBroadcastChannel', () => {
   });
 
   it('scopes the channel lookup to the manager sourceId', async () => {
-    getAllChannels.mockResolvedValue([{ id: 0, psk: 'AQ==' }]);
+    getAllChannels.mockResolvedValue([{ id: 0, psk: 'AQ==', name: 'LongFast' }]);
     await resolveBroadcastChannel(manager, db);
     expect(getAllChannels).toHaveBeenCalledWith('meshtastic-src');
   });
 
   it('returns the default-keyed channel when it is slot 0', async () => {
     getAllChannels.mockResolvedValue([
-      { id: 0, psk: 'AQ==' },
-      { id: 2, psk: 'cHJpdmF0ZWtleQ==' },
+      { id: 0, psk: 'AQ==', name: 'LongFast' },
+      { id: 2, psk: 'cHJpdmF0ZWtleQ==', name: 'Secret' },
     ]);
     expect(await resolveBroadcastChannel(manager, db)).toBe(0);
   });
 
   it('returns the default-keyed channel even when it is NOT slot 0', async () => {
     getAllChannels.mockResolvedValue([
-      { id: 0, psk: 'cHJpdmF0ZWtleQ==' }, // private primary
-      { id: 3, psk: 'AQ==' },             // default-keyed secondary
+      { id: 0, psk: 'cHJpdmF0ZWtleQ==', name: 'LongFast' }, // private primary
+      { id: 3, psk: 'AQ==', name: 'LongFast' },             // default-keyed secondary
     ]);
     expect(await resolveBroadcastChannel(manager, db)).toBe(3);
   });
 
   it('treats an unencrypted (null/empty PSK) channel as mesh-readable', async () => {
     getAllChannels.mockResolvedValue([
-      { id: 0, psk: 'cHJpdmF0ZWtleQ==' },
-      { id: 1, psk: null },
-      { id: 2, psk: '' },
+      { id: 0, psk: 'cHJpdmF0ZWtleQ==', name: 'LongFast' },
+      { id: 1, psk: null, name: 'LongFast' },
+      { id: 2, psk: '', name: 'LongFast' },
     ]);
     expect(await resolveBroadcastChannel(manager, db)).toBe(1);
   });
 
+  it('accepts any 1-byte shorthand PSK, not just the literal default byte (#4691)', async () => {
+    // Byte 0xD4 (212) base64-encodes to "1A==" — a 1-byte shorthand outside
+    // the literal "AQ==" (0x01) the old check required.
+    getAllChannels.mockResolvedValue([{ id: 0, psk: '1A==', name: 'LongFast' }]);
+    expect(await resolveBroadcastChannel(manager, db)).toBe(0);
+  });
+
+  it('rejects a mesh-readable PSK whose channel name is not a ModemPreset name (#4691)', async () => {
+    // 1-byte PSK, but a custom name — the on-wire hash won't match any other
+    // node's factory-configured channel, so it's not actually relayable.
+    getAllChannels.mockResolvedValue([
+      { id: 0, psk: 'AQ==', name: 'MyPrivateChannel' },
+      { id: 2, psk: 'AQ==', name: 'MediumFast' },
+    ]);
+    expect(await resolveBroadcastChannel(manager, db)).toBe(2);
+  });
+
+  it('rejects the deprecated VeryLongSlow preset name even with a mesh-readable PSK (#4691)', async () => {
+    // Firmware's getModemPresetDisplayName() has no case for index 2 and
+    // always falls through to "Invalid" on-device, so no real channel name
+    // can ever equal "VeryLongSlow" on the wire.
+    getAllChannels.mockResolvedValue([{ id: 0, psk: 'AQ==', name: 'VeryLongSlow' }]);
+    expect(await resolveBroadcastChannel(manager, db)).toBe(0); // falls back, not selected as "readable"
+  });
+
   it('prefers the lowest-numbered mesh-readable channel', async () => {
     getAllChannels.mockResolvedValue([
-      { id: 5, psk: 'AQ==' },
-      { id: 1, psk: 'AQ==' },
-      { id: 3, psk: 'AQ==' },
+      { id: 5, psk: 'AQ==', name: 'LongFast' },
+      { id: 1, psk: 'AQ==', name: 'LongFast' },
+      { id: 3, psk: 'AQ==', name: 'LongFast' },
     ]);
     expect(await resolveBroadcastChannel(manager, db)).toBe(1);
   });
 
   it('falls back to channel 0 when every channel uses a private key', async () => {
     getAllChannels.mockResolvedValue([
-      { id: 0, psk: 'cHJpdmF0ZTA=' },
-      { id: 2, psk: 'cHJpdmF0ZTI=' },
+      { id: 0, psk: 'cHJpdmF0ZTA=', name: 'LongFast' },
+      { id: 2, psk: 'cHJpdmF0ZTI=', name: 'LongFast' },
     ]);
     expect(await resolveBroadcastChannel(manager, db)).toBe(0);
   });
@@ -151,8 +179,8 @@ describe('resolveBroadcastChannel', () => {
 
   it('ignores channels with out-of-range indices', async () => {
     getAllChannels.mockResolvedValue([
-      { id: 101, psk: 'AQ==' }, // bogus MQTT-style index, must be skipped
-      { id: 4, psk: 'AQ==' },
+      { id: 101, psk: 'AQ==', name: 'LongFast' }, // bogus MQTT-style index, must be skipped
+      { id: 4, psk: 'AQ==', name: 'LongFast' },
     ]);
     expect(await resolveBroadcastChannel(manager, db)).toBe(4);
   });
@@ -163,25 +191,25 @@ describe('resolveBroadcastChannel', () => {
     // encoding a traceroute on it NAKs NO_CHANNEL (6). The disabled NULL-psk
     // slots must be skipped and we fall back to the enabled PRIMARY slot 0.
     getAllChannels.mockResolvedValue([
-      { id: 0, psk: 'cHJpdmF0ZWtleQ==', role: 1 }, // PRIMARY, private key
-      { id: 1, psk: null, role: 0 },               // DISABLED
-      { id: 2, psk: null, role: 0 },               // DISABLED
+      { id: 0, psk: 'cHJpdmF0ZWtleQ==', role: 1, name: 'LongFast' }, // PRIMARY, private key
+      { id: 1, psk: null, role: 0, name: 'LongFast' },               // DISABLED
+      { id: 2, psk: null, role: 0, name: 'LongFast' },               // DISABLED
     ]);
     expect(await resolveBroadcastChannel(manager, db)).toBe(0);
   });
 
   it('skips a DISABLED (null-psk) slot in favor of a lower-priority enabled default-keyed one', async () => {
     getAllChannels.mockResolvedValue([
-      { id: 1, psk: null, role: 0 },   // DISABLED (null psk) — must be skipped
-      { id: 2, psk: 'AQ==', role: 2 }, // enabled SECONDARY on the default key
+      { id: 1, psk: null, role: 0, name: 'LongFast' },   // DISABLED (null psk) — must be skipped
+      { id: 2, psk: 'AQ==', role: 2, name: 'LongFast' }, // enabled SECONDARY on the default key
     ]);
     expect(await resolveBroadcastChannel(manager, db)).toBe(2);
   });
 
   it('selects an enabled default-keyed SECONDARY over a private PRIMARY', async () => {
     getAllChannels.mockResolvedValue([
-      { id: 0, psk: 'cHJpdmF0ZQ==', role: 1 }, // PRIMARY, private
-      { id: 3, psk: 'AQ==', role: 2 },         // enabled default-key SECONDARY
+      { id: 0, psk: 'cHJpdmF0ZQ==', role: 1, name: 'LongFast' }, // PRIMARY, private
+      { id: 3, psk: 'AQ==', role: 2, name: 'LongFast' },         // enabled default-key SECONDARY
     ]);
     expect(await resolveBroadcastChannel(manager, db)).toBe(3);
   });

--- a/src/server/utils/resolveDestinationChannel.ts
+++ b/src/server/utils/resolveDestinationChannel.ts
@@ -161,7 +161,7 @@ export async function resolveBroadcastChannel(
     .filter(
       (ch) =>
         isValidChannelIndex(ch.id) &&
-        ch.role !== 0 &&
+        ch.role !== 0 && // undefined role (no row/older data) is treated as enabled, not DISABLED
         isMeshReadablePsk(ch.psk) &&
         isWellKnownChannelName(ch.name),
     )

--- a/src/server/utils/resolveDestinationChannel.ts
+++ b/src/server/utils/resolveDestinationChannel.ts
@@ -1,5 +1,6 @@
 import type databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
+import { MODEM_PRESET_CHANNEL_NAMES } from '../../utils/loraFrequency.js';
 
 /**
  * Meshtastic supports channel indexes 0–7 (PRIMARY plus up to seven
@@ -9,14 +10,24 @@ import { logger } from '../../utils/logger.js';
 export const MAX_MESHTASTIC_CHANNEL_INDEX = 7;
 
 /**
- * The well-known default Meshtastic PSK: a single 0x01 byte, stored base64 as
- * "AQ==". The firmware expands this to the public default channel key that
- * every node ships with, so any node in the mesh can decrypt a channel that
- * uses it. A channel with no PSK at all is unencrypted and likewise readable by
- * everyone. These are the only channels guaranteed traversable by intermediate
- * nodes — which is what traceroute requires (issue #3696).
+ * ModemPreset index 2 ("VeryLongSlow") is deprecated and has no case in
+ * firmware's `getModemPresetDisplayName()` — it always falls through to
+ * "Invalid" on-device, so no real channel name can ever equal it. Excluded
+ * from the well-known-name match below to mirror firmware's
+ * `Channels::isWellKnownChannel()` (issue #4691).
  */
-const DEFAULT_PSK_BASE64 = 'AQ==';
+const NON_MATCHING_PRESET_INDEX = 2;
+
+/**
+ * Channel names that mirror one of firmware's ModemPreset display names
+ * (`Channels::isWellKnownChannel()` matches PSK size against this set of
+ * names, not just the LongFast/primary case).
+ */
+const WELL_KNOWN_CHANNEL_NAMES = new Set(
+  Object.entries(MODEM_PRESET_CHANNEL_NAMES)
+    .filter(([index]) => Number(index) !== NON_MATCHING_PRESET_INDEX)
+    .map(([, name]) => name),
+);
 
 export function isValidChannelIndex(value: unknown): value is number {
   return (
@@ -76,8 +87,12 @@ export async function resolveDestinationChannel(
 }
 
 /**
- * True when a channel's PSK is one that every node in the mesh can decrypt:
- * the well-known default key ("AQ==") or no key at all (unencrypted).
+ * True when a channel's PSK is one every node in the mesh can compute: no key
+ * at all (unencrypted), or any 1-byte shorthand PSK. Firmware's
+ * `channelFileUsesPublicKey()` treats every 1-byte PSK (0x01-0xFF) as part of
+ * the public "defaultpsk" family, not just the literal default byte
+ * (0x01/"AQ=="), so a 1-byte value like "1A==" (0xD4) expands to the same
+ * shared key space (issue #4691).
  *
  * The ingest path stores an unencrypted channel as NULL psk (meshtasticManager
  * only base64-encodes a PSK when `psk.length > 0`, otherwise leaves it
@@ -85,7 +100,24 @@ export async function resolveDestinationChannel(
  * row that slipped in with `''`.
  */
 function isMeshReadablePsk(psk: string | null | undefined): boolean {
-  return psk == null || psk === '' || psk === DEFAULT_PSK_BASE64;
+  if (psk == null || psk === '') return true;
+  try {
+    return Buffer.from(psk, 'base64').length === 1;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True when a channel's name matches one of firmware's ModemPreset display
+ * names. Combined with {@link isMeshReadablePsk}, this mirrors firmware's
+ * `Channels::isWellKnownChannel()`: the on-wire channel hash is
+ * `hash(name) XOR hash(psk)`, so a mesh-readable PSK under a custom name
+ * still hashes to something no other node's factory-configured channel
+ * matches (issue #4691).
+ */
+function isWellKnownChannelName(name: string | null | undefined): boolean {
+  return name != null && WELL_KNOWN_CHANNEL_NAMES.has(name);
 }
 
 /**
@@ -121,10 +153,18 @@ export async function resolveBroadcastChannel(
   // (issue #4173). Disabled slots are stored with a NULL psk, which would
   // otherwise pass isMeshReadablePsk() below and, if lower-numbered than the
   // primary, get selected (e.g. private-key PRIMARY at 0 + disabled slots 1–7).
-  // Among enabled slots we still prefer a mesh-readable (default-key/unencrypted)
-  // one so every intermediate node can decrypt & append the hop (issue #3696).
+  // Among enabled slots we still prefer a well-known channel — mesh-readable
+  // PSK AND a name matching a ModemPreset display name — so every
+  // intermediate node's factory-configured channel hashes to the same value
+  // and can decrypt & append the hop (issues #3696, #4691).
   const readable = channels
-    .filter((ch) => isValidChannelIndex(ch.id) && ch.role !== 0 && isMeshReadablePsk(ch.psk))
+    .filter(
+      (ch) =>
+        isValidChannelIndex(ch.id) &&
+        ch.role !== 0 &&
+        isMeshReadablePsk(ch.psk) &&
+        isWellKnownChannelName(ch.name),
+    )
     .sort((a, b) => a.id - b.id);
 
   if (readable.length > 0) {


### PR DESCRIPTION
## Summary

Fixes #4691.

`resolveBroadcastChannel()` picks a channel every intermediate node can decrypt and relay for traceroutes, but three call sites still used the target node's raw stored channel — reproducing the original "Unknown" hop bug (#3696) when that channel is a private secondary. The resolver itself also had two correctness gaps versus how firmware actually decides a "well-known" channel.

- **Three bypassing paths now route through `resolveBroadcastChannel()`:**
  - `src/server/routes/v1/actions.ts` — `POST /traceroute` (v1 API)
  - `src/server/meshtasticManager.ts` — auto-traceroute scheduler
  - `src/server/meshtasticManager.ts` — traceroute auto-responder
- **`isMeshReadablePsk()`** now accepts any 1-byte shorthand PSK (`Buffer.from(psk, 'base64').length === 1`), not just the literal `AQ==` — firmware's `channelFileUsesPublicKey()` treats every 1-byte PSK as part of the public "defaultpsk" family.
- **`resolveBroadcastChannel()`** now also requires the channel's *name* to match a `MODEM_PRESET_CHANNEL_NAMES` entry (excluding the always-non-matching `VeryLongSlow`/index 2), mirroring firmware's `Channels::isWellKnownChannel()`. The on-wire channel hash is `hash(name) XOR hash(psk)`, so a mesh-readable PSK under a custom name still won't match any other node's factory-configured channel.

## Test plan

- [x] Extended `resolveDestinationChannel.test.ts` with cases for 1-byte shorthand PSKs outside the literal default byte, and channel-name mismatches (including the deprecated `VeryLongSlow` preset).
- [x] Updated `actions.test.ts` and `meshRequestRoutes.test.ts` fixtures/assertions for the new resolver behavior.
- [x] Full `vitest` suite: 14,614 passed, 0 failed (793 skipped — no PostgreSQL/MySQL containers in this environment; see CLAUDE.md).
- [x] `npm run lint:ci` — clean (no new ratchet violations).
- [x] `tsc --noEmit -p tsconfig.server.json` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_0172LvocT23wwpp12xLRUZqD)_