### PR TITLE
fix(automations): show the triggering message in the run log (#4711)

### DIFF
--- a/src/components/automations/AutomationsPage.css
+++ b/src/components/automations/AutomationsPage.css
@@ -191,3 +191,17 @@
 .ae-trace-reason { font-size: 0.8rem; margin-top: 0.2rem; padding-left: 0.4rem; }
 .ae-trace-steps-wrap { margin-top: 0.35rem; }
 .ae-trace-steps-wrap > summary { cursor: pointer; font-size: 0.78rem; }
+
+/* Run log — the captured trigger, front and centre (#4711) */
+.ae-run-meta { display: flex; flex-wrap: wrap; gap: 0.25rem 0.85rem; margin-top: 0.4rem; }
+.ae-run-fact {
+  display: inline-flex; align-items: center; gap: 0.3rem;
+  font-size: 0.8rem; color: var(--color-text-muted); min-width: 0; word-break: break-word;
+}
+.ae-run-text {
+  margin-top: 0.4rem; padding: 0.35rem 0.6rem;
+  border-left: 3px solid var(--color-surface-active); border-radius: var(--radius-sm, 6px);
+  background: var(--color-bg); color: var(--color-text);
+  font-size: 0.86rem; white-space: pre-wrap; word-break: break-word;
+}
+.ae-run-raw { overflow-x: auto; margin-bottom: 0; font-size: 0.72rem; }

--- a/src/components/automations/AutomationsPage.runLog.test.tsx
+++ b/src/components/automations/AutomationsPage.runLog.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * AutomationsPage — Runs view (#4711).
+ *
+ * The engine has always persisted the full triggering `ctx.fields` bag in
+ * `automation_runs.triggerEvent`, and the API has always returned it; the Runs
+ * view just never rendered it, leaving a raw JSON step dump as the only clue why
+ * a rule fired. These prove the run row now leads with date/time, node, channel
+ * and the message itself, and that the step trace is readable rather than raw.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import AutomationsPage from './AutomationsPage';
+
+// Same module-scope `setBaseUrl` requirement as AutomationsPage.templateGallery.test.tsx.
+vi.mock('../../services/api', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), setBaseUrl: vi.fn() },
+}));
+
+import apiService from '../../services/api';
+
+const mockedGet = apiService.get as unknown as ReturnType<typeof vi.fn>;
+
+const AUTOMATION = {
+  id: 'auto-1',
+  name: 'Ping responder',
+  description: null,
+  enabled: true,
+  config: JSON.stringify({ nodes: [{ id: 't1', type: 'trigger.message', params: {} }], edges: [] }),
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+};
+
+const TRIGGER_EVENT = {
+  from: 1128074276, fromId: '!433d1ba4', fromName: 'Base Station',
+  to: 4294967295, text: 'ping the mesh', channel: 2, channelName: 'gauntlet',
+  isDM: false, isChannel: true, hops: 1, protocol: 'meshtastic', sourceId: 'src-1',
+};
+
+const STEPS = [
+  { nodeId: 't1', type: 'trigger.message', outcome: 'activated' },
+  { nodeId: 'a1', type: 'action.sendMessage', outcome: 'action:ok' },
+];
+
+function mockRuns(runs: unknown[]) {
+  mockedGet.mockImplementation((url: string) => {
+    if (url === '/api/automations') return Promise.resolve([AUTOMATION]);
+    if (url.endsWith('/runs')) return Promise.resolve(runs);
+    return Promise.resolve([]);
+  });
+}
+
+async function openRuns() {
+  render(<MemoryRouter><AutomationsPage /></MemoryRouter>);
+  await userEvent.click(await screen.findByRole('button', { name: 'Runs' }));
+}
+
+beforeEach(() => { mockedGet.mockReset(); });
+
+describe('AutomationsPage — Runs view', () => {
+  it('shows the triggering node, channel and message text', async () => {
+    mockRuns([{
+      id: 'run-1', status: 'completed', sourceId: 'src-1', startedAt: 1_700_000_123_000,
+      log: JSON.stringify(STEPS), triggerEvent: JSON.stringify(TRIGGER_EVENT),
+    }]);
+    await openRuns();
+
+    expect(await screen.findByText('Runs: Ping responder')).toBeInTheDocument();
+    expect(screen.getByText('Base Station')).toBeInTheDocument();
+    expect(screen.getByText('gauntlet')).toBeInTheDocument();
+    expect(screen.getByText('ping the mesh')).toBeInTheDocument();
+    // Existing facts are kept, not replaced.
+    expect(screen.getByText('completed')).toBeInTheDocument();
+    expect(screen.getByText(new Date(1_700_000_123_000).toLocaleString())).toBeInTheDocument();
+  });
+
+  it('renders the step trace with labels instead of a raw JSON dump', async () => {
+    mockRuns([{
+      id: 'run-1', status: 'completed', sourceId: 'src-1', startedAt: 1_700_000_123_000,
+      log: JSON.stringify(STEPS), triggerEvent: JSON.stringify(TRIGGER_EVENT),
+    }]);
+    await openRuns();
+
+    expect(await screen.findByText('execution trace (2 steps)')).toBeInTheDocument();
+    expect(screen.getByText('action.sendMessage')).toBeInTheDocument();
+    expect(screen.getByText(/action ran/)).toBeInTheDocument();
+    // The old behavior dumped the whole log array as one string.
+    expect(screen.queryByText(JSON.stringify(STEPS))).not.toBeInTheDocument();
+  });
+
+  it('keeps the full captured payload available behind a details toggle', async () => {
+    const raw = JSON.stringify(TRIGGER_EVENT);
+    mockRuns([{
+      id: 'run-1', status: 'completed', sourceId: 'src-1', startedAt: 1_700_000_123_000,
+      log: JSON.stringify(STEPS), triggerEvent: raw,
+    }]);
+    await openRuns();
+
+    expect(await screen.findByText('trigger payload')).toBeInTheDocument();
+    expect(screen.getByText(raw)).toBeInTheDocument();
+  });
+
+  it('renders a DM run without inventing a channel', async () => {
+    mockRuns([{
+      id: 'run-dm', status: 'completed', sourceId: 'src-1', startedAt: 1_700_000_123_000,
+      log: JSON.stringify(STEPS),
+      triggerEvent: JSON.stringify({ from: 42, fromName: 'Kokoshell', text: 'hello', isDM: true, channel: 0 }),
+    }]);
+    await openRuns();
+
+    expect(await screen.findByText('Kokoshell')).toBeInTheDocument();
+    expect(screen.getByText('DM')).toBeInTheDocument();
+    expect(screen.queryByText('ch 0')).not.toBeInTheDocument();
+  });
+
+  it('survives a run with a missing or malformed payload', async () => {
+    mockRuns([
+      { id: 'run-null', status: 'failed', sourceId: null, startedAt: 1_700_000_123_000, log: null, triggerEvent: null },
+      { id: 'run-bad', status: 'failed', sourceId: null, startedAt: 1_700_000_124_000, log: '{oops', triggerEvent: '{oops' },
+    ]);
+    await openRuns();
+
+    expect(await screen.findByText('Runs: Ping responder')).toBeInTheDocument();
+    expect(screen.getAllByText('failed')).toHaveLength(2);
+    // An unparseable log is still shown raw rather than silently dropped.
+    expect(screen.getAllByText('{oops').length).toBeGreaterThan(0);
+  });
+
+  it('shows the empty state when the rule has never fired', async () => {
+    mockRuns([]);
+    await openRuns();
+    expect(await screen.findByText('No runs yet.')).toBeInTheDocument();
+  });
+});

