### PR TITLE
fix(pkg): declare the supported Node range in engines (#4703)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,9 @@
         "workbox-window": "^7.4.0",
         "ws": "^8.21.1"
       },
+      "engines": {
+        "node": ">=22"
+      },
       "optionalDependencies": {
         "@rollup/rollup-linux-arm-gnueabihf": "^4.62.4",
         "@rollup/rollup-linux-arm64-musl": "^4.62.4",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "license": "BSD-3-Clause",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "vite",
     "dev:server": "tsx --watch src/server/server.ts",


### PR DESCRIPTION
Follow-up from #4703.

## Why

`package.json` had **no `engines` field**, so npm never warned anyone they were on
an unsupported Node. In #4703 the reporter was running **Node 18** — four majors
below our floor — and only discovered it when a native module crashed at systemd
start:

```
The module .../re2.node was compiled against a different Node.js version using
NODE_MODULE_VERSION 147. This version of Node.js requires NODE_MODULE_VERSION 108.
```

Nothing in the install told them. That's the silent-failure mode this closes.

## The range

`>=22` matches every build path we ship:

| Path | Node |
| --- | --- |
| CI matrix | 22.x / 24.x / 25.x |
| `Dockerfile` | 24.15.0 |
| `Dockerfile.armv7` | 22.22.2 |
| LXC template | NodeSource 24 |

So nothing currently green starts failing.

## Verified, not assumed

Ran a real install on Node 18 with this exact field:

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'enginetest@1.0.0',
npm warn EBADENGINE   required: { node: '>=22' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }
```

It names both the required and the actual version — enough for a user to
self-diagnose before anything crashes at runtime.

## Why not `engine-strict`

I also tested `engine-strict=true`, which upgrades that warning to a hard failure:

```
npm error code EBADENGINE
npm error notsup Required: {"node":">=22"}
```

**I deliberately did not include it.** `engine-strict` applies to *every transitive
dependency's* `engines` range, not just ours — on a tree this size that risks
blocking installs for reasons that have nothing to do with our own floor. The
warning already ends the silent failure. If you'd rather have the hard stop, it's
a one-line `.npmrc` addition, but it deserves its own PR and a full install test
across the matrix first.

## Testing

`package.json` and `package-lock.json` both parse; lockfile regenerated via
`npm install --package-lock-only` so the root entry carries `engines` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G