### PR TITLE
fix(admin): dispatch meshbeacon config on both admin paths (#4739)

### DIFF
--- a/src/server/routes/adminRoutes.configTypeCoverage.test.ts
+++ b/src/server/routes/adminRoutes.configTypeCoverage.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Config-type registry vs. adminRoutes dispatch coverage (#4739).
+ *
+ * `CONFIG_TYPE_MAP` decides whether a config type is *recognised*; two separate
+ * `switch` statements in `adminRoutes.ts` — one for the local node, one for
+ * remote admin — decide whether it is *formatted into a response*. A type in
+ * the registry but missing from a switch passes the lookup, falls through with
+ * `config` unset, and reaches the user as "Unknown config type: <id>", which
+ * reads like an unsupported feature rather than the dispatch gap it is.
+ *
+ * That has happened twice: #1852 (`telemetry`) and #4739 (`meshbeacon`). Both
+ * were one-line fixes, and both were found by a user rather than by CI. This
+ * test closes the class — adding a config type to the registry without wiring
+ * both switches now fails here instead of shipping.
+ *
+ * Source extraction rather than an HTTP exercise, deliberately: the switches
+ * sit deep inside a large handler behind device/session mocking, and what needs
+ * guarding is a *list*, not behaviour. The repo uses this pattern elsewhere
+ * (see `server.settings-persistence.test.ts`).
+ *
+ * Regions are used rather than "the case labels above the generic body",
+ * because several types (`mqtt`, `device`, `lora`, `position`, `security`)
+ * carry bespoke cases outside the generic fallthrough group. Anchoring on the
+ * group alone reported those as missing when they are handled perfectly well.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { CONFIG_TYPES } from '../constants/configTypes.js';
+
+const source = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'adminRoutes.ts'),
+  'utf8',
+);
+
+/** Boundaries of the two dispatch switches inside the config-load handler. */
+const REMOTE_MARKER = '// Remote node - request config with session passkey';
+const AFTER_MARKER = '// Handle channel config (works for both local and remote)';
+
+function regions(): { local: string; remote: string } {
+  const r = source.indexOf(REMOTE_MARKER);
+  const c = source.indexOf(AFTER_MARKER);
+  expect(r, `marker missing — retarget this test: ${REMOTE_MARKER}`).toBeGreaterThan(-1);
+  expect(c, `marker missing — retarget this test: ${AFTER_MARKER}`).toBeGreaterThan(r);
+  return { local: source.slice(0, r), remote: source.slice(r, c) };
+}
+
+function caseLabels(region: string): Set<string> {
+  return new Set(Array.from(region.matchAll(/^\s*case '([a-z0-9_]+)':/gm), (m) => m[1]));
+}
+
+const ALL_IDS = CONFIG_TYPES.map((e) => e.id);
+const MODULE_IDS = CONFIG_TYPES.filter((e) => e.kind === 'module').map((e) => e.id);
+
+describe('adminRoutes config dispatch covers the registry', () => {
+  // Guards the guard: an extraction bug returning nothing would make every
+  // coverage assertion below vacuously pass.
+  it('extracts a plausible case list from both regions', () => {
+    const { local, remote } = regions();
+    expect(caseLabels(local).size).toBeGreaterThan(20);
+    expect(caseLabels(remote).size).toBeGreaterThan(20);
+  });
+
+  it('registry includes the two types that previously drifted', () => {
+    expect(MODULE_IDS).toContain('telemetry');   // #1852
+    expect(MODULE_IDS).toContain('meshbeacon');  // #4739
+  });
+
+  it('handles every registered config type on the local-node path', () => {
+    const handled = caseLabels(regions().local);
+    expect(ALL_IDS.filter((id) => !handled.has(id))).toEqual([]);
+  });
+
+  it('handles every registered config type on the remote-node path', () => {
+    // The reported #4739 failure came through remote admin's "Load All Config".
+    const handled = caseLabels(regions().remote);
+    expect(ALL_IDS.filter((id) => !handled.has(id))).toEqual([]);
+  });
+});

--- a/src/server/routes/adminRoutes.ts
+++ b/src/server/routes/adminRoutes.ts
@@ -439,6 +439,7 @@ router.post('/load-config', requireAdmin(), async (req, res) => {
           case 'paxcounter':
           case 'statusmessage':
           case 'trafficmanagement':
+          case 'meshbeacon':
             const moduleKey = MODULE_FIELD_BY_ID[configType];
             if (moduleKey && finalConfig.moduleConfig?.[moduleKey]) {
               config = finalConfig.moduleConfig[moduleKey];
@@ -585,6 +586,7 @@ router.post('/load-config', requireAdmin(), async (req, res) => {
           case 'paxcounter':
           case 'statusmessage':
           case 'trafficmanagement':
+          case 'meshbeacon':
             config = remoteConfig || { enabled: false };
             break;
         }


### PR DESCRIPTION
Closes #4739.

`meshbeacon` was registered in the canonical config-type registry but absent from the two `switch` statements in `adminRoutes.ts` that format a loaded config into a response. It passed the `CONFIG_TYPE_MAP` lookup, fell through with `config` unset, and hit the catch-all — surfacing to the user as **"Unknown config type: meshbeacon"**, which reads like an unsupported feature rather than the dispatch gap it is.

The case bodies were already generic (`MODULE_FIELD_BY_ID[configType]` locally, raw `remoteConfig` remotely), so only the dispatch lists were stale. The reported failure came via remote admin's "Load All Config", but the local path had the same gap.

## The guard matters more than the fix

This is the **second** occurrence of the same drift — #1852 was `telemetry`, this is `meshbeacon` — and both reached a user before anyone noticed. A one-line fix leaves the third one waiting.

So this also adds a test asserting every registered config type appears in **both** switches. Confirmed to fail on both paths with the fix reverted, rather than being assumed to work.

Two things it had to get right, both found by the guard failing on correct code first:

- Several types (`mqtt`, `device`, `lora`, `position`, `security`) carry **bespoke cases outside** the generic fallthrough group. My first version anchored on that group and reported them as missing when they are handled fine. It now extracts by region.
- `MODULE_FIELD_BY_ID[configType]` appears **twice** in the file — the first occurrence is in a registry-driven branch with no switch at all, so anchoring on it silently extracted nothing. I checked whether that was a third drift site; it isn't, it's fully generic.

Because a source-extraction test can pass vacuously, it asserts it found a plausible number of labels *before* trusting any "nothing missing" result.

## Verification

- Full suite: **15,705 passed, 0 failed**, with PostgreSQL and MySQL up.
- `lint:ci` clean, `tsc` clean.
- Mutation-checked: reverting the fix fails the guard on both the local and remote paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G
