### PR TITLE
feat(nodes): badge nodes with incomplete NodeInfo (#4720)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -347,6 +347,7 @@
   "nodes.hop_one": "hop",
   "nodes.hop_other": "hops",
   "nodes.via_mqtt": "Connected via MQTT",
+  "nodes.incomplete_badge": "Incomplete — no NodeInfo received yet, so this node is missing its name or hardware info",
   "nodes.copy_nodeinfo": "Copy NodeInfo from another source",
   "nodes.copy_nodeinfo_title": "Copy NodeInfo",
   "nodes.security_risk_generic": "Key security issue detected",

--- a/src/components/NodeIncompleteBadge.test.tsx
+++ b/src/components/NodeIncompleteBadge.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * NodeIncompleteBadge (#4720) — the badge itself, plus the `isNodeComplete`
+ * contract it is driven by.
+ *
+ * The badge is only as trustworthy as the predicate behind it, and that
+ * predicate has two deliberate subtleties that a naive "is the name set?" check
+ * would get wrong (see `isNodeComplete` in utils/nodeHelpers.ts):
+ *   - a firmware-default `Node !xxxxxxxx` longName means NODEINFO has NOT
+ *     arrived, even though longName is non-empty;
+ *   - a default shortName (last 4 hex of the id) is perfectly valid and must
+ *     NOT count as incomplete.
+ * Both are pinned here so the badge can't start lying if the predicate drifts.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { render, screen } from '@testing-library/react';
+import { NodeIncompleteBadge } from './NodeIncompleteBadge';
+import { isNodeComplete } from '../utils/nodeHelpers';
+
+describe('NodeIncompleteBadge', () => {
+  it('renders an inert, labelled indicator (not a button)', () => {
+    render(<NodeIncompleteBadge />);
+
+    const badge = screen.getByTestId('node-incomplete-badge');
+    expect(badge).toBeInTheDocument();
+    // Facts-left / actions-right (#4379): this belongs to the indicator group,
+    // so it must not be interactive.
+    expect(badge.tagName).toBe('SPAN');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(badge).toHaveClass('node-indicator-icon');
+  });
+
+  it('carries an accessible explanation, not just a tooltip', () => {
+    render(<NodeIncompleteBadge />);
+    const badge = screen.getByTestId('node-incomplete-badge');
+    // i18n is unconfigured under jsdom, so t() echoes the key — same convention
+    // as NodeUnmessageableBadge.test.tsx. A tooltip alone would leave the badge
+    // meaningless to a screen reader, hence both attributes.
+    expect(badge).toHaveAttribute('title', 'nodes.incomplete_badge');
+    expect(badge).toHaveAttribute('aria-label', 'nodes.incomplete_badge');
+  });
+
+  it('has its locale key registered, so it renders real copy in the app', () => {
+    // The jsdom assertions above pass even if the key was never added to
+    // en.json — this is the one that would catch that.
+    // Vitest runs from the project root; `import.meta.url` isn't a file: URL
+    // after transform, so resolve from cwd instead.
+    const en = JSON.parse(
+      readFileSync(`${process.cwd()}/public/locales/en.json`, 'utf-8'),
+    ) as Record<string, string>;
+    expect(en['nodes.incomplete_badge']).toMatch(/NodeInfo/i);
+  });
+});
+
+describe('isNodeComplete — the predicate the badge renders', () => {
+  const complete = { nodeId: '!433d1ba4', longName: 'Base Station', shortName: 'BASE', hwModel: 43 };
+
+  it('treats a fully populated node as complete (no badge)', () => {
+    expect(isNodeComplete(complete)).toBe(true);
+  });
+
+  it('treats a firmware-default "Node !xxxxxxxx" longName as INCOMPLETE', () => {
+    // Non-empty, but it means NODEINFO never arrived — the case a naive
+    // truthiness check on longName would miss.
+    expect(isNodeComplete({ ...complete, longName: 'Node !433d1ba4' })).toBe(false);
+  });
+
+  it('treats a default-looking shortName as COMPLETE', () => {
+    // Firmware uses the last 4 hex chars as the default shortName, so plenty of
+    // genuinely-synced nodes look like this. Badging them would be wrong.
+    expect(isNodeComplete({ ...complete, shortName: '1ba4' })).toBe(true);
+  });
+
+  it('is incomplete when any NODEINFO-derived field is missing', () => {
+    expect(isNodeComplete({ ...complete, longName: null })).toBe(false);
+    expect(isNodeComplete({ ...complete, shortName: null })).toBe(false);
+    expect(isNodeComplete({ ...complete, hwModel: null })).toBe(false);
+    expect(isNodeComplete({ ...complete, hwModel: undefined })).toBe(false);
+  });
+
+  it('treats hwModel 0 as present — 0 is a real hardware model, not "unset"', () => {
+    expect(isNodeComplete({ ...complete, hwModel: 0 })).toBe(true);
+  });
+});

--- a/src/components/NodeIncompleteBadge.tsx
+++ b/src/components/NodeIncompleteBadge.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from 'react-i18next';
+import { UiIcon } from './icons';
+
+/**
+ * The "we haven't received this node's NODEINFO yet" badge, shown in the node
+ * list's indicator group (issue #4720, feature-parity tracker #4718 item H).
+ *
+ * MeshMonitor already *knew* which nodes were incomplete — `isNodeComplete()`
+ * has long driven the `showIncompleteNodes` filter — but when such a node was
+ * on screen nothing marked it as partial. The only visible difference was a
+ * "Copy NodeInfo" action gated on `nodes:write`, so a read-only user saw a node
+ * that looked fully synced and simply had a blank-ish name.
+ *
+ * Inert by design, like the location / MQTT / telemetry icons beside it: it
+ * states a fact. The remedy (copying NodeInfo from another source) stays in the
+ * action group, still permission-gated — see `NodeUnmessageableBadge` for the
+ * same facts-left / actions-right split introduced by #4379.
+ */
+export function NodeIncompleteBadge() {
+  const { t } = useTranslation();
+
+  const label = t(
+    'nodes.incomplete_badge',
+    'Incomplete — no NodeInfo received yet, so this node is missing its name or hardware info'
+  );
+
+  return (
+    <span
+      className="node-indicator-icon"
+      data-testid="node-incomplete-badge"
+      title={label}
+      aria-label={label}
+    >
+      <UiIcon name="help" size={15} />
+    </span>
+  );
+}
+
+export default NodeIncompleteBadge;

--- a/src/components/NodesTab.test.tsx
+++ b/src/components/NodesTab.test.tsx
@@ -210,6 +210,46 @@ describe('NodesTab', () => {
       expect(indicatorGroup).not.toContain('NodeDetailsButton');
     });
 
+    // #4720 — an incomplete node used to be indistinguishable from a synced one
+    // unless you held nodes:write, which revealed the Copy NodeInfo action. The
+    // badge states the fact for everyone; the remedy stays permission-gated.
+    describe('incomplete-node badge (#4720)', () => {
+      it('puts the incomplete badge among the inert indicators, with no props', () => {
+        expect(indicatorGroup).toContain('<NodeIncompleteBadge />');
+        expect(actionGroup).not.toContain('NodeIncompleteBadge');
+      });
+
+      it('shows the badge to read-only users — it is NOT permission-gated', () => {
+        // This is the whole point of the issue. The Copy NodeInfo action below
+        // shares the same `!isNodeComplete(node)` condition but adds
+        // `hasPermission('nodes', 'write')`; if that guard ever creeps onto the
+        // badge, read-only users go back to seeing nothing at all.
+        const badgeAt = indicatorGroup.indexOf('<NodeIncompleteBadge />');
+        const guard = indicatorGroup.slice(
+          indicatorGroup.lastIndexOf('{', badgeAt),
+          badgeAt,
+        );
+        expect(guard).toContain('!isNodeComplete(node)');
+        expect(guard).not.toMatch(/hasPermission/);
+      });
+
+      it('leaves the Copy NodeInfo remedy permission-gated', () => {
+        // The badge is a fact (ungated); copying NodeInfo mutates data and must
+        // stay behind nodes:write.
+        const copyAt = actionGroup.indexOf("t('nodes.copy_nodeinfo')");
+        const guard = actionGroup.slice(0, copyAt);
+        expect(guard).toMatch(/hasPermission\('nodes', 'write'\)/);
+      });
+
+      it('drives the badge off the shared predicate, not a local re-derivation', () => {
+        // isNodeComplete already encodes two subtleties (a firmware-default
+        // "Node !xxxxxxxx" longName is incomplete; a default 4-hex shortName is
+        // NOT). A second, hand-rolled check here would drift from the filter and
+        // from Auto-Ack's node.completeness.
+        expect(src).toMatch(/import \{[^}]*isNodeComplete[^}]*\} from '\.\.\/utils\/nodeHelpers'/);
+      });
+    });
+
     it('offers Node Details on every node, not just unmessageable ones', () => {
       const detailsAt = actionGroup.indexOf('<NodeDetailsButton');
       const guard = actionGroup.slice(actionGroup.lastIndexOf('{', detailsAt), detailsAt);

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -50,6 +50,7 @@ import { BaseMap } from './map/BaseMap';
 import { MapLoadingOverlay } from './map/MapLoadingOverlay';
 import { MapModeIndicator } from './map/MapModeIndicator';
 import { NodeUnmessageableBadge } from './NodeUnmessageableBadge';
+import { NodeIncompleteBadge } from './NodeIncompleteBadge';
 import { NodeDetailsButton } from './NodeDetailsButton';
 import nodeRowStyles from './NodeRowActions.module.css';
 import { NeighborLinksLayer, type NeighborLinkDescriptor } from './map/layers/NeighborLinksLayer';
@@ -2286,6 +2287,11 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                           <span className="node-indicator-icon" title={t('nodes.has_remote_admin')}><UiIcon name="wrench" size={15} /></span>
                         )}
                         {node.isUnmessagable && <NodeUnmessageableBadge />}