--- a/src/components/automations/AutomationsPage.runLog.test.tsx
+++ b/src/components/automations/AutomationsPage.runLog.test.tsx
@@ -91,7 +91,7 @@ describe('AutomationsPage — Runs view', () => {
     expect(screen.queryByText(JSON.stringify(STEPS))).not.toBeInTheDocument();
   });
 
-  it('keeps the full captured payload available behind a details toggle', async () => {
+  it('keeps the full captured payload available behind a details toggle, pretty-printed', async () => {
     const raw = JSON.stringify(TRIGGER_EVENT);
     mockRuns([{
       id: 'run-1', status: 'completed', sourceId: 'src-1', startedAt: 1_700_000_123_000,
@@ -100,7 +100,12 @@ describe('AutomationsPage — Runs view', () => {
     await openRuns();
 
     expect(await screen.findByText('trigger payload')).toBeInTheDocument();
-    expect(screen.getByText(raw)).toBeInTheDocument();
+    // `getByText` collapses whitespace, so assert on the element: the payload is
+    // stored minified and rendered indented (#4716 review), losing nothing.
+    const pre = document.querySelector('details .ae-run-raw') as HTMLElement;
+    expect(pre).not.toBeNull();
+    expect(JSON.parse(pre.textContent!)).toEqual(TRIGGER_EVENT);
+    expect(pre.textContent).toContain('\n  "fromName": "Base Station"');
   });
 
   it('renders a DM run without inventing a channel', async () => {

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -459,7 +459,8 @@ function RunRow({ run }: { run: Run }) {
       {run.triggerEvent && (
         <details className="ae-trace-steps-wrap">
           <summary className="ae-muted">trigger payload</summary>
-          <pre className="ae-muted ae-run-raw">{run.triggerEvent}</pre>
+          {/* Stored minified; `pretty` falls back to the raw string if it won't parse. */}
+          <pre className="ae-muted ae-run-raw">{pretty(run.triggerEvent)}</pre>
         </details>
       )}
     </div>

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -14,6 +14,8 @@ import AutomationBuilder, { type VariableOption, type SourceOption, type Unified
 import AutomationTester from './AutomationTester';
 import LiveTracePanel from './LiveTracePanel';
 import TemplateGallery, { type InstalledAutomationRow } from './TemplateGallery';
+import { StepList, type TraceStep } from './outcomeMeta';
+import { summarizeTriggerEvent, parseJsonColumn } from './eventSummary';
 import { UiIcon } from '../icons';
 import { compile, decompile, type WorkflowForm } from './compile';
 import './AutomationsPage.css';
@@ -27,7 +29,11 @@ interface Variable {
   type: 'string' | 'integer' | 'float' | 'boolean' | 'flag';
   scope: 'global' | 'source' | 'node' | 'sourceNode'; readonly: boolean; config: string;
 }
-interface Run { id: string; status: string; sourceId: string | null; startedAt: number; log: string | null; }
+interface Run {
+  id: string; status: string; sourceId: string | null; startedAt: number; log: string | null;
+  /** JSON `ctx.fields` bag captured when the rule fired — the triggering message (#4711). */
+  triggerEvent: string | null;
+}
 
 const VARIABLE_TYPES = ['string', 'integer', 'float', 'boolean', 'flag', 'json'] as const;
 const VARIABLE_SCOPES: { value: Variable['scope']; label: string }[] = [
@@ -412,6 +418,54 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
   );
 }
 
+/**
+ * One persisted run. Leads with what a human debugging the rule actually needs
+ * (#4711) — when it fired, which node, which channel, and the triggering message
+ * itself — and tucks the step trace and raw payload behind `<details>`.
+ */
+function RunRow({ run }: { run: Run }) {
+  const summary = summarizeTriggerEvent(parseJsonColumn<Record<string, unknown>>(run.triggerEvent));
+  const steps = parseJsonColumn<TraceStep[]>(run.log);
+  const statusColor = run.status === 'completed' ? 'var(--color-success)' : run.status === 'failed' ? 'var(--color-error)' : 'inherit';
+  return (
+    <div className="ae-card">
+      <div className="ae-row">
+        <div className="ae-row-main">
+          <span style={{ fontWeight: 700, color: statusColor }}>{run.status}</span>
+          <span className="ae-chip">{run.sourceId ?? '—'}</span>
+        </div>
+        <span className="ae-muted">{new Date(run.startedAt).toLocaleString()}</span>
+      </div>
+
+      {(summary.node || summary.channel || summary.detail) && (
+        <div className="ae-run-meta">
+          {summary.node && <span className="ae-run-fact"><UiIcon name="user" size={13} /> {summary.node}</span>}
+          {summary.channel && <span className="ae-run-fact"><UiIcon name="channels" size={13} /> {summary.channel}</span>}
+          {summary.detail && <span className="ae-run-fact"><UiIcon name="info" size={13} /> {summary.detail}</span>}
+        </div>
+      )}
+      {summary.text && <div className="ae-run-text">{summary.text}</div>}
+
+      {steps && steps.length > 0 && (
+        <details className="ae-trace-steps-wrap">
+          <summary className="ae-muted">execution trace ({steps.length} steps)</summary>
+          <StepList steps={steps} />
+        </details>
+      )}
+      {/* Unparseable log — show it raw rather than dropping the only diagnostic. */}
+      {!steps && run.log && (
+        <pre className="ae-muted ae-run-raw">{run.log}</pre>
+      )}
+      {run.triggerEvent && (
+        <details className="ae-trace-steps-wrap">
+          <summary className="ae-muted">trigger payload</summary>
+          <pre className="ae-muted ae-run-raw">{run.triggerEvent}</pre>
+        </details>
+      )}
+    </div>
+  );
+}
+
 function RunLog({ automation, onClose }: { automation: Automation; onClose: () => void }) {
   const [runs, setRuns] = useState<Run[]>([]);
   useEffect(() => { apiService.get<Run[]>(`/api/automations/${automation.id}/runs`).then(setRuns).catch(() => setRuns([])); }, [automation.id]);
@@ -420,18 +474,7 @@ function RunLog({ automation, onClose }: { automation: Automation; onClose: () =
       <button className="ae-btn ae-btn--ghost" onClick={onClose} style={{ marginBottom: '0.75rem' }}><UiIcon name="back" size={15} /> Back</button>
       <h2 className="ae-title" style={{ fontSize: '1.25rem' }}>Runs: {automation.name}</h2>
       {runs.length === 0 && <div className="ae-empty">No runs yet.</div>}
-      {runs.map((r) => (
-        <div className="ae-card" key={r.id}>
-          <div className="ae-row">
-            <div className="ae-row-main">
-              <span style={{ fontWeight: 700, color: r.status === 'completed' ? 'var(--color-success)' : r.status === 'failed' ? 'var(--color-error)' : 'inherit' }}>{r.status}</span>
-              <span className="ae-chip">{r.sourceId ?? '—'}</span>
-            </div>
-            <span className="ae-muted">{new Date(r.startedAt).toLocaleString()}</span>
-          </div>
-          {r.log && <pre className="ae-muted" style={{ overflowX: 'auto', marginBottom: 0, fontSize: '0.72rem' }}>{r.log}</pre>}
-        </div>
-      ))}
+      {runs.map((r) => <RunRow run={r} key={r.id} />)}
     </div>
   );
 }

--- a/src/components/automations/LiveTracePanel.tsx
+++ b/src/components/automations/LiveTracePanel.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useWebSocketContext } from '../../contexts/WebSocketContext';
 import { StepList, type TraceStep } from './outcomeMeta';
+import { summarizeTriggerEvent, summaryLine } from './eventSummary';
 import { UiIcon } from '../icons';
 
 const TRACE_DURATION_MS = 5 * 60_000;
@@ -35,34 +36,6 @@ interface LiveTracePanelProps {
   /** Whether the rule is enabled — disabled rules never evaluate, so warn. */
   enabled: boolean;
   onClose: () => void;
-}
-
-/** A compact one-line summary of the triggering event for the entry header. */
-function summarizeEvent(triggerType: string, event: Record<string, unknown>): string {
-  const bits: string[] = [];
-  if (triggerType === 'trigger.message') {
-    if (event.from != null) bits.push(`from ${event.from}`);
-    if (event.channel != null) bits.push(`ch ${event.channel}`);
-    if (typeof event.text === 'string') bits.push(`"${event.text}"`);
-  } else if (triggerType === 'trigger.telemetry') {
-    bits.push(`${event.telemetryType ?? '?'} = ${event.value ?? '?'}`);
-  } else if (triggerType === 'trigger.meshBeacon') {
-    bits.push(`beacon · node ${event.nodeNum ?? '?'}`);
-    if (typeof event.message === 'string' && event.message) bits.push(`"${event.message}"`);
-    if (event.offerChannelName) bits.push(`offers ${event.offerChannelName}`);
-  } else if (triggerType === 'trigger.geofence') {
-    bits.push(`${event.event ?? '?'} · node ${event.nodeNum ?? '?'}`);
-  } else if (triggerType === 'trigger.becameMobile') {
-    bits.push(`became mobile · node ${event.nodeNum ?? '?'}`);
-  } else if (triggerType === 'trigger.leftHome') {
-    const dist = typeof event.distanceMeters === 'number' ? `${Math.round(event.distanceMeters)}m` : '?';
-    bits.push(`left home ${dist} · node ${event.nodeNum ?? '?'}`);
-  } else if (triggerType === 'trigger.system') {
-    bits.push(String(event.event ?? ''));
-  } else if (event.nodeNum != null) {
-    bits.push(`node ${event.nodeNum}`);
-  }
-  return bits.join(' · ') || '(no event payload)';
 }
 
 const OUTCOME_BADGE: Record<string, { label: string; cls: string }> = {
@@ -174,7 +147,7 @@ export default function LiveTracePanel({ automationId, automationName, enabled, 
               <div className="ae-trace-entry-head">
                 <span className={`ae-test-badge ae-test-badge--${badge.cls}`}>{badge.label}</span>
                 <span className="ae-muted">{new Date(e.ts).toLocaleTimeString()}</span>
-                <span className="ae-trace-entry-summary">{summarizeEvent(e.triggerType, e.event)}</span>
+                <span className="ae-trace-entry-summary">{summaryLine(summarizeTriggerEvent(e.event))}</span>
               </div>
               {!fired && e.reason && <div className="ae-muted ae-trace-reason">↳ {e.reason}</div>}
               {fired && e.steps && e.steps.length > 0 && (

--- a/src/components/automations/eventSummary.test.ts
+++ b/src/components/automations/eventSummary.test.ts
@@ -1,0 +1,130 @@
+/**
+ * #4711 — the run log has to show what actually triggered a rule. These pin the
+ * field-driven summarizer against the real `ctx.fields` bags every trigger
+ * builder in `src/server/services/automation/triggerContext.ts` produces.
+ */
+import { describe, it, expect } from 'vitest';
+import { summarizeTriggerEvent, summaryLine, parseJsonColumn } from './eventSummary';
+
+describe('summarizeTriggerEvent', () => {
+  it('pulls node, channel and text out of a Meshtastic message payload', () => {
+    const s = summarizeTriggerEvent({
+      from: 1128074276, fromId: '!433d1ba4', fromName: 'Base Station',
+      to: 4294967295, text: 'ping', channel: 2, channelName: 'gauntlet',
+      isDM: false, isChannel: true, protocol: 'meshtastic',
+    });
+    expect(s.node).toBe('Base Station');
+    expect(s.channel).toBe('gauntlet');
+    expect(s.text).toBe('ping');
+  });
+
+  it('handles a real captured MQTT run payload, which carries no channelName', () => {
+    // Copied verbatim from `GET /api/automations/:id/runs` on a live instance:
+    // an MQTT-sourced Auto-Ack run. `channelName` is absent (the channel is an
+    // MQTT channel-database identity), so the index has to carry the label.
+    const s = summarizeTriggerEvent({
+      from: 2956827772, fromId: '!b03d9c7c', fromName: 'KA1KG Node 1',
+      to: 4294967295, toId: '!ffffffff', text: 'Test', channel: 102,
+      senderLabel: 'KA1KG Node 1', portnum: 1, packetId: 1501735753,
+      viaMqttSource: true, zeroHop: 0, isDM: false, isChannel: true, isBroadcast: true,
+      snr: 0, viaMqtt: true, protocol: 'meshtastic', protocolShort: 'MT',
+      sourceId: 'feb9a2cc-dbb3-4bb2-9b9f-cb038c74421a', timestamp: 1786651269849,
+    });
+    expect(s).toEqual({ node: 'KA1KG Node 1', channel: 'ch 102', text: 'Test', detail: undefined });
+  });
+
+  it('falls back to the node id, then the raw nodeNum, when there is no name', () => {
+    expect(summarizeTriggerEvent({ from: 123, fromId: '!0000007b' }).node).toBe('!0000007b');
+    expect(summarizeTriggerEvent({ from: 123 }).node).toBe('123');
+    expect(summarizeTriggerEvent({ nodeNum: 456 }).node).toBe('node 456');
+  });
+
+  it('labels an unnamed channel by index, and a DM as a DM', () => {
+    expect(summarizeTriggerEvent({ channel: 0, isDM: false }).channel).toBe('ch 0');
+    expect(summarizeTriggerEvent({ channel: 0, isDM: true }).channel).toBe('DM');
+    // A MeshCore DM carries no channel index at all.
+    expect(summarizeTriggerEvent({ isDM: true }).channel).toBe('DM');
+    expect(summarizeTriggerEvent({ text: 'hi' }).channel).toBeUndefined();
+  });
+
+  it('elides a MeshCore pubkey sender rather than letting it run on', () => {
+    const pubkey = 'a'.repeat(64);
+    const s = summarizeTriggerEvent({ from: pubkey, fromId: pubkey, text: 'hi', protocol: 'meshcore' });
+    expect(s.node).toHaveLength(24);
+    expect(s.node?.endsWith('…')).toBe(true);
+  });
+
+  it('prefers a MeshCore sender name over the pubkey', () => {
+    const s = summarizeTriggerEvent({
+      from: 'b'.repeat(64), fromId: 'b'.repeat(64), fromName: 'Kokoshell',
+      text: 'hello', channel: 1, channelName: 'public', isChannel: true, protocol: 'meshcore',
+    });
+    expect(s.node).toBe('Kokoshell');
+    expect(s.channel).toBe('public');
+  });
+
+  it('summarizes a telemetry reading with its unit', () => {
+    expect(summarizeTriggerEvent({ nodeNum: 7, telemetryType: 'batteryLevel', value: 42, unit: '%' }).detail)
+      .toBe('batteryLevel = 42 %');
+    expect(summarizeTriggerEvent({ nodeNum: 7, telemetryType: 'voltage', value: 3.9 }).detail)
+      .toBe('voltage = 3.9');
+  });
+
+  it('summarizes geofence, system, leftHome, becameMobile and node-change payloads', () => {
+    expect(summarizeTriggerEvent({ event: 'enter', nodeNum: 9, distanceKm: 1.2 }).detail).toBe('enter');
+    expect(summarizeTriggerEvent({ event: 'source-disconnected', reason: 'socket closed' }).detail)
+      .toBe('source-disconnected — socket closed');
+    expect(summarizeTriggerEvent({ nodeNum: 9, distanceMeters: 1234.6, thresholdMeters: 500 }).detail)
+      .toBe('left home · 1235m');
+    expect(summarizeTriggerEvent({ nodeNum: 9, previousMobile: 0, mobile: 1 }).detail).toBe('became mobile');
+    expect(summarizeTriggerEvent({ nodeNum: 9, changed: ['longName', 'hwModel'] }).detail)
+      .toBe('changed: longName, hwModel');
+  });
+
+  it('reads a MeshBeacon body as the text, and its offer as the detail', () => {
+    const s = summarizeTriggerEvent({ nodeNum: 11, message: 'join us', offerChannelName: 'RegionMesh', hasOffer: true });
+    expect(s.text).toBe('join us');
+    expect(s.node).toBe('node 11');
+    const offerOnly = summarizeTriggerEvent({ nodeNum: 11, offerChannelName: 'RegionMesh', hasOffer: true });
+    expect(offerOnly.detail).toBe('offers RegionMesh');
+  });
+
+  it('returns an empty summary for a payload with nothing human-facing', () => {
+    // trigger.schedule — a cron tick carries no mesh payload at all.
+    expect(summarizeTriggerEvent({ sourceId: 'src-1', timestamp: 1 })).toEqual({
+      node: undefined, channel: undefined, text: undefined, detail: undefined,
+    });
+    expect(summarizeTriggerEvent(null)).toEqual({});
+    expect(summarizeTriggerEvent(undefined)).toEqual({});
+  });
+
+  it('ignores blank strings rather than rendering empty facts', () => {
+    const s = summarizeTriggerEvent({ fromName: '   ', fromId: '!abc', text: '', channelName: '' });
+    expect(s.node).toBe('!abc');
+    expect(s.text).toBeUndefined();
+    expect(s.channel).toBeUndefined();
+  });
+});
+
+describe('summaryLine', () => {
+  it('joins the parts into the live-trace one-liner', () => {
+    const line = summaryLine(summarizeTriggerEvent({
+      from: 123, fromName: 'Alpha', channel: 2, channelName: 'gauntlet', text: 'ping', isDM: false,
+    }));
+    expect(line).toBe('from Alpha · gauntlet · "ping"');
+  });
+
+  it('falls back to a placeholder when there is nothing to say', () => {
+    expect(summaryLine({})).toBe('(no event payload)');
+  });
+});
+
+describe('parseJsonColumn', () => {
+  it('parses valid JSON and returns null for absent or malformed input', () => {
+    expect(parseJsonColumn<{ a: number }>('{"a":1}')).toEqual({ a: 1 });
+    expect(parseJsonColumn('not json')).toBeNull();
+    expect(parseJsonColumn('null')).toBeNull();
+    expect(parseJsonColumn(null)).toBeNull();
+    expect(parseJsonColumn('')).toBeNull();
+  });
+});

--- a/src/components/automations/eventSummary.test.ts
+++ b/src/components/automations/eventSummary.test.ts
@@ -81,6 +81,20 @@ describe('summarizeTriggerEvent', () => {
       .toBe('changed: longName, hwModel');
   });
 
+  it('keys each detail on the field unique to its builder, not a reusable one', () => {
+    // Review feedback on #4716: `value` and `mobile` are generic enough that a
+    // future builder could plausibly carry them. Only `telemetryType` may mean
+    // telemetry, and only `previousMobile` may mean a mobility flip — otherwise a
+    // payload that merely happens to have `value`/`mobile` gets mislabelled.
+    expect(summarizeTriggerEvent({ nodeNum: 1, value: 42 }).detail).toBeUndefined();
+    expect(summarizeTriggerEvent({ nodeNum: 1, mobile: 1 }).detail).toBeUndefined();
+    // …and the genuine articles still resolve.
+    expect(summarizeTriggerEvent({ nodeNum: 1, telemetryType: 'ch1Voltage', value: 12 }).detail)
+      .toBe('ch1Voltage = 12');
+    expect(summarizeTriggerEvent({ nodeNum: 1, previousMobile: 0, mobile: 1 }).detail)
+      .toBe('became mobile');
+  });
+
   it('reads a MeshBeacon body as the text, and its offer as the detail', () => {
     const s = summarizeTriggerEvent({ nodeNum: 11, message: 'join us', offerChannelName: 'RegionMesh', hasOffer: true });
     expect(s.text).toBe('join us');

--- a/src/components/automations/eventSummary.ts
+++ b/src/components/automations/eventSummary.ts
@@ -62,16 +62,22 @@ function channelLabel(e: Record<string, unknown>): string | undefined {
  * The one trigger-specific line, keyed off marker fields unique to each builder:
  * `telemetryType` (telemetry), `distanceMeters` (leftHome), `previousMobile`
  * (becameMobile), `changed` (node discovered/updated), `event` (geofence + system).
+ *
+ * Order matters only where a payload could carry two markers; today none do.
  */
 function detailLabel(e: Record<string, unknown>): string | undefined {
-  if (e.telemetryType != null || e.value != null) {
+  // Each test keys ONLY on the field unique to its builder, never on a field a
+  // future builder might plausibly reuse (`value`, `mobile`): a bare `value` must
+  // not read as telemetry, and a bare `mobile` must not read as a mobility flip.
+  const telemetryType = str(e.telemetryType);
+  if (telemetryType) {
     const unit = str(e.unit);
-    return `${str(e.telemetryType) ?? '?'} = ${str(e.value) ?? '?'}${unit ? ` ${unit}` : ''}`;
+    return `${telemetryType} = ${str(e.value) ?? '?'}${unit ? ` ${unit}` : ''}`;
   }
   if (typeof e.distanceMeters === 'number') {
     return `left home · ${Math.round(e.distanceMeters)}m`;
   }
-  if (e.previousMobile != null || e.mobile != null) {
+  if (e.previousMobile != null) {
     return 'became mobile';
   }
   if (Array.isArray(e.changed)) {

--- a/src/components/automations/eventSummary.ts
+++ b/src/components/automations/eventSummary.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared, human-readable summary of a trigger's captured event payload — the
+ * `ctx.fields` bag the engine persists on every run as `automation_runs.triggerEvent`
+ * and streams live over `automation:trace`.
+ *
+ * Used by both the live trace panel and the persisted run log (#4711) so the two
+ * never drift in how "which message set this off" reads.
+ *
+ * Deliberately **field-driven, not trigger-type-driven**: a run row records the
+ * payload but not the trigger type, and an automation's trigger can be edited
+ * after the fact, so deriving the shape from the rule's current config would
+ * mislabel history. The field bags are distinctive enough to tell apart on their
+ * own (see `triggerContext.ts` for every builder).
+ */
+
+/** A node id long enough to be a MeshCore pubkey is elided rather than wrapped. */
+const MAX_NODE_LABEL = 24;
+
+export interface EventSummary {
+  /** Who the event is about — display name preferred over a raw id/nodeNum. */
+  node?: string;
+  /** Where it arrived: the channel's name, else `ch N`, else `DM`. */
+  channel?: string;
+  /** The body text, when the trigger carries one (message, beacon). */
+  text?: string;
+  /** Trigger-specific extra: telemetry reading, geofence crossing, system event. */
+  detail?: string;
+}
+
+/** Non-empty trimmed string, or undefined. Numbers/booleans stringify. */
+function str(v: unknown): string | undefined {
+  if (v == null) return undefined;
+  const s = String(v).trim();
+  return s === '' ? undefined : s;
+}
+
+function elide(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
+/**
+ * Sender/subject label. `fromName` already degrades long → short → id upstream;
+ * MeshCore falls back to a 64-char pubkey, so the raw id is elided.
+ */
+function nodeLabel(e: Record<string, unknown>): string | undefined {
+  const named = str(e.fromName) ?? str(e.fromId) ?? str(e.from);
+  if (named) return elide(named, MAX_NODE_LABEL);
+  const nodeNum = str(e.nodeNum);
+  return nodeNum ? `node ${nodeNum}` : undefined;
+}
+
+/**
+ * Channel label. A DM has no meaningful channel, and MeshCore DMs/room posts
+ * carry no channel index at all, so both collapse to `DM`.
+ */
+function channelLabel(e: Record<string, unknown>): string | undefined {
+  if (e.isDM === true) return 'DM';
+  return str(e.channelName) ?? (e.channel != null ? `ch ${str(e.channel)}` : undefined);
+}
+
+/**
+ * The one trigger-specific line, keyed off marker fields unique to each builder:
+ * `telemetryType` (telemetry), `distanceMeters` (leftHome), `previousMobile`
+ * (becameMobile), `changed` (node discovered/updated), `event` (geofence + system).
+ */
+function detailLabel(e: Record<string, unknown>): string | undefined {
+  if (e.telemetryType != null || e.value != null) {
+    const unit = str(e.unit);
+    return `${str(e.telemetryType) ?? '?'} = ${str(e.value) ?? '?'}${unit ? ` ${unit}` : ''}`;
+  }
+  if (typeof e.distanceMeters === 'number') {
+    return `left home · ${Math.round(e.distanceMeters)}m`;
+  }
+  if (e.previousMobile != null || e.mobile != null) {
+    return 'became mobile';
+  }
+  if (Array.isArray(e.changed)) {
+    return e.changed.length > 0 ? `changed: ${e.changed.join(', ')}` : 'no fields changed';
+  }
+  // Geofence crossings ('enter'/'exit'/'dwell') and system events ('bootup', …)
+  // both key on `event`; a system event may add a `reason`.
+  const event = str(e.event);
+  if (event) {
+    const reason = str(e.reason);
+    return reason ? `${event} — ${reason}` : event;
+  }
+  // A beacon advertising a mesh, when it carried no message text of its own.
+  const offer = str(e.offerChannelName);
+  return offer ? `offers ${offer}` : undefined;
+}
+
+/** Break a captured trigger payload into the parts worth showing a human. */
+export function summarizeTriggerEvent(event: Record<string, unknown> | null | undefined): EventSummary {
+  if (!event || typeof event !== 'object') return {};
+  return {
+    node: nodeLabel(event),
+    channel: channelLabel(event),
+    // `message` is the MeshBeacon body; `text` is a message body.
+    text: str(event.text) ?? str(event.message),
+    detail: detailLabel(event),
+  };
+}
+
+/** Flatten a summary into the single line the live trace feed shows per entry. */
+export function summaryLine(s: EventSummary): string {
+  const bits: string[] = [];
+  if (s.node) bits.push(`from ${s.node}`);
+  if (s.channel) bits.push(s.channel);
+  if (s.detail) bits.push(s.detail);
+  if (s.text) bits.push(`"${s.text}"`);
+  return bits.join(' · ') || '(no event payload)';
+}
+
+/**
+ * Parse a persisted `triggerEvent` / `log` JSON column. Returns null for absent
+ * or malformed JSON so callers can fall back to the raw string rather than
+ * blanking a run row that is otherwise readable.
+ */
+export function parseJsonColumn<T>(raw: string | null | undefined): T | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed == null ? null : (parsed as T);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #4711

## The problem

The Runs view showed status, source, timestamp — and then a raw JSON dump of the step array. To answer "which message set this off?" you had to read `automation_runs.triggerEvent` out of the database by hand.

## The finding

Nothing was missing from the backend. The engine has **always** persisted the complete `ctx.fields` bag as `automation_runs.triggerEvent` (`automationEngineService.ts` `fireAutomation`), and `GET /api/automations/:id/runs` has always returned the whole record. The frontend `Run` interface simply didn't declare the field, so it was dropped on the floor.

Confirmed against a live instance before writing any code — a real MQTT-sourced Auto-Ack run already carried `fromName: "KA1KG Node 1"`, `text: "Test"`, `channel: 102`.

**So this is frontend-only: no schema, migration, or engine change, and every historical run benefits immediately.**

## The change

Each run row now leads with what the issue asked for — date/time, node, channel, and the message itself:

```
completed  feb9a2cc-dbb3-4bb2-9b9f-cb038c74421a        8/13/2026, 4:01:09 PM
 KA1KG Node 1    ch 102
 | Test
 > execution trace (4 steps)
 > trigger payload
```

- **`eventSummary.ts`** (new) — shared summarizer over a captured trigger payload.
- **`AutomationsPage.tsx`** — `RunRow` renders the sender/channel/text, swaps the raw `<pre>` log dump for the shared `StepList`, and keeps the full payload behind a `trigger payload` toggle. An unparseable `log` still falls back to raw text rather than vanishing.
- **`LiveTracePanel.tsx`** — drops its private near-duplicate summarizer for the shared one, so the live and persisted views can't drift. The live panel gains name-over-nodeNum labels and DM/channel-name handling for free.

### Why the summarizer is field-driven, not trigger-type-driven

A run row does **not** persist its trigger type, and a rule's trigger can be edited after the fact — so deriving the shape from the automation's *current* config would mislabel historical runs. Each builder's field bag is distinctive enough to identify on its own (`telemetryType`, `distanceMeters`, `previousMobile`, `changed`, `event`), so the summarizer keys on those instead. This also means it degrades sanely on payload shapes it has never seen.

Sender label degrades name → id → nodeNum, and MeshCore 64-char pubkeys are elided rather than allowed to run on. DMs render as `DM` instead of a meaningless channel index.

## Testing

- `eventSummary.test.ts` — 14 cases across every trigger builder's real field bag, **including the exact live MQTT payload above**, which pins the case where `channelName` is absent and the channel index has to carry the label.
- `AutomationsPage.runLog.test.tsx` — 6 cases: node/channel/text rendering, labelled step trace (asserting the old raw dump is gone), payload toggle, DM handling, and survival of null/malformed JSON.
- Full suite: **15,446 passed / 0 failed**, 0 failed suites (PostgreSQL + MySQL containers up).
- `tsc --noEmit` clean; `lint:ci` clean (no in-repo FAILs).
- Deployed to the dev container and driven in a real browser against real run data — screenshot above is that instance, including a run that correctly falls back to `!94da9130` where the node has no name.

## Note for the reporter

On MQTT-sourced runs the channel shows as `ch 102` rather than a name: `channelName` isn't populated on those payloads, and 102 is a channel-database identity. The raw index is the best label available without a lookup — happy to resolve it to a name in a follow-up if that's worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G
