### PR TITLE
feat(rf): site planner UI — predictive coverage becomes reachable (#4727)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -5068,5 +5068,22 @@
   "survey.hops_direct": "Direct",
   "survey.hops_n_one": "{{count}} hop",
   "survey.hops_n_other": "{{count}} hops",
-  "nodes.position_history_simplified": "Trail simplified — intermediate fixes between these points are not drawn."
+  "nodes.position_history_simplified": "Trail simplified — intermediate fixes between these points are not drawn.",
+  "site_planner.title": "Site planner",
+  "site_planner.pick_origin": "Click a node or anywhere on the map to choose a transmitter site.",
+  "site_planner.origin_node": "Predicting from {{name}}.",
+  "site_planner.origin_point": "Predicting from {{lat}}, {{lng}} (no node here yet).",
+  "site_planner.tx_height": "TX antenna (m)",
+  "site_planner.rx_height": "RX antenna (m)",
+  "site_planner.radius": "Search radius (km)",
+  "site_planner.tx_power": "TX power (dBm)",
+  "site_planner.tx_gain": "TX gain (dBi)",
+  "site_planner.sensitivity": "Sensitivity (dBm)",
+  "site_planner.seeded": "Read from this radio: {{fields}}. Everything else is assumed — edit if you know better.",
+  "site_planner.not_seeded": "No radio config available, so all values are assumed. Edit them to match your setup.",
+  "site_planner.predict": "Predict coverage",
+  "site_planner.running": "Predicting…",
+  "site_planner.clear": "Clear",
+  "site_planner.failed": "Could not compute coverage.",
+  "site_planner.caveat": "Modelled from terrain only — no buildings, foliage or multipath. A prediction, not a measurement."
 }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -5085,5 +5085,8 @@
   "site_planner.running": "Predicting…",
   "site_planner.clear": "Clear",
   "site_planner.failed": "Could not compute coverage.",
-  "site_planner.caveat": "Modelled from terrain only — no buildings, foliage or multipath. A prediction, not a measurement."
+  "site_planner.caveat": "Modelled from terrain only — no buildings, foliage or multipath. A prediction, not a measurement.",
+  "site_planner.transmitter": "Transmitter",
+  "site_planner.proposed_site": "Proposed site",
+  "site_planner.frequency": "Frequency (MHz)"
 }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -5088,5 +5088,6 @@
   "site_planner.caveat": "Modelled from terrain only — no buildings, foliage or multipath. A prediction, not a measurement.",
   "site_planner.transmitter": "Transmitter",
   "site_planner.proposed_site": "Proposed site",
-  "site_planner.frequency": "Frequency (MHz)"
+  "site_planner.frequency": "Frequency (MHz)",
+  "site_planner.unknown_region": "This radio reports region {{region}}, which MeshMonitor has no frequency band for. Set the frequency manually — the default below is a guess."
 }

--- a/src/components/MapAnalysis/LinkProfileController.tsx
+++ b/src/components/MapAnalysis/LinkProfileController.tsx
@@ -1,13 +1,11 @@
 import React, { useEffect, useRef } from 'react';
 import { CircleMarker, Polyline, Tooltip, useMap } from 'react-leaflet';
 import { useSettings } from '../../contexts/SettingsContext';
-import { nearestPoint, measureLabel } from '../../utils/measureDistance';
+import { measureLabel } from '../../utils/measureDistance';
+import { resolvePickedPoint } from './mapClickPicker';
 import type { LinkEndpoint, LinkVerdict } from '../../utils/linkProfile';
 import { VERDICT_COLOR } from '../../utils/linkProfile';
 import './LinkProfileController.css';
-
-/** Screen-space snap threshold (px) for treating a click as "on" a node. */
-const SNAP_PX = 24;
 
 /** Amber shown while the drawer hasn't resolved a verdict yet (or none applies). */
 const PENDING_COLOR = '#f59e0b';
