### PR TITLE
fix(ui): three mobile/map CSS quirks (#4774, #4772, #4758)

### DIFF
--- a/src/components/SearchModal/SearchModal.css
+++ b/src/components/SearchModal/SearchModal.css
@@ -280,18 +280,28 @@
 }
 
 @media (max-width: 768px) {
+  /* Stop the overlay above the bottom navigation bar so the nav stays visible
+     and tappable instead of being covered (the overlay and the nav share
+     z-index 10001, and the overlay paints later). The nav reserves
+     --app-nav-bar-height + safe-area-inset-bottom, so clearing exactly that
+     docks the modal right above it (#4774). The keyboard inset is still handled
+     by the base .search-modal-overlay padding-bottom (issue #2994). */
+  .search-modal-overlay {
+    bottom: calc(var(--app-nav-bar-height, 56px) + env(safe-area-inset-bottom, 0px));
+  }
+
   .search-modal {
     width: 100%;
     max-width: 100%;
-    max-height: 100vh;
-    max-height: calc(100dvh - var(--keyboard-inset, 0px));
-    height: 100vh;
-    height: calc(100dvh - var(--keyboard-inset, 0px));
+    /* Fill the overlay, which already clears the nav bar (and, via its
+       padding-bottom, the keyboard). */
+    height: 100%;
+    max-height: 100%;
     border-radius: 0;
     padding-top: env(safe-area-inset-top);
-    /* Stack the iOS home-indicator inset on top of the keyboard inset so the
-       search input stays above both (issue #2994). */
-    padding-bottom: calc(env(safe-area-inset-bottom));
+    /* The overlay's bottom offset already clears the home-indicator inset, so
+       no extra padding-bottom is needed here (#4774). */
+    padding-bottom: 0;
   }
 
   .search-filters {

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -1218,7 +1218,11 @@
 /* Responsive design */
 @media (max-width: 768px) {
   .nodes-split-view {
-    top: 48px; /* Mobile header is 48px */
+    /* Clear the header including the iOS safe-area inset. A flat 48px ignored
+       env(safe-area-inset-top), so in an iOS standalone/PWA the taller
+       safe-area header overlapped the map and pushed its bottom controls
+       off-screen (#4772). Mirrors the bottom edge's safe-area handling below. */
+    top: calc(var(--header-height) + env(safe-area-inset-top, 0px));
     /* The left rail became a bottom bar (#4473 phase 2), so the map/list split
        spans the full width and instead has to clear the bar, which is fixed
        over the bottom of the viewport. */
@@ -1896,7 +1900,11 @@
 .node-popup {
   min-width: 200px;
   max-width: 280px;
-  max-height: 400px;
+  /* Cap relative to the viewport rather than a flat 400px so a fully-populated
+     Info tab (name, IDs, role, hw, hops, elevation, accuracy, position source,
+     timestamp, action buttons) fits without a scrollbar on desktop, while short
+     viewports still clamp to 70vh and scroll (#4758). */
+  max-height: min(70vh, 600px);
   overflow-y: auto;
   overflow-x: hidden;
   font-family: system-ui, -apple-system, sans-serif;


### PR DESCRIPTION
Batches three small, independent CSS quirks. Pure CSS — no JS/TS, no tests affected. Frontend build passes.

## #4774 — Mobile: search modal hid the bottom nav
The search-modal overlay and the bottom nav both use `z-index: 10001`, and the overlay paints later, so it covered the nav with no way to navigate away. On mobile the overlay now stops above the nav bar (`--app-nav-bar-height + safe-area-inset-bottom`) and the modal fills that shortened region — the nav stays visible and tappable. The `--keyboard-inset` handling from #2994 is preserved via the base overlay `padding-bottom`.

## #4772 — iOS PWA: map controls hidden behind the safe area
`.nodes-split-view` used a flat `top: 48px` that ignored `env(safe-area-inset-top)`. In iOS standalone/PWA mode the header (which already pads for the safe area) is taller than 48px, so the map rendered under it and pushed the bottom controls off-screen. Now:
```css
top: calc(var(--header-height) + env(safe-area-inset-top, 0px));
```
mirroring the bottom edge's existing safe-area pattern.

## #4758 — Desktop: node popup shows a scrollbar
`.node-popup` had a flat `max-height: 400px`, so a fully-populated Info tab (name, IDs, role, hardware, hops, elevation, accuracy, position source, timestamp, buttons) overflowed and scrolled even on desktop. Now `max-height: min(70vh, 600px)` — fits the content on desktop, still clamps + scrolls on short viewports.

## Verification note
These are mobile/PWA-facing layout changes I validated by reasoning + a clean Vite build; the iOS-standalone and mobile-viewport rendering (#4774, #4772) is worth a quick device spot-check after merge, since I can't run iOS Safari here.

## Not included
#4770 (non-linear age slider) is split into a separate PR — it needs a settings-cap raise (168h→720h) + validation and a two-instance slider rework, which doesn't belong with pure CSS fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)