### PR TITLE
fix(i18n): offer Polish, and fail CI when a ready translation is not listed

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -13,8 +13,17 @@ import HttpBackend from 'i18next-http-backend';
 import { appBasename } from '../init';
 
 /**
- * Available languages configuration
- * Add new languages here as they become available via Weblate
+ * Available languages configuration.
+ *
+ * Hand-maintained on purpose — shipping a translation is an editorial call, not
+ * an automatic consequence of a file existing. But it drifts: Weblate adds
+ * locale files continuously and this list does not, so Traditional Chinese sat
+ * at 99% translated and unselectable until a contributor noticed (#4742), and
+ * Polish reached 89% the same way.
+ *
+ * `i18nLanguageCoverage.test.ts` now fails when a locale crosses the
+ * readiness threshold without being listed here, so the next one surfaces in
+ * CI instead of waiting for a user to report it.
  */
 export const AVAILABLE_LANGUAGES = [
   { code: 'en', name: 'English', nativeName: 'English' },
@@ -24,6 +33,7 @@ export const AVAILABLE_LANGUAGES = [
   { code: 'ru', name: 'Russian', nativeName: 'Русский' },
   { code: 'zh_Hans', name: 'Chinese (Simplified)', nativeName: '简体中文' },
   { code: 'zh_Hant', name: 'Chinese (Traditional)', nativeName: '繁體中文' },
+  { code: 'pl', name: 'Polish', nativeName: 'Polski' },
 ];
 
 void i18n

--- a/src/config/i18nLanguageCoverage.test.ts
+++ b/src/config/i18nLanguageCoverage.test.ts
@@ -18,10 +18,13 @@
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { AVAILABLE_LANGUAGES } from './i18n';
 
-const LOCALE_DIR = resolve('public/locales');
+// Resolved from this file rather than the process cwd, so the guard does not
+// depend on where the runner happens to be invoked from (review, #4748).
+const LOCALE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../../public/locales');
 
 /**
  * Non-empty share at or above which a translation is considered shippable.
@@ -41,19 +44,38 @@ const READY_THRESHOLD_PCT = 50;
  * silently dropped: if one improves past the threshold, or another sub-threshold
  * language is added, this test fails and a human decides.
  */
-const KNOWN_PARTIAL = ['de', 'es'];
+const KNOWN_PARTIAL = ['de', 'es'];  // keep alphabetical — compared order-sensitively
+
+/**
+ * Every leaf string in a locale object, keyed by dotted path.
+ *
+ * Recursive rather than top-level-only. `en.json` is mostly flat but carries a
+ * nested `map` group, and a flat pass had two problems: it made English score
+ * 99.98% against itself, and — the reason this recurses instead of just
+ * skipping non-strings — any nested group added later would be silently
+ * excluded from every locale's score, so a badly-translated section could hide
+ * inside a passing number (review, #4748).
+ */
+function leafStrings(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${k}` : k;
+    if (typeof v === 'string') out[path] = v;
+    else if (v && typeof v === 'object' && !Array.isArray(v)) {
+      Object.assign(out, leafStrings(v as Record<string, unknown>, path));
+    }
+  }
+  return out;
+}
 
 function coveragePct(): Record<string, number> {
-  const en = JSON.parse(readFileSync(join(LOCALE_DIR, 'en.json'), 'utf8')) as Record<string, unknown>;
-  // Only leaf strings. `en.json` carries one nested group (`map`), and counting
-  // it in the denominator made even English score 99.98% — a metric that cannot
-  // reach 100 for the reference locale is measuring the wrong thing.
-  const keys = Object.keys(en).filter((k) => typeof en[k] === 'string');
+  const en = leafStrings(JSON.parse(readFileSync(join(LOCALE_DIR, 'en.json'), 'utf8')));
+  const keys = Object.keys(en);
   const out: Record<string, number> = {};
   for (const file of readdirSync(LOCALE_DIR).filter((f) => f.endsWith('.json'))) {
     const code = file.replace(/\.json$/, '');
-    const d = JSON.parse(readFileSync(join(LOCALE_DIR, file), 'utf8')) as Record<string, unknown>;
-    const nonEmpty = keys.filter((k) => typeof d[k] === 'string' && (d[k] as string).trim() !== '').length;
+    const d = leafStrings(JSON.parse(readFileSync(join(LOCALE_DIR, file), 'utf8')));
+    const nonEmpty = keys.filter((k) => typeof d[k] === 'string' && d[k].trim() !== '').length;
     out[code] = (100 * nonEmpty) / keys.length;
   }
   return out;
@@ -68,6 +90,17 @@ describe('language selector covers the translations that are ready', () => {
     const cov = coveragePct();
     expect(Object.keys(cov).length).toBeGreaterThan(5);
     expect(cov.en).toBe(100);
+    // Nested groups are counted, so the corpus is larger than the flat key set.
+    expect(Object.keys(leafStrings(JSON.parse(readFileSync(join(LOCALE_DIR, 'en.json'), 'utf8')))).length)
+      .toBeGreaterThan(1000);
+  });
+
+  it('has a listed language actually clearing the threshold', () => {
+    // Otherwise a corpus-wide collapse would leave every assertion here passing
+    // for the wrong reason: nothing "ready but unlisted", because nothing ready
+    // (review, #4748).
+    const cov = coveragePct();
+    expect(cov.pl).toBeGreaterThanOrEqual(READY_THRESHOLD_PCT);
   });
 
   it('lists every locale that has reached the readiness threshold', () => {

--- a/src/config/i18nLanguageCoverage.test.ts
+++ b/src/config/i18nLanguageCoverage.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Language-selector vs. locale-file drift guard.
+ *
+ * `AVAILABLE_LANGUAGES` is hand-maintained (shipping a translation is an
+ * editorial call), while Weblate adds locale files continuously. The two drift,
+ * and the drift is invisible: nothing breaks, a finished translation simply
+ * never appears in the picker.
+ *
+ * That is not hypothetical. Traditional Chinese reached ~99% translated and
+ * stayed unselectable until an outside contributor noticed (#4742), and Polish
+ * reached ~89% the same way. Both were one-line fixes nobody knew were needed.
+ *
+ * Coverage is measured as NON-EMPTY values, not key presence. Weblate writes
+ * every key into every locale file, so key-count coverage reads ~99% for a file
+ * that is entirely untranslated — a metric that would call every language ready.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { AVAILABLE_LANGUAGES } from './i18n';
+
+const LOCALE_DIR = resolve('public/locales');
+
+/**
+ * Non-empty share at or above which a translation is considered shippable.
+ *
+ * The exact number matters little: the corpus is strongly bimodal — actively
+ * translated locales sit above 80%, dormant ones below 1% — so anything in the
+ * wide gap separates them. 50% is chosen because below it the UI is
+ * majority-English anyway, which is arguably worse than offering English.
+ */
+const READY_THRESHOLD_PCT = 50;
+
+/**
+ * Listed locales currently BELOW the threshold.
+ *
+ * These predate the policy. Removing a language people may already be using is
+ * a product decision, not a lint fix, so they are pinned here rather than
+ * silently dropped: if one improves past the threshold, or another sub-threshold
+ * language is added, this test fails and a human decides.
+ */
+const KNOWN_PARTIAL = ['de', 'es'];
+
+function coveragePct(): Record<string, number> {
+  const en = JSON.parse(readFileSync(join(LOCALE_DIR, 'en.json'), 'utf8')) as Record<string, unknown>;
+  // Only leaf strings. `en.json` carries one nested group (`map`), and counting
+  // it in the denominator made even English score 99.98% — a metric that cannot
+  // reach 100 for the reference locale is measuring the wrong thing.
+  const keys = Object.keys(en).filter((k) => typeof en[k] === 'string');
+  const out: Record<string, number> = {};
+  for (const file of readdirSync(LOCALE_DIR).filter((f) => f.endsWith('.json'))) {
+    const code = file.replace(/\.json$/, '');
+    const d = JSON.parse(readFileSync(join(LOCALE_DIR, file), 'utf8')) as Record<string, unknown>;
+    const nonEmpty = keys.filter((k) => typeof d[k] === 'string' && (d[k] as string).trim() !== '').length;
+    out[code] = (100 * nonEmpty) / keys.length;
+  }
+  return out;
+}
+
+const listed = new Set(AVAILABLE_LANGUAGES.map((l) => l.code));
+
+describe('language selector covers the translations that are ready', () => {
+  it('reads a plausible corpus', () => {
+    // Guards the guard: a path or parsing mistake returning nothing would make
+    // every assertion below vacuously pass.
+    const cov = coveragePct();
+    expect(Object.keys(cov).length).toBeGreaterThan(5);
+    expect(cov.en).toBe(100);
+  });
+
+  it('lists every locale that has reached the readiness threshold', () => {
+    const cov = coveragePct();
+    const readyButUnlisted = Object.entries(cov)
+      .filter(([code, pct]) => pct >= READY_THRESHOLD_PCT && !listed.has(code))
+      .map(([code, pct]) => `${code} (${pct.toFixed(1)}%)`);
+
+    expect(
+      readyButUnlisted,
+      'These translations are ready but not offered in the language selector. ' +
+      'Add them to AVAILABLE_LANGUAGES in src/config/i18n.ts.',
+    ).toEqual([]);
+  });
+
+  it('pins which listed languages are still substantially untranslated', () => {
+    // Not a failure in itself — but it should never change silently. Users
+    // selecting these get a mostly-English UI.
+    const cov = coveragePct();
+    const partial = Object.keys(cov)
+      .filter((code) => listed.has(code) && cov[code] < READY_THRESHOLD_PCT)
+      .sort();
+
+    expect(
+      partial,
+      'A listed language crossed the threshold (remove it from KNOWN_PARTIAL) ' +
+      'or a substantially untranslated one was added (confirm that is intended).',
+    ).toEqual(KNOWN_PARTIAL);
+  });
+
+  it('has a locale file for every language it offers', () => {
+    // The inverse drift: offering a language whose file was renamed or removed
+    // would 404 at runtime and silently fall back to English.
+    const cov = coveragePct();
+    const missing = [...listed].filter((code) => !(code in cov));
+    expect(missing, 'Listed languages with no locale file.').toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes the language-selector drift I flagged while triaging #4742.

## The problem

`AVAILABLE_LANGUAGES` is hand-maintained — deliberately, since shipping a translation is an editorial call — while Weblate adds locale files continuously. The two drift, and **the drift is invisible**: nothing breaks, a finished translation simply never appears in the picker.

Traditional Chinese reached ~99% translated and stayed unselectable until an outside contributor noticed (#4742). **Polish is at ~89% and had gone exactly the same way.** Two one-line fixes nobody knew were needed is the tell that this wants a guard, not a third one-line fix.

| locale | non-empty | listed |
|---|---:|---|
| zh_Hant | 98.6% | yes (since #4742) |
| **pl** | **88.8%** | **was NO → now yes** |
| fr | 86.9% | yes |
| zh_Hans | 86.3% | yes |
| ru | 81.9% | yes |
| es | 14.5% | yes |
| de | 5.7% | yes |
| nb_NO / pt_BR / sv | <1% | no |

## The fix

Polish is now offered, and a test fails when any locale crosses the readiness threshold without being listed. Mutation-checked: removing Polish again makes it fail, naming the locale and where to add it.

**Coverage is measured as non-empty values, not key presence.** This matters — Weblate writes every key into every locale file, so *key-count* coverage reads ~99% for a file that is entirely untranslated. That metric would call every language ready and catch nothing.

Measuring leaf strings also turned up that `en.json` scored 99.98% against itself: one nested group (`map`) was sitting in the denominator. A metric that can't reach 100% for the reference locale is measuring the wrong thing, so the denominator is now leaf strings only.

## What I deliberately did not change

**German (5.7%) and Spanish (14.5%) stay listed.** Users selecting them get a mostly-English UI, which is arguably worse than not offering them — but removing a language people may already be using is a product decision, not a lint fix.

They're pinned in `KNOWN_PARTIAL` instead, so the set can't change silently in either direction: if one improves past the threshold, or another sub-threshold language is added, the test fails and a human decides. Happy to unlist them if you'd rather.

## Verification

- Full suite: **15,137 passed, 0 failed**. `lint:ci` and `tsc` clean.
- 815 skipped as in recent PRs — PG/MySQL containers stay stopped so they can't break the hardware system-test runner on this host. No schema/migration/repository code here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G