@@ -43,7 +41,7 @@ export interface LinkProfileControllerProps {
  *  - It is a **controlled** component: picked endpoints live in
  *    `MapAnalysisContext` (`linkEndpoints`), not local state, so the bottom
  *    drawer can read them too. Every pick is emitted via `onPick`.
- *  - A click that doesn't land within `SNAP_PX` screen pixels of the nearest
+ *  - A click that doesn't land within `MAP_PICK_SNAP_PX` screen pixels of the nearest
  *    candidate node still picks — as an arbitrary (non-node) endpoint at the
  *    raw clicked lat/lng. This lets the tool profile a link to/from a point
  *    that has no node, unlike the node-only Measure tool.
@@ -94,28 +92,14 @@ const LinkProfileController: React.FC<LinkProfileControllerProps> = ({
     if (!enabled) return;
     const container = map.getContainer();
     const onClick = (e: MouseEvent) => {
-      // Let map controls (zoom, attribution, tileset toggle) work normally.
-      const target = e.target as HTMLElement | null;
-      if (target && target.closest('.leaflet-control')) return;
+      // Shared with the Site Planner so both tools agree on what counts as
+      // "on" a node (see mapClickPicker). Returns null for clicks on Leaflet
+      // controls, which must keep working while a pick tool is active.
+      const picked = resolvePickedPoint(map, e, pointsRef.current) as LinkEndpoint | null;
+      if (!picked) return;
       // Stop the marker popup / map click from also handling this event.
       e.stopPropagation();
       e.preventDefault();
-      const latlng = map.mouseEventToLatLng(e);
-      const nearest = nearestPoint(pointsRef.current, latlng.lat, latlng.lng);
-
-      let picked: LinkEndpoint | null = null;
-      if (nearest) {
-        const rect = container.getBoundingClientRect();
-        const clickPx = { x: e.clientX - rect.left, y: e.clientY - rect.top };
-        const nearestPx = map.latLngToContainerPoint([nearest.lat, nearest.lng]);
-        const distPx = Math.hypot(clickPx.x - nearestPx.x, clickPx.y - nearestPx.y);
-        if (distPx < SNAP_PX) {
-          picked = { ...nearest, isNode: true };
-        }
-      }
-      if (!picked) {
-        picked = { id: `pt-${latlng.lat},${latlng.lng}`, lat: latlng.lat, lng: latlng.lng, isNode: false };
-      }
 
       const prev = endpointsRef.current;
       let next: LinkEndpoint[];

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -4,11 +4,15 @@ import type maplibregl from 'maplibre-gl';
 import 'leaflet/dist/leaflet.css';
 import { useSettings } from '../../contexts/SettingsContext';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
+import { useSource } from '../../contexts/SourceContext';
 import { useAnalysisNodes } from './useAnalysisNodes';
 import MeasureDistanceController from '../MeasureDistanceController';
 import type { MeasurePoint } from '../../utils/measureDistance';
 import LinkProfileController from './LinkProfileController';
 import LinkProfileDrawer from './LinkProfileDrawer';
+import SitePlannerOriginController from './SitePlannerOriginController';
+import SitePlannerPanel from './SitePlannerPanel';
+import PredictedCoverageLayer from '../map/layers/PredictedCoverageLayer';
 import LinkProfileHoverLayer from './LinkProfileHoverLayer';
 import type { LinkEndpoint } from '../../utils/linkProfile';
 import { BaseMap } from '../map/BaseMap';
@@ -62,6 +66,12 @@ export default function MapAnalysisCanvas() {
     measureMode,
     setMeasureMode,
     linkProfileMode,
+    sitePlannerMode,
+    setSitePlannerMode,
+    sitePlannerOrigin,
+    setSitePlannerOrigin,
+    predictedCoverage,
+    setPredictedCoverage,
     setLinkProfileMode,
     linkEndpoints,
     setLinkEndpoints,
@@ -69,6 +79,10 @@ export default function MapAnalysisCanvas() {
     setExaggeration,
     mapViewRef,
   } = useMapAnalysisCtx();
+  // Seeds the Site Planner's radio parameters (#4727). Null outside a
+  // SourceProvider, which the panel handles by falling back to assumed values
+  // rather than inventing a config.
+  const { sourceId: activeSourceId } = useSource();
 
   // #3636: measurement endpoints, from the same visible+positioned node list
   // the markers layer uses so the two never disagree.
@@ -276,6 +290,21 @@ export default function MapAnalysisCanvas() {
             verdict={linkVerdict}
           />
         )}
+        {/* Site Planner (#4727). The predicted-coverage polygon sits BELOW the
+            node markers so a prediction never hides the real data it is
+            reasoning about. */}
+        {sitePlannerMode && (
+          <SitePlannerOriginController
+            active={sitePlannerMode}
+            points={linkEndpointCandidates}
+            origin={sitePlannerOrigin}
+            onPick={setSitePlannerOrigin}
+            onExit={() => setSitePlannerMode(false)}
+          />
+        )}
+        <Pane name="predictedCoverage" style={{ zIndex: 420 }}>
+          <PredictedCoverageLayer coverage={predictedCoverage} visible={sitePlannerMode} />
+        </Pane>
         <Pane name="waypoints" style={{ zIndex: 650 }}>
           {config.layers.waypoints.enabled && <WaypointsLayer />}
         </Pane>
@@ -321,6 +350,13 @@ export default function MapAnalysisCanvas() {
       <MapLegend />
       <FollowResumeButton />
       <LinkProfileDrawer />
+      <SitePlannerPanel
+        open={sitePlannerMode}
+        sourceId={activeSourceId}
+        origin={sitePlannerOrigin}
+        onClose={() => setSitePlannerMode(false)}
+        onCoverage={setPredictedCoverage}
+      />
     </div>
   );
 }

--- a/src/components/MapAnalysis/MapAnalysisContext.tsx
+++ b/src/components/MapAnalysis/MapAnalysisContext.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, useRef, useState, ReactNode, type RefObject } from 'react';
 import { useMapAnalysisConfig } from '../../hooks/useMapAnalysisConfig';
 import type { LinkEndpoint, LinkVerdict } from '../../utils/linkProfile';
+import type { SitePlannerOrigin } from './SitePlannerOriginController';
+import type { PredictedCoverage } from '../map/layers/predictedCoverageGeometry';
 
 export interface SelectedTarget {
   type: 'node' | 'segment' | 'neighbor' | 'trail';
@@ -52,6 +54,13 @@ type CtxShape = ReturnType<typeof useMapAnalysisConfig> & {
    * toolbar's button handlers, not here (see `MapAnalysisToolbar.tsx`).
    */
   linkProfileMode: boolean;
+  /** Site Planner (#4727): origin-pick mode, chosen origin, and the last result. */
+  sitePlannerMode: boolean;
+  setSitePlannerMode: (v: boolean) => void;
+  sitePlannerOrigin: SitePlannerOrigin | null;
+  setSitePlannerOrigin: (v: SitePlannerOrigin | null) => void;
+  predictedCoverage: PredictedCoverage | null;
+  setPredictedCoverage: (v: PredictedCoverage | null) => void;
   setLinkProfileMode: (m: boolean) => void;
   /** Picked endpoints (0..2) for the Link Profile tool; transient, not persisted. */
   linkEndpoints: LinkEndpoint[];
@@ -110,6 +119,9 @@ export function MapAnalysisProvider({ children }: { children: ReactNode }) {
   const [followPaused, setFollowPaused] = useState(false);
   const [measureMode, setMeasureMode] = useState(false);
   const [linkProfileMode, setLinkProfileMode] = useState(false);
+  const [sitePlannerMode, setSitePlannerMode] = useState(false);
+  const [sitePlannerOrigin, setSitePlannerOrigin] = useState<SitePlannerOrigin | null>(null);
+  const [predictedCoverage, setPredictedCoverage] = useState<PredictedCoverage | null>(null);
   const [linkEndpoints, setLinkEndpoints] = useState<LinkEndpoint[]>([]);
   const [linkVerdict, setLinkVerdict] = useState<LinkVerdict | null>(null);
   const [hoverPoint, setHoverPoint] = useState<{ lat: number; lng: number } | null>(null);
@@ -127,6 +139,12 @@ export function MapAnalysisProvider({ children }: { children: ReactNode }) {
         measureMode,
         setMeasureMode,
         linkProfileMode,
+        sitePlannerMode,
+        setSitePlannerMode,
+        sitePlannerOrigin,
+        setSitePlannerOrigin,
+        predictedCoverage,
+        setPredictedCoverage,
         setLinkProfileMode,
         linkEndpoints,
         setLinkEndpoints,

--- a/src/components/MapAnalysis/MapAnalysisToolbar.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.tsx
@@ -1,7 +1,7 @@
 import { useMemo, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
-  ArrowLeft, LocateFixed, Maximize, Clock, Ruler, Mountain, RotateCcw,
+  ArrowLeft, LocateFixed, Maximize, Clock, Ruler, Mountain, RadioTower, RotateCcw,
   MapPin, Palette, Flag, CircleDashed, Radar, Route, Share2, Flame, Spline, Signal, Box, Users,
 } from 'lucide-react';
 import { useDashboardSources } from '../../hooks/useDashboardData';
@@ -69,6 +69,8 @@ export default function MapAnalysisToolbar() {
     measureMode,
     setMeasureMode,
     linkProfileMode,
+    sitePlannerMode,
+    setSitePlannerMode,
     setLinkProfileMode,
     reset,
   } = useMapAnalysisCtx();
@@ -274,6 +276,31 @@ export default function MapAnalysisToolbar() {
           aria-label="Link Profile"
         >
           <Mountain size={ICON} />
+        </button>
+      )}
+
+      {/* Site Planner (#4727). Gated on elevation like Link Profile — both are
+          terrain tools and neither can say anything useful without a DEM.
+          Unlike Link Profile it needs NO existing nodes: siting a repeater is
+          the main use, and that means places where no node exists yet. */}
+      {elevationEnabled && (
+        <button
+          type="button"
+          className={`map-analysis-layer-btn icon-only ${sitePlannerMode ? 'active' : ''}`}
+          onClick={() => {
+            const next = !sitePlannerMode;
+            setSitePlannerMode(next);
+            // Mutually exclusive with the other click-capturing tools —
+            // two capture-phase listeners would both eat the same click.
+            if (next) {
+              setMeasureMode(false);
+              setLinkProfileMode(false);
+            }
+          }}
+          title="Site Planner — predict outbound coverage over terrain from any point"
+          aria-label="Site Planner"
+        >
+          <RadioTower size={ICON} />
         </button>
       )}
       {UNTIMED_LAYERS.map(({ key, label, icon }) => (

--- a/src/components/MapAnalysis/MapAnalysisToolbar.tsx
+++ b/src/components/MapAnalysis/MapAnalysisToolbar.tsx
@@ -243,9 +243,15 @@ export default function MapAnalysisToolbar() {
         type="button"
         className={`map-analysis-layer-btn icon-only ${measureMode ? 'active' : ''}`}
         onClick={() => {
-          setMeasureMode(!measureMode);
-          // Mutually exclusive with the Link Profile picker (#4111 Phase 2).
-          if (!measureMode) setLinkProfileMode(false);
+          const next = !measureMode;
+          setMeasureMode(next);
+          // Mutually exclusive with every other click-capturing tool — each
+          // installs a capture-phase listener, so two active at once both
+          // consume the same click (#4111 Phase 2, extended for #4727).
+          if (next) {
+            setLinkProfileMode(false);
+            setSitePlannerMode(false);
+          }
         }}
         disabled={analysisNodes.length < 2}
         title={analysisNodes.length < 2
@@ -265,9 +271,15 @@ export default function MapAnalysisToolbar() {
           type="button"
           className={`map-analysis-layer-btn icon-only ${linkProfileMode ? 'active' : ''}`}
           onClick={() => {
-            setLinkProfileMode(!linkProfileMode);
-            // Mutually exclusive with the Measure tool.
-            if (!linkProfileMode) setMeasureMode(false);
+            const next = !linkProfileMode;
+            setLinkProfileMode(next);
+            // Mutually exclusive with the other click-capturing tools. This has
+            // to be symmetric: every one of these installs a capture-phase
+            // click listener, so any two active at once both eat the same click.
+            if (next) {
+              setMeasureMode(false);
+              setSitePlannerMode(false);
+            }
           }}
           disabled={analysisNodes.length < 2}
           title={analysisNodes.length < 2

--- a/src/components/MapAnalysis/SitePlannerOriginController.tsx
+++ b/src/components/MapAnalysis/SitePlannerOriginController.tsx
@@ -11,6 +11,7 @@
  * building a pair.
  */
 import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { CircleMarker, Tooltip, useMap } from 'react-leaflet';
 import { resolvePickedPoint, type PickCandidate } from './mapClickPicker';
 
@@ -36,6 +37,7 @@ export default function SitePlannerOriginController({
   onExit,
 }: SitePlannerOriginControllerProps) {
   const map = useMap();
+  const { t } = useTranslation();
 
   // Keep the latest candidates reachable from the stable click handler without
   // re-registering the listener on every render.
@@ -91,7 +93,7 @@ export default function SitePlannerOriginController({
       className="site-planner-origin"
     >
       <Tooltip permanent direction="top" offset={[0, -8]}>
-        {origin.isNode ? (origin.name ?? 'Transmitter') : 'Proposed site'}
+        {origin.isNode ? (origin.name ?? t('site_planner.transmitter')) : t('site_planner.proposed_site')}
       </Tooltip>
     </CircleMarker>
   );

--- a/src/components/MapAnalysis/SitePlannerOriginController.tsx
+++ b/src/components/MapAnalysis/SitePlannerOriginController.tsx
@@ -1,0 +1,98 @@
+/**
+ * Origin picker for the Site Planner (#4727).
+ *
+ * Maintainer decision: the prediction origin may be an existing node OR an
+ * arbitrary clicked point — siting a repeater is the main use, and that means
+ * asking about places where no node exists yet.
+ *
+ * Shares `resolvePickedPoint` with the Terrain Link Profile tool so both agree
+ * on what counts as clicking "on" a node. This differs from that tool in
+ * taking exactly ONE point: each click replaces the origin rather than
+ * building a pair.
+ */
+import { useEffect, useRef } from 'react';
+import { CircleMarker, Tooltip, useMap } from 'react-leaflet';
+import { resolvePickedPoint, type PickCandidate } from './mapClickPicker';
+
+export interface SitePlannerOrigin extends PickCandidate {
+  isNode: boolean;
+  name?: string;
+}
+
+export interface SitePlannerOriginControllerProps {
+  active: boolean;
+  /** Positioned nodes eligible for snapping. */
+  points: PickCandidate[];
+  origin: SitePlannerOrigin | null;
+  onPick: (origin: SitePlannerOrigin) => void;
+  onExit?: () => void;
+}
+
+export default function SitePlannerOriginController({
+  active,
+  points,
+  origin,
+  onPick,
+  onExit,
+}: SitePlannerOriginControllerProps) {
+  const map = useMap();
+
+  // Keep the latest candidates reachable from the stable click handler without
+  // re-registering the listener on every render.
+  const pointsRef = useRef(points);
+  pointsRef.current = points;
+  const onPickRef = useRef(onPick);
+  onPickRef.current = onPick;
+
+  useEffect(() => {
+    if (!active) return;
+    const container = map.getContainer();
+    const prev = container.style.cursor;
+    container.style.cursor = 'crosshair';
+    return () => { container.style.cursor = prev; };
+  }, [active, map]);
+
+  useEffect(() => {
+    if (!active) return;
+    const container = map.getContainer();
+    const onClick = (e: MouseEvent) => {
+      const picked = resolvePickedPoint(map, e, pointsRef.current);
+      if (!picked) return; // a Leaflet control — leave it alone
+      // Suppress the marker popup / map click that would otherwise follow.
+      e.stopPropagation();
+      e.preventDefault();
+      onPickRef.current(picked as SitePlannerOrigin);
+    };
+    container.addEventListener('click', onClick, true);
+    return () => container.removeEventListener('click', onClick, true);
+  }, [active, map]);
+
+  useEffect(() => {
+    if (!active || !onExit) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onExit(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [active, onExit]);
+
+  if (!active || !origin) return null;
+
+  return (
+    <CircleMarker
+      center={[origin.lat, origin.lng]}
+      radius={7}
+      // Filled for a snapped node, hollow for a bare coordinate — the same
+      // visual grammar the Link Profile tool uses for the same distinction.
+      pathOptions={{
+        color: '#7b61ff',
+        weight: 2,
+        fillColor: '#7b61ff',
+        fillOpacity: origin.isNode ? 0.9 : 0,
+      }}
+      className="site-planner-origin"
+    >
+      <Tooltip permanent direction="top" offset={[0, -8]}>
+        {origin.isNode ? (origin.name ?? 'Transmitter') : 'Proposed site'}
+      </Tooltip>
+    </CircleMarker>
+  );
+}

--- a/src/components/MapAnalysis/SitePlannerPanel.module.css
+++ b/src/components/MapAnalysis/SitePlannerPanel.module.css
@@ -1,0 +1,92 @@
+/* Site Planner panel (#4727). Scoped module — see CLAUDE.md. */
+
+.sitePlanner {
+  position: absolute;
+  top: 4rem;
+  right: 0.75rem;
+  z-index: 1000;
+  width: min(340px, calc(100vw - 1.5rem));
+  max-height: calc(100% - 5rem);
+  overflow-y: auto;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.sitePlannerHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.sitePlannerHead h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.sitePlannerHint {
+  margin: 0.5rem 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.sitePlannerGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.sitePlannerField {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.78rem;
+}
+
+.sitePlannerField input {
+  width: 100%;
+  padding: 0.25rem 0.35rem;
+}
+
+.sitePlannerSeeded,
+.sitePlannerCaveat {
+  margin: 0.6rem 0 0;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.sitePlannerError {
+  margin: 0.5rem 0 0;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--color-error);
+  border-radius: 4px;
+  color: var(--color-error);
+  font-size: 0.8rem;
+}
+
+.sitePlannerActions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.sitePlannerRun {
+  flex: 1;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid var(--color-accent);
+  border-radius: 4px;
+  background: var(--color-accent);
+  color: var(--color-accent-text);
+  cursor: pointer;
+}
+
+.sitePlannerRun:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/components/MapAnalysis/SitePlannerPanel.test.tsx
+++ b/src/components/MapAnalysis/SitePlannerPanel.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Site Planner panel (#4727).
+ *
+ * This drives a prediction users will act on, so the assertions concentrate on
+ * honesty: that it says which numbers came from the radio and which were
+ * assumed, that it refuses to predict without an origin, and that it never
+ * presents the output as measured coverage.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const getCurrentConfig = vi.fn();
+const post = vi.fn();
+
+vi.mock('../../services/api', () => ({
+  default: {
+    getCurrentConfig: (...a: unknown[]) => getCurrentConfig(...a),
+    post: (...a: unknown[]) => post(...a),
+  },
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string, p?: Record<string, unknown>) => (p ? `${k}:${JSON.stringify(p)}` : k) }),
+}));
+vi.mock('../icons/UiIcon', () => ({ UiIcon: ({ name }: { name: string }) => <i data-icon={name} /> }));
+
+import SitePlannerPanel from './SitePlannerPanel';
+
+const origin = { id: 'n1', lat: 30, lng: -97, isNode: true, name: 'Hilltop' };
+
+const renderPanel = (props: Record<string, unknown> = {}) =>
+  render(
+    <SitePlannerPanel
+      open
+      sourceId="src-a"
+      origin={origin}
+      onClose={() => {}}
+      onCoverage={props.onCoverage as never ?? (() => {})}
+      {...props}
+    />,
+  );
+
+beforeEach(() => {
+  getCurrentConfig.mockReset().mockResolvedValue({ deviceConfig: { lora: { region: 1, txPower: 27 } } });
+  post.mockReset().mockResolvedValue({ success: true, data: { radials: [], assumptions: [] } });
+});
+
+describe('SitePlannerPanel', () => {
+  it('renders nothing when closed', () => {
+    renderPanel({ open: false });
+    expect(screen.queryByTestId('site-planner-panel')).toBeNull();
+  });
+
+  it('seeds radio values from the live LoRa config and says which came from it', async () => {
+    renderPanel();
+    await waitFor(() => expect(getCurrentConfig).toHaveBeenCalledWith('src-a'));
+
+    await waitFor(() =>
+      expect((screen.getByTestId('site-planner-txPowerDbm') as HTMLInputElement).value).toBe('27'));
+    expect(screen.getByTestId('site-planner-seeded').textContent).toMatch(/site_planner\.seeded/);
+  });
+
+  it('says values are assumed when the radio cannot be read', async () => {
+    // A prediction on guessed inputs looks exactly as confident as one on real
+    // inputs, so the difference has to be stated.
+    getCurrentConfig.mockRejectedValue(new Error('offline'));
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('site-planner-seeded').textContent).toMatch(/not_seeded/));
+  });
+
+  it('refuses to predict without an origin', async () => {
+    renderPanel({ origin: null });
+    await waitFor(() => expect(getCurrentConfig).toHaveBeenCalled());
+
+    expect((screen.getByTestId('site-planner-run') as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByTestId('site-planner-origin').textContent).toMatch(/pick_origin/);
+  });
+
+  it('distinguishes a node origin from a bare coordinate', async () => {
+    const { rerender } = renderPanel();
+    await waitFor(() => expect(screen.getByTestId('site-planner-origin').textContent).toMatch(/origin_node/));
+
+    rerender(
+      <SitePlannerPanel open sourceId="src-a" onClose={() => {}} onCoverage={() => {}}
+        origin={{ id: 'pt', lat: 31, lng: -98, isNode: false }} />,
+    );
+    // A proposed site with no node must not be labelled as one.
+    expect(screen.getByTestId('site-planner-origin').textContent).toMatch(/origin_point/);
+  });
+
+  it('posts the seeded parameters and hands the result up', async () => {
+    const onCoverage = vi.fn();
+    const user = userEvent.setup();
+    renderPanel({ onCoverage });
+    await waitFor(() => expect(getCurrentConfig).toHaveBeenCalled());
+
+    await user.click(screen.getByTestId('site-planner-run'));
+
+    await waitFor(() => expect(post).toHaveBeenCalledWith('/rf/coverage', expect.objectContaining({
+      origin: { lat: 30, lng: -97 },
+      txPowerDbm: 27,
+    })));
+    await waitFor(() => expect(onCoverage).toHaveBeenCalled());
+  });
+
+  it('surfaces a failure instead of leaving a stale polygon on the map', async () => {
+    const onCoverage = vi.fn();
+    const user = userEvent.setup();
+    post.mockImplementation(() => { throw new Error('boom'); });
+    renderPanel({ onCoverage });
+    await waitFor(() => expect(getCurrentConfig).toHaveBeenCalled());
+
+    await user.click(screen.getByTestId('site-planner-run'));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+    // Clearing the coverage matters: a failed re-run must not leave the
+    // previous prediction drawn as though it were current.
+    expect(onCoverage).toHaveBeenCalledWith(null);
+  });
+
+  it('always states that this is modelled, not measured', async () => {
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('site_planner.caveat')).toBeTruthy());
+  });
+});

--- a/src/components/MapAnalysis/SitePlannerPanel.test.tsx
+++ b/src/components/MapAnalysis/SitePlannerPanel.test.tsx
@@ -122,6 +122,38 @@ describe('SitePlannerPanel', () => {
     expect(onCoverage).toHaveBeenCalledWith(null);
   });
 
+  it('re-seeds when the source changes', async () => {
+    // Carrying one radio's frequency and power to another would predict with
+    // the wrong radio while still claiming the values were read from a device.
+    const { rerender } = renderPanel();
+    await waitFor(() => expect(getCurrentConfig).toHaveBeenCalledWith('src-a'));
+
+    getCurrentConfig.mockResolvedValue({ deviceConfig: { lora: { region: 2, txPower: 14 } } });
+    rerender(
+      <SitePlannerPanel open sourceId="src-b" origin={origin} onClose={() => {}} onCoverage={() => {}} />,
+    );
+
+    await waitFor(() => expect(getCurrentConfig).toHaveBeenCalledWith('src-b'));
+    await waitFor(() =>
+      expect((screen.getByTestId('site-planner-txPowerDbm') as HTMLInputElement).value).toBe('14'));
+  });
+
+  it('lets the user correct the frequency the seeding guessed', async () => {
+    // Previously seeded-but-unreachable: a non-US user whose seeding failed
+    // had no way to fix the band.
+    const user = userEvent.setup();
+    renderPanel();
+    await waitFor(() => expect(getCurrentConfig).toHaveBeenCalled());
+
+    const input = screen.getByTestId('site-planner-frequencyMhz') as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, '868');
+    await user.click(screen.getByTestId('site-planner-run'));
+
+    await waitFor(() => expect(post).toHaveBeenCalledWith('/rf/coverage',
+      expect.objectContaining({ frequencyHz: 868e6 })));
+  });
+
   it('always states that this is modelled, not measured', async () => {
     renderPanel();
     await waitFor(() => expect(screen.getByText('site_planner.caveat')).toBeTruthy());

--- a/src/components/MapAnalysis/SitePlannerPanel.tsx
+++ b/src/components/MapAnalysis/SitePlannerPanel.tsx
@@ -158,9 +158,11 @@ export default function SitePlannerPanel({
       {/* Which numbers are real and which are assumed. A prediction computed on
           a guessed frequency looks exactly as confident as one that isn't. */}
       <p className={styles.sitePlannerSeeded} data-testid="site-planner-seeded">
-        {params.seededFrom.length > 0
-          ? t('site_planner.seeded', { fields: params.seededFrom.join(', ') })
-          : t('site_planner.not_seeded')}
+        {params.unknownRegion != null
+          ? t('site_planner.unknown_region', { region: params.unknownRegion })
+          : params.seededFrom.length > 0
+            ? t('site_planner.seeded', { fields: params.seededFrom.join(', ') })
+            : t('site_planner.not_seeded')}
       </p>
 
       {error && <p className={styles.sitePlannerError} role="alert">{error}</p>}

--- a/src/components/MapAnalysis/SitePlannerPanel.tsx
+++ b/src/components/MapAnalysis/SitePlannerPanel.tsx
@@ -33,7 +33,14 @@ export default function SitePlannerPanel({
 }: SitePlannerPanelProps) {
   const { t } = useTranslation();
   const [params, setParams] = useState<SitePlannerDefaults>(() => buildSitePlannerDefaults(null));
-  const [seeded, setSeeded] = useState(false);
+  /**
+   * Which source the current values were seeded from. Keyed by source rather
+   * than a plain boolean so switching sources re-seeds: carrying one radio's
+   * frequency and power over to another would predict with the wrong radio
+   * while still claiming the values were read from a device (review, #4746).
+   */
+  const [seededFor, setSeededFor] = useState<string | null | undefined>(undefined);
+  const seeded = seededFor === (sourceId ?? null);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -53,7 +60,7 @@ export default function SitePlannerPanel({
         // says the values are assumed.
         if (!cancelled) setParams(buildSitePlannerDefaults(null));
       } finally {
-        if (!cancelled) setSeeded(true);
+        if (!cancelled) setSeededFor(sourceId ?? null);
       }
     })();
     return () => { cancelled = true; };
@@ -127,6 +134,19 @@ export default function SitePlannerPanel({
       </p>
 
       <div className={styles.sitePlannerGrid}>
+        {/* Shown in MHz: nobody reasons about a radio in hertz, and this was
+            seeded-but-unreachable before — a non-US user whose seeding failed
+            had no way to correct the band (review, #4746). */}
+        <label className={styles.sitePlannerField}>
+          <span>{t('site_planner.frequency')}</span>
+          <input
+            type="number"
+            step={0.1}
+            value={Math.round((params.frequencyHz / 1e6) * 10) / 10}
+            data-testid="site-planner-frequencyMhz"
+            onChange={(e) => update('frequencyHz', Number(e.target.value) * 1e6)}
+          />
+        </label>
         {num('txHeightM', t('site_planner.tx_height'))}
         {num('rxHeightM', t('site_planner.rx_height'))}
         {num('radiusKm', t('site_planner.radius'))}

--- a/src/components/MapAnalysis/SitePlannerPanel.tsx
+++ b/src/components/MapAnalysis/SitePlannerPanel.tsx
@@ -1,0 +1,166 @@
+/**
+ * Site Planner panel (#4727).
+ *
+ * The control surface for predictive RF coverage. A dedicated panel rather
+ * than a toolbar entry (maintainer decision): every other map layer is data
+ * plus a lookback toggle, whereas this needs origin, antenna heights and a
+ * link budget, and it needs room to state what the model does not account for.
+ *
+ * Radio parameters seed from the source's live LoRa config and stay editable.
+ * Which fields actually came from the device is surfaced, because a prediction
+ * silently computed on a guessed frequency looks exactly as authoritative as
+ * one computed on the real thing.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import apiService from '../../services/api';
+import { UiIcon } from '../icons/UiIcon';
+import { buildSitePlannerDefaults, type SitePlannerDefaults, type LoraConfigLike } from './sitePlannerDefaults';
+import type { PredictedCoverage } from '../map/layers/predictedCoverageGeometry';
+import type { SitePlannerOrigin } from './SitePlannerOriginController';
+import styles from './SitePlannerPanel.module.css';
+
+export interface SitePlannerPanelProps {
+  open: boolean;
+  sourceId?: string | null;
+  origin: SitePlannerOrigin | null;
+  onClose: () => void;
+  onCoverage: (coverage: PredictedCoverage | null) => void;
+}
+
+export default function SitePlannerPanel({
+  open, sourceId, origin, onClose, onCoverage,
+}: SitePlannerPanelProps) {
+  const { t } = useTranslation();
+  const [params, setParams] = useState<SitePlannerDefaults>(() => buildSitePlannerDefaults(null));
+  const [seeded, setSeeded] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Seed once per source. Re-seeding on every open would discard edits the
+  // user made deliberately.
+  useEffect(() => {
+    if (!open || seeded) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const config = await apiService.getCurrentConfig(sourceId ?? undefined);
+        if (cancelled) return;
+        setParams(buildSitePlannerDefaults(config?.deviceConfig?.lora as LoraConfigLike | undefined));
+      } catch {
+        // A device that cannot be reached is not an error here — the planner
+        // still works on fallbacks, and `seededFrom` stays empty so the UI
+        // says the values are assumed.
+        if (!cancelled) setParams(buildSitePlannerDefaults(null));
+      } finally {
+        if (!cancelled) setSeeded(true);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [open, seeded, sourceId]);
+
+  const update = <K extends keyof SitePlannerDefaults>(key: K, value: SitePlannerDefaults[K]) =>
+    setParams((p) => ({ ...p, [key]: value }));
+
+  const predict = useCallback(async () => {
+    if (!origin) return;
+    setRunning(true);
+    setError(null);
+    try {
+      const res = await apiService.post<{ success: boolean; data: PredictedCoverage }>(
+        '/rf/coverage',
+        {
+          origin: { lat: origin.lat, lng: origin.lng },
+          txHeightM: params.txHeightM,
+          rxHeightM: params.rxHeightM,
+          frequencyHz: params.frequencyHz,
+          txPowerDbm: params.txPowerDbm,
+          txGainDbi: params.txGainDbi,
+          rxGainDbi: params.rxGainDbi,
+          lossesDb: params.lossesDb,
+          sensitivityDbm: params.sensitivityDbm,
+          radiusKm: params.radiusKm,
+        },
+      );
+      onCoverage(res?.data ?? null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t('site_planner.failed'));
+      onCoverage(null);
+    } finally {
+      setRunning(false);
+    }
+  }, [origin, params, onCoverage, t]);
+
+  if (!open) return null;
+
+  const num = (key: keyof SitePlannerDefaults, label: string, step = 1) => (
+    <label className={styles.sitePlannerField}>
+      <span>{label}</span>
+      <input
+        type="number"
+        step={step}
+        value={params[key] as number}
+        data-testid={`site-planner-${key}`}
+        onChange={(e) => update(key, Number(e.target.value) as never)}
+      />
+    </label>
+  );
+
+  return (
+    <aside className={styles.sitePlanner} data-testid="site-planner-panel">
+      <header className={styles.sitePlannerHead}>
+        <h3><UiIcon name="activity" /> {t('site_planner.title')}</h3>
+        <button type="button" onClick={onClose} aria-label={t('common.close')}>
+          <UiIcon name="close" />
+        </button>
+      </header>
+
+      <p className={styles.sitePlannerHint} data-testid="site-planner-origin">
+        {origin
+          ? (origin.isNode
+              ? t('site_planner.origin_node', { name: origin.name ?? origin.id })
+              : t('site_planner.origin_point', {
+                  lat: origin.lat.toFixed(5),
+                  lng: origin.lng.toFixed(5),
+                }))
+          : t('site_planner.pick_origin')}
+      </p>
+
+      <div className={styles.sitePlannerGrid}>
+        {num('txHeightM', t('site_planner.tx_height'))}
+        {num('rxHeightM', t('site_planner.rx_height'))}
+        {num('radiusKm', t('site_planner.radius'))}
+        {num('txPowerDbm', t('site_planner.tx_power'))}
+        {num('txGainDbi', t('site_planner.tx_gain'))}
+        {num('sensitivityDbm', t('site_planner.sensitivity'))}
+      </div>
+
+      {/* Which numbers are real and which are assumed. A prediction computed on
+          a guessed frequency looks exactly as confident as one that isn't. */}
+      <p className={styles.sitePlannerSeeded} data-testid="site-planner-seeded">
+        {params.seededFrom.length > 0
+          ? t('site_planner.seeded', { fields: params.seededFrom.join(', ') })
+          : t('site_planner.not_seeded')}
+      </p>
+
+      {error && <p className={styles.sitePlannerError} role="alert">{error}</p>}
+
+      <div className={styles.sitePlannerActions}>
+        <button
+          type="button"
+          className={styles.sitePlannerRun}
+          disabled={!origin || running}
+          data-testid="site-planner-run"
+          onClick={() => void predict()}
+        >
+          {running ? t('site_planner.running') : t('site_planner.predict')}
+        </button>
+        <button type="button" onClick={() => onCoverage(null)} data-testid="site-planner-clear">
+          {t('site_planner.clear')}
+        </button>
+      </div>
+
+      <p className={styles.sitePlannerCaveat}>{t('site_planner.caveat')}</p>
+    </aside>
+  );
+}

--- a/src/components/MapAnalysis/mapClickPicker.test.ts
+++ b/src/components/MapAnalysis/mapClickPicker.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared map-click picker (#4727).
+ *
+ * Now serves BOTH the Terrain Link Profile and the Site Planner, so a change
+ * here silently changes two tools. The behaviours pinned are the ones a user
+ * would feel: snapping is screen-space (so it feels identical at every zoom),
+ * Leaflet controls stay clickable while a pick tool is active, and a snapped
+ * result keeps the node's identity rather than degrading to a bare coordinate.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolvePickedPoint, MAP_PICK_SNAP_PX } from './mapClickPicker';
+
+/** Minimal Leaflet-map stand-in: 1 degree == 100 px, origin at (0,0). */
+function fakeMap(overrides: Record<string, unknown> = {}) {
+  return {
+    getContainer: () => ({ getBoundingClientRect: () => ({ left: 0, top: 0 }) }),
+    mouseEventToLatLng: (e: MouseEvent) => ({ lat: e.clientY / 100, lng: e.clientX / 100 }),
+    latLngToContainerPoint: ([lat, lng]: [number, number]) => ({ x: lng * 100, y: lat * 100 }),
+    ...overrides,
+  } as any;
+}
+
+const evt = (x: number, y: number, target: unknown = null) =>
+  ({ clientX: x, clientY: y, target }) as unknown as MouseEvent;
+
+const NODE = { id: 'node-a', lat: 1, lng: 1, name: 'Hilltop' };
+
+describe('resolvePickedPoint', () => {
+  it('snaps to a node within the threshold and keeps its identity', () => {
+    // Degrading a snapped node to a bare coordinate would lose the name the
+    // panel shows and the node the caller expects.
+    const picked = resolvePickedPoint(fakeMap(), evt(100 + 5, 100 + 5), [NODE]);
+    expect(picked).toMatchObject({ id: 'node-a', name: 'Hilltop', isNode: true });
+  });
+
+  it('treats a click beyond the threshold as an arbitrary point', () => {
+    const picked = resolvePickedPoint(fakeMap(), evt(100 + MAP_PICK_SNAP_PX + 10, 100), [NODE]);
+    expect(picked?.isNode).toBe(false);
+    expect(picked?.id).not.toBe('node-a');
+  });
+
+  it('measures the threshold in SCREEN pixels, not degrees', () => {
+    // The same geographic offset must snap when zoomed in and not when zoomed
+    // out — a fixed metre radius would be unhittable at low zoom.
+    const zoomedOut = fakeMap({ latLngToContainerPoint: ([lat, lng]: [number, number]) => ({ x: lng * 1, y: lat * 1 }) });
+    const zoomedIn = fakeMap({ latLngToContainerPoint: ([lat, lng]: [number, number]) => ({ x: lng * 10_000, y: lat * 10_000 }) });
+
+    // Click at the node's own screen position snaps under either projection…
+    expect(resolvePickedPoint(zoomedOut, evt(1, 1), [NODE])?.isNode).toBe(true);
+    // …but a click 50px away from a far-apart node does not.
+    expect(resolvePickedPoint(zoomedIn, evt(10_050, 10_000), [NODE])?.isNode).toBe(false);
+  });
+
+  it('returns null for clicks on Leaflet controls so they keep working', () => {
+    // Without this the capture-phase listener swallows zoom/attribution
+    // clicks and the map becomes unusable while a tool is active.
+    const control = { closest: (sel: string) => (sel === '.leaflet-control' ? {} : null) };
+    expect(resolvePickedPoint(fakeMap(), evt(100, 100, control), [NODE])).toBeNull();
+  });
+
+  it('works with no candidate nodes at all', () => {
+    // Siting a repeater where nothing is deployed yet is the Site Planner's
+    // whole purpose.
+    const picked = resolvePickedPoint(fakeMap(), evt(250, 250), []);
+    expect(picked).toMatchObject({ isNode: false });
+    expect(picked?.lat).toBeCloseTo(2.5, 6);
+    expect(picked?.lng).toBeCloseTo(2.5, 6);
+  });
+
+  it('honours an explicit threshold override', () => {
+    const far = evt(100 + 40, 100);
+    expect(resolvePickedPoint(fakeMap(), far, [NODE])?.isNode).toBe(false);
+    expect(resolvePickedPoint(fakeMap(), far, [NODE], 60)?.isNode).toBe(true);
+  });
+
+  it('picks the nearest of several candidates', () => {
+    const near = { id: 'near', lat: 1, lng: 1 };
+    const far = { id: 'far', lat: 5, lng: 5 };
+    expect(resolvePickedPoint(fakeMap(), evt(100, 100), [far, near])?.id).toBe('near');
+  });
+});

--- a/src/components/MapAnalysis/mapClickPicker.ts
+++ b/src/components/MapAnalysis/mapClickPicker.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared map-click resolution for pick-a-point map tools (#4727).
+ *
+ * "Click a node, or click anywhere" is the interaction both the Terrain Link
+ * Profile and the Site Planner need: a click within `MAP_PICK_SNAP_PX` screen
+ * pixels of a positioned node resolves to that node, anything else resolves to
+ * the raw clicked coordinate.
+ *
+ * Extracted from `LinkProfileController` when the Site Planner needed the same
+ * behaviour. Two copies of a snap threshold would drift silently — the tools
+ * would start disagreeing about what counts as "on" a node, which is the kind
+ * of inconsistency users feel but cannot describe.
+ *
+ * Screen-space rather than geographic distance is deliberate: the snap should
+ * feel the same at every zoom level, and a fixed metre radius would be
+ * unhittable when zoomed out and enormous when zoomed in.
+ */
+import type { Map as LeafletMap } from 'leaflet';
+import { nearestPoint } from '../../utils/measureDistance';
+
+/** Screen-space snap threshold (px) for treating a click as "on" a node. */
+export const MAP_PICK_SNAP_PX = 24;
+
+export interface PickCandidate {
+  id: string;
+  lat: number;
+  lng: number;
+}
+
+export type PickedPoint<T extends PickCandidate> = (T | PickCandidate) & { isNode: boolean };
+
+/**
+ * Resolve a raw map click to either a nearby node or the clicked coordinate.
+ *
+ * Returns `null` for clicks on Leaflet controls (zoom, attribution, tileset
+ * toggle) so those keep working while a pick tool is active — without this the
+ * capture-phase listener swallows them and the map becomes unusable.
+ */
+export function resolvePickedPoint<T extends PickCandidate>(
+  map: LeafletMap,
+  e: MouseEvent,
+  points: T[],
+  snapPx: number = MAP_PICK_SNAP_PX,
+): PickedPoint<T> | null {
+  const target = e.target as HTMLElement | null;
+  if (target && target.closest('.leaflet-control')) return null;
+
+  const container = map.getContainer();
+  const latlng = map.mouseEventToLatLng(e);
+  const nearest = nearestPoint(points, latlng.lat, latlng.lng);
+
+  if (nearest) {
+    const rect = container.getBoundingClientRect();
+    const clickPx = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    const nearestPx = map.latLngToContainerPoint([nearest.lat, nearest.lng]);
+    if (Math.hypot(clickPx.x - nearestPx.x, clickPx.y - nearestPx.y) < snapPx) {
+      // Spread the candidate so callers keep whatever else it carried (name,
+      // nodeNum, …) rather than being handed a bare coordinate.
+      return { ...(nearest as T), isNode: true };
+    }
+  }
+
+  return {
+    id: `pt-${latlng.lat},${latlng.lng}`,
+    lat: latlng.lat,
+    lng: latlng.lng,
+    isNode: false,
+  };
+}

--- a/src/components/MapAnalysis/sitePlannerDefaults.test.ts
+++ b/src/components/MapAnalysis/sitePlannerDefaults.test.ts
@@ -62,6 +62,28 @@ describe('buildSitePlannerDefaults', () => {
     expect(d.seededFrom).not.toContain('frequency');
   });
 
+  it('names a region it has no band for, instead of a generic "assumed"', () => {
+    // Review catch on #4746: REGION_FREQ_INFO stops short of several amateur
+    // and newer EU regions (27-32). A device on one of those was falling back
+    // to the US band with only a generic disclosure. Naming the region turns a
+    // silent gap into something the user can act on.
+    const d = buildSitePlannerDefaults({ region: 29 }); // EU_866
+    expect(d.unknownRegion).toBe(29);
+    expect(d.seededFrom).not.toContain('frequency');
+    expect(d.frequencyHz).toBe(SITE_PLANNER_FALLBACKS.frequencyHz);
+  });
+
+  it('does not flag an unknown region when no region was reported at all', () => {
+    // "No radio config" and "region we cannot map" are different situations
+    // and must not produce the same message.
+    expect(buildSitePlannerDefaults(null).unknownRegion).toBeNull();
+    expect(buildSitePlannerDefaults({ txPower: 20 }).unknownRegion).toBeNull();
+  });
+
+  it('does not flag a region it CAN map', () => {
+    expect(buildSitePlannerDefaults({ region: 1 }).unknownRegion).toBeNull();
+  });
+
   it('assumes a peer handheld receiver, not a base station', () => {
     // Receiver height drives predicted reach; assuming a mast would inflate it.
     expect(buildSitePlannerDefaults(null).rxHeightM).toBeLessThanOrEqual(2);

--- a/src/components/MapAnalysis/sitePlannerDefaults.test.ts
+++ b/src/components/MapAnalysis/sitePlannerDefaults.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Site Planner seeding (#4727).
+ *
+ * Maintainer decision: prefill from the radio's live LoRa config. The failure
+ * mode is quiet — a plausible polygon computed on the wrong region's frequency
+ * — so these tests care most about which values came from the device and which
+ * were assumed.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildSitePlannerDefaults, SITE_PLANNER_FALLBACKS } from './sitePlannerDefaults';
+import { regionCenterFrequencyHz } from '../configuration/constants';
+
+describe('buildSitePlannerDefaults', () => {
+  it('seeds frequency from the configured region', () => {
+    // US (1) sits in the 902–928 MHz band.
+    const d = buildSitePlannerDefaults({ region: 1 });
+    expect(d.frequencyHz).toBe(regionCenterFrequencyHz(1));
+    expect(d.frequencyHz).toBeGreaterThan(900e6);
+    expect(d.frequencyHz).toBeLessThan(930e6);
+    expect(d.seededFrom).toContain('frequency');
+  });
+
+  it('seeds a different band for a different region', () => {
+    // EU_433 must not silently predict on the US band.
+    const eu = buildSitePlannerDefaults({ region: 2 });
+    expect(eu.frequencyHz).toBeGreaterThan(430e6);
+    expect(eu.frequencyHz).toBeLessThan(440e6);
+  });
+
+  it('keeps a transmit power of 0 rather than replacing it with the default', () => {
+    // 0 dBm is legitimate; truthiness would silently substitute 30 and
+    // overstate range by a wide margin.
+    const d = buildSitePlannerDefaults({ region: 1, txPower: 0 });
+    expect(d.txPowerDbm).toBe(0);
+    expect(d.seededFrom).toContain('txPower');
+  });
+
+  it('falls back without claiming the value came from the device', () => {
+    const d = buildSitePlannerDefaults(null);
+    expect(d.frequencyHz).toBe(SITE_PLANNER_FALLBACKS.frequencyHz);
+    expect(d.txPowerDbm).toBe(SITE_PLANNER_FALLBACKS.txPowerDbm);
+    expect(d.seededFrom).toEqual([]);
+  });
+
+  it('reports partial seeding accurately', () => {
+    // Region known, power not: the UI must not imply both were read.
+    const d = buildSitePlannerDefaults({ region: 1 });
+    expect(d.seededFrom).toContain('frequency');
+    expect(d.seededFrom).not.toContain('txPower');
+    expect(d.txPowerDbm).toBe(SITE_PLANNER_FALLBACKS.txPowerDbm);
+  });
+
+  it('ignores a non-finite device value instead of propagating NaN', () => {
+    const d = buildSitePlannerDefaults({ region: 1, txPower: NaN as unknown as number });
+    expect(Number.isFinite(d.txPowerDbm)).toBe(true);
+    expect(d.seededFrom).not.toContain('txPower');
+  });
+
+  it('falls back for an unknown region rather than fabricating a frequency', () => {
+    const d = buildSitePlannerDefaults({ region: 9999 });
+    expect(d.frequencyHz).toBe(SITE_PLANNER_FALLBACKS.frequencyHz);
+    expect(d.seededFrom).not.toContain('frequency');
+  });
+
+  it('assumes a peer handheld receiver, not a base station', () => {
+    // Receiver height drives predicted reach; assuming a mast would inflate it.
+    expect(buildSitePlannerDefaults(null).rxHeightM).toBeLessThanOrEqual(2);
+  });
+});

--- a/src/components/MapAnalysis/sitePlannerDefaults.ts
+++ b/src/components/MapAnalysis/sitePlannerDefaults.ts
@@ -1,0 +1,87 @@
+/**
+ * Seeding the Site Planner from a radio's live configuration (#4727).
+ *
+ * Maintainer decision: prefill frequency and transmit power from the selected
+ * source's actual LoRa config rather than generic constants, so a prediction
+ * reflects the user's real radio. Everything stays editable — the point is a
+ * better starting position, not a locked one.
+ *
+ * The failure this guards against is quiet and nasty: a plausible-looking
+ * coverage polygon computed on the wrong region's frequency and a default
+ * power the radio never used. Every field therefore falls back only when the
+ * device genuinely did not report a value, and `seededFrom` records which
+ * fields came from the device so the UI can say so.
+ */
+import { regionCenterFrequencyHz } from '../configuration/constants';
+
+/** The subset of a device's LoRa config this needs. */
+export interface LoraConfigLike {
+  region?: number | null;
+  modemPreset?: number | null;
+  txPower?: number | null;
+  /** dBi; firmware exposes a single scalar antenna gain. */
+  txGain?: number | null;
+}
+
+export interface SitePlannerDefaults {
+  frequencyHz: number;
+  txPowerDbm: number;
+  txGainDbi: number;
+  rxGainDbi: number;
+  lossesDb: number;
+  sensitivityDbm: number;
+  txHeightM: number;
+  rxHeightM: number;
+  radiusKm: number;
+  /** Field names genuinely taken from the device, for UI disclosure. */
+  seededFrom: string[];
+}
+
+/**
+ * Fallbacks used only where the device reported nothing.
+ *
+ * 915 MHz and 30 dBm describe a US-region radio at maximum legal power, which
+ * is the most common deployment — but it IS a guess, which is why the UI
+ * distinguishes seeded fields from assumed ones.
+ */
+export const SITE_PLANNER_FALLBACKS = {
+  frequencyHz: 915e6,
+  txPowerDbm: 30,
+  txGainDbi: 2,
+  rxGainDbi: 2,
+  lossesDb: 1,
+  /** Long-range LoRa preset sensitivity; the model's most optimistic input. */
+  sensitivityDbm: -130,
+  txHeightM: 10,
+  /** A peer handheld, not a base station — deliberately pessimistic. */
+  rxHeightM: 2,
+  radiusKm: 15,
+} as const;
+
+export function buildSitePlannerDefaults(lora?: LoraConfigLike | null): SitePlannerDefaults {
+  const seededFrom: string[] = [];
+
+  const freq = regionCenterFrequencyHz(lora?.region);
+  if (freq != null) seededFrom.push('frequency');
+
+  // `!= null` rather than truthiness: 0 dBm is a legitimate transmit power
+  // (some regions cap low), and truthiness would silently replace it with 30.
+  const txPower = lora?.txPower != null && Number.isFinite(lora.txPower) ? Number(lora.txPower) : null;
+  if (txPower != null) seededFrom.push('txPower');
+
+  const txGain = lora?.txGain != null && Number.isFinite(lora.txGain) ? Number(lora.txGain) : null;
+  if (txGain != null) seededFrom.push('txGain');
+
+  return {
+    frequencyHz: freq ?? SITE_PLANNER_FALLBACKS.frequencyHz,
+    txPowerDbm: txPower ?? SITE_PLANNER_FALLBACKS.txPowerDbm,
+    txGainDbi: txGain ?? SITE_PLANNER_FALLBACKS.txGainDbi,
+    rxGainDbi: SITE_PLANNER_FALLBACKS.rxGainDbi,
+    lossesDb: SITE_PLANNER_FALLBACKS.lossesDb,
+    sensitivityDbm: SITE_PLANNER_FALLBACKS.sensitivityDbm,
+    txHeightM: SITE_PLANNER_FALLBACKS.txHeightM,
+    rxHeightM: SITE_PLANNER_FALLBACKS.rxHeightM,
+    radiusKm: SITE_PLANNER_FALLBACKS.radiusKm,
+    seededFrom,
+  };
+}

--- a/src/components/MapAnalysis/sitePlannerDefaults.ts
+++ b/src/components/MapAnalysis/sitePlannerDefaults.ts
@@ -35,6 +35,16 @@ export interface SitePlannerDefaults {
   radiusKm: number;
   /** Field names genuinely taken from the device, for UI disclosure. */
   seededFrom: string[];
+  /**
+   * Set when the radio reported a region MeshMonitor has no frequency band
+   * for, so the UI can say which one rather than showing a generic "assumed".
+   *
+   * `REGION_FREQ_INFO` is transcribed from firmware and currently stops short
+   * of several amateur and newer EU regions (27-32 as of writing). Guessing a
+   * band from the region's NAME would be worse than falling back: the guess
+   * would be reported as read-from-device and silently shift every prediction.
+   */
+  unknownRegion: number | null;
 }
 
 /**
@@ -63,6 +73,10 @@ export function buildSitePlannerDefaults(lora?: LoraConfigLike | null): SitePlan
 
   const freq = regionCenterFrequencyHz(lora?.region);
   if (freq != null) seededFrom.push('frequency');
+  // The radio told us a region but we have no band for it — a materially
+  // different situation from "no radio config at all", and one the user can
+  // fix immediately now that frequency is editable.
+  const unknownRegion = lora?.region != null && freq == null ? Number(lora.region) : null;
 
   // `!= null` rather than truthiness: 0 dBm is a legitimate transmit power
   // (some regions cap low), and truthiness would silently replace it with 30.
@@ -83,5 +97,6 @@ export function buildSitePlannerDefaults(lora?: LoraConfigLike | null): SitePlan
     rxHeightM: SITE_PLANNER_FALLBACKS.rxHeightM,
     radiusKm: SITE_PLANNER_FALLBACKS.radiusKm,
     seededFrom,
+    unknownRegion,
   };
 }

--- a/src/components/configuration/constants.ts
+++ b/src/components/configuration/constants.ts
@@ -268,6 +268,25 @@ export function getPresetBandwidthKHz(preset: number, wideLora: boolean): number
  * bounds (not in REGION_FREQ_INFO) and null/undefined regions are treated as
  * permissive (all presets legal).
  */
+/**
+ * Representative frequency for a region, in Hz — the centre of its band.
+ *
+ * Path loss varies with frequency, so a coverage prediction (#4727) needs one.
+ * The centre is used rather than either edge because a mesh's actual channel
+ * sits somewhere inside the band and the endpoints would bias every estimate
+ * in the same direction. Across these bands the choice moves free-space loss
+ * by well under a dB, which is far below the model's own error.
+ *
+ * Returns null for a region with no known band, so callers fall back to their
+ * own default rather than silently predicting on a fabricated frequency.
+ */
+export function regionCenterFrequencyHz(region: number | null | undefined): number | null {
+  if (region == null) return null;
+  const info = REGION_FREQ_INFO[region];
+  if (!info) return null;
+  return ((info.start + info.end) / 2) * 1_000_000;
+}
+
 export function isPresetLegalForRegion(
   region: number | null | undefined,
   preset: number


### PR DESCRIPTION
Closes #4727.

Makes predictive RF coverage reachable. #4741 landed the model, sweep, API and map layer as a tested foundation with no UI entry point; this is the control surface, built to the four decisions you made on the issue.

## The four decisions, as implemented

**Dedicated panel, not a toolbar entry.** Every other map layer is data plus a lookback toggle. This needs an origin, antenna heights and a link budget — and room to state what the model ignores.

**Origin is any node OR any point.** Siting a repeater is the main use, and that means asking about places with no node yet.

Rather than reimplement the Link Profile tool's node-snapping, I extracted `resolvePickedPoint` into `mapClickPicker.ts` and migrated **both** tools onto it. Two copies of a snap threshold drift silently, and the tools would start disagreeing about what counts as clicking "on" a node — the kind of inconsistency users feel but can't articulate. LinkProfileController's 18 existing tests pass unchanged, which is what made the extraction safe to do.

**Radio values seed from the live LoRa config**, frequency derived from the configured region's band centre, everything editable.

The part that mattered most here: the panel reports **which fields actually came from the device**. A prediction computed on a guessed frequency looks exactly as authoritative as one computed on the real thing, so that difference has to be visible rather than implied. A transmit power of `0` dBm is preserved rather than replaced by the default — truthiness there would silently substitute 30 dBm and overstate range by a wide margin.

**#4741 merged as a foundation**, so this closes the issue.

## Two things I decided while wiring it

**The polygon renders below the node markers** (pane z-index 420). A prediction should never obscure the measured data it's reasoning about.

**The Site Planner is mutually exclusive with Measure and Link Profile.** All three install capture-phase click listeners; two active at once would both consume the same click. The toolbar enforces it on activation.

## Verification

- Full suite: **15,104 passed, 0 failed**, 0 failed suites.
- MapAnalysis suites specifically: 266 passed, including LinkProfileController's 18 across the extraction.
- `lint:ci` clean, `tsc` clean.

**On the test count:** 815 skipped versus 109 in my recent runs — the PostgreSQL/MySQL suites are skipping because I stopped those containers to free ports the hardware system-test runner on this host needs (they broke the rc3 release PR). This change touches no schema, migration or repository code, and CI runs both backends as service containers, so the gap is covered there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G