+                        {/* #4720: mark a node we have no NODEINFO for. The row is
+                            otherwise indistinguishable from a synced one unless you
+                            hold nodes:write, which reveals the Copy NodeInfo action
+                            below — this states the fact for everyone. */}
+                        {!isNodeComplete(node) && <NodeIncompleteBadge />}
                         {/* The read-only half of the security warning. Its clickable
                             twin lives in the action group below. */}
                         {(node.keyIsLowEntropy || node.duplicateKeyDetected || node.keySecurityIssueDetails) && !hasPermission('security', 'write') && (


### PR DESCRIPTION
Closes #4720. Refs #4718 (feature-parity tracker, item H).

## The gap, once I looked

The tracker framed this as "MeshMonitor can't distinguish partial nodes". It can — and more of the machinery existed than the tracker credited:

- `isNodeComplete()` already drives the `showIncompleteNodes` filter, used in **six** places in `NodesTab.tsx`
- Auto-Acknowledge already reasons about it via the `node.completeness` tri-state
- An incomplete node already offers a **Copy NodeInfo** action

The real defect is narrower and sharper: that Copy action is gated on `nodes:write`. **A read-only user therefore saw nothing at all** — a partial node looked exactly like a synced one, just with an odd name. The app knew the fact and only told the people who could already act on it.

## The change

An inert `NodeIncompleteBadge` in the indicator group, deliberately **not** permission-gated:

```
📍 🌐 📡 ❓        │  [Copy NodeInfo] [Details]
   facts (all users)  │  actions (nodes:write)
```

Same facts-left / actions-right split #4379 established, and the same shape as its neighbour `NodeUnmessageableBadge` (inert `<span>`, no props, `node-indicator-icon`). The *remedy* stays behind `nodes:write`; only the *statement of fact* is universal.

It reuses the shared `isNodeComplete` predicate rather than re-deriving completeness, so the badge cannot drift from the filter or from Auto-Ack.

## Why the tests are shaped this way

`isNodeComplete` encodes two subtleties a re-implementation would get wrong, and a wrong badge is worse than no badge — so both are pinned:

- a firmware-default `Node !433d1ba4` longName is **non-empty but still incomplete** (NODEINFO never arrived)
- a default 4-hex shortName is **perfectly valid** and must *not* be badged — plenty of genuinely-synced nodes look like that
- plus `hwModel: 0`, a real hardware model, not "unset"

`NodesTab` renders under Leaflet and a stack of contexts and can't be mounted, so the structural claims use the file's existing source-extraction pattern. The load-bearing one asserts the badge's guard contains `!isNodeComplete(node)` and **no `hasPermission`** — if that guard ever creeps on, read-only users silently go back to seeing nothing, which is the whole bug.

One more: a test reads `en.json` directly, because the jsdom assertions pass even when the locale key was never registered (`t()` echoes the key under test).

## Testing

- 8 new tests; `NodesTab.test.tsx` + badge suite: 46 passed / 0 failed
- Full suite: **14,853 passed / 0 failed / 0 failed suites**
- `tsc --noEmit` clean; `lint:ci` clean

**Two honest caveats:**
1. That full run skipped 815 tests because the PostgreSQL/MySQL containers were down. Irrelevant here — this touches no schema, migration or repository code — and CI runs both as service containers.
2. My first full run showed 30 failing suites; that was my own worktree setup error (uninitialised `protobufs` submodule → `encode failed` / missing `mesh.proto`), not the diff. After `git submodule update --init`, all 70 of those re-ran clean with no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G