### PR TITLE
fix(config): resolve every firmware region name; stop writing UNSET back to radios

### DIFF
--- a/src/components/configuration/LoRaConfigSection.test.tsx
+++ b/src/components/configuration/LoRaConfigSection.test.tsx
@@ -141,14 +141,27 @@ describe('LoRaConfigSection', () => {
   describe('Amateur Radio Region Warning (#3924)', () => {
     it('flags the ITU 2m amateur regions (27, 28) as amateur bands', () => {
       expect(isAmateurRadioRegion(27)).toBe(true); // ITU1_2M
-      expect(isAmateurRadioRegion(28)).toBe(true); // ITU23_2M
+      expect(isAmateurRadioRegion(28)).toBe(true); // ITU2_2M
     });
 
     it('keeps the amateur region set in sync with REGION_MAP values', () => {
       expect(AMATEUR_RADIO_REGIONS[27]).toBe('ITU1_2M');
-      expect(AMATEUR_RADIO_REGIONS[28]).toBe('ITU23_2M');
+      // 28 is `ITU2_2M` upstream. MeshMonitor previously called it `ITU23_2M`,
+      // conflating ITU regions 2 and 3 — which are separate codes (28 and 33).
+      expect(AMATEUR_RADIO_REGIONS[28]).toBe('ITU2_2M');
       expect(REGION_MAP['ITU1_2M']).toBe(27);
+      expect(REGION_MAP['ITU2_2M']).toBe(28);
+      // The old spelling still resolves, for stored/exported configs.
       expect(REGION_MAP['ITU23_2M']).toBe(28);
+    });
+
+    it('flags the amateur bands that were previously unrecognised', () => {
+      // 33-37 are amateur 2m/70cm/1.25m allocations. They were absent from
+      // AMATEUR_RADIO_REGIONS, so a user on one of them got no amateur-band
+      // warning at all — a second consequence of the same drift.
+      for (const region of [33, 34, 35, 36, 37]) {
+        expect(isAmateurRadioRegion(region)).toBe(true);
+      }
     });
 
     it('does not flag standard ISM/SRD regions as amateur bands', () => {

--- a/src/components/configuration/constants.ts
+++ b/src/components/configuration/constants.ts
@@ -143,8 +143,19 @@ export const REGION_OPTIONS: RegionOption[] = [
 // when one of these regions is selected.
 //
 // Values mirror Config.LoRaConfig.RegionCode (meshtastic/protobufs config.proto):
-//   27 = ITU1_2M   (ITU Region 1 amateur 2m, 144-146 MHz)
-//   28 = ITU23_2M  (ITU Region 2/3 amateur 2m, 144-148 MHz)
+//   27 = ITU1_2M     (ITU Region 1 amateur 2m,    144-146 MHz)
+//   28 = ITU2_2M     (ITU Region 2 amateur 2m,    144-148 MHz)
+//   33 = ITU3_2M     (ITU Region 3 amateur 2m,    144-148 MHz)
+//   34 = ITU1_70CM   (ITU Region 1 amateur 70cm,  430-440 MHz)
+//   35 = ITU2_70CM   (ITU Region 2 amateur 70cm,  420-450 MHz)
+//   36 = ITU3_70CM   (ITU Region 3 amateur 70cm,  430-450 MHz)
+//   37 = ITU2_125CM  (ITU Region 2 amateur 1.25m, 220-225 MHz)
+//
+// This block previously listed `28 = ITU23_2M (ITU Region 2/3)`, a name the
+// protobuf does not define and which merged two distinct codes. A comment
+// claiming to mirror the protobuf while stating something else is worse than
+// no comment: it is exactly what would reassure someone checking whether the
+// mapping was complete. It was not — see REGION_MAP's own note.
 //
 // NOTE (issue #3924, Part 1 — preset legality filtering):
 // There is NO protobuf wire field that carries a region -> preset legality map.

--- a/src/components/configuration/constants.ts
+++ b/src/components/configuration/constants.ts
@@ -160,7 +160,14 @@ export const REGION_OPTIONS: RegionOption[] = [
 // which mirror that table + math WITHOUT requiring a protobuf submodule bump.
 export const AMATEUR_RADIO_REGIONS: Record<number, string> = {
   27: 'ITU1_2M',
-  28: 'ITU23_2M'
+  // Upstream names 28 ITU2_2M and 33 ITU3_2M separately; the old combined
+  // `ITU23_2M` spelling was MeshMonitor's own and matched neither.
+  28: 'ITU2_2M',
+  33: 'ITU3_2M',
+  34: 'ITU1_70CM',
+  35: 'ITU2_70CM',
+  36: 'ITU3_70CM',
+  37: 'ITU2_125CM'
 };
 
 /**
@@ -363,6 +370,20 @@ export const PRESET_MAP: Record<string, number> = {
 };
 
 // Mapping from string region names to numeric values
+/**
+ * Firmware-reported region NAME -> numeric RegionCode.
+ *
+ * Load-bearing and destructive when incomplete. `ConfigurationTab` resolves a
+ * string-valued region with `REGION_MAP[name] || 0`, so an unknown name becomes
+ * UNSET(0) — and that value is then included in the `setLoRaConfig` payload,
+ * which is a whole-struct replace. A user on an unmapped region who saved any
+ * unrelated LoRa setting would have written UNSET back to their radio, taking
+ * it off its band. That was the case for every amateur 2m/70cm/1.25m region
+ * until this was completed.
+ *
+ * Must therefore stay in step with `RegionCode` in `meshtastic/config.proto`.
+ * `regionCodeMapping.test.ts` fails if the protobuf gains a name this lacks.
+ */
 export const REGION_MAP: Record<string, number> = {
   'UNSET': 0, 'US': 1, 'EU_433': 2, 'EU_868': 3, 'CN': 4, 'JP': 5,
   'ANZ': 6, 'KR': 7, 'TW': 8, 'RU': 9, 'IN': 10, 'NZ_865': 11,
@@ -370,8 +391,13 @@ export const REGION_MAP: Record<string, number> = {
   'MY_433': 16, 'MY_919': 17, 'SG_923': 18, 'PH_433': 19,
   'PH_868': 20, 'PH_915': 21, 'ANZ_433': 22, 'KZ_433': 23,
   'KZ_863': 24, 'NP_865': 25, 'BR_902': 26, 'ITU1_2M': 27,
-  'ITU23_2M': 28, 'EU_866': 29, 'EU_874': 30, 'EU_917': 31,
-  'EU_N_868': 32
+  'ITU2_2M': 28, 'EU_866': 29, 'EU_874': 30, 'EU_917': 31,
+  'EU_N_868': 32, 'ITU3_2M': 33, 'ITU1_70CM': 34, 'ITU2_70CM': 35,
+  'ITU3_70CM': 36, 'ITU2_125CM': 37,
+  // Legacy alias: MeshMonitor previously called value 28 `ITU23_2M`, conflating
+  // ITU regions 2 and 3 — which are separate codes upstream (28 and 33). Kept
+  // so any stored/exported config using the old spelling still resolves.
+  'ITU23_2M': 28
 };
 
 // Timezone presets in POSIX TZ format

--- a/src/components/configuration/regionCodeMapping.test.ts
+++ b/src/components/configuration/regionCodeMapping.test.ts
@@ -1,0 +1,85 @@
+/**
+ * RegionCode mapping drift guard.
+ *
+ * `REGION_MAP` turns a firmware-reported region NAME into its numeric code.
+ * `ConfigurationTab` resolves it as `REGION_MAP[name] || 0`, so a name this
+ * table lacks silently becomes UNSET(0) — and that value goes straight into the
+ * `setLoRaConfig` payload, which is a whole-struct replace. A user on an
+ * unmapped region who saved any unrelated LoRa setting would have written UNSET
+ * back to their radio, taking it off its band.
+ *
+ * Every amateur 2m/70cm/1.25m region was in exactly that state: present in the
+ * protobuf and in the picker, absent from this map. The picker knowing about a
+ * region while the reader does not is the specific shape of drift this guards.
+ *
+ * Reads the protobuf directly rather than restating it, so a submodule bump
+ * that adds a region fails here instead of shipping.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { REGION_MAP, REGION_OPTIONS } from './constants';
+
+/** Name -> value, straight from `enum RegionCode`. */
+function protobufRegions(): Record<string, number> {
+  const proto = readFileSync(resolve('protobufs/meshtastic/config.proto'), 'utf8');
+  const block = /enum RegionCode\s*\{([\s\S]*?)\n\s*\}/.exec(proto);
+  expect(block, 'RegionCode enum not found — did the protobuf layout change?').toBeTruthy();
+  const out: Record<string, number> = {};
+  // The trailing `[...]` allows for option annotations such as
+  // `UA_868 = 15 [deprecated = true];`, which a naive pattern skips — and
+  // skipping one would make this guard quietly under-report.
+  for (const m of block![1].matchAll(/^\s*([A-Z][A-Z0-9_]*)\s*=\s*(\d+)\s*(?:\[[^\]]*\])?\s*;/gm)) {
+    out[m[1]] = Number(m[2]);
+  }
+  return out;
+}
+
+describe('REGION_MAP stays in step with the protobuf', () => {
+  it('parses a plausible enum', () => {
+    // Guards the guard: a layout change returning nothing would make the
+    // coverage assertions below vacuously pass.
+    const pb = protobufRegions();
+    expect(Object.keys(pb).length).toBeGreaterThan(30);
+    expect(pb.US).toBe(1);
+    expect(pb.UNSET).toBe(0);
+    // Pinned because the annotation form nearly escaped the pattern above.
+    expect(pb.UA_868).toBe(15);
+  });
+
+  it('resolves every region name a device can report', () => {
+    const pb = protobufRegions();
+    const unresolvable = Object.keys(pb).filter((n) => !(n in REGION_MAP));
+
+    expect(
+      unresolvable,
+      'These names would resolve to UNSET(0) and could be written back to the radio. ' +
+      'Add them to REGION_MAP in src/components/configuration/constants.ts.',
+    ).toEqual([]);
+  });
+
+  it('agrees with the protobuf on every value', () => {
+    const pb = protobufRegions();
+    const wrong = Object.keys(pb)
+      .filter((n) => n in REGION_MAP && REGION_MAP[n] !== pb[n])
+      .map((n) => `${n}: ours=${REGION_MAP[n]} protobuf=${pb[n]}`);
+    expect(wrong).toEqual([]);
+  });
+
+  it('offers every region in the picker that it can read', () => {
+    // The inverse drift: being able to read a region but not select it.
+    const values = new Set(REGION_OPTIONS.map((o) => o.value));
+    const missing = Object.entries(protobufRegions())
+      .filter(([, v]) => !values.has(v))
+      .map(([n, v]) => `${n} (${v})`);
+    expect(missing).toEqual([]);
+  });
+
+  it('keeps the legacy ITU23_2M spelling resolvable', () => {
+    // MeshMonitor's own former name for 28, which conflated ITU regions 2 and
+    // 3 (separate codes upstream). Stored or exported configs may still use it.
+    expect(REGION_MAP['ITU23_2M']).toBe(28);
+    expect(REGION_MAP['ITU2_2M']).toBe(28);
+    expect(REGION_MAP['ITU3_2M']).toBe(33);
+  });
+});


### PR DESCRIPTION
Chasing the "missing region frequency bands" I flagged after #4746 turned up **a worse and unrelated bug underneath it**.

## The bug: MeshMonitor could write UNSET back to a radio

`REGION_MAP` turns a firmware-reported region *name* into its numeric code, and `ConfigurationTab` resolves it as `REGION_MAP[name] || 0`.

Six names the protobuf defines were missing: `ITU2_2M`(28), `ITU3_2M`(33), `ITU1_70CM`(34), `ITU2_70CM`(35), `ITU3_70CM`(36), `ITU2_125CM`(37). Each resolved to **UNSET(0)**.

That value isn't only displayed — it goes into the `setLoRaConfig` payload, which is a **whole-struct replace**. So a user on any amateur 2m/70cm/1.25m band who opened the Configuration tab and saved *any* unrelated LoRa setting would have written UNSET back to their radio, taking it off its band.

The region picker offered all of these already. Only reading them back was broken.

## The naming inconsistency was the cause, not a cosmetic detail

Value 28 is `ITU2_2M` upstream. MeshMonitor called it `ITU23_2M`, conflating ITU regions 2 and 3 — which are **separate codes** (28 and 33).

A previous review flagged this as cosmetic. It isn't: it's precisely why a device reporting the real protobuf name resolved to nothing. The old spelling is retained as an alias so stored and exported configs still load.

**Second symptom of the same drift:** regions 33–37 were also absent from `AMATEUR_RADIO_REGIONS`, so users on those bands got no amateur-radio warning at all.

## On the original finding — there is nothing to transcribe

I fetched firmware master's `RadioInterface.cpp`. Its `regions[]` table defines **26 regions, and none of these six are among them**. The protobuf declares the codes; the firmware hasn't implemented their bands.

So the frequency gap is upstream, not ours. Guessing values from names like `EU_866` was the trap I declined earlier — now confirmed rather than merely suspected. The Site Planner already discloses that gap at runtime (#4746).

## Guard

A test reads `enum RegionCode` straight from the protobuf and fails when a name can't be resolved, a value disagrees, or a readable region is missing from the picker. Mutation-checked: removing the new entries fails it with the list and the file to fix.

It also pins `UA_868 = 15 [deprecated = true]` — the annotation form nearly escaped my pattern, and a parser that skipped it would have under-reported silently.

## Verification

- Full suite: **15,139 passed, 0 failed**. `lint:ci` and `tsc` clean.
- One existing sync test updated: it hardcoded the old `ITU23_2M` name. Its *intent* (map and set agree) is preserved and extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G
