### PR TITLE
fix(meshcore): reserve channel 0 for the implicit Public channel (#4733)

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsConfigSection.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsConfigSection.test.tsx
@@ -158,6 +158,25 @@ describe('MeshCoreChannelsConfigSection — add channel', () => {
     expect(secretInput.value).toBe('0102030405060708090a0b0c0d0e0f10');
   });
 
+  // Regression for #4733: slot 0 is the implicit MeshCore "Public" channel.
+  // "Add channel" must never propose it, even starting from a completely
+  // empty channel list (e.g. before the first device sync has landed).
+  it('never proposes slot 0, even with an empty channel list', async () => {
+    csrfFetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    render(
+      <MeshCoreChannelsConfigSection baseUrl="" sourceId="src-a" canWrite={true} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText('No channels reported by the device yet.')).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByText('+ Add channel'));
+
+    expect(screen.getByText('Adding channel 1')).toBeTruthy();
+    expect(screen.queryByText('Adding channel 0')).toBeNull();
+  });
+
   it('Save sends PUT to /api/channels/<idx> with base64 PSK + sourceId, then re-fetches', async () => {
     csrfFetchMock
       // initial list

--- a/src/components/MeshCore/MeshCoreChannelsConfigSection.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsConfigSection.tsx
@@ -173,10 +173,14 @@ export const MeshCoreChannelsConfigSection: React.FC<MeshCoreChannelsConfigSecti
     return () => { cancelled = true; };
   }, [baseUrl, sourceId, csrfFetch, reloadTick]);
 
-  // Find the smallest free channel index (starting at 0). Used by "Add channel".
+  // Find the smallest free channel index, starting at 1 — slot 0 is reserved
+  // for MeshCore's implicit "Public" channel and must never be offered as a
+  // destination for a newly added channel (issue #4733). The server mirrors
+  // this with a hard reject on writes to channel 0; this is the UI-side
+  // belt-and-braces so "Add channel" never even proposes it.
   const nextFreeIdx = useMemo(() => {
     const used = new Set(channels.map(c => c.id));
-    for (let i = 0; i < 256; i++) if (!used.has(i)) return i;
+    for (let i = 1; i < 256; i++) if (!used.has(i)) return i;
     return 255;
   }, [channels]);
 

--- a/src/server/meshcoreManager.channels.test.ts
+++ b/src/server/meshcoreManager.channels.test.ts
@@ -158,12 +158,13 @@ describe('MeshCoreManager — syncChannelsFromDevice', () => {
     });
   });
 
