### PR TITLE
chore(release): 4.14.2-rc4

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor-desktop",
-  "version": "4.12.0-rc1",
+  "version": "4.14.2-rc4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor-desktop",
-      "version": "4.12.0-rc1",
+      "version": "4.14.2-rc4",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.14.2-rc3",
+  "version": "4.14.2-rc4",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.14.2-rc3",
+  "version": "4.14.2-rc4",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.14.2-rc3
-appVersion: "4.14.2-rc3"
+version: 4.14.2-rc4
+appVersion: "4.14.2-rc4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.2-rc3",
+  "version": "4.14.2-rc4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.14.2-rc3",
+      "version": "4.14.2-rc4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.2-rc3",
+  "version": "4.14.2-rc4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Release version bump: 4.14.2-rc4

Bumps the version across all five release files (+ desktop lock):
- `package.json` / `package-lock.json`
- `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`)
- `desktop/src-tauri/tauri.conf.json`
- `desktop/package.json` / `desktop/package-lock.json`

### Rolls up 6 unreleased commits since v4.14.2-rc3

**Features**
- RF site planner UI — predictive coverage (#4727)
- Clearer public-key mismatch messaging (#4738)
- Waypoint rebroadcast Android-notification warning; still off by default (#4752)

**Fixes**
- Resolve every firmware region name; stop writing UNSET to radios (#4749)
- Offer Polish; fail CI when a ready translation isn't listed (#4748)
- Stop hiding real messages that mention `areyoumeshingwith.us` (#4751)

No migrations or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)