### PR TITLE
fix(map): bound position-history rendering and fetching (#4743)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -5067,5 +5067,6 @@
   "survey.no_hops": "No answered traceroutes yet, so reach is unknown.",
   "survey.hops_direct": "Direct",
   "survey.hops_n_one": "{{count}} hop",
-  "survey.hops_n_other": "{{count}} hops"
+  "survey.hops_n_other": "{{count}} hops",
+  "nodes.position_history_simplified": "Trail simplified — intermediate fixes between these points are not drawn."
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import { ResourceType } from './types/permission';
 import api, { type ChannelDatabaseEntry } from './services/api';
 import { getPacketStats } from './services/packetApi';
 import { logger } from './utils/logger';
+import { MAX_ACCUMULATED_POSITION_FIXES } from './utils/positionHistoryDownsample';
 import { isTxDisabledBody } from './utils/txDisabled';
 import { resolveNeighborInfoErrorToast } from './utils/neighborInfoError';
 // generateArrowMarkers moved to useTraceroutePaths hook
@@ -1307,20 +1308,7 @@ function App() {
       const accumulated: PositionHistoryItem[] = [];
       let beforeCursor: number | undefined;
       const MAX_PAGES = 50; // safety bound (~15k fixes) against a runaway loop
-      /**
-       * Stop paging once we hold this many fixes (#4743).
-       *
-       * A node on estimated positions is relocated every time a neighbour
-       * reports, so it can hold far more history than a GPS node. Walking all
-       * 50 pages meant 50 sequential round trips, each followed by a state
-       * update and a full re-render of the trail — a large part of the freeze
-       * on its own, separately from the DOM cost the map paid.
-       *
-       * Well above what the map draws (see MAX_RENDERED_POSITION_POINTS), so
-       * the visible trail still spans the node's full recorded history; this
-       * only stops accumulating detail nothing consumes.
-       */
-      const MAX_ACCUMULATED_FIXES = 5000;
+
 
       try {
         for (let page = 0; page < MAX_PAGES; page++) {
@@ -1346,7 +1334,8 @@ function App() {
           // Next page: strictly older than the oldest fix just received. A
           // boundary fix split by the row cap is always older than this, so it
           // re-assembles on the next page without duplicating an emitted fix.
-          if (accumulated.length >= MAX_ACCUMULATED_FIXES) break;
+          // Stop paging once we hold enough (#4743) — see the constant's comment.
+          if (accumulated.length >= MAX_ACCUMULATED_POSITION_FIXES) break;
 
           const oldest = pageItems[0].timestamp;
           if (beforeCursor !== undefined && oldest >= beforeCursor) break; // no-progress guard

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1307,6 +1307,20 @@ function App() {
       const accumulated: PositionHistoryItem[] = [];
       let beforeCursor: number | undefined;
       const MAX_PAGES = 50; // safety bound (~15k fixes) against a runaway loop
+      /**
+       * Stop paging once we hold this many fixes (#4743).
+       *
+       * A node on estimated positions is relocated every time a neighbour
+       * reports, so it can hold far more history than a GPS node. Walking all
+       * 50 pages meant 50 sequential round trips, each followed by a state
+       * update and a full re-render of the trail — a large part of the freeze
+       * on its own, separately from the DOM cost the map paid.
+       *
+       * Well above what the map draws (see MAX_RENDERED_POSITION_POINTS), so
+       * the visible trail still spans the node's full recorded history; this
+       * only stops accumulating detail nothing consumes.
+       */
+      const MAX_ACCUMULATED_FIXES = 5000;
 
       try {
         for (let page = 0; page < MAX_PAGES; page++) {
@@ -1332,6 +1346,8 @@ function App() {
           // Next page: strictly older than the oldest fix just received. A
           // boundary fix split by the row cap is always older than this, so it
           // re-assembles on the next page without duplicating an emitted fix.
+          if (accumulated.length >= MAX_ACCUMULATED_FIXES) break;
+
           const oldest = pageItems[0].timestamp;
           if (beforeCursor !== undefined && oldest >= beforeCursor) break; // no-progress guard
           beforeCursor = oldest;

--- a/src/components/NodesTab.positionHistoryBound.test.ts
+++ b/src/components/NodesTab.positionHistoryBound.test.ts
@@ -14,7 +14,11 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { downsamplePositionHistory, MAX_RENDERED_POSITION_POINTS } from '../utils/positionHistoryDownsample';
+import {
+  downsamplePositionHistory,
+  MAX_RENDERED_POSITION_POINTS,
+  MAX_ACCUMULATED_POSITION_FIXES,
+} from '../utils/positionHistoryDownsample';
 
 const dir = dirname(fileURLToPath(import.meta.url));
 const nodesTab = readFileSync(join(dir, 'NodesTab.tsx'), 'utf8');
@@ -64,13 +68,12 @@ describe('history fetching is bounded', () => {
   it('stops accumulating once it holds enough fixes', () => {
     // The other half of the freeze: 50 sequential requests, each followed by a
     // state update and a full re-render of the trail.
-    expect(app).toContain('MAX_ACCUMULATED_FIXES');
-    expect(app).toContain('if (accumulated.length >= MAX_ACCUMULATED_FIXES) break;');
+    expect(app).toContain('if (accumulated.length >= MAX_ACCUMULATED_POSITION_FIXES) break;');
   });
 
   it('fetches more than it draws, so the trail still spans full history', () => {
-    const m = /const MAX_ACCUMULATED_FIXES = (\d+);/.exec(app);
-    expect(m, 'MAX_ACCUMULATED_FIXES not found').toBeTruthy();
-    expect(Number(m![1])).toBeGreaterThan(MAX_RENDERED_POSITION_POINTS);
+    // Both caps are now exported from one module, so this compares the real
+    // values rather than a number scraped out of source text (review note).
+    expect(MAX_ACCUMULATED_POSITION_FIXES).toBeGreaterThan(MAX_RENDERED_POSITION_POINTS);
   });
 });

--- a/src/components/NodesTab.positionHistoryBound.test.ts
+++ b/src/components/NodesTab.positionHistoryBound.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Position-history render bound (#4743).
+ *
+ * Tapping a marker for a node on estimated positions froze the UI for ~1 minute
+ * on mobile: the map built one `<Polyline>` plus one rich `<Popup>` per segment
+ * over a history that can reach 15,000 fixes.
+ *
+ * Source-extraction rather than a render test: mounting NodesTab needs the map
+ * stack, contexts and Leaflet, and what has to hold is that the segment loop
+ * reads the BOUNDED array. A render test that mounted 15,000 segments to prove
+ * they are slow would itself be the bug.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { downsamplePositionHistory, MAX_RENDERED_POSITION_POINTS } from '../utils/positionHistoryDownsample';
+
+const dir = dirname(fileURLToPath(import.meta.url));
+const nodesTab = readFileSync(join(dir, 'NodesTab.tsx'), 'utf8');
+const app = readFileSync(join(dir, '..', 'App.tsx'), 'utf8');
+
+/** The memo that builds the trail's Polyline/Popup elements. */
+function segmentBuilderSource(): string {
+  const start = nodesTab.indexOf('const positionHistoryElements = useMemo(');
+  expect(start, 'positionHistoryElements memo not found — retarget this test').toBeGreaterThan(-1);
+  const end = nodesTab.indexOf('const historyArrows', start);
+  expect(end).toBeGreaterThan(start);
+  return nodesTab.slice(start, end);
+}
+
+describe('trail rendering is bounded', () => {
+  it('builds segments from the downsampled array, not the raw history', () => {
+    const src = segmentBuilderSource();
+    expect(src).toContain('renderedPositionHistory');
+    // The unbounded array must not drive the element loop — that is the freeze.
+    expect(src).not.toContain('filteredPositionHistory');
+  });
+
+  it('derives the bounded array through the shared cap', () => {
+    expect(nodesTab).toContain('downsamplePositionHistory(filteredPositionHistory, MAX_RENDERED_POSITION_POINTS)');
+  });
+
+  it('keeps the legend reading the FULL filtered history', () => {
+    // Bounding the drawing must not shrink the reported time span; the legend
+    // states the trail's real oldest/newest.
+    const start = nodesTab.indexOf('const positionHistoryLegendData = useMemo(');
+    const src = nodesTab.slice(start, start + 400);
+    expect(src).toContain('filteredPositionHistory');
+  });
+
+  it('caps a realistic estimated-position history to a renderable size', () => {
+    // End to end on the real helper: 15,000 fixes is the size the reporter hit.
+    const history = Array.from({ length: 15_000 }, (_, i) => ({ timestamp: i }));
+    const drawn = downsamplePositionHistory(history, MAX_RENDERED_POSITION_POINTS);
+
+    expect(drawn.length).toBeLessThanOrEqual(MAX_RENDERED_POSITION_POINTS);
+    expect(drawn[0].timestamp).toBe(0);
+    expect(drawn[drawn.length - 1].timestamp).toBe(14_999);
+  });
+});
+
+describe('history fetching is bounded', () => {
+  it('stops accumulating once it holds enough fixes', () => {
+    // The other half of the freeze: 50 sequential requests, each followed by a
+    // state update and a full re-render of the trail.
+    expect(app).toContain('MAX_ACCUMULATED_FIXES');
+    expect(app).toContain('if (accumulated.length >= MAX_ACCUMULATED_FIXES) break;');
+  });
+
+  it('fetches more than it draws, so the trail still spans full history', () => {
+    const m = /const MAX_ACCUMULATED_FIXES = (\d+);/.exec(app);
+    expect(m, 'MAX_ACCUMULATED_FIXES not found').toBeTruthy();
+    expect(Number(m![1])).toBeGreaterThan(MAX_RENDERED_POSITION_POINTS);
+  });
+});

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -9,6 +9,7 @@ import { TabType } from '../types/ui';
 import { nodePassesTransportFilter, transportCutoffSec } from '../utils/nodeTransport';
 import { getNodeTypeCategory } from '../utils/nodeTypeCategory';
 import { effectiveMapMaxAgeHours } from '../utils/mapAge';
+import { downsamplePositionHistory, MAX_RENDERED_POSITION_POINTS } from '../utils/positionHistoryDownsample';
 import { createNodeIcon, getHopColor } from '../utils/mapIcons';
 import { getPositionHistoryColor, generateHeadingAwarePath, generatePositionHistoryArrows, snrToColor } from '../utils/mapHelpers.tsx';
 import { convertSpeed } from '../utils/speedConversion';
@@ -694,6 +695,27 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     return positionHistory;
   }, [showMotion, positionHistory, positionHistoryHours]);
 
+  /**
+   * Trail actually drawn, bounded to `MAX_RENDERED_POSITION_POINTS` (#4743).
+   *
+   * A node using estimated positions is relocated every time a neighbour
+   * reports, so its history reaches thousands of fixes — one `<Polyline>` plus
+   * one rich `<Popup>` each, which froze the UI for about a minute on mobile.
+   * A time window alone does not bound this: even 24 hours of estimated
+   * positions can hold thousands of entries.
+   *
+   * `filteredPositionHistory` stays the source of truth for the legend's time
+   * span, so the reported oldest/newest remain exact while the drawing is
+   * capped.
+   */
+  const renderedPositionHistory = useMemo(
+    () => downsamplePositionHistory(filteredPositionHistory, MAX_RENDERED_POSITION_POINTS),
+    [filteredPositionHistory],
+  );
+
+  /** True when the drawn trail omits intermediate fixes — surfaced in the popup. */
+  const positionHistoryDownsampled = renderedPositionHistory.length < filteredPositionHistory.length;
+
   // Memoize position history legend data for MapLegend
   const positionHistoryLegendData = useMemo(() => {
     if (filteredPositionHistory.length < 2) return undefined;
@@ -707,15 +729,15 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
   // Memoize position history polyline elements
   const positionHistoryElements = useMemo(() => {
-    if (filteredPositionHistory.length < 2) return null;
+    if (renderedPositionHistory.length < 2) return null;
 
     const elements: React.ReactElement[] = [];
-    const segmentCount = filteredPositionHistory.length - 1;
+    const segmentCount = renderedPositionHistory.length - 1;
     const segmentColors: string[] = [];
 
     for (let i = 0; i < segmentCount; i++) {
-      const startPos = filteredPositionHistory[i];
-      const endPos = filteredPositionHistory[i + 1];
+      const startPos = renderedPositionHistory[i];
+      const endPos = renderedPositionHistory[i + 1];
       const color = getPositionHistoryColor(i, segmentCount, overlayColors.positionHistoryOld, overlayColors.positionHistoryNew);
       segmentColors.push(color);
 
@@ -751,6 +773,14 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               <div className="route-usage">
                 <strong>To:</strong> {formatDateTime(new Date(endPos.timestamp), timeFormat, dateFormat)}
               </div>
+              {/* The trail is thinned for very dense histories (#4743), so a
+                  segment can span more fixes than it draws. Say so rather than
+                  implying these two points were consecutive. */}
+              {positionHistoryDownsampled && (
+                <div className="route-usage">
+                  <em>{t('nodes.position_history_simplified')}</em>
+                </div>
+              )}
               {startPos.groundSpeed !== undefined && (() => {
                 const { speed, unit } = convertSpeed(startPos.groundSpeed, distanceUnit);
                 return (
@@ -775,7 +805,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     }
 
     const historyArrows = generatePositionHistoryArrows(
-      filteredPositionHistory,
+      renderedPositionHistory,
       segmentColors,
       30,
       distanceUnit
@@ -783,7 +813,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     elements.push(...historyArrows);
 
     return elements;
-  }, [filteredPositionHistory, overlayColors.positionHistoryOld, overlayColors.positionHistoryNew, positionHistoryLineStyle, positionHistoryPointsOnly, timeFormat, dateFormat, distanceUnit]);
+  }, [renderedPositionHistory, positionHistoryDownsampled, t, overlayColors.positionHistoryOld, overlayColors.positionHistoryNew, positionHistoryLineStyle, positionHistoryPointsOnly, timeFormat, dateFormat, distanceUnit]);
 
   // Detect touch device to disable hover tooltips on mobile
   const [isTouchDevice, setIsTouchDevice] = useState(false);

--- a/src/utils/positionHistoryDownsample.test.ts
+++ b/src/utils/positionHistoryDownsample.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Position-history downsampling (#4743).
+ *
+ * This bounds what the map draws, so the properties that matter are: the cap is
+ * actually respected, the trail keeps its true endpoints (the legend reads
+ * them), and order is preserved so the line does not zig-zag backwards.
+ */
+import { describe, it, expect } from 'vitest';
+import { downsamplePositionHistory, MAX_RENDERED_POSITION_POINTS } from './positionHistoryDownsample';
+
+const seq = (n: number) => Array.from({ length: n }, (_, i) => i);
+
+describe('downsamplePositionHistory', () => {
+  it('returns the input untouched when already within the cap', () => {
+    expect(downsamplePositionHistory(seq(10), 500)).toEqual(seq(10));
+    expect(downsamplePositionHistory(seq(500), 500)).toEqual(seq(500));
+  });
+
+  it('never exceeds the cap, across a wide range of input sizes', () => {
+    for (const n of [501, 1000, 5000, 15_000, 100_000]) {
+      expect(downsamplePositionHistory(seq(n), 500).length).toBeLessThanOrEqual(500);
+    }
+  });
+
+  it('keeps the true first and last entries', () => {
+    // The legend reads oldest/newest off this array. Dropping an endpoint would
+    // misreport the trail's time span while the line still looked correct.
+    const out = downsamplePositionHistory(seq(15_000), 500);
+    expect(out[0]).toBe(0);
+    expect(out[out.length - 1]).toBe(14_999);
+  });
+
+  it('preserves order', () => {
+    const out = downsamplePositionHistory(seq(9999), 400);
+    for (let i = 1; i < out.length; i++) expect(out[i]).toBeGreaterThan(out[i - 1]);
+  });
+
+  it('never emits a duplicate index', () => {
+    // Rounding can land twice on the same index near the end, which would draw
+    // a zero-length segment and an empty popup.
+    for (const [n, cap] of [[501, 500], [502, 500], [999, 998], [1001, 1000]]) {
+      const out = downsamplePositionHistory(seq(n), cap);
+      expect(new Set(out).size).toBe(out.length);
+    }
+  });
+
+  it('samples roughly evenly rather than clustering', () => {
+    // A naive "take the first N" would keep the trail's start and silently drop
+    // everything recent — the opposite of useful.
+    const out = downsamplePositionHistory(seq(10_000), 100);
+    const mid = out[Math.floor(out.length / 2)];
+    expect(mid).toBeGreaterThan(4_000);
+    expect(mid).toBeLessThan(6_000);
+  });
+
+  it('handles degenerate inputs without throwing', () => {
+    expect(downsamplePositionHistory([], 500)).toEqual([]);
+    expect(downsamplePositionHistory([1], 500)).toEqual([1]);
+    expect(downsamplePositionHistory([1, 2], 1)).toEqual([1, 2]);
+    expect(downsamplePositionHistory([], 0)).toEqual([]);
+  });
+
+  it('exposes a render budget that is bounded and smooth', () => {
+    expect(MAX_RENDERED_POSITION_POINTS).toBeGreaterThanOrEqual(200);
+    expect(MAX_RENDERED_POSITION_POINTS).toBeLessThanOrEqual(1000);
+  });
+});

--- a/src/utils/positionHistoryDownsample.ts
+++ b/src/utils/positionHistoryDownsample.ts
@@ -22,6 +22,12 @@
  * Evenly sample `items` down to at most `maxPoints`, always keeping the first
  * and last entries.
  *
+ * One documented exception to "at most": `maxPoints` below 2 still returns two
+ * entries (first and last) when the input has them, because a single point
+ * draws no segment and callers of this are drawing lines. The cap is a
+ * rendering budget, and one point is not a smaller drawing than two — it is no
+ * drawing at all.
+ *
  * Preserving the endpoints is load-bearing: the map legend reads the oldest and
  * newest timestamps off this array, so dropping either would misreport the
  * trail's time span while the line itself still looked right.
@@ -56,3 +62,16 @@ export function downsamplePositionHistory<T>(items: T[], maxPoints: number): T[]
  * still drives the legend's time span.
  */
 export const MAX_RENDERED_POSITION_POINTS = 500;
+
+/**
+ * Maximum position fixes accumulated by the progressive history fetch.
+ *
+ * Lives beside the render budget so the relationship between them is visible:
+ * this must stay comfortably ABOVE `MAX_RENDERED_POSITION_POINTS`, so the
+ * drawn trail still spans the node's full recorded history and only detail
+ * nothing consumes is dropped.
+ *
+ * Bounds the OTHER half of the #4743 freeze — walking all 50 pages meant 50
+ * sequential round trips, each followed by a state update and a full re-render.
+ */
+export const MAX_ACCUMULATED_POSITION_FIXES = 5000;

--- a/src/utils/positionHistoryDownsample.ts
+++ b/src/utils/positionHistoryDownsample.ts
@@ -1,0 +1,58 @@
+/**
+ * Position-history downsampling (#4743).
+ *
+ * The map draws one `<Polyline>` AND one rich `<Popup>` per segment of a node's
+ * position trail. A node using estimated positions has its location
+ * recalculated every time a neighbour reports, so its history grows far faster
+ * than a GPS node's — 15,000 fixes is reachable, which is ~15,000 polylines and
+ * ~15,000 popups. That froze the UI for about a minute on mobile.
+ *
+ * Bounding the RENDER rather than the data is the right lever here. A time
+ * window alone does not fix it: estimated positions accumulate so quickly that
+ * even 24 hours can hold thousands of fixes. Capping the element count bounds
+ * the DOM no matter how dense the history or how wide the window.
+ *
+ * Downsampling is visually near-lossless for this use — a trail drawn from 500
+ * evenly-spaced fixes is indistinguishable from one drawn from 15,000 at any
+ * zoom the map offers — but it IS lossy about intermediate detail, which is why
+ * callers are expected to say so rather than present the trail as complete.
+ */
+
+/**
+ * Evenly sample `items` down to at most `maxPoints`, always keeping the first
+ * and last entries.
+ *
+ * Preserving the endpoints is load-bearing: the map legend reads the oldest and
+ * newest timestamps off this array, so dropping either would misreport the
+ * trail's time span while the line itself still looked right.
+ */
+export function downsamplePositionHistory<T>(items: T[], maxPoints: number): T[] {
+  if (maxPoints < 2) return items.length <= 1 ? items.slice() : [items[0], items[items.length - 1]];
+  if (items.length <= maxPoints) return items.slice();
+
+  const last = items.length - 1;
+  const out: T[] = [];
+  // Distribute maxPoints-1 intervals across the range, then append the true
+  // final item. Rounding can repeat an index near the end, so guard against
+  // emitting the same element twice.
+  const step = last / (maxPoints - 1);
+  let previousIndex = -1;
+  for (let i = 0; i < maxPoints - 1; i++) {
+    const index = Math.round(i * step);
+    if (index === previousIndex) continue;
+    out.push(items[index]);
+    previousIndex = index;
+  }
+  if (previousIndex !== last) out.push(items[last]);
+  return out;
+}
+
+/**
+ * Maximum trail segments rendered at once.
+ *
+ * 500 keeps the drawn line smooth at every zoom level the map exposes while
+ * holding the element count somewhere a browser handles comfortably. This is a
+ * rendering budget, not a data limit — the full history is still fetched and
+ * still drives the legend's time span.
+ */
+export const MAX_RENDERED_POSITION_POINTS = 500;


### PR DESCRIPTION
Fixes #4743.

Tapping a map marker for a node using estimated positions froze the UI for ~1 minute on mobile. The issue's root-cause analysis was accurate — I verified both cited sites — and checking it turned up two things that change the fix.

## The freeze has two independent causes

The issue describes the DOM explosion: one `<Polyline>` **plus one rich `<Popup>`** per segment, over a history that reaches 15,000 fixes.

But `App.tsx` also walks **up to 50 sequential pages**, calling `setPositionHistory([...accumulated])` after each one — 50 round trips, each triggering a full re-render of the trail. Fixing only the rendering would have left that churn in place, so both are bounded.

## A time window would not have fixed it

`positionHistoryHours` already exists (`NodesTab.tsx:691`) and already filters. It defaults to `null`, so the first suggested fix — cap the window — looked right.

It isn't sufficient. A node on estimated positions is relocated **every time a neighbour reports**, so even a 24-hour window can hold thousands of fixes. Capping the *element count* bounds the DOM regardless of how wide the window is or how dense the history gets, so the trail is now downsampled to a fixed render budget (500 points) rather than merely filtered by time.

## Honesty about what is drawn

- **The legend still reads the full filtered history**, so the reported oldest/newest timestamps stay exact while the drawing is capped. The sampler preserves the true first and last entries specifically so this cannot drift — a dropped endpoint would misreport the trail's span while the line still looked correct.
- **Downsampling is lossy about intermediate detail**, so a segment popup now says the trail is simplified rather than implying the two points were consecutive fixes.
- The fetch cap (5,000) is well above the render budget, so the visible trail still spans the node's full recorded history.

## Deliberately not changed

**The default `positionHistoryHours` of `null`.** Bounding the render fixes the freeze on its own, and narrowing what every user sees by default is a product decision, not a bug fix. Worth noting `MeshCoreMap.tsx:153` already defaults to a bounded number, so there is in-repo precedent if you do want it — say the word.

## Verification

- Full suite: **15,794 passed, 0 failed**, with PostgreSQL and MySQL up.
- `lint:ci` clean, `tsc` clean.
- The regression test was mutation-checked: pointing the segment loop back at the unbounded array fails it.

The test is source-extraction rather than a render test — mounting NodesTab needs the map stack, contexts and Leaflet, and a test that mounted 15,000 segments to prove they are slow would itself be the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G
