### PR TITLE
feat(automations): anchor a geofence to a waypoint (#4722)

### DIFF
--- a/src/components/automations/AutomationBuilder.tsx
+++ b/src/components/automations/AutomationBuilder.tsx
@@ -160,7 +160,9 @@ export function FieldInput({ field, value, onChange, variables, sources, channel
       );
       break;
     case 'geofence':
-      control = <GeofenceFieldInput value={value as GeofenceShape | undefined} onChange={onChange} />;
+      // #4722: `sources` is needed for the waypoint-anchor mode — waypoints are
+      // per-source, so the fence has to name which source's waypoint it means.
+      control = <GeofenceFieldInput value={value as GeofenceShape | undefined} sources={sources} onChange={onChange} />;
       break;
     case 'nodeMulti':
       control = <NodeMultiFieldInput value={value} onChange={onChange} nodes={nodes} />;

--- a/src/components/automations/GeofenceFieldInput.tsx
+++ b/src/components/automations/GeofenceFieldInput.tsx
@@ -5,38 +5,63 @@
  * Meshtastic geofence-alert UI uses) with a circle/polygon toggle, and exposes
  * the drawn {@link GeofenceShape} as the automation trigger's `shape` param.
  * Switching shape type clears the current region, mirroring GeofenceTriggersSection.
+ *
+ * #4722 adds a third mode: instead of drawing, anchor the fence to a waypoint.
+ * The stored value is then a `GeofenceWaypointAnchor` rather than a shape, and
+ * the engine resolves it to a circle on every check — so moving the waypoint
+ * moves the fence with no edit here.
  */
 import { useId, useState } from 'react';
 import GeofenceMapEditor from '../GeofenceMapEditor';
+import GeofenceWaypointPicker from './GeofenceWaypointPicker';
 import type { GeofenceShape } from '../auto-responder/types';
+import type { SourceOption } from './AutomationBuilder';
+import { isWaypointAnchor, type GeofenceWaypointAnchor } from './geofenceAnchor';
 
-export default function GeofenceFieldInput({ value, onChange }: {
-  value: GeofenceShape | undefined;
-  onChange: (shape: GeofenceShape | undefined) => void;
+type Mode = 'circle' | 'polygon' | 'waypoint';
+type Value = GeofenceShape | GeofenceWaypointAnchor | undefined;
+
+export default function GeofenceFieldInput({ value, sources = [], onChange }: {
+  value: Value;
+  sources?: SourceOption[];
+  onChange: (value: Value) => void;
 }) {
-  const [shapeType, setShapeType] = useState<'circle' | 'polygon'>(value?.type ?? 'circle');
+  const [mode, setMode] = useState<Mode>(
+    isWaypointAnchor(value) ? 'waypoint' : ((value as GeofenceShape | undefined)?.type ?? 'circle'),
+  );
   // Unique radio-group name so multiple editors on one page don't interfere.
   const radioName = useId();
 
-  const selectType = (type: 'circle' | 'polygon') => {
-    if (type === shapeType) return;
-    setShapeType(type);
-    onChange(undefined); // clear the old region so a stale shape isn't saved
+  const selectMode = (next: Mode) => {
+    if (next === mode) return;
+    setMode(next);
+    onChange(undefined); // clear the old region/anchor so nothing stale is saved
   };
+
+  const anchor = isWaypointAnchor(value) ? value : undefined;
+  const drawn = isWaypointAnchor(value) ? undefined : (value as GeofenceShape | undefined);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
       <div className="ae-btn-row" role="radiogroup" aria-label="Geofence shape">
         <label className="ae-switch">
           <input type="radio" name={radioName} value="circle"
-            checked={shapeType === 'circle'} onChange={() => selectType('circle')} /> Circle
+            checked={mode === 'circle'} onChange={() => selectMode('circle')} /> Circle
         </label>
         <label className="ae-switch">
           <input type="radio" name={radioName} value="polygon"
-            checked={shapeType === 'polygon'} onChange={() => selectType('polygon')} /> Polygon
+            checked={mode === 'polygon'} onChange={() => selectMode('polygon')} /> Polygon
+        </label>
+        <label className="ae-switch">
+          <input type="radio" name={radioName} value="waypoint"
+            checked={mode === 'waypoint'} onChange={() => selectMode('waypoint')} /> Waypoint
         </label>
       </div>
-      <GeofenceMapEditor shape={value ?? null} onShapeChange={onChange} shapeType={shapeType} />
+      {mode === 'waypoint' ? (
+        <GeofenceWaypointPicker value={anchor} sources={sources} onChange={onChange} />
+      ) : (
+        <GeofenceMapEditor shape={drawn ?? null} onShapeChange={onChange} shapeType={mode} />
+      )}
     </div>
   );
 }

--- a/src/components/automations/GeofenceWaypointPicker.tsx
+++ b/src/components/automations/GeofenceWaypointPicker.tsx
@@ -1,0 +1,124 @@
+/**
+ * GeofenceWaypointPicker (#4722) — pick the waypoint a geofence follows.
+ *
+ * Anchoring to a waypoint rather than drawing a region means the fence moves
+ * when the waypoint does, with no edit to the automation. The source is chosen
+ * explicitly because waypoints are per-source while automations are global (see
+ * `geofenceAnchor.ts`), so a fence has to name which source's waypoint it means.
+ */
+import { useEffect, useState } from 'react';
+import apiService from '../../services/api';
+import type { SourceOption } from './AutomationBuilder';
+import { isCompleteAnchor, type GeofenceWaypointAnchor } from './geofenceAnchor';
+
+interface WaypointRow {
+  waypointId: number;
+  name?: string;
+  latitude?: number;
+  longitude?: number;
+}
+
+const DEFAULT_RADIUS_KM = 0.5;
+
+export default function GeofenceWaypointPicker({ value, sources, onChange }: {
+  value: Partial<GeofenceWaypointAnchor> | undefined;
+  sources: SourceOption[];
+  onChange: (anchor: GeofenceWaypointAnchor | undefined) => void;
+}) {
+  const [waypoints, setWaypoints] = useState<WaypointRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const sourceId = value?.sourceId ?? '';
+  const radiusKm = value?.radiusKm ?? DEFAULT_RADIUS_KM;
+
+  // Reload whenever the chosen source changes. A source with no waypoints is a
+  // normal state, not an error — it just leaves nothing to anchor to.
+  useEffect(() => {
+    if (!sourceId) { setWaypoints([]); setLoadError(null); return; }
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+    apiService.get<unknown>(`/api/sources/${encodeURIComponent(sourceId)}/waypoints`)
+      .then((body) => {
+        if (cancelled) return;
+        // The endpoint returns a bare array on some paths and an enveloped
+        // `{ data }` on others (see useWaypoints), so accept both.
+        const rows = Array.isArray(body)
+          ? body
+          : Array.isArray((body as { data?: unknown })?.data)
+            ? (body as { data: unknown[] }).data
+            : [];
+        setWaypoints(rows as WaypointRow[]);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setWaypoints([]);
+        setLoadError(e instanceof Error ? e.message : 'Failed to load waypoints');
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [sourceId]);
+
+  /** Emit only a complete anchor; a half-filled one would never fire. */
+  const emit = (next: Partial<GeofenceWaypointAnchor>) => {
+    const merged = { type: 'waypoint' as const, sourceId, radiusKm, waypointId: value?.waypointId, ...next };
+    onChange(isCompleteAnchor(merged) ? (merged as GeofenceWaypointAnchor) : undefined);
+  };
+
+  const label = (w: WaypointRow) => {
+    const name = (w.name ?? '').trim();
+    return name ? `${name} (#${w.waypointId})` : `Waypoint #${w.waypointId}`;
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <label className="ae-field-label" htmlFor="ae-wp-source">Source</label>
+      <select
+        id="ae-wp-source"
+        className="ae-select"
+        value={sourceId}
+        onChange={(e) => {
+          // Changing source invalidates the waypoint id — ids are only unique
+          // within a source, so keeping it would point at a different place.
+          onChange(undefined);
+          emit({ sourceId: e.target.value, waypointId: undefined });
+        }}
+      >
+        <option value="">— select source —</option>
+        {sources.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+      </select>
+
+      <label className="ae-field-label" htmlFor="ae-wp-id">Waypoint</label>
+      <select
+        id="ae-wp-id"
+        className="ae-select"
+        value={value?.waypointId ?? ''}
+        disabled={!sourceId || loading}
+        onChange={(e) => emit({ waypointId: e.target.value === '' ? undefined : Number(e.target.value) })}
+      >
+        <option value="">{loading ? 'loading…' : '— select waypoint —'}</option>
+        {waypoints.map((w) => <option key={w.waypointId} value={w.waypointId}>{label(w)}</option>)}
+      </select>
+      {loadError && <div className="ae-error-list">{loadError}</div>}
+      {!loading && !loadError && sourceId && waypoints.length === 0 && (
+        <div className="ae-muted">This source has no waypoints to anchor to.</div>
+      )}
+
+      <label className="ae-field-label" htmlFor="ae-wp-radius">Radius (km)</label>
+      <input
+        id="ae-wp-radius"
+        className="ae-input"
+        type="number"
+        min="0"
+        step="0.1"
+        value={radiusKm}
+        onChange={(e) => emit({ radiusKm: e.target.value === '' ? undefined : Number(e.target.value) })}
+      />
+      <div className="ae-help-text">
+        The fence follows the waypoint — move the waypoint and the region moves with it.
+        If the waypoint is deleted or expires, the rule stops firing rather than falling back to another region.
+      </div>
+    </div>
+  );
+}

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -221,7 +221,7 @@ export const TRIGGERS: BlockDef[] = [
           { value: 'dwell', label: 'Moves while inside the region' },
         ],
       },
-      { name: 'shape', label: 'Region', kind: 'geofence', help: 'Draw a circle (center + radius) or a polygon on the map.' },
+      { name: 'shape', label: 'Region', kind: 'geofence', help: 'Draw a circle (center + radius) or a polygon on the map, or anchor the fence to a waypoint so it follows the waypoint when it moves.' },
       COOLDOWN,
       COOLDOWN_SCOPE,
     ],

--- a/src/components/automations/geofenceAnchor.test.ts
+++ b/src/components/automations/geofenceAnchor.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Client-side waypoint-anchor helpers (#4722).
+ *
+ * `isCompleteAnchor` is the editor's mirror of the engine's
+ * `normalizeGeofenceAnchor`. If the two disagree, the builder happily saves a
+ * fence the engine then refuses to resolve — a rule that looks configured and
+ * silently never fires. These pin the agreement.
+ */
+import { describe, it, expect } from 'vitest';
+import { isWaypointAnchor, isCompleteAnchor } from './geofenceAnchor';
+
+describe('isWaypointAnchor', () => {
+  it('distinguishes an anchor from the drawn-region shapes', () => {
+    expect(isWaypointAnchor({ type: 'waypoint', sourceId: 's', waypointId: 1, radiusKm: 1 })).toBe(true);
+    expect(isWaypointAnchor({ type: 'circle', center: { lat: 0, lng: 0 }, radiusKm: 1 })).toBe(false);
+    expect(isWaypointAnchor({ type: 'polygon', vertices: [] })).toBe(false);
+    expect(isWaypointAnchor(undefined)).toBe(false);
+    expect(isWaypointAnchor(null)).toBe(false);
+  });
+});
+
+describe('isCompleteAnchor — mirrors the engine parser', () => {
+  const full = { type: 'waypoint' as const, sourceId: 'src-a', waypointId: 42, radiusKm: 0.5 };
+
+  it('accepts a fully specified anchor', () => {
+    expect(isCompleteAnchor(full)).toBe(true);
+  });
+
+  it('accepts waypoint id 0 — a real id, not "unset"', () => {
+    // The obvious falsy-check bug: `if (!waypointId)` would reject this.
+    expect(isCompleteAnchor({ ...full, waypointId: 0 })).toBe(true);
+  });
+
+  it('rejects a missing or blank source', () => {
+    expect(isCompleteAnchor({ ...full, sourceId: '' })).toBe(false);
+    expect(isCompleteAnchor({ ...full, sourceId: '   ' })).toBe(false);
+    expect(isCompleteAnchor({ ...full, sourceId: undefined })).toBe(false);
+  });
+
+  it('rejects a missing waypoint', () => {
+    expect(isCompleteAnchor({ ...full, waypointId: undefined })).toBe(false);
+    expect(isCompleteAnchor({ ...full, waypointId: Number.NaN })).toBe(false);
+  });
+
+  it('rejects a non-positive radius, which could never be entered', () => {
+    expect(isCompleteAnchor({ ...full, radiusKm: 0 })).toBe(false);
+    expect(isCompleteAnchor({ ...full, radiusKm: -1 })).toBe(false);
+    expect(isCompleteAnchor({ ...full, radiusKm: undefined })).toBe(false);
+  });
+
+  it('rejects nothing at all', () => {
+    expect(isCompleteAnchor(undefined)).toBe(false);
+  });
+});

--- a/src/components/automations/geofenceAnchor.ts
+++ b/src/components/automations/geofenceAnchor.ts
@@ -1,0 +1,40 @@
+/**
+ * Waypoint-anchored geofence value (#4722) — the client half of the type the
+ * engine resolves in `src/server/services/automation/geo.ts`.
+ *
+ * Deliberately NOT added to the `GeofenceShape` union in
+ * `src/components/auto-responder/types.ts`: that union is shared with the
+ * Meshtastic geofence-alert UI, which has no waypoint concept and narrows on
+ * `type` exhaustively. Widening it there would silently change behaviour in a
+ * feature this issue never touched.
+ *
+ * `sourceId` is part of the value because automations are global while
+ * waypoints are per-source — see the engine-side note for why the fence pins
+ * its source rather than following the moving node's.
+ */
+export interface GeofenceWaypointAnchor {
+  type: 'waypoint';
+  sourceId: string;
+  waypointId: number;
+  radiusKm: number;
+}
+
+/** The two things a geofence field can hold: a drawn region, or an anchor. */
+export type GeofenceFieldValue = { type: 'circle' | 'polygon' } | GeofenceWaypointAnchor;
+
+export function isWaypointAnchor(v: unknown): v is GeofenceWaypointAnchor {
+  return !!v && typeof v === 'object' && (v as { type?: unknown }).type === 'waypoint';
+}
+
+/**
+ * True when the anchor is complete enough for the engine to resolve. Mirrors
+ * `normalizeGeofenceAnchor` server-side: a blank source or non-positive radius
+ * yields a fence that can never fire, so the editor should not call it valid.
+ * Waypoint id 0 IS valid — it is a real id, not "unset".
+ */
+export function isCompleteAnchor(a: Partial<GeofenceWaypointAnchor> | undefined): boolean {
+  if (!a) return false;
+  if (typeof a.sourceId !== 'string' || a.sourceId.trim() === '') return false;
+  if (!Number.isFinite(a.waypointId)) return false;
+  return Number.isFinite(a.radiusKm) && (a.radiusKm as number) > 0;
+}

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -874,6 +874,136 @@ describe('AutomationEngineService', () => {
     expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(1);
   });
 
+  // #4722 — a geofence anchored to a waypoint instead of a drawn region.
+  describe('geofence anchored to a waypoint', () => {
+    const anchoredGraph: AutomationGraph = {
+      version: 1,
+      nodes: [
+        {
+          id: 't',
+          type: 'trigger.geofence',
+          params: { event: 'enter', shape: { type: 'waypoint', sourceId: 'src-a', waypointId: 42, radiusKm: 5 } },
+        },
+        { id: 'a', type: 'action.notify', params: { body: 'entered' } },
+      ],
+      edges: [{ from: 't', to: 'a' }],
+    };
+
+    it('fires on entry, resolving the fence from the waypoint', async () => {
+      const { calls, deps } = recorder();
+      await createEnabled('geo-wp', anchoredGraph);
+      const pos = { lat: 1, lon: 0 }; // ~111km from the waypoint → outside
+      const data = {
+        getNode: async () => ({ nodeNum: 5, latitude: pos.lat, longitude: pos.lon }),
+        getTelemetry: async () => null,
+        getWaypoint: async () => ({ latitude: 0, longitude: 0 }),
+      };
+      const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data, now: () => clock });
+      await engine.load();
+
+      expect(await engine.checkGeofences(5, 'default')).toBe(0); // baseline (outside)
+      pos.lat = 0.01; // ~1.1km → inside
+      expect(await engine.checkGeofences(5, 'default')).toBe(1);
+      expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(1);
+    });
+
+    it('follows the waypoint when it moves, with no edit to the automation', async () => {
+      // The whole reason to anchor rather than draw: the node never moves here,
+      // only the waypoint does, and that alone must produce an entry.
+      const { deps } = recorder();
+      await createEnabled('geo-wp-move', anchoredGraph);
+      const waypoint = { latitude: 10, longitude: 10 }; // far from the node
+      const data = {
+        getNode: async () => ({ nodeNum: 5, latitude: 0, longitude: 0 }),
+        getTelemetry: async () => null,
+        getWaypoint: async () => waypoint,
+      };
+      const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data, now: () => clock });
+      await engine.load();
+
+      expect(await engine.checkGeofences(5, 'default')).toBe(0); // baseline (outside)
+      waypoint.latitude = 0.01; waypoint.longitude = 0; // dragged onto the node
+      expect(await engine.checkGeofences(5, 'default')).toBe(1);
+    });
+
+    it('fails CLOSED when the waypoint is gone — never falls back to another region', async () => {
+      // A deleted/expired waypoint must not fire. Firing on a stale or default
+      // region would alert about a place the user believes no longer exists.
+      const { calls, deps } = recorder();
+      await createEnabled('geo-wp-deleted', anchoredGraph);
+      const data = {
+        getNode: async () => ({ nodeNum: 5, latitude: 0, longitude: 0 }), // dead centre
+        getTelemetry: async () => null,
+        getWaypoint: async () => null, // deleted
+      };
+      const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data, now: () => clock });
+      await engine.load();
+
+      expect(await engine.checkGeofences(5, 'default')).toBe(0);
+      expect(await engine.checkGeofences(5, 'default')).toBe(0);
+      expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(0);
+    });
+
+    it('fails closed when the provider has no waypoint support at all', async () => {
+      const { calls, deps } = recorder();
+      await createEnabled('geo-wp-unsupported', anchoredGraph);
+      // No getWaypoint on the provider — the optional-method contract.
+      const data = {
+        getNode: async () => ({ nodeNum: 5, latitude: 0, longitude: 0 }),
+        getTelemetry: async () => null,
+      };
+      const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data, now: () => clock });
+      await engine.load();
+
+      expect(await engine.checkGeofences(5, 'default')).toBe(0);
+      expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(0);
+    });
+
+    it('survives a throwing waypoint lookup rather than killing the whole sweep', async () => {
+      // checkGeofences loops every geofence automation; one bad DB read must not
+      // take down the fences that follow it.
+      const { calls, deps } = recorder();
+      await createEnabled('geo-wp-throws', anchoredGraph);
+      const data = {
+        getNode: async () => ({ nodeNum: 5, latitude: 0, longitude: 0 }),
+        getTelemetry: async () => null,
+        getWaypoint: async () => { throw new Error('db down'); },
+      };
+      const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data, now: () => clock });
+      await engine.load();
+
+      await expect(engine.checkGeofences(5, 'default')).resolves.toBe(0);
+      expect(calls.filter((c) => c.fn === 'notify')).toHaveLength(0);
+    });
+
+    it('leaves drawn-region fences on the synchronous path (no waypoint lookup)', async () => {
+      const { deps } = recorder();
+      await createEnabled('geo-drawn', {
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.geofence', params: { event: 'enter', lat: 0, lon: 0, radiusKm: 5 } },
+          { id: 'a', type: 'action.notify', params: { body: 'entered' } },
+        ],
+        edges: [{ from: 't', to: 'a' }],
+      });
+      const pos = { lat: 1, lon: 0 };
+      let waypointLookups = 0;
+      const data = {
+        getNode: async () => ({ nodeNum: 5, latitude: pos.lat, longitude: pos.lon }),
+        getTelemetry: async () => null,
+        getWaypoint: async () => { waypointLookups++; return { latitude: 99, longitude: 99 }; },
+      };
+      const engine = new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data, now: () => clock });
+      await engine.load();
+
+      await engine.checkGeofences(5, 'default');
+      pos.lat = 0.01;
+      expect(await engine.checkGeofences(5, 'default')).toBe(1);
+      // A drawn fence must not pay for — or be perturbed by — waypoint resolution.
+      expect(waypointLookups).toBe(0);
+    });
+  });
+
   it('system: a trigger only fires for its configured event (prefilter)', async () => {
     const { calls, deps } = recorder();
     await createEnabled('on-boot', {

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -52,7 +52,7 @@ import {
 import type { MeshCoreMessage } from '../../meshcoreManager.js';
 import type { ReticulumMessageRow } from '../../../db/repositories/reticulum.js';
 import { scheduleCron, validateCron } from '../../utils/cronScheduler.js';
-import { haversineKm, geofenceFires, pointInShape, geofenceCenter, normalizeGeofenceParams, type GeofenceMode } from './geo.js';
+import { haversineKm, geofenceFires, pointInShape, geofenceCenter, normalizeGeofenceParams, normalizeGeofenceAnchor, shapeFromWaypoint, type GeofenceMode, type GeofenceShape } from './geo.js';
 import { evaluateGraph, type EvaluatorHooks } from './graphEvaluator.js';
 import { automationTraceBus } from './automationTraceBus.js';
 import { evaluateCondition } from './conditionEvaluator.js';
@@ -841,7 +841,32 @@ export class AutomationEngineService {
     for (const a of entries) {
       const p = (a.triggerNode.params ?? {}) as Record<string, unknown>;
       const mode = (String(p.event ?? 'enter') as GeofenceMode);
-      const shape = normalizeGeofenceParams(p);
+
+      // #4722: a fence may be anchored to a waypoint instead of a drawn region.
+      // Resolve it per check so moving the waypoint moves the fence. It fails
+      // CLOSED — a deleted waypoint (or a provider without waypoint support)
+      // never fires rather than falling back to some other region.
+      const anchor = normalizeGeofenceAnchor(p);
+      let shape: GeofenceShape | null;
+      if (anchor) {
+        const position = this.data.getWaypoint
+          ? await this.data.getWaypoint(anchor.sourceId, anchor.waypointId).catch(() => null)
+          : null;
+        if (!position) {
+          if (automationTraceBus.activeCount() > 0 && automationTraceBus.isTracing(a.id, now)) {
+            this.emitTrace(
+              a,
+              buildGeofenceContext(nodeNum, mode, node.latitude, node.longitude, 0, sourceId, now),
+              now,
+              { outcome: 'prefiltered', reason: `waypoint ${anchor.waypointId} not found on source ${anchor.sourceId} — fence cannot be resolved` },
+            );
+          }
+          continue;
+        }
+        shape = shapeFromWaypoint(anchor, position);
+      } else {
+        shape = normalizeGeofenceParams(p);
+      }
       if (!shape) continue;
 
       const inside = pointInShape(node.latitude, node.longitude, shape);

--- a/src/server/services/automation/engineContext.ts
+++ b/src/server/services/automation/engineContext.ts
@@ -50,6 +50,20 @@ export interface NodeDataProvider {
    */
   getChannelName?(sourceId: string | null, channelIndex: number): Promise<string | null>;
   /**
+   * Current position of a waypoint, for a geofence anchored to one rather than
+   * to a drawn region (#4722). Resolved on every geofence check so moving the
+   * waypoint moves the fence with no edit to the automation.
+   *
+   * Returns null when the waypoint is gone — deleted, or belonging to a source
+   * that no longer exists. Such a fence must fail CLOSED (never fire) rather
+   * than fall back to some other region: silently fencing the wrong place is
+   * worse than not firing, and the trace says which waypoint went missing.
+   *
+   * Optional — providers that don't implement it disable waypoint anchoring
+   * entirely, which is the same fail-closed behaviour.
+   */
+  getWaypoint?(sourceId: string, waypointId: number): Promise<{ latitude: number; longitude: number } | null>;
+  /**
    * All channels for a source as {slot, name, psk, role}, for resolving a
    * unified channel (by name) to its local slot when sending. Optional.
    */

--- a/src/server/services/automation/geo.ts
+++ b/src/server/services/automation/geo.ts
@@ -25,6 +25,64 @@ export type GeofenceShape =
   | { type: 'circle'; center: { lat: number; lng: number }; radiusKm: number }
   | { type: 'polygon'; vertices: Array<{ lat: number; lng: number }> };
 
+/**
+ * A geofence anchored to a waypoint instead of a drawn region (#4722).
+ *
+ * This is NOT a `GeofenceShape`: it carries no coordinates, because the whole
+ * point is that the fence follows the waypoint. It resolves to a circle at
+ * evaluation time, so moving the waypoint moves the fence with no edit to the
+ * automation.
+ *
+ * `sourceId` is stored explicitly rather than taken from the position event.
+ * Automations are global while waypoints are per-source, so resolving against
+ * the moving node's source would make one fence mean different physical places
+ * for different nodes — surprising, and impossible to see from the rule. Pinning
+ * the source keeps a fence to exactly one place on the map, while still letting
+ * a node from ANY source cross it.
+ */
+export type GeofenceWaypointAnchor = {
+  type: 'waypoint';
+  sourceId: string;
+  waypointId: number;
+  radiusKm: number;
+};
+
+/**
+ * Read a waypoint anchor out of a geofence trigger's params, or null when the
+ * params describe a drawn region (or nothing usable).
+ *
+ * Deliberately separate from {@link normalizeGeofenceParams}: that function is
+ * pure and total, and an anchor cannot become a shape without a database read.
+ * Keeping them apart means every existing caller of `normalizeGeofenceParams`
+ * keeps its synchronous contract.
+ */
+export function normalizeGeofenceAnchor(params: Record<string, unknown>): GeofenceWaypointAnchor | null {
+  const raw = params?.shape;
+  if (!raw || typeof raw !== 'object') return null;
+  const s = raw as Record<string, unknown>;
+  if (s.type !== 'waypoint') return null;
+
+  const sourceId = typeof s.sourceId === 'string' ? s.sourceId.trim() : '';
+  const waypointId = Number(s.waypointId);
+  const radiusKm = Number(s.radiusKm);
+  if (!sourceId) return null;
+  if (!Number.isFinite(waypointId)) return null;
+  if (!Number.isFinite(radiusKm) || radiusKm <= 0) return null;
+  return { type: 'waypoint', sourceId, waypointId, radiusKm };
+}
+
+/** Build the circle a resolved waypoint stands for. */
+export function shapeFromWaypoint(
+  anchor: GeofenceWaypointAnchor,
+  position: { latitude: number; longitude: number },
+): GeofenceShape {
+  return {
+    type: 'circle',
+    center: { lat: position.latitude, lng: position.longitude },
+    radiusKm: anchor.radiusKm,
+  };
+}
+
 /** Point-in-polygon via ray casting (mirrors `src/utils/geometry.ts`). */
 export function pointInPolygon(lat: number, lon: number, vertices: Array<{ lat: number; lng: number }>): boolean {
   if (vertices.length < 3) return false;

--- a/src/server/services/automation/geo.waypointAnchor.test.ts
+++ b/src/server/services/automation/geo.waypointAnchor.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Waypoint-anchored geofence parsing (#4722).
+ *
+ * The anchor is parsed separately from `normalizeGeofenceParams` because it
+ * cannot become a shape without a database read. These pin that separation —
+ * an anchor must never leak out of the shape parser, and a drawn region must
+ * never be mistaken for an anchor — plus the validation that keeps a
+ * half-configured anchor from fencing the wrong place.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeGeofenceAnchor,
+  normalizeGeofenceParams,
+  shapeFromWaypoint,
+  pointInShape,
+} from './geo.js';
+
+const anchorParams = {
+  event: 'enter',
+  shape: { type: 'waypoint', sourceId: 'src-a', waypointId: 42, radiusKm: 0.5 },
+};
+
+describe('normalizeGeofenceAnchor', () => {
+  it('reads a fully specified waypoint anchor', () => {
+    expect(normalizeGeofenceAnchor(anchorParams)).toEqual({
+      type: 'waypoint', sourceId: 'src-a', waypointId: 42, radiusKm: 0.5,
+    });
+  });
+
+  it('accepts waypoint id 0 — a legitimate id, not "unset"', () => {
+    const a = normalizeGeofenceAnchor({ shape: { ...anchorParams.shape, waypointId: 0 } });
+    expect(a?.waypointId).toBe(0);
+  });
+
+  it('rejects an anchor missing the source, since the fence would be ambiguous', () => {
+    // Automations are global and waypoint ids are only unique per source, so an
+    // anchor without a sourceId cannot identify one place on the map.
+    expect(normalizeGeofenceAnchor({ shape: { ...anchorParams.shape, sourceId: '' } })).toBeNull();
+    expect(normalizeGeofenceAnchor({ shape: { ...anchorParams.shape, sourceId: '   ' } })).toBeNull();
+    const { sourceId: _omitted, ...noSource } = anchorParams.shape;
+    expect(normalizeGeofenceAnchor({ shape: noSource })).toBeNull();
+  });
+
+  it('rejects a non-positive or missing radius', () => {
+    // A zero-radius fence can never be entered; better to not resolve at all
+    // than to install a rule that silently never fires.
+    for (const radiusKm of [0, -1, Number.NaN, undefined]) {
+      expect(normalizeGeofenceAnchor({ shape: { ...anchorParams.shape, radiusKm } })).toBeNull();
+    }
+  });
+
+  it('rejects a non-numeric waypoint id', () => {
+    expect(normalizeGeofenceAnchor({ shape: { ...anchorParams.shape, waypointId: 'abc' } })).toBeNull();
+  });
+
+  it('returns null for drawn regions and for empty params', () => {
+    expect(normalizeGeofenceAnchor({ shape: { type: 'circle', center: { lat: 1, lng: 2 }, radiusKm: 1 } })).toBeNull();
+    expect(normalizeGeofenceAnchor({ shape: { type: 'polygon', vertices: [] } })).toBeNull();
+    expect(normalizeGeofenceAnchor({})).toBeNull();
+  });
+});
+
+describe('anchor and shape parsers stay disjoint', () => {
+  it('normalizeGeofenceParams does not resolve a waypoint anchor to a region', () => {
+    // If this ever returned a shape, an anchored fence would silently evaluate
+    // against a bogus region instead of failing closed.
+    expect(normalizeGeofenceParams(anchorParams)).toBeNull();
+  });
+
+  it('normalizeGeofenceAnchor does not claim a legacy flat lat/lon fence', () => {
+    const legacy = { lat: 40, lon: -74, radiusKm: 2 };
+    expect(normalizeGeofenceAnchor(legacy)).toBeNull();
+    expect(normalizeGeofenceParams(legacy)).toEqual({
+      type: 'circle', center: { lat: 40, lng: -74 }, radiusKm: 2,
+    });
+  });
+});
+
+describe('shapeFromWaypoint', () => {
+  it('centres a circle of the anchor radius on the waypoint', () => {
+    const anchor = normalizeGeofenceAnchor(anchorParams)!;
+    expect(shapeFromWaypoint(anchor, { latitude: 26.7, longitude: -80.05 })).toEqual({
+      type: 'circle', center: { lat: 26.7, lng: -80.05 }, radiusKm: 0.5,
+    });
+  });
+
+  it('moves the fence when the waypoint moves', () => {
+    const anchor = normalizeGeofenceAnchor(anchorParams)!;
+    const node = { lat: 26.7, lng: -80.05 };
+
+    const before = shapeFromWaypoint(anchor, { latitude: 26.7, longitude: -80.05 });
+    expect(pointInShape(node.lat, node.lng, before)).toBe(true);
+
+    // Same automation, no edit — the waypoint has simply been dragged away.
+    const after = shapeFromWaypoint(anchor, { latitude: 27.9, longitude: -82.4 });
+    expect(pointInShape(node.lat, node.lng, after)).toBe(false);
+  });
+});

--- a/src/server/services/automation/meshNodeData.ts
+++ b/src/server/services/automation/meshNodeData.ts
@@ -35,6 +35,26 @@ export function createMeshNodeDataProvider(): NodeDataProvider {
       }
     },
 
+    /**
+     * #4722 — current position of a waypoint a geofence is anchored to.
+     *
+     * An EXPIRED waypoint reads as gone. `expireAt` is epoch *seconds* (null or
+     * 0 = never expires, matching `waypoints.listAsync`), and an expired
+     * waypoint has already vanished from the map — continuing to fence the spot
+     * it used to occupy would fire on a region the user believes no longer
+     * exists. Failing closed here is the safer half of that trade.
+     */
+    async getWaypoint(sourceId, waypointId) {
+      try {
+        const w = await databaseService.waypoints.getAsync(sourceId, waypointId);
+        if (!w || w.latitude == null || w.longitude == null) return null;
+        if (w.expireAt != null && w.expireAt !== 0 && w.expireAt < Math.floor(Date.now() / 1000)) return null;
+        return { latitude: Number(w.latitude), longitude: Number(w.longitude) };
+      } catch {
+        return null;
+      }
+    },
+
     async getChannelName(sourceId, channelIndex) {
       try {
         const ch = await databaseService.channels.getChannelById(channelIndex, sourceId ?? undefined);


### PR DESCRIPTION
Closes #4722. Refs #4718 (feature-parity tracker, item I).

Apple alerts when nodes enter/exit geofenced waypoints. MeshMonitor had both halves already — a `trigger.geofence` with enter/exit/dwell, and a full waypoints feature — but no way to join them. Fencing a waypoint meant hand-drawing a circle over it and re-drawing whenever the waypoint moved.

A geofence trigger can now carry `shape: { type: 'waypoint', sourceId, waypointId, radiusKm }`, resolved to a circle on **every** check, so moving the waypoint moves the fence with no edit to the automation.

## Why the source is pinned in the config

Automations are **global**; waypoints are **per-source**. So "the region is this waypoint" needs a rule for *which* source's waypoint.

Resolving against the moving node's source would make one fence mean **different physical places for different nodes**, invisible from the rule itself. Pinning the source keeps a fence to exactly one place on the map, while still letting a node from any source cross it. (Confirmed with @Yeraze before building.)

Because ids are only unique within a source, changing source in the editor clears the waypoint id rather than carrying it to a different place.

## It fails closed

A deleted waypoint, an **expired** one, a provider without waypoint support, or a throwing DB read all yield *no fire*, plus a trace reason naming the missing waypoint. Never a fallback region.

Firing on a stale fence would alert about a place the user believes no longer exists — worse than silence. Expiry is enforced too (`expireAt` is epoch **seconds**, null/0 = never), since an expired waypoint has already left the map.

## Structure

- **Anchor parsing is disjoint from `normalizeGeofenceParams`.** That function is pure and total; an anchor cannot become a shape without a DB read. Keeping them apart preserves every existing caller's synchronous contract, and tests assert neither parser claims the other's input — if the shape parser ever resolved an anchor, an anchored fence would evaluate against a bogus region instead of failing closed.
- **`getWaypoint` is an optional `NodeDataProvider` method**, matching the file's existing "absent → degrades to X" convention. Absent means fail-closed.
- **Drawn fences pay nothing.** A call-counter test asserts a drawn region triggers **zero** waypoint lookups — a per-position DB read across every geofence automation would be a real cost.
- **`GeofenceShape` was NOT widened.** That union is shared with the Meshtastic geofence-alert UI, which narrows on `type` exhaustively and has no waypoint concept; adding a variant would have changed behaviour in a feature this issue never touched. The anchor is a separate type.
- **The editor only emits a *complete* anchor.** For a fail-closed trigger a half-filled config is the worst outcome — the rule looks configured and silently never fires. `isCompleteAnchor` mirrors the engine parser, tests pin the agreement.

## Testing

Two subtleties both parsers must agree on, pinned on both sides:
- **waypoint id `0` is a real id**, not "unset" — a falsy check would silently drop it
- **a non-positive radius is rejected**, not saved as a fence that can never be entered

Engine tests cover: fires on entry; **follows the waypoint when only the waypoint moves**; fails closed on deleted / unsupported / throwing lookups; and drawn fences staying on the synchronous path.

- 18 new tests; automations suite 375 passed / 0 failed
- Full suite: **14,868 passed / 0 failed / 0 failed suites**
- `tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.server.json`; `lint:ci` clean

**Caveat:** that full run skipped 815 tests because the PostgreSQL/MySQL containers were down. Irrelevant here — no schema, migration or repository change — and CI runs both as service containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G