### PR TITLE
fix(messages): stop hiding real messages that mention areyoumeshingwith.us (#4751)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import { type TemperatureUnit } from './utils/temperature';
 // calculateDistance and formatDistance moved to useTraceroutePaths hook
 import { DeviceInfo, Channel } from './types/device';
 import { MeshMessage } from './types/message';
+import { isMqttBridgeMessage } from './utils/messageFilters';
 import { NodeFilters } from './types/ui';
 import { getHashTabRedirectTarget } from './utils/tabHashRedirect';
 import { ResourceType } from './types/permission';
@@ -928,36 +929,6 @@ function App() {
     dmMessagesContainerRef,
     applyPollMessages,
   } = useMessagingView();
-
-  // Function to detect MQTT/bridge messages that should be filtered
-  const isMqttBridgeMessage = (msg: MeshMessage): boolean => {
-    // Primary check: use the viaMqtt field from the packet if available
-    if (msg.viaMqtt === true) {
-      return true;
-    }
-
-    // Filter messages from unknown senders
-    if (msg.from === 'unknown' || msg.fromNodeId === 'unknown') {
-      return true;
-    }
-
-    // Filter MQTT-related text patterns (fallback for older messages without viaMqtt)
-    const mqttPatterns = [
-      'mqtt.',
-      'areyoumeshingwith.us',
-      /^\d+\.\d+\.\d+\.[a-f0-9]+$/, // Version patterns like "2.5.7.f77c87d"
-      /^\/.*\.(js|css|proto|html)/, // File paths
-      /^[A-Z]{2,3}[�\x00-\x1F\x7F-\xFF]+/, // Garbage data patterns
-    ];
-
-    return mqttPatterns.some(pattern => {
-      if (typeof pattern === 'string') {
-        return msg.text.includes(pattern);
-      } else {
-        return pattern.test(msg.text);
-      }
-    });
-  };
 
   // Load configuration and check connection status on startup
   useEffect(() => {

--- a/src/utils/messageFilters.test.ts
+++ b/src/utils/messageFilters.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { isMqttBridgeMessage } from './messageFilters';
+import type { MeshMessage } from '../types/message';
+
+/** Build a minimal MeshMessage with sensible non-MQTT defaults. */
+function makeMessage(overrides: Partial<MeshMessage> = {}): MeshMessage {
+  return {
+    id: 'src_123_456',
+    from: 'Test Node',
+    to: 'Broadcast',
+    fromNodeId: '!abcd1234',
+    toNodeId: '!ffffffff',
+    text: 'hello',
+    channel: 0,
+    timestamp: new Date('2026-08-16T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('isMqttBridgeMessage', () => {
+  // Regression: issue #4751 — a real URL a user typed was substring-matched
+  // against the 'areyoumeshingwith.us' MQTT-broker blocklist and hidden.
+  it('does NOT filter a genuine mesh message whose body contains areyoumeshingwith.us (viaMqtt: false)', () => {
+    const msg = makeMessage({ text: 'Check out map.areyoumeshingwith.us', viaMqtt: false });
+    expect(isMqttBridgeMessage(msg)).toBe(false);
+  });
+
+  it('does NOT filter a genuine mesh message whose body contains "mqtt." (viaMqtt: false)', () => {
+    const msg = makeMessage({ text: 'try broker.mqtt.example', viaMqtt: false });
+    expect(isMqttBridgeMessage(msg)).toBe(false);
+  });
+
+  it('still filters a real MQTT bridge packet (viaMqtt: true)', () => {
+    const msg = makeMessage({ text: 'anything at all', viaMqtt: true });
+    expect(isMqttBridgeMessage(msg)).toBe(true);
+  });
+
+  it('filters messages from unknown senders regardless of viaMqtt', () => {
+    expect(isMqttBridgeMessage(makeMessage({ from: 'unknown' }))).toBe(true);
+    expect(isMqttBridgeMessage(makeMessage({ fromNodeId: 'unknown' }))).toBe(true);
+  });
+
+  describe('legacy fallback (viaMqtt absent)', () => {
+    it('filters a legacy message that matches an MQTT text pattern', () => {
+      const msg = makeMessage({ text: 'mqtt.areyoumeshingwith.us', viaMqtt: undefined });
+      expect(isMqttBridgeMessage(msg)).toBe(true);
+    });
+
+    it('filters a legacy version-string bridge line', () => {
+      const msg = makeMessage({ text: '2.5.7.f77c87d', viaMqtt: undefined });
+      expect(isMqttBridgeMessage(msg)).toBe(true);
+    });
+
+    it('does not filter ordinary legacy text', () => {
+      const msg = makeMessage({ text: 'hello from the mesh', viaMqtt: undefined });
+      expect(isMqttBridgeMessage(msg)).toBe(false);
+    });
+
+    it('does not filter example.com in legacy text', () => {
+      const msg = makeMessage({ text: 'visit example.com today', viaMqtt: undefined });
+      expect(isMqttBridgeMessage(msg)).toBe(false);
+    });
+  });
+});

--- a/src/utils/messageFilters.ts
+++ b/src/utils/messageFilters.ts
@@ -1,0 +1,59 @@
+import { MeshMessage } from '../types/message.js';
+
+/**
+ * Text patterns used to recognise MQTT/bridge status lines in messages that
+ * predate the `viaMqtt` packet field. This is a heuristic of last resort — a
+ * bare substring/regex match over the message body — so it is only consulted
+ * for legacy messages where `viaMqtt` is absent. See {@link isMqttBridgeMessage}.
+ */
+const MQTT_TEXT_PATTERNS: Array<string | RegExp> = [
+  'mqtt.',
+  'areyoumeshingwith.us',
+  /^\d+\.\d+\.\d+\.[a-f0-9]+$/, // Version patterns like "2.5.7.f77c87d"
+  /^\/.*\.(js|css|proto|html)/, // File paths
+  /^[A-Z]{2,3}[�\x00-\x1F\x7F-\xFF]+/, // Garbage data patterns
+];
+
+/**
+ * Detect MQTT/bridge messages that should be hidden from the chat UI when the
+ * user has "Show MQTT messages" disabled.
+ *
+ * Resolution order:
+ *  1. `viaMqtt === true` → definitely a bridge message.
+ *  2. Unknown sender → hide (we have no node identity to attribute it to).
+ *  3. `viaMqtt` present but false → authoritative: this is a genuine mesh
+ *     packet, never run the text heuristic on it.
+ *  4. `viaMqtt` absent (legacy message) → fall back to the text-pattern
+ *     heuristic in {@link MQTT_TEXT_PATTERNS}.
+ *
+ * Step 3 exists because the text heuristic does a bare substring match — e.g.
+ * a body containing `areyoumeshingwith.us` — and produces false positives on
+ * legitimate message text (issue #4751: `map.areyoumeshingwith.us` is a real
+ * URL a user typed, not a bridge status line). Trusting the `viaMqtt` flag
+ * whenever the packet carries it removes that whole class of false positives.
+ */
+export function isMqttBridgeMessage(msg: MeshMessage): boolean {
+  // Primary check: use the viaMqtt field from the packet if available
+  if (msg.viaMqtt === true) {
+    return true;
+  }
+
+  // Filter messages from unknown senders
+  if (msg.from === 'unknown' || msg.fromNodeId === 'unknown') {
+    return true;
+  }
+
+  // A modern packet that carries viaMqtt === false is authoritative — do not
+  // second-guess it with the substring heuristic below (issue #4751).
+  if (msg.viaMqtt !== undefined) {
+    return false;
+  }
+
+  // Legacy fallback for messages that predate the viaMqtt field.
+  return MQTT_TEXT_PATTERNS.some(pattern => {
+    if (typeof pattern === 'string') {
+      return msg.text.includes(pattern);
+    }
+    return pattern.test(msg.text);
+  });
+}


### PR DESCRIPTION
## Summary
Fixes #4751 — messages containing certain URLs (e.g. `map.areyoumeshingwith.us`) vanished from the channel view.

## Root cause
`isMqttBridgeMessage()` (an inline closure in `App.tsx`) hides MQTT-bridge status lines from the channel view. Its fallback heuristic does a **bare substring match** against a blocklist that includes the literal string `areyoumeshingwith.us` (the community MQTT broker domain) and `mqtt.`. A normal user message like `Check out map.areyoumeshingwith.us` contains that substring, so it was classified as a bridge message and filtered out by `ChannelsTab` **before render** — the message was sent and stored, but never drawn. `example.com` matches no pattern, which is why it rendered fine.

The text heuristic was only ever meant as a fallback for legacy messages that predate the `viaMqtt` packet field, but it ran unconditionally — including on modern packets carrying `viaMqtt === false`.

## Fix
Trust the `viaMqtt` flag when it is present: a packet with `viaMqtt === false` is authoritative and is never run through the substring heuristic. The heuristic now only applies to legacy messages where `viaMqtt` is absent. This removes the whole class of false positives.

Also extracted the inline closure into `src/utils/messageFilters.ts` so it's unit-testable, and added regression tests.

## A note on the report
The issue attributes the trigger to the **"Show link previews"** setting. That's a misattribution — the filter is gated on the **"Show MQTT messages"** toggle (default off), which has zero coupling to link previews in code. The `LinkPreview` / `renderMessageWithLinks` paths were traced and ruled out (their regex requires an `http(s)://`/`www.` prefix that the test strings don't even have; nothing throws). Worth confirming with the reporter that they had "Show MQTT messages" off, but it doesn't change the fix.

## Tests
- New `src/utils/messageFilters.test.ts` (8 cases): asserts `map.areyoumeshingwith.us` + `viaMqtt:false` renders, a real `viaMqtt:true` packet is still filtered, unknown senders still filtered, and the legacy `viaMqtt`-absent fallback still catches genuine bridge lines.
- Existing `ChannelsTab` tests pass unchanged.
- `npm run lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)