-  it('handles an empty channel list without throwing', async () => {
+  it('handles an empty channel list without throwing, seeding the synthetic Public row for slot 0', async () => {
     const { manager, upsertCalls } = makeManager({
       getChannelsResponse: { success: true, data: [] },
     });
     await manager.syncChannelsFromDevice();
-    expect(upsertCalls).toHaveLength(0);
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0].data).toMatchObject({ id: 0, name: 'Public', psk: null });
   });
 
   it('stores psk as null when the device reports an empty secret', async () => {
@@ -207,8 +208,55 @@ describe('MeshCoreManager — syncChannelsFromDevice', () => {
       },
     });
     await manager.syncChannelsFromDevice();
-    expect(upsertCalls).toHaveLength(1);
+    // The real configured slot 3, plus the synthetic Public row seeded for
+    // slot 0 since the device didn't report a real channel there.
+    expect(upsertCalls).toHaveLength(2);
     expect(upsertCalls[0].data.id).toBe(3);
+    expect(upsertCalls[1].data).toMatchObject({ id: 0, name: 'Public', psk: null });
+  });
+
+  it('seeds the synthetic Public row for slot 0 when the device reports it as an empty/unconfigured slot', async () => {
+    const zero = '00'.repeat(16);
+    const { manager, upsertCalls } = makeManager({
+      getChannelsResponse: {
+        success: true,
+        data: [{ channel_idx: 0, name: '', secret_hex: zero }],
+      },
+    });
+    await manager.syncChannelsFromDevice();
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0].data).toMatchObject({ id: 0, name: 'Public', psk: null });
+  });
+
+  it('does not overwrite a real user-configured channel 0 with the synthetic Public placeholder', async () => {
+    const { manager, upsertCalls } = makeManager({
+      getChannelsResponse: {
+        success: true,
+        data: [{ channel_idx: 0, name: 'MyRealChannel', secret_hex: 'ab'.repeat(16) }],
+      },
+    });
+    await manager.syncChannelsFromDevice();
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0].data).toMatchObject({
+      id: 0,
+      name: 'MyRealChannel',
+      psk: Buffer.from('ab'.repeat(16), 'hex').toString('base64'),
+    });
+  });
+
+  it('never deletes the DB row for slot 0, even when the device reports it as unconfigured', async () => {
+    const zero = '00'.repeat(16);
+    const { manager, deleteCalls, upsertCalls } = makeManager({
+      preExistingRows: [{ id: 0, name: 'Public', psk: null }],
+      getChannelsResponse: {
+        success: true,
+        data: [{ channel_idx: 0, name: '', secret_hex: zero }],
+      },
+    });
+    await manager.syncChannelsFromDevice();
+    expect(deleteCalls).toEqual([]);
+    // Re-seeded (idempotent) rather than deleted.
+    expect(upsertCalls.map(c => c.data.id)).toEqual([0]);
   });
 
   it('reconciles: deletes DB rows for slots the device no longer treats as configured', async () => {

--- a/src/server/meshcoreManager.channels.test.ts
+++ b/src/server/meshcoreManager.channels.test.ts
@@ -390,4 +390,26 @@ describe('MeshCoreManager — setChannel / deleteChannel', () => {
     const { manager } = makeManager({ deviceType: MeshCoreDeviceType.REPEATER });
     await expect(manager.deleteChannel(0)).rejects.toThrow(/Companion mode/);
   });
+
+  // Regression for #4733 code review: deleting a misconfigured channel 0 is
+  // the documented recovery path ("delete it to restore Public"). Confirm the
+  // re-sync that deleteChannel() triggers actually re-seeds the synthetic
+  // Public placeholder rather than leaving slot 0 with no DB row at all.
+  it('deleteChannel(0) re-seeds the synthetic Public row once the device reports the slot empty', async () => {
+    const zero = '00'.repeat(16);
+    const { manager, deleteCalls, upsertCalls } = makeManager({
+      preExistingRows: [{ id: 0, name: 'MyMisconfiguredChannel', psk: 'realsecret' }],
+      // Post-delete device state: slot 0 now reads as empty/unconfigured.
+      getChannelsResponse: {
+        success: true,
+        data: [{ channel_idx: 0, name: '', secret_hex: zero }],
+      },
+    });
+    await manager.deleteChannel(0);
+
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0].data).toMatchObject({ id: 0, name: 'Public', psk: null });
+    // Slot 0 is exempt from the reconcile-delete pass — it's re-seeded, not deleted.
+    expect(deleteCalls).toEqual([]);
+  });
 });

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -151,6 +151,15 @@ function isConfiguredMeshCoreChannel(ch: { name: string; secretHex: string }): b
   return hasName || hasSecret;
 }
 
+/**
+ * Display name for MeshCore's implicit slot-0 "Public" channel (#4733).
+ * Firmware never reports a name/secret for it — it reads as an empty slot
+ * (see `isConfiguredMeshCoreChannel`) — so it needs a synthetic DB row to be
+ * visible anywhere a channel needs to be picked from a list, e.g. the
+ * Automation Engine's "On channel" trigger.
+ */
+const MESHCORE_PUBLIC_CHANNEL_NAME = 'Public';
+
 // MeshCore device types
 export enum MeshCoreDeviceType {
   UNKNOWN = 0,
@@ -2600,6 +2609,29 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       );
     }
 
+    // Slot 0 is MeshCore's implicit "Public" broadcast channel. Firmware
+    // reports it exactly like an empty slot (no name, all-zero secret), so it
+    // never lands in `configured` above and would otherwise have no DB row at
+    // all — invisible to every DB-driven consumer (Automation Engine channel
+    // picker, auto-ack/auto-announce pickers, etc — issue #4733). Seed a
+    // synthetic placeholder whenever the device hasn't reported a REAL
+    // channel 0 of its own, so "Public" always has a stable DB identity.
+    if (!configured.some(ch => ch.channelIdx === 0)) {
+      await databaseService.channels.upsertChannel(
+        {
+          id: 0,
+          name: MESHCORE_PUBLIC_CHANNEL_NAME,
+          psk: null,
+          role: null,
+          uplinkEnabled: null,
+          downlinkEnabled: null,
+          positionPrecision: null,
+        },
+        this.sourceId,
+        { allowBlankName: true },
+      );
+    }
+
     // Reconcile: remove DB rows for slots the device positively reported as
     // unconfigured. This covers (a) out-of-band deletes via meshcore-cli and
     // (b) cleanup of legacy installs that had unconfigured-slot rows from
@@ -2608,13 +2640,16 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     // `reportedIdxSet` is every slot the firmware actually answered for. A row
     // whose idx is NOT in it carries no evidence either way — the enumeration
     // may simply have stopped short — so it is preserved. Only "reported AND
-    // not configured" is treated as a delete.
+    // not configured" is treated as a delete. Slot 0 is exempt outright: it
+    // always carries either the device's real channel or the synthetic
+    // "Public" placeholder seeded just above, never a stale row to clean up.
     const reportedIdxSet = new Set(channels.map(ch => ch.channelIdx));
     const configuredIdxSet = new Set(configured.map(ch => ch.channelIdx));
     const existing = await databaseService.channels.getAllChannels(this.sourceId);
     let removed = 0;
     let preserved = 0;
     for (const row of existing) {
+      if (row.id === 0) continue;
       if (configuredIdxSet.has(row.id)) continue;
       if (!reportedIdxSet.has(row.id)) {
         // Unreported: the scan never reached this slot. Leave it be.

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2541,6 +2541,14 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   /**
    * Delete a channel slot on the device. Re-syncs the DB from the device
    * afterwards so the local mirror reflects the firmware's view.
+   *
+   * Deleting idx 0 is intentionally allowed (see the channelId===0 guard on
+   * `PUT /channels/:id`, which blocks writes but not deletes) — it is the
+   * recovery path for a channel that got misconfigured onto slot 0 before
+   * this reservation existed. The re-sync below will find slot 0 reporting
+   * empty and re-seed the synthetic "Public" placeholder (#4733) — this is
+   * the intended outcome, not a bug: "delete channel 0" always resolves to
+   * "channel 0 is Public again," never to "channel 0 has no DB row."
    */
   async deleteChannel(idx: number): Promise<void> {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) {

--- a/src/server/routes/channelRoutes.test.ts
+++ b/src/server/routes/channelRoutes.test.ts
@@ -344,6 +344,16 @@ describe('PUT /channels/:id', () => {
     expect(res.body.error).toContain('16 bytes');
   });
 
+  it('rejects writes to MeshCore channel 0 — reserved for the implicit Public channel (#4733)', async () => {
+    mockDb.sources.getSource.mockResolvedValue({ type: 'meshcore' });
+    const sixteen = Buffer.alloc(16).toString('base64');
+    const res = await request(app).put('/channels/0').send({ name: 'mc', psk: sixteen, sourceId: 'mc-1' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('MESHCORE_CHANNEL_ZERO_RESERVED');
+    expect(res.body.error).toContain('Public');
+    expect(mockMeshcoreManager.setChannel).not.toHaveBeenCalled();
+  });
+
   it('503s for MeshCore when no manager is registered', async () => {
     mockDb.sources.getSource.mockResolvedValue({ type: 'meshcore' });
     mockSourceRegistry.getManager.mockReturnValue(undefined);

--- a/src/server/routes/channelRoutes.test.ts
+++ b/src/server/routes/channelRoutes.test.ts
@@ -405,6 +405,22 @@ describe('DELETE /channels/:id', () => {
     // Verify the manager registry was queried for the correct source
     expect(mockSourceRegistry.getManager).toHaveBeenCalledWith('meshcore-1');
   });
+
+  // #4733: unlike Meshtastic, MeshCore channel 0 CAN be deleted — this is the
+  // documented recovery path for a channel that got misconfigured onto slot 0
+  // before writes to it were blocked (deleting it lets syncChannelsFromDevice
+  // re-seed the synthetic Public placeholder on the next sync).
+  it('MeshCore: allows deleting channel 0 (the reserved-slot recovery path)', async () => {
+    mockDb.sources.getSource.mockResolvedValue({ type: 'meshcore' });
+    mockSourceRegistry.getManager.mockReturnValue(mockMeshcoreManager);
+    mockMeshcoreManager.deleteChannel.mockResolvedValue(undefined);
+
+    const res = await request(app).delete('/channels/0').send({ sourceId: 'meshcore-1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockMeshcoreManager.deleteChannel).toHaveBeenCalledWith(0);
+  });
 });
 
 describe('POST /channels/:slotId/import', () => {

--- a/src/server/routes/channelRoutes.ts
+++ b/src/server/routes/channelRoutes.ts
@@ -464,6 +464,16 @@ router.put('/:id', requireAuth(), requireSourceId('body'), async (req: Request, 
       return res.status(400).json({ error: 'Invalid channel ID. Must be between 0-7' });
     }
 
+    // Slot 0 on a MeshCore device is the implicit "Public" broadcast channel
+    // — firmware has no concept of "set channel 0", and letting a write land
+    // there displaces the synthetic Public row `syncChannelsFromDevice`
+    // maintains for it (issue #4733). Reject outright rather than silently
+    // overwriting; the client's "Add channel" flow never proposes slot 0.
+    if (sourceType === 'meshcore' && channelId === 0) {
+      return fail(res, 400, 'MESHCORE_CHANNEL_ZERO_RESERVED',
+        'Channel 0 is reserved for the MeshCore Public channel and cannot be modified. Delete it to restore Public, then add your channel to a different slot.');
+    }
+
     // MM-SEC-4: per-channel write gate — caller needs write permission for
     // the SPECIFIC channel they're modifying, not just channel_0.
     const channelResource = `channel_${channelId}` as import('../../types/permission.js').ResourceType;

--- a/src/server/routes/channelRoutes.ts
+++ b/src/server/routes/channelRoutes.ts
@@ -471,7 +471,9 @@ router.put('/:id', requireAuth(), requireSourceId('body'), async (req: Request, 
     // overwriting; the client's "Add channel" flow never proposes slot 0.
     if (sourceType === 'meshcore' && channelId === 0) {
       return fail(res, 400, 'MESHCORE_CHANNEL_ZERO_RESERVED',
-        'Channel 0 is reserved for the MeshCore Public channel and cannot be modified. Delete it to restore Public, then add your channel to a different slot.');
+        'Channel 0 is reserved for the MeshCore Public channel and cannot be written to. ' +
+        'If a channel was previously misconfigured onto slot 0, delete it (DELETE is still allowed ' +
+        'for slot 0) to restore Public, then add your channel to slot 1 or higher.');
     }
 
     // MM-SEC-4: per-channel write gate — caller needs write permission for


### PR DESCRIPTION
## Summary

Fixes #4733.

MeshCore's slot-0 "Public" broadcast channel is never reported by firmware with a name or secret — `GetChannel(0)` on an unconfigured Public slot returns an empty name and an all-zero 16-byte secret, identical to any other unused slot (confirmed directly in the `@liamcottle/meshcore.js` connection layer, which comments channel index 0 as "reserved (0 for now, ie. 'public')"). MeshMonitor's `isConfiguredMeshCoreChannel` filter therefore always treated it as empty, so it never got a DB row. Two symptoms followed:

1. **"Add channel" displaced Public.** The next-free-slot scan started at index 0, so the very first channel a user added landed on slot 0 and overwrote the implicit Public channel.
2. **The Automation Engine couldn't target Public.** Its "On channel" picker is built directly from the `channels` table (`databaseService.channels.getAllChannels(sourceId)`), and since Public never had a row, it was never selectable — while Meshtastic's equivalent Primary/LongFast channel (which *does* get a row) showed up fine.

## Changes

- `src/server/meshcoreManager.ts`: `syncChannelsFromDevice` now seeds a synthetic "Public" DB row for slot 0 whenever the device doesn't report a real channel there, and slot 0 is now exempt from the reconcile-delete pass (so the synthetic row is never treated as a stale entry to clean up). A device that *does* report a real, named channel at slot 0 is left untouched — only genuinely empty/unreported slot 0s get the placeholder.
- `src/components/MeshCore/MeshCoreChannelsConfigSection.tsx`: the "Add channel" free-slot scan now starts at index 1 instead of 0 (belt-and-braces — the server-side seeding above already keeps slot 0 occupied in the DB after the first sync, but this protects the very first add before any sync has landed).
- `src/server/routes/channelRoutes.ts`: `PUT /channels/:id` now rejects writes to channel 0 for MeshCore sources outright (`MESHCORE_CHANNEL_ZERO_RESERVED`), so a race or a direct API call can't clobber Public either. Deleting an existing (pre-fix) misconfigured channel 0 is still allowed, so an affected user can reclaim the slot.

## Test plan

- [x] Added/updated unit tests in `meshcoreManager.channels.test.ts` covering: empty channel list seeds Public, a real channel elsewhere still seeds Public for slot 0, a real user channel at slot 0 is never overwritten by the placeholder, and slot 0 is never deleted during reconciliation.
- [x] Added a regression test in `MeshCoreChannelsConfigSection.test.tsx` asserting "Add channel" proposes index 1, never 0, even from an empty channel list.
- [x] Added a route test in `channelRoutes.test.ts` asserting `PUT /channels/0` on a MeshCore source 400s with `MESHCORE_CHANNEL_ZERO_RESERVED` and never reaches the device manager.
- [x] `npm run typecheck` clean.
- [x] `npm run lint:ci` clean (no new baseline violations).
- [x] Full `vitest` suite run locally (after initializing the `protobufs`/`takpacket-sdk` submodules) — 0 failures outside the pre-existing environmental protobuf-submodule gap, which resolved once submodules were initialized.

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_014zL3jf2cVS5MnFFXhCGWB9)_