### PR TITLE
feat(waypoints): warn about Android notification spam when enabling rebroadcast (#4752)

### DIFF
--- a/src/components/WaypointEditorModal.css
+++ b/src/components/WaypointEditorModal.css
@@ -102,6 +102,8 @@
   display: flex;
   align-items: flex-start;
   gap: 0.4rem;
+  /* Slightly more than .form-hint's 4px: this sits below the hint and reads as
+     a distinct caution, so the extra breathing room is intentional. */
   margin-top: 6px;
   color: var(--color-warning);
   font-size: 0.85em;

--- a/src/components/WaypointEditorModal.css
+++ b/src/components/WaypointEditorModal.css
@@ -98,6 +98,16 @@
   font-size: 0.85rem;
 }
 
+.waypoint-rebroadcast-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.4rem;
+  margin-top: 6px;
+  color: var(--color-warning);
+  font-size: 0.85em;
+  line-height: 1.35;
+}
+
 .waypoint-editor-icon-group {
   border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-sm);

--- a/src/components/WaypointEditorModal.test.tsx
+++ b/src/components/WaypointEditorModal.test.tsx
@@ -61,7 +61,11 @@ describe('WaypointEditorModal — create mode', () => {
     fireEvent.change(rebroadcastInput, { target: { value: '15' } });
     expect(queryByRole('note')?.textContent).toMatch(/Android/i);
 
-    // Clearing it hides the warning again.
+    // Clearing it hides the warning again. Whitespace-only counts as cleared:
+    // the display guard uses `.trim().length > 0`, matching validate()'s own
+    // trim, so the warning and the "interval is set" check never diverge.
+    fireEvent.change(rebroadcastInput, { target: { value: '   ' } });
+    expect(queryByRole('note')).toBeNull();
     fireEvent.change(rebroadcastInput, { target: { value: '' } });
     expect(queryByRole('note')).toBeNull();
   });

--- a/src/components/WaypointEditorModal.test.tsx
+++ b/src/components/WaypointEditorModal.test.tsx
@@ -50,6 +50,22 @@ describe('WaypointEditorModal — create mode', () => {
     });
   });
 
+  it('shows the Android-notification warning only once a rebroadcast interval is entered (#4752)', () => {
+    const { container, queryByRole } = renderModal({ defaultCoords: { lat: 1, lon: 2 } });
+    // Off by default: no rebroadcast value, so no warning.
+    expect(queryByRole('note')).toBeNull();
+
+    const rebroadcastInput = container.querySelector(
+      'input[type="number"][min="10"][step="1"]',
+    ) as HTMLInputElement;
+    fireEvent.change(rebroadcastInput, { target: { value: '15' } });
+    expect(queryByRole('note')?.textContent).toMatch(/Android/i);
+
+    // Clearing it hides the warning again.
+    fireEvent.change(rebroadcastInput, { target: { value: '' } });
+    expect(queryByRole('note')).toBeNull();
+  });
+
   it('rejects out-of-range latitude', async () => {
     const { onSave, getByText, container } = renderModal();
     const inputs = container.querySelectorAll('input[type="number"][step="0.000001"]');

--- a/src/components/WaypointEditorModal.tsx
+++ b/src/components/WaypointEditorModal.tsx
@@ -362,6 +362,13 @@ export default function WaypointEditorModal(props: WaypointEditorModalProps) {
           <span className="form-hint">
             Minimum 10 minutes. The scheduler rebroadcasts at most one waypoint per minute across the whole mesh.
           </span>
+          {rebroadcast.trim().length > 0 && (
+            <span className="waypoint-rebroadcast-warning" role="note">
+              <UiIcon name="alert" size={14} /> Android clients notify on every
+              rebroadcast, so repeat broadcasts can spam users in range. Leave
+              this blank unless the waypoint really needs to stay refreshed.
+            </span>
+          )}
         </label>
 
         {error && (


### PR DESCRIPTION
## Summary
Addresses #4752 (Option B). Keeps the scheduled-rebroadcast feature and its already-safe default, and adds the missing piece: a UI warning about Android notification behavior when a user enables rebroadcast.

## Default is already Off — confirmed, no change needed
Rebroadcast is off unless a user explicitly types an interval:
- `rebroadcast_interval_s` column has **no `DEFAULT`** on any backend → `NULL` (`053_create_waypoints.ts`).
- Create route maps omitted/`null` → `null` (`waypoints.ts:164-167`).
- Editor field starts empty for new waypoints (`WaypointEditorModal.tsx`), and empty → `null`.
- Scheduler only fires for rows where `rebroadcastIntervalS IS NOT NULL AND > 0` (`waypoints.ts:230-231`).

## What this PR adds
A caution under the "Rebroadcast every" field, shown **only when an interval is entered**:

> ⚠️ Android clients notify on every rebroadcast, so repeat broadcasts can spam users in range. Leave this blank unless the waypoint really needs to stay refreshed.

Rationale: the official Meshtastic Android client notifies on every incoming waypoint packet, so each scheduled rebroadcast pings every Android user in range (Apple only notifies on first receipt).

## Notes
- Uses `UiIcon name="alert"` (per the no-hardcoded-emoji rule) and the semantic `--color-warning` token.
- The feature is **not** disabled or removed — this is the "keep, opt-in, warn" path.

## Tests
- New case asserts the warning is absent by default, appears once an interval is typed, and disappears when cleared.
- Full `WaypointEditorModal` suite passes (11/11); `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)