### PR TITLE
chore(release): 4.14.2-rc3

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.14.2-rc2",
+  "version": "4.14.2-rc3",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.14.2-rc2",
+  "version": "4.14.2-rc3",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",
@@ -18,7 +18,9 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis"],
+    "targets": [
+      "nsis"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.14.2-rc2
-appVersion: "4.14.2-rc2"
+version: 4.14.2-rc3
+appVersion: "4.14.2-rc3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.2-rc2",
+  "version": "4.14.2-rc3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.14.2-rc2",
+      "version": "4.14.2-rc3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.2-rc2",
+  "version": "4.14.2-rc3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump for the next release candidate: **4.14.2-rc2 → 4.14.2-rc3**.

All five version surfaces updated per CLAUDE.md — `package.json`, `package-lock.json` (regenerated via `npm install --package-lock-only`), `helm/meshmonitor/Chart.yaml` (both `version` *and* `appVersion`), `desktop/src-tauri/tauri.conf.json`, and `desktop/package.json`. Verified all six values are consistent, and the lock diff is exactly two lines — version fields only, no dependency churn.

Carries the `system-test` label: version-bump/release chores always run the hardware system tests.

## Changes since rc2

**Features**
- Predictive RF coverage — Fresnel + path-loss model, radial sweep, API and map layer (#4741, closes #4727)
- Passive network survey — reach, neighbours and hop distribution (#4737, closes #4726)
- Actionable MeshBeacon invitation card (#4735, closes #4723)
- Anchor a geofence to a waypoint (#4732, closes #4722)
- Badge nodes with incomplete NodeInfo (#4730, closes #4720)
- Traditional Chinese in the language selector (#4742) — thanks @rncchen

**Fixes**
- Automation Runs log now shows the triggering message (#4716, closes #4711) — merged ~2.5 min after the rc2 cut, so it ships here rather than in rc2
- Map froze for ~1 minute when opening a node with a large estimated-position history (#4744, closes #4743)
- MeshBeacon config load failed with "Unknown config type: meshbeacon" (#4740, closes #4739)
- MeshCore channel 0 reserved for the implicit Public channel (#4734, closes #4733)

## Verification

- Full suite: **15,794 passed, 0 failed**, with PostgreSQL and MySQL up.
- `lint:ci` clean, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G