### PR TITLE
fix(ios-pwa): reserve the top safe-area inset in the app chrome (#4772)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -988,7 +988,7 @@ body {
   border: 1px solid var(--color-surface-hover);
   /* Desktop: constrain to viewport height */
   min-height: 400px;
-  max-height: calc(100vh - var(--header-height) - 12rem);
+  max-height: calc(100vh - var(--header-offset) - 12rem);
   display: flex;
   flex-direction: column;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -7,6 +7,23 @@
   --sidebar-width: 60px;
   --banner-height: 36px;
 
+  /*
+   * iOS safe-area inset, read through a variable rather than env() directly.
+   * env() cannot be set from script, so indirecting it is what lets the shell's
+   * standalone-PWA geometry be exercised in a desktop browser:
+   *   document.documentElement.style.setProperty('--safe-area-top', '59px')
+   *
+   * --header-offset is "where the header ends" = its own height plus the inset
+   * it reserves above itself. ANYTHING anchored below the fixed header must use
+   * --header-offset, never --header-height on its own: in an iOS standalone PWA
+   * the inset is ~47-59px, so a bare --header-height offset puts the element
+   * under the header, which is what hid the map view's chrome in #4772.
+   * Off iOS (and in-browser, where the browser chrome absorbs the inset) the
+   * inset is 0 and --header-offset === --header-height.
+   */
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --header-offset: calc(var(--header-height) + var(--safe-area-top));
+
   /* Spacing scale */
   --spacing-xs: 0.25rem;
   --spacing-sm: 0.5rem;
@@ -783,7 +800,7 @@ body {
 
 .app-main {
   padding: 2rem;
-  padding-top: calc(var(--header-height) + 2rem); /* Account for fixed header + desired padding */
+  padding-top: calc(var(--header-offset) + 2rem); /* Account for fixed header (incl. its safe-area inset) + desired padding */
   padding-bottom: max(2rem, env(safe-area-inset-bottom)); /* Account for iPhone home indicator */
   width: calc(100% - var(--sidebar-width)); /* Full width minus sidebar */
   margin: 0;
@@ -1671,10 +1688,10 @@ body {
     font-size: 0.875rem; /* 14px - reduced from 16px */
   }
 
-  .app-header {
-    padding: 0.25rem 0.5rem;
-    /* height and left now use CSS variables that are updated in the :root above */
-  }
+  /* NOTE: the mobile `.app-header` padding lives in AppHeader.css's own mobile
+     block. It was here, and never applied — App.css is imported first, so this
+     file loses same-specificity ties to AppHeader.css's base rule (#4772).
+     Header height and left still come from the CSS variables set in :root above. */
 
   /* Adjust filter popup for sidebar on mobile */
   .filter-popup-overlay {
@@ -1683,7 +1700,7 @@ body {
 
   .app-main {
     padding: 0.5rem;
-    padding-top: calc(var(--header-height) + 0.5rem); /* Account for fixed header + desired padding */
+    padding-top: calc(var(--header-offset) + 0.5rem); /* Account for fixed header (incl. its safe-area inset) + desired padding */
     /* Clear the bottom bar as well as the iPhone home indicator — the bar is
        fixed and would otherwise cover the end of the content. */
     padding-bottom: calc(
@@ -3074,7 +3091,7 @@ body {
   border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   position: sticky;
-  top: var(--header-height);
+  top: var(--header-offset);
   z-index: 10;
 }
 
@@ -3230,7 +3247,7 @@ body {
   }
 
   .app-main {
-    padding-top: calc(var(--header-height) + 0.25rem);
+    padding-top: calc(var(--header-offset) + 0.25rem);
     padding-bottom: calc(
       var(--app-nav-bar-height, 44px) + max(0.25rem, env(safe-area-inset-bottom))
     );
@@ -3238,8 +3255,8 @@ body {
 
   /* Compact channel conversation for landscape */
   .channels-tab-content {
-    height: calc(100vh - var(--header-height) - 0.25rem - max(0.25rem, env(safe-area-inset-bottom)));
-    height: calc(100dvh - var(--header-height) - 0.25rem - max(0.25rem, env(safe-area-inset-bottom)));
+    height: calc(100vh - var(--header-offset) - 0.25rem - max(0.25rem, env(safe-area-inset-bottom)));
+    height: calc(100dvh - var(--header-offset) - 0.25rem - max(0.25rem, env(safe-area-inset-bottom)));
   }
 
   .channels-header h2 {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3507,7 +3507,7 @@ function App() {
             path="packetmonitor"
             element={
               <ErrorBoundary fallbackTitle="Packet Monitor failed to load">
-                <div style={{ height: 'calc(100dvh - var(--header-height, 60px) - 4rem)', overflow: 'hidden' }}>
+                <div style={{ height: 'calc(100dvh - var(--header-offset, 60px) - 4rem)', overflow: 'hidden' }}>
                   {isMqtt && sourceId ? (
                     <MqttPacketMonitorView baseUrl={baseUrl} sourceId={sourceId} />
                   ) : (

--- a/src/components/AppBanners/AppBanners.css
+++ b/src/components/AppBanners/AppBanners.css
@@ -4,8 +4,10 @@
   position: fixed;
   left: var(--sidebar-width);
   right: 0;
+  /* No safe-area padding: banners hang off the BOTTOM of the header, which
+     already reserves the inset in --header-offset. Adding it again here padded
+     every banner by a second status bar's worth of space (#4772). */
   padding: 8px 16px;
-  padding-top: calc(8px + env(safe-area-inset-top));
   text-align: center;
   font-size: 14px;
   font-weight: 500;
@@ -14,7 +16,7 @@
 }
 
 .warning-banner {
-  top: var(--header-height);
+  top: var(--header-offset);
   background-color: var(--color-error);
   color: var(--color-bg-sunken);
   border-bottom: 2px solid var(--color-danger);
@@ -110,7 +112,8 @@
   .warning-banner,
   .update-banner {
     font-size: 13px;
-    padding-top: calc(6px + env(safe-area-inset-top));
+    /* Inset deliberately absent — see the base rule. */
+    padding-top: 6px;
     padding-bottom: 6px;
     padding-left: 12px;
   }

--- a/src/components/AppBanners/AppBanners.tsx
+++ b/src/components/AppBanners/AppBanners.tsx
@@ -117,7 +117,7 @@ export const AppBanners: React.FC<AppBannersProps> = ({
       {showTxBanner && (
         <div
           className="warning-banner"
-          style={{ top: 'var(--header-height)' }}
+          style={{ top: 'var(--header-offset)' }}
         >
           <UiIcon name="alert" />{' '}
           {isTxDisabled
@@ -132,8 +132,8 @@ export const AppBanners: React.FC<AppBannersProps> = ({
         const bannersAbove = [showTxBanner].filter(Boolean).length + index;
         const topOffset =
           bannersAbove === 0
-            ? 'var(--header-height)'
-            : `calc(var(--header-height) + (var(--banner-height) * ${bannersAbove}))`;
+            ? 'var(--header-offset)'
+            : `calc(var(--header-offset) + (var(--banner-height) * ${bannersAbove}))`;
 
         return (
           <div key={issue.type} className="warning-banner" style={{ top: topOffset }}>
@@ -157,8 +157,8 @@ export const AppBanners: React.FC<AppBannersProps> = ({
           const warningBannersCount = [showTxBanner].filter(Boolean).length + configIssues.length;
           const topOffset =
             warningBannersCount === 0
-              ? 'var(--header-height)'
-              : `calc(var(--header-height) + (var(--banner-height) * ${warningBannersCount}))`;
+              ? 'var(--header-offset)'
+              : `calc(var(--header-offset) + (var(--banner-height) * ${warningBannersCount}))`;
 
           return (
             <div className="update-banner" style={{ top: topOffset }}>

--- a/src/components/AppHeader/AppHeader.css
+++ b/src/components/AppHeader/AppHeader.css
@@ -3,12 +3,21 @@
   background: var(--color-bg-raised);
   border-bottom: 1px solid var(--color-surface);
   padding: 1.5rem 2rem;
-  padding-top: max(1.5rem, env(safe-area-inset-top)); /* Account for iPhone notch/status bar */
+  /*
+   * The iPhone notch/status-bar inset is ADDED to both the padding and the
+   * height — it is not max()'d into the padding alone. `height` plus
+   * `box-sizing: border-box` means padding can never grow the box, so an inset
+   * taller than the padding merely ate the content box: in an iOS standalone
+   * PWA the header's contents rendered below its background band, floating over
+   * the page (#4772). Growing the box by the inset keeps the content row
+   * exactly --header-height tall wherever the inset lands.
+   */
+  padding-top: calc(1.5rem + var(--safe-area-top, 0px));
   position: fixed;
   top: 0;
   left: var(--sidebar-width);
   right: 0;
-  height: var(--header-height);
+  height: var(--header-offset, var(--header-height));
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -244,6 +253,19 @@
 
 /* Mobile responsive */
 @media (max-width: 768px) {
+  /*
+   * The mobile padding lives HERE rather than in App.css's mobile block, where
+   * it used to sit and never applied: App.css is imported before this file, so
+   * its `.app-header` shorthand lost the same-specificity tie to the base rule
+   * above and the header kept its 1.5rem/2rem desktop padding. Against a 40px
+   * mobile --header-height that left a zero-height content box even before any
+   * safe-area inset entered the picture (#4772).
+   */
+  .app-header {
+    padding: 0.25rem 0.5rem;
+    padding-top: calc(0.25rem + var(--safe-area-top, 0px));
+  }
+
   .app-header .header-logo,
   .app-header .node-info,
   .app-header h1 {
@@ -273,9 +295,11 @@
 @media (max-height: 500px) and (orientation: landscape) {
   .app-header {
     padding: 0.5rem 1rem;
-    padding-top: max(0.5rem, env(safe-area-inset-top));
+    padding-top: calc(0.5rem + var(--safe-area-top, 0px));
     height: auto;
-    min-height: 40px;
+    /* --header-offset, not a bare 40px: `height: auto` lets the box grow, but
+       only the min-height carries the inset when the row is short. */
+    min-height: var(--header-offset, 40px);
   }
 
   .app-header h1 {

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -4,9 +4,26 @@
 
 /* ── Page layout ─────────────────────────────────────────────────────────── */
 
+/*
+ * This page is the PWA's start_url (it is the `path="*"` landing route), so on
+ * an iOS home-screen install it is the FIRST thing the safe-area insets hit —
+ * and it handled none of them (#4772). `viewport-fit=cover` means 100dvh spans
+ * the physical screen, insets included: the topbar (and its hamburger, the only
+ * way into the source list) rendered underneath the status bar, and the bottom
+ * of the column sat under the home indicator.
+ *
+ * Insetting the whole column keeps the background painting edge to edge while
+ * every child lays out inside the safe area. `position: fixed` descendants —
+ * the mobile sidebar drawer and its backdrop — are viewport-relative and so
+ * escape this padding; they carry the insets themselves in the mobile block.
+ */
 .dashboard-page {
   height: 100vh;
   height: 100dvh;
+  padding-top: var(--safe-area-top, env(safe-area-inset-top, 0px));
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  padding-left: env(safe-area-inset-left, 0px);
+  padding-right: env(safe-area-inset-right, 0px);
   display: flex;
   flex-direction: column;
   background: var(--color-bg);
@@ -799,12 +816,16 @@
     font-size: 0.8rem;
   }
 
-  /* Sidebar becomes a slide-in overlay drawer */
+  /* Sidebar becomes a slide-in overlay drawer.
+     Fixed positioning is viewport-relative, so .dashboard-page's safe-area
+     padding does not apply here — the drawer places itself against the topbar's
+     bottom edge (--header-offset) and lifts its own foot clear of the home
+     indicator (#4772). */
   .dashboard-sidebar {
     position: fixed;
-    top: var(--header-height, 64px);
-    left: 0;
-    bottom: 0;
+    top: var(--header-offset, var(--header-height, 64px));
+    left: env(safe-area-inset-left, 0px);
+    bottom: env(safe-area-inset-bottom, 0px);
     /* Overlay drawer has a fixed width; ignore the desktop resize var. */
     width: 260px;
     z-index: 999;
@@ -825,7 +846,7 @@
   /* Backdrop fades in when drawer is open */
   .dashboard-sidebar-backdrop {
     display: block;
-    top: var(--header-height, 64px);
+    top: var(--header-offset, var(--header-height, 64px));
   }
 
   .dashboard-sidebar-backdrop.open {

--- a/src/styles/headerSafeAreaClearance.test.ts
+++ b/src/styles/headerSafeAreaClearance.test.ts
@@ -117,6 +117,17 @@ describe('header safe-area clearance (#4772)', () => {
     expect(ruleBody(mobile, '.dashboard-sidebar-backdrop')).toMatch(/top:\s*var\(--header-offset/);
   });
 
+  it('subtracts the full header footprint from viewport-height math', () => {
+    // `calc(100vh - var(--header-height) - …)` overstates the room left below a
+    // header that is inset-taller than its nominal height, so the panel runs off
+    // the bottom of the screen by exactly the inset.
+    const viewportMath = [...appCss.matchAll(/calc\(100d?vh\s*-\s*var\(--header-(\w+)\)/g)].map(
+      (m) => m[1]
+    );
+    expect(viewportMath.length).toBeGreaterThan(0);
+    expect(viewportMath.every((v) => v === 'offset')).toBe(true);
+  });
+
   it('hangs the banners off the bottom of the header without re-adding the inset', () => {
     expect(ruleBody(bannersCss, '.warning-banner')).toMatch(/top:\s*var\(--header-offset\)/);
     // Double-counting: the header already reserved the inset above the banner.

--- a/src/styles/headerSafeAreaClearance.test.ts
+++ b/src/styles/headerSafeAreaClearance.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression tests for content sitting UNDER the fixed header on an iOS
+ * standalone PWA (#4772) — the top-edge counterpart to bottomBarClearance.test.ts
+ * (#4473) and the bottom-bar inset fixes in SourceNav.mobile.test.ts (#4497).
+ *
+ * With `viewport-fit=cover` and `display: standalone`, iOS reports a
+ * ~47-59px `env(safe-area-inset-top)` that the browser absorbs in a normal tab
+ * and the app must absorb itself when installed. Two failures compounded:
+ *
+ *   1. `.app-header` added the inset to its padding only. With a fixed `height`
+ *      and `box-sizing: border-box`, padding cannot grow the box — the inset
+ *      just ate the content box, so the header's contents rendered below its
+ *      background band.
+ *   2. Everything anchored below the header offset by `--header-height`, which
+ *      excludes that inset — worst of all `.nodes-split-view`, which used a
+ *      hardcoded `top: 48px` and covered the shell's chrome on the map view.
+ *
+ * The contract these assert: the header reserves the inset in its own height,
+ * and every offset below it uses `--header-offset` (height + inset), never a
+ * bare `--header-height` or a constant. jsdom does no layout and no cascade, so
+ * these read the stylesheet source, like the other stylesheet assertions here.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const appCss = readFileSync(resolve('src/App.css'), 'utf-8');
+const headerCss = readFileSync(resolve('src/components/AppHeader/AppHeader.css'), 'utf-8');
+const nodesCss = readFileSync(resolve('src/styles/nodes.css'), 'utf-8');
+const bannersCss = readFileSync(resolve('src/components/AppBanners/AppBanners.css'), 'utf-8');
+const bannersTsx = readFileSync(resolve('src/components/AppBanners/AppBanners.tsx'), 'utf-8');
+const dashboardCss = readFileSync(resolve('src/styles/dashboard.css'), 'utf-8');
+
+/** Body of a rule, searched by exact selector text at any indent. */
+function ruleBody(css: string, selector: string): string | null {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = css.match(new RegExp(escaped + '\\s*\\{([^}]*)\\}'));
+  return m ? m[1] : null;
+}
+
+describe('header safe-area clearance (#4772)', () => {
+  it('defines the offset token as header height plus the top inset', () => {
+    // Indirected through --safe-area-top rather than calling env() inline: env()
+    // cannot be set from script, so this is also the seam that lets the
+    // standalone-PWA geometry be driven in a desktop browser.
+    expect(appCss).toMatch(/--safe-area-top:\s*env\(safe-area-inset-top,\s*0px\)/);
+    expect(appCss).toMatch(
+      /--header-offset:\s*calc\(var\(--header-height\)\s*\+\s*var\(--safe-area-top\)\)/
+    );
+  });
+
+  it('grows the header box by the inset instead of only padding it', () => {
+    const body = ruleBody(headerCss, '.app-header');
+    expect(body).not.toBeNull();
+    // The declaration that failed: max() into padding under a fixed height
+    // cannot move the background band down, it only crushes the content box.
+    expect(body!).not.toMatch(/padding-top:\s*max\(/);
+    expect(body!).toMatch(/padding-top:\s*calc\([^;]*--safe-area-top/);
+    expect(body!).toMatch(/height:\s*var\(--header-offset/);
+  });
+
+  it('keeps the mobile header padding where it actually wins the cascade', () => {
+    // App.css is imported before AppHeader.css, so its `.app-header` rules lose
+    // same-specificity ties to AppHeader.css's base rule. The mobile padding
+    // therefore has to live in AppHeader.css's own mobile block.
+    const headerMobile = headerCss.slice(headerCss.indexOf('@media (max-width: 768px)'));
+    expect(ruleBody(headerMobile, '.app-header')).toMatch(
+      /padding-top:\s*calc\([^;]*--safe-area-top/
+    );
+
+    const appMobile = appCss.slice(appCss.indexOf('@media (max-width: 768px)'));
+    // Comments stripped: the redirect note left behind names the selector.
+    expect(appMobile.replace(/\/\*[\s\S]*?\*\//g, '')).not.toMatch(/\.app-header\s*\{/);
+  });
+
+  it('anchors the map/list split view to the offset, not a constant', () => {
+    const body = ruleBody(nodesCss, '.nodes-split-view');
+    expect(body).not.toBeNull();
+    expect(body!).toMatch(/top:\s*var\(--header-offset\)/);
+
+    // The mobile block must not reintroduce a hardcoded top: it was 48px against
+    // a 40px mobile header and could never carry the inset.
+    const mobile = nodesCss.slice(nodesCss.indexOf('@media (max-width: 768px)'));
+    const mobileBody = ruleBody(mobile, '.nodes-split-view');
+    expect(mobileBody).not.toBeNull();
+    expect(mobileBody!.replace(/\/\*[\s\S]*?\*\//g, '')).not.toMatch(/top:/);
+  });
+
+  it('offsets app-main below the header in every orientation', () => {
+    const paddings = [...appCss.matchAll(/padding-top:\s*calc\(var\(--header-(\w+)\)/g)].map(
+      (m) => m[1]
+    );
+    expect(paddings.length).toBeGreaterThan(0);
+    expect(paddings.every((v) => v === 'offset')).toBe(true);
+  });
+
+  it('insets the dashboard page, which is where an installed PWA actually opens', () => {
+    // `path="*"` in main.tsx makes DashboardPage the landing route, and
+    // staticServing.ts sets the manifest start_url to BASE_URL + '/'. It is a
+    // self-contained 100dvh page with its own topbar, so it inherits none of the
+    // app-shell offsets above and handled no insets at all: its topbar — with
+    // the hamburger that opens the source list — rendered under the status bar.
+    const body = ruleBody(dashboardCss, '.dashboard-page');
+    expect(body).not.toBeNull();
+    expect(body!).toMatch(/padding-top:\s*var\(--safe-area-top/);
+    expect(body!).toMatch(/padding-bottom:\s*env\(safe-area-inset-bottom/);
+  });
+
+  it('lifts the dashboard drawer clear of both insets', () => {
+    // The drawer is `position: fixed`, so it is viewport-relative and the page's
+    // padding above does not contain it.
+    const mobile = dashboardCss.slice(dashboardCss.indexOf('@media (max-width: 768px)'));
+    const drawer = ruleBody(mobile, '.dashboard-sidebar');
+    expect(drawer).not.toBeNull();
+    expect(drawer!).toMatch(/top:\s*var\(--header-offset/);
+    expect(drawer!).toMatch(/bottom:\s*env\(safe-area-inset-bottom/);
+    expect(ruleBody(mobile, '.dashboard-sidebar-backdrop')).toMatch(/top:\s*var\(--header-offset/);
+  });
+
+  it('hangs the banners off the bottom of the header without re-adding the inset', () => {
+    expect(ruleBody(bannersCss, '.warning-banner')).toMatch(/top:\s*var\(--header-offset\)/);
+    // Double-counting: the header already reserved the inset above the banner.
+    expect(bannersCss).not.toMatch(/padding-top:[^;]*safe-area-inset-top/);
+    // The stacked-banner offsets are inline styles on the elements themselves.
+    expect(bannersTsx).not.toMatch(/var\(--header-height\)/);
+    expect(bannersTsx).toMatch(/var\(--header-offset\)/);
+  });
+});

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -25,7 +25,9 @@
 /* Fullscreen Map Layout for Nodes */
 .nodes-split-view {
   position: fixed;
-  top: var(--header-height); /* Below header */
+  /* --header-offset, not --header-height: the header reserves the iOS top inset
+     inside its own box, so the bare height lands this view under it (#4772). */
+  top: var(--header-offset); /* Below header */
   left: var(--sidebar-width); /* After sidebar */
   right: 0;
   bottom: 0;
@@ -1218,7 +1220,13 @@
 /* Responsive design */
 @media (max-width: 768px) {
   .nodes-split-view {
-    top: 48px; /* Mobile header is 48px */
+    /* No `top` here on purpose. It was a hardcoded 48px, which was wrong twice
+       over: the mobile header is 40px (--header-height in App.css's mobile
+       :root), leaving an 8px strip of page behind the map, and a constant
+       cannot carry the iOS safe-area inset, so in a standalone PWA this view
+       started ~59px above where the header ends and swallowed the shell's
+       chrome (#4772). The base rule's `top: var(--header-offset)` resolves
+       against the mobile --header-height and tracks the inset. */
     /* The left rail became a bottom bar (#4473 phase 2), so the map/list split
        spans the full width and instead has to clear the bar, which is fixed
        over the bottom of the viewport. */


### PR DESCRIPTION
Fixes #4772.

## What was actually broken

On an iOS home-screen install (`display: standalone` + `viewport-fit=cover`) the app has to absorb the ~47-59px `env(safe-area-inset-top)` that a normal browser tab absorbs for it. Nothing did, so the chrome rendered *underneath* the status bar. With `apple-mobile-web-app-status-bar-style="black"` painting an opaque bar over it, the user was left with a full-screen map, its zoom buttons and the FEATURES panel — and no way back to any other view.

**The reported surface is the dashboard, not the Nodes tab.** `path="*"` in `main.tsx` makes `DashboardPage` the landing route and `staticServing.ts` points the manifest's `start_url` at it, so that is where an installed PWA opens. `src/styles/dashboard.css` is a self-contained `100dvh` page that handled no insets at all, so its topbar — carrying the hamburger that is the only way into the source list — sat entirely behind the status bar.

The issue's suggested root cause (`nodes.css` `top: 48px`) was a real defect too, just on a different screen; it is fixed here as well.

## Changes

Every one of these is a no-op wherever the inset is 0 — desktop, Android, and in-browser on iOS.

- **`--safe-area-top` / `--header-offset` tokens** in `:root`. Everything anchored below the fixed header now offsets by `--header-offset` (height + inset) instead of `--header-height`. Reading the inset through a custom property rather than calling `env()` inline is also the testing seam: `env()` cannot be set from script, a variable can.
- **`.dashboard-page`** insets the whole column on all four edges; **`.dashboard-sidebar`** and its backdrop are `position: fixed`, escape that padding, and carry the insets themselves.
- **`.app-header`** adds the inset to its **height**, not just its padding. Under `box-sizing: border-box` a fixed `height` means padding can never grow the box, so the inset merely ate the content box and the header's contents rendered below its own background band.
- **The mobile `.app-header` padding moves to `AppHeader.css`**, where it actually wins. Sitting in `App.css` it lost the same-specificity tie to `AppHeader.css`'s base rule (App.css is imported first), so the mobile header kept desktop `1.5rem/2rem` padding against a 40px height — a zero-height content box even before any inset. This is the `#3532` cascade trap again, one file over.
- **`.nodes-split-view`** drops its hardcoded `top: 48px`, which was wrong twice over: the mobile header is 40px, and a constant cannot track an inset.
- **Banners** stop adding the inset a second time — they hang off the bottom of a header that already reserved it.

## Verification

Driven in the running dev container at 390x844 with the inset simulated via `--safe-area-top: 59px`, plus a stand-in status-bar overlay for the screenshots:

| | before | after |
|---|---|---|
| dashboard topbar | `0 → 40` (entirely behind the status bar) | `59 → 99` |
| Nodes header band | `0 → 64`, buttons at `45 → 74` straddling the status bar and floating over the map | `0 → 99`, buttons at `64 → 93` |
| Nodes map view | `top: 48` (over the header) | `top: 99` |
| desktop 1440x900 | header `0 → 60`, split view `60 → 900` | unchanged |

Full suite: 15,998 passed / 0 failed / 0 suite failures (815 skipped — the PostgreSQL and MySQL suites; no schema change here). `lint:ci` ratchet clean, `tsc --noEmit` clean.

New regression tests in `src/styles/headerSafeAreaClearance.test.ts` — the top-edge counterpart to `bottomBarClearance.test.ts` (#4473) and the bottom-bar inset guards in `SourceNav.mobile.test.ts` (#4497). Stylesheet-source assertions, since jsdom does neither layout nor cascade.

## Not covered

- Bottom/left/right insets still call `env()` directly, matching the existing convention, so only the top inset is simulatable from script.
- On a 390px viewport the Nodes header row still overflows when the source name is long (the Sign In button clips). Pre-existing and unrelated; this change reduces the overflow by 24px rather than introducing it.
- Not verified on real hardware — I have no iOS device. Worth a check on Wilhelm's iPhone before closing the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G