### PR TITLE
fix: refresh MQTT device telemetry node metrics

### DIFF
--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -246,6 +246,60 @@ describe('ingestServiceEnvelope — ignore gate (defense-in-depth)', () => {
   });
 });
 
+describe('ingestServiceEnvelope — MQTT device telemetry snapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (databaseService.ignoredNodes.isIgnoredCached as any).mockReturnValue(false);
+  });
+
+  it('updates the latest node device metrics from MQTT TELEMETRY_APP packets', async () => {
+    (meshtasticProtobufService.processPayload as any).mockImplementationOnce(() => ({
+      deviceMetrics: {
+        batteryLevel: 0,
+        voltage: 4.11,
+        channelUtilization: 2.5,
+        airUtilTx: 0,
+        uptimeSeconds: 12345,
+      },
+    }));
+
+    const result = await ingestServiceEnvelope({
+      sourceId: 'bridge-1',
+      envelope: envFor(NODE_IN, 67 /* TELEMETRY_APP */),
+    });
+
+    expect(result.ingested).toBe(true);
+    expect(databaseService.insertTelemetryAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ telemetryType: 'batteryLevel', value: 0 }),
+      'bridge-1',
+    );
+    expect(databaseService.insertTelemetryAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ telemetryType: 'voltage', value: 4.11 }),
+      'bridge-1',
+    );
+    expect(databaseService.insertTelemetryAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ telemetryType: 'channelUtilization', value: 2.5 }),
+      'bridge-1',
+    );
+    expect(databaseService.insertTelemetryAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ telemetryType: 'airUtilTx', value: 0 }),
+      'bridge-1',
+    );
+
+    const node = (databaseService.upsertNodeAsync as any).mock.calls.at(-1)[0];
+    expect(node).toEqual(expect.objectContaining({
+      nodeNum: NODE_IN,
+      nodeId: '!7ff80a48',
+      batteryLevel: 0,
+      voltage: 4.11,
+      channelUtilization: 2.5,
+      airUtilTx: 0,
+      viaMqtt: true,
+    }));
+    expect(node.uptimeSeconds).toBeUndefined();
+  });
+});
+
 describe('ingestServiceEnvelope — POSITION geo evaluation', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/server/mqttIngestion.ts
+++ b/src/server/mqttIngestion.ts
@@ -603,7 +603,7 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
           any = true;
         }
       }
-      void databaseService.upsertNodeAsync({
+      const node: Partial<DbNode> = {
         nodeNum: fromNum,
         nodeId: fromNodeId,
         // Intentionally omit longName/shortName/hwModel: this upsert only
@@ -616,7 +616,27 @@ async function ingestServiceEnvelopeInner(input: MqttIngestionInput): Promise<Mq
         transportMechanism: TransportMechanism.MQTT, transportLastMqtt: mqttSeenAt(),
         createdAt: nowMs,
         updatedAt: nowMs,
-      }, sourceId).catch(err => logger.error('MQTT upsertNode failed:', err));
+      };
+      const deviceMetrics = t.deviceMetrics ?? t.device_metrics;
+      if (deviceMetrics && typeof deviceMetrics === 'object') {
+        const batteryLevel = deviceMetrics.batteryLevel ?? deviceMetrics.battery_level;
+        const voltage = deviceMetrics.voltage;
+        const channelUtilization = deviceMetrics.channelUtilization ?? deviceMetrics.channel_utilization;
+        const airUtilTx = deviceMetrics.airUtilTx ?? deviceMetrics.air_util_tx;
+        if (typeof batteryLevel === 'number' && Number.isFinite(batteryLevel)) {
+          node.batteryLevel = batteryLevel;
+        }
+        if (typeof voltage === 'number' && Number.isFinite(voltage)) {
+          node.voltage = voltage;
+        }
+        if (typeof channelUtilization === 'number' && Number.isFinite(channelUtilization)) {
+          node.channelUtilization = channelUtilization;
+        }
+        if (typeof airUtilTx === 'number' && Number.isFinite(airUtilTx)) {
+          node.airUtilTx = airUtilTx;
+        }
+      }
+      void databaseService.upsertNodeAsync(node, sourceId).catch(err => logger.error('MQTT upsertNode failed:', err));
       return any ? { ingested: true, portnum } : { ingested: false, reason: 'decode-error', portnum };
     }
 


### PR DESCRIPTION
## Summary
MQTT `TELEMETRY_APP` ingestion already stores device metrics in the telemetry history table, but the latest node snapshot was only refreshed for `lastHeard`. That leaves MQTT-sourced nodes with graphable battery/voltage history while node-list and node-detail summary fields can remain blank or stale.

This PR makes MQTT device telemetry match the direct Meshtastic ingest behavior by copying DeviceMetrics into the node row snapshot when present.

## Changes
- Update MQTT `TELEMETRY_APP` ingestion to include `batteryLevel`, `voltage`, `channelUtilization`, and `airUtilTx` in the node upsert when `deviceMetrics` is present.
- Preserve the existing name-clobber guard by continuing to omit `longName`, `shortName`, and `hwModel` from telemetry refreshes.
- Add a regression test proving MQTT device telemetry writes both telemetry rows and the latest node snapshot, including valid zero values.

## Issues Resolved
None.

## Documentation Updates
No documentation changes needed. This is a transport parity bug fix for existing MQTT telemetry behavior.

## Testing
- [x] `npx vitest run src/server/mqttIngestion.test.ts --reporter=verbose` — 63 passed
- [x] `npx tsc -p tsconfig.server.json --noEmit`
- [x] `npm run lint:ci`
- [x] `npx vitest run --reporter=json --outputFile=/tmp/meshmonitor-vitest.json` — success: true, passed: 15145, failed: 0, suitesFailed: 0, pending: 815
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run build:server`

Prepared with assistance from OpenAI Codex.
