### PR TITLE
feat(i18n): add Traditional Chinese to language selector

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -23,6 +23,7 @@ export const AVAILABLE_LANGUAGES = [
   { code: 'fr', name: 'French', nativeName: 'Français' },
   { code: 'ru', name: 'Russian', nativeName: 'Русский' },
   { code: 'zh_Hans', name: 'Chinese (Simplified)', nativeName: '简体中文' },
+  { code: 'zh_Hant', name: 'Chinese (Traditional)', nativeName: '繁體中文' },
 ];
 
 void i18n


### PR DESCRIPTION
## Summary

Adds Traditional Chinese (`zh_Hant`) as a selectable option in the language selector. The entry is appended to `AVAILABLE_LANGUAGES` in `src/config/i18n.ts`, following the same format and naming convention as the existing `zh_Hans` entry, with the native name displayed as 繁體中文.

Translation strings for `zh_Hant` are already managed through Weblate, so this change only exposes the locale in the UI — no translation files are added or modified in this PR.

## Testing

Built and ran the app locally. The language selector shows 繁體中文, and selecting it switches the UI to Traditional Chinese as expected, with no missing-key fallbacks observed.