### PR TITLE
chore(docker): install linux-headers for node-gyp source builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,12 @@ WORKDIR /app
 # be able to compile it from source. `build-base` (C/C++ compiler) is what's new
 # here; `python3` is node-gyp's other requirement (also installed in the runtime
 # stage, but the stages are independent). Also a fallback for any other native
-# dep missing a prebuilt for the target arch.
-RUN apk add --no-cache build-base python3
+# dep missing a prebuilt for the target arch. `linux-headers` is required by
+# node-gyp for sources that include kernel headers (musl does not ship them with
+# build-base, unlike glibc distros) — not currently exercised by the amd64/arm64
+# builds, which resolve prebuilts, but it is what turns a source-compile
+# fallback from "sometimes works" into "works".
+RUN apk add --no-cache build-base python3 linux-headers
 
 # Copy package files
 COPY package*.json ./


### PR DESCRIPTION
Commits a Dockerfile change that was sitting uncommitted in the working tree, so it lands deliberately rather than being swept into an unrelated commit.

## What it does

Adds `linux-headers` to the builder stage's `apk add`. That stage exists so node-gyp can compile native deps with no prebuilt for the target arch — `re2` on Alpine/musl arm being the case the existing comment names. `build-base` supplies the compiler, but on musl it doesn't bring kernel headers the way glibc distros do, so any source including them fails to configure.

Builder stage only; the runtime image is unaffected.

## Being straight about the justification

**This does not fix a currently failing build.** The main Dockerfile's `linux/amd64` and `linux/arm64` builds resolve prebuilts and are green without it, and `Dockerfile.armv7` installs no build tooling at all. It hardens a fallback path that already exists rather than repairing something broken.

I've said so in the commit message and extended the inline comment to explain what the package is for, so a future reader doesn't have to infer whether it was load-bearing.

If you'd rather not carry a speculative package, closing this is entirely reasonable — the change came from the working tree rather than from a reported failure.

## What I deliberately excluded

The working tree also had **two deleted files**: `docs/internal/dev-notes/TX_DISABLED_PHASE1_SPEC.md` and `TX_DISABLED_PHASE2_SPEC.md`. I did not include those deletions, and restored both.

They are not stale scratch — they're referenced from five places, four with specific section numbers:

- `src/server/services/remoteAdminService.ts:62` → PHASE1 §4 (production code)
- `src/server/meshtasticManager.txDisabled.test.ts:13` → PHASE1 §2-4
- `src/server/meshtasticManager.autoAckResponderPingTxDisabled.test.ts:14` → PHASE1 §7
- `src/server/meshtasticManager.remoteLocalStatsScheduler.txDisabled.test.ts:7` → PHASE1 §7
- `docs/internal/dev-notes/MESHCORE_RECEIVE_ONLY_PHASE2_SPEC.md:5` uses PHASE2 as its stated template

Deleting them would leave five dangling pointers into removed documents. If retiring them is wanted, those references need rewriting in the same change — that's a separate piece of work, not a drive-by deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G
