### PR TITLE
feat(map): non-linear age filter with week/month reach (#4770)

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -47,6 +47,7 @@ import { nodePassesTransportFilter } from '../../utils/nodeTransport';
 import { shouldDiscardPosition } from '../../utils/nullIsland';
 import { getDiscardInvalidPositions } from '../../utils/positionDisplayConfig';
 import { effectiveMapMaxAgeHours } from '../../utils/mapAge';
+import { ageFilterStops, nearestAgeStopIndex, formatAgeStop } from '../../utils/mapAgeSteps';
 import { resolveMapEndpoint } from '../../utils/nodeHelpers';
 import api from '../../services/api';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
@@ -752,36 +753,37 @@ export default function DashboardMap({
           {/* Map Features age slider (#3322): hides node markers, traceroutes,
               and route segments older than the chosen age. Ranges 1h–maxNodeAge. */}
           {(() => {
+            // Non-linear discrete stops (1h..30d) via mapAgeSteps (#4770),
+            // bounded by the per-source maxNodeAgeHours setting.
             const maxHours = Math.max(1, Math.round(maxNodeAgeHours));
+            const stops = ageFilterStops(maxHours);
+            const topIndex = stops.length - 1;
             const currentHours = Math.min(Math.max(1, Math.round(effectiveMaxAge)), maxHours);
-            const formatDuration = (hours: number): string => {
-              if (hours >= maxHours) return 'All';
-              if (hours < 24) return `${hours}h`;
-              const days = Math.floor(hours / 24);
-              const remainingHours = hours % 24;
-              return remainingHours === 0 ? `${days}d` : `${days}d ${remainingHours}h`;
-            };
+            const currentIndex = nearestAgeStopIndex(stops, currentHours);
+            const label = (idx: number) => formatAgeStop(stops[idx], maxHours);
             return (
               <div className="map-control-item" style={{ flexDirection: 'column', alignItems: 'stretch', gap: '0.25rem' }}>
                 <span>Maximum age</span>
                 <div className="position-history-slider">
                   <input
                     type="range"
-                    min={1}
-                    max={maxHours}
-                    value={currentHours}
+                    min={0}
+                    max={topIndex}
+                    step={1}
+                    value={currentIndex}
                     aria-label="Maximum age"
-                    aria-valuemin={1}
-                    aria-valuemax={maxHours}
-                    aria-valuenow={currentHours}
-                    aria-valuetext={formatDuration(currentHours)}
-                    disabled={maxHours <= 1}
+                    aria-valuemin={0}
+                    aria-valuemax={topIndex}
+                    aria-valuenow={currentIndex}
+                    aria-valuetext={label(currentIndex)}
+                    disabled={topIndex < 1}
                     onChange={(e) => {
-                      const value = parseInt(e.target.value, 10);
-                      setMapMaxAgeHours(value >= maxHours ? null : value);
+                      const idx = parseInt(e.target.value, 10);
+                      // Top stop == the setting cap → store null so the map follows the setting.
+                      setMapMaxAgeHours(idx >= topIndex ? null : stops[idx]);
                     }}
                   />
-                  <span className="slider-value">{formatDuration(currentHours)}</span>
+                  <span className="slider-value">{label(currentIndex)}</span>
                 </div>
               </div>
             );

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -9,6 +9,7 @@ import { TabType } from '../types/ui';
 import { nodePassesTransportFilter, transportCutoffSec } from '../utils/nodeTransport';
 import { getNodeTypeCategory } from '../utils/nodeTypeCategory';
 import { effectiveMapMaxAgeHours } from '../utils/mapAge';
+import { ageFilterStops, nearestAgeStopIndex, formatAgeStop } from '../utils/mapAgeSteps';
 import { downsamplePositionHistory, MAX_RENDERED_POSITION_POINTS } from '../utils/positionHistoryDownsample';
 import { createNodeIcon, getHopColor } from '../utils/mapIcons';
 import { getPositionHistoryColor, generateHeadingAwarePath, generatePositionHistoryArrows, snrToColor } from '../utils/mapHelpers.tsx';
@@ -2554,37 +2555,39 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                       traceroutes, and route segments older than the chosen age.
                       Ranges 1h–maxNodeAgeHours (settings); default = max ("All"). */}
                   {(() => {
+                    // Non-linear discrete stops (1h..30d) instead of a linear
+                    // per-hour tick — see mapAgeSteps (#4770). Bounded by the
+                    // per-source maxNodeAgeHours setting.
                     const maxHours = Math.max(1, Math.round(maxNodeAgeHours));
+                    const stops = ageFilterStops(maxHours);
+                    const topIndex = stops.length - 1;
                     const currentHours = Math.min(Math.max(1, Math.round(effectiveMapMaxAge)), maxHours);
-                    const formatDuration = (hours: number): string => {
-                      if (hours >= maxHours) return t('map.maxAgeAll', 'All');
-                      if (hours < 24) return `${hours}h`;
-                      const days = Math.floor(hours / 24);
-                      const remainingHours = hours % 24;
-                      return remainingHours === 0 ? `${days}d` : `${days}d ${remainingHours}h`;
-                    };
+                    const currentIndex = nearestAgeStopIndex(stops, currentHours);
+                    const label = (idx: number) =>
+                      formatAgeStop(stops[idx], maxHours, t('map.maxAgeAll', 'All'));
                     return (
                       <div className="map-control-item" style={{ flexDirection: 'column', alignItems: 'stretch', gap: '0.25rem' }}>
                         <span>{t('map.maximumAge', 'Maximum age')}</span>
                         <div className="position-history-slider">
                           <input
                             type="range"
-                            min={1}
-                            max={maxHours}
-                            value={currentHours}
+                            min={0}
+                            max={topIndex}
+                            step={1}
+                            value={currentIndex}
                             aria-label={t('map.maximumAge', 'Maximum age')}
-                            aria-valuemin={1}
-                            aria-valuemax={maxHours}
-                            aria-valuenow={currentHours}
-                            aria-valuetext={formatDuration(currentHours)}
-                            disabled={maxHours <= 1}
+                            aria-valuemin={0}
+                            aria-valuemax={topIndex}
+                            aria-valuenow={currentIndex}
+                            aria-valuetext={label(currentIndex)}
+                            disabled={topIndex < 1}
                             onChange={(e) => {
-                              const value = parseInt(e.target.value, 10);
-                              // At max, store null so the map follows the setting.
-                              setMapMaxAgeHours(value >= maxHours ? null : value);
+                              const idx = parseInt(e.target.value, 10);
+                              // Top stop == the setting cap → store null so the map follows the setting.
+                              setMapMaxAgeHours(idx >= topIndex ? null : stops[idx]);
                             }}
                           />
-                          <span className="slider-value">{formatDuration(currentHours)}</span>
+                          <span className="slider-value">{label(currentIndex)}</span>
                         </div>
                       </div>
                     );

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -2013,7 +2013,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
               id="maxNodeAge"
               type="number"
               min="1"
-              max="168"
+              max="720"
               value={draft.maxNodeAgeHours}
               onChange={(e) => updateField('maxNodeAgeHours', parseInt(e.target.value))}
               className="setting-input"

--- a/src/constants/nodeDisplayDefaults.test.ts
+++ b/src/constants/nodeDisplayDefaults.test.ts
@@ -77,8 +77,9 @@ describe('parseNodeDisplayNumber', () => {
     ['0', 24], // 0 is below maxNodeAgeHours' min of 1 -> clamps to default
     ['-5', 24], // negative is out of range -> clamps to default (NOT '-5' verbatim)
     ['24', 24],
-    ['168', 168], // upper bound, inclusive
-    ['169', 24], // above upper bound -> default
+    ['168', 168], // 1 week — still well within the 720h (30d) cap (#4770)
+    ['720', 720], // upper bound, inclusive (30 days)
+    ['721', 24], // above upper bound -> default
     ['1', 1], // lower bound, inclusive
   ];
 

--- a/src/constants/nodeDisplayDefaults.ts
+++ b/src/constants/nodeDisplayDefaults.ts
@@ -73,7 +73,7 @@ export const NODE_DISPLAY_STRING_DEFAULTS = { nodeHopsCalculation: 'nodeinfo' } 
 /**
  * Accepted ranges. Lifted verbatim from the existing server-side write
  * validation so the read-side clamp and the write-side 400 can never disagree:
- *   maxNodeAgeHours                   settingsRoutes.ts:345-351   1..168
+ *   maxNodeAgeHours                   settingsRoutes.ts (reads this range)  1..720
  *   inactiveNodeThresholdHours        settingsRoutes.ts:363-368   1..720
  *   inactiveNodeCheckIntervalMinutes  settingsRoutes.ts:370-377   1..1440
  *   inactiveNodeCooldownHours         settingsRoutes.ts:379-384   1..720
@@ -86,7 +86,7 @@ export const NODE_DISPLAY_STRING_DEFAULTS = { nodeHopsCalculation: 'nodeinfo' } 
 export const NODE_DISPLAY_RANGES: Readonly<Partial<Record<
   NodeDisplayNumericKey, { min: number; max: number; integer: boolean }
 >>> = {
-  maxNodeAgeHours:                  { min: 1, max: 168,  integer: true },
+  maxNodeAgeHours:                  { min: 1, max: 720,  integer: true },
   inactiveNodeThresholdHours:       { min: 1, max: 720,  integer: true },
   inactiveNodeCheckIntervalMinutes: { min: 1, max: 1440, integer: true },
   inactiveNodeCooldownHours:        { min: 1, max: 720,  integer: true },

--- a/src/server/routes/settingsRoutes.test.ts
+++ b/src/server/routes/settingsRoutes.test.ts
@@ -893,7 +893,7 @@ describe('settingsRoutes', () => {
   describe('POST /api/settings — WP2 per-source route hardening (#4412 §6.2 a-g)', () => {
     // (a) maxNodeAgeHours range validation (§3.5)
     describe('(a) maxNodeAgeHours range validation', () => {
-      it.each([0, 169, 'abc', ''])('rejects %s with 400 INVALID_MAX_NODE_AGE_HOURS', async (value) => {
+      it.each([0, 721, 'abc', ''])('rejects %s with 400 INVALID_MAX_NODE_AGE_HOURS', async (value) => {
         const app = createApp(adminUser);
         const res = await request(app)
           .post('/api/settings')
@@ -904,7 +904,7 @@ describe('settingsRoutes', () => {
         expect(databaseService.settings.setSettings).not.toHaveBeenCalled();
       });
 
-      it.each([1, 24, 168])('accepts %s with 200', async (value) => {
+      it.each([1, 24, 168, 720])('accepts %s with 200', async (value) => {
         const app = createApp(adminUser);
         await request(app)
           .post('/api/settings')

--- a/src/utils/mapAgeSteps.test.ts
+++ b/src/utils/mapAgeSteps.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AGE_FILTER_STOP_HOURS,
+  ageFilterStops,
+  nearestAgeStopIndex,
+  formatAgeStop,
+} from './mapAgeSteps';
+
+describe('ageFilterStops', () => {
+  it('returns canonical stops below the cap plus the cap itself as the top stop', () => {
+    // cap 720 (30d) exposes the full ladder; the cap coincides with a canonical stop.
+    expect(ageFilterStops(720)).toEqual([1, 3, 6, 12, 24, 72, 168, 336, 720]);
+  });
+
+  it('bounds the ladder by the setting cap (default 24h shows only short stops)', () => {
+    expect(ageFilterStops(24)).toEqual([1, 3, 6, 12, 24]);
+    expect(ageFilterStops(168)).toEqual([1, 3, 6, 12, 24, 72, 168]);
+  });
+
+  it('appends a non-canonical cap as the final stop', () => {
+    // 200 isn't a canonical stop; it becomes the top ("All") stop above 168.
+    expect(ageFilterStops(200)).toEqual([1, 3, 6, 12, 24, 72, 168, 200]);
+    // 10 drops the 12h stop and caps at 10.
+    expect(ageFilterStops(10)).toEqual([1, 3, 6, 10]);
+  });
+
+  it('rounds and floors the cap to at least a single stop', () => {
+    expect(ageFilterStops(1)).toEqual([1]);
+    expect(ageFilterStops(0)).toEqual([1]);
+    expect(ageFilterStops(2.6)).toEqual([1, 3]); // rounds to 3
+  });
+});
+
+describe('nearestAgeStopIndex', () => {
+  const stops = ageFilterStops(720); // [1,3,6,12,24,72,168,336,720]
+
+  it('snaps an exact stop to its own index', () => {
+    expect(nearestAgeStopIndex(stops, 24)).toBe(4);
+    expect(nearestAgeStopIndex(stops, 720)).toBe(8);
+  });
+
+  it('snaps an arbitrary stored value to the nearest stop', () => {
+    expect(nearestAgeStopIndex(stops, 30)).toBe(4); // 30 nearer 24 than 72
+    expect(nearestAgeStopIndex(stops, 60)).toBe(5); // 60 nearer 72 than 24
+    expect(nearestAgeStopIndex(stops, 500)).toBe(7); // 500 nearer 336 than 720
+  });
+
+  it('resolves an exact halfway tie to the longer stop', () => {
+    // 9 is exactly halfway between 6 (idx 2) and 12 (idx 3) → 12h wins.
+    expect(nearestAgeStopIndex(stops, 9)).toBe(3);
+    // 48 is exactly halfway between 24 (idx 4) and 72 (idx 5) → 72h wins.
+    expect(nearestAgeStopIndex(stops, 48)).toBe(5);
+  });
+
+  it('clamps below the first and above the last stop', () => {
+    expect(nearestAgeStopIndex(stops, 0)).toBe(0);
+    expect(nearestAgeStopIndex(stops, 9999)).toBe(8);
+  });
+});
+
+describe('formatAgeStop', () => {
+  it('renders the top stop as the All label', () => {
+    expect(formatAgeStop(720, 720)).toBe('All');
+    expect(formatAgeStop(24, 24, 'Alle')).toBe('Alle');
+  });
+
+  it('renders sub-day stops in hours', () => {
+    expect(formatAgeStop(1, 720)).toBe('1h');
+    expect(formatAgeStop(12, 720)).toBe('12h');
+  });
+
+  it('renders multi-day stops in days', () => {
+    expect(formatAgeStop(24, 720)).toBe('1d');
+    expect(formatAgeStop(72, 720)).toBe('3d');
+    expect(formatAgeStop(168, 720)).toBe('7d');
+    expect(formatAgeStop(336, 720)).toBe('14d');
+  });
+
+  it('appends trailing hours for non-whole-day stops', () => {
+    expect(formatAgeStop(30, 720)).toBe('1d 6h');
+  });
+});
+
+describe('AGE_FILTER_STOP_HOURS', () => {
+  it('is strictly ascending and tops out at 30 days', () => {
+    for (let i = 1; i < AGE_FILTER_STOP_HOURS.length; i++) {
+      expect(AGE_FILTER_STOP_HOURS[i]).toBeGreaterThan(AGE_FILTER_STOP_HOURS[i - 1]);
+    }
+    expect(AGE_FILTER_STOP_HOURS[AGE_FILTER_STOP_HOURS.length - 1]).toBe(720);
+  });
+});

--- a/src/utils/mapAgeSteps.ts
+++ b/src/utils/mapAgeSteps.ts
@@ -1,0 +1,68 @@
+/**
+ * Non-linear stops for the Map Features "Maximum age" slider (#4770).
+ *
+ * A linear one-hour-per-tick slider is unusable once the range stretches to
+ * weeks: 720 ticks to cover 1h..30d. The slider instead snaps to these
+ * human-scale stops. The stops are always bounded by the per-source
+ * `maxNodeAgeHours` setting — the setting's value is the final ("All") stop, so
+ * the slider can never select an age the setting would clamp away (see
+ * {@link ../utils/mapAge.ts effectiveMapMaxAgeHours}).
+ */
+export const AGE_FILTER_STOP_HOURS: readonly number[] = [
+  1, // 1h
+  3, // 3h
+  6, // 6h
+  12, // 12h
+  24, // 1d
+  72, // 3d
+  168, // 7d
+  336, // 14d
+  720, // 30d
+];
+
+/**
+ * Ordered slider stops for a given setting cap (`maxHours`): every canonical
+ * stop strictly below the cap, then the cap itself as the top stop. The top
+ * stop is rendered as "All" and stored as `null` (follow the setting).
+ *
+ * Always returns at least `[cap]`, so a cap of 1 yields a single (disabled)
+ * stop.
+ */
+export function ageFilterStops(maxHours: number): number[] {
+  const cap = Math.max(1, Math.round(maxHours));
+  const stops = AGE_FILTER_STOP_HOURS.filter((h) => h < cap);
+  stops.push(cap);
+  return stops;
+}
+
+/**
+ * Index of the stop nearest to `hours`. Ties resolve to the longer stop so an
+ * exactly-halfway stored value snaps up rather than down. Used to position the
+ * slider from an arbitrary stored age (which may not equal any stop).
+ */
+export function nearestAgeStopIndex(stops: number[], hours: number): number {
+  let best = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < stops.length; i++) {
+    const dist = Math.abs(stops[i] - hours);
+    if (dist <= bestDist) {
+      bestDist = dist;
+      best = i; // ascending iteration → ties keep the later (longer) stop
+    }
+  }
+  return best;
+}
+
+/**
+ * Human-readable label for an age-filter stop. The top stop (>= `maxHours`)
+ * renders as `allLabel`; otherwise sub-day values read as `${h}h` and longer
+ * ones as `${d}d` (with a trailing `${h}h` only when not a whole number of
+ * days).
+ */
+export function formatAgeStop(hours: number, maxHours: number, allLabel = 'All'): string {
+  if (hours >= maxHours) return allLabel;
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  const remainingHours = hours % 24;
+  return remainingHours === 0 ? `${days}d` : `${days}d ${remainingHours}h`;
+}


### PR DESCRIPTION
Fixes #4770.

## Problem
The map "Maximum age" slider was a linear 1h-per-tick control capped at `maxNodeAgeHours` (default 24h, hard max **168h / 1 week**). Past that the only option was "All" (every node ever seen). There was no way to see, say, nodes active in the last two weeks but not ancient ones — and a 168-tick linear slider is unusable at multi-day scale.

## Changes
- **Longer reach:** raise `NODE_DISPLAY_RANGES.maxNodeAgeHours` cap **168h → 720h (30 days)**. `settingsRoutes` validates against this same constant, so the write-side 400 moves with it automatically; the SettingsTab number input max follows (`168 → 720`). Default stays 24h.
- **Non-linear stepper:** both age sliders (`NodesTab` + `Dashboard/DashboardMap`) now snap to discrete human-scale stops — **1h, 3h, 6h, 12h, 1d, 3d, 7d, 14d, 30d, All** — bounded by the per-source setting. The slider is index-based; `aria-valuetext` still reports the human label ("3d", "All", …) for screen readers.
- **Shared util:** new `src/utils/mapAgeSteps.ts` (`ageFilterStops`, `nearestAgeStopIndex`, `formatAgeStop`) with unit tests, so the two slider instances can't drift apart.

## Semantics preserved
- The top stop equals the setting cap and stores `null` (= "follow the setting"), exactly as before.
- The read-side clamp (`effectiveMapMaxAgeHours`) already bounds to `[1, setting]`, so no change was needed there — the stepper is always a subset of what the setting allows.
- An arbitrary previously-stored value (e.g. 48h) snaps to the nearest stop for display; the stored value drives filtering until the user moves the slider.

## Tests
- New `mapAgeSteps.test.ts` (13 cases): ladder bounding by cap, non-canonical caps, nearest-stop snapping incl. tie-rounds-up, labels.
- Updated `nodeDisplayDefaults.test.ts` boundary cases for the 720h cap (720 valid, 721 → default).
- `NodesTab` + `Dashboard` suites pass (158); frontend build + `tsc` on touched files clean; lint ratchet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)