### PR TITLE
fix(telemetry): label EnvironmentMetrics current as mA, not A

### DIFF
--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -162,6 +162,7 @@ import { migration as addReticulumDestinationPositionMigration, runMigration144P
 import { migration as addReticulumInterfaceRadioConfigMigration, runMigration145Postgres, runMigration145Mysql } from '../server/migrations/145_add_reticulum_interface_radio_config.js';
 import { migration as createReticulumPathsMigration, runMigration146Postgres, runMigration146Mysql } from '../server/migrations/146_create_reticulum_paths.js';
 import { migration as addMeshBeaconOffersMigration, runMigration147Postgres, runMigration147Mysql } from '../server/migrations/147_add_mesh_beacon_offers.js';
+import { migration as fixEnvCurrentUnitMigration, runMigration148Postgres, runMigration148Mysql } from '../server/migrations/148_fix_env_current_unit.js';
 
 // ============================================================================
 // Registry
@@ -2350,4 +2351,20 @@ registry.register({
   sqlite: (db) => addMeshBeaconOffersMigration.up(db),
   postgres: (client) => runMigration147Postgres(client),
   mysql: (pool) => runMigration147Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 148: relabel historical `envCurrent` telemetry rows 'A' -> 'mA'.
+// EnvironmentMetrics.current is milliamps (firmware getCurrent_mA()); the
+// canonical unit map was corrected, this backfills the per-row stored unit on
+// pre-existing rows. Value is untouched (already raw mA). GLOBAL, idempotent.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 148,
+  name: 'fix_env_current_unit',
+  settingsKey: 'migration_148_fix_env_current_unit',
+  sqlite: (db) => fixEnvCurrentUnitMigration.up(db),
+  postgres: (client) => runMigration148Postgres(client),
+  mysql: (pool) => runMigration148Mysql(pool),
 });

--- a/src/server/meshtasticManager.telemetryCanonical.test.ts
+++ b/src/server/meshtasticManager.telemetryCanonical.test.ts
@@ -71,7 +71,8 @@ describe('MeshtasticManager - canonical telemetry normalization (#3506)', () => 
     expect(storedValue('envVoltage')).toBeCloseTo(3.7, 2);
     expect(storedUnit('envVoltage')).toBe('V');
     expect(storedValue('envCurrent')).toBeCloseTo(0.12, 2);
-    expect(storedUnit('envCurrent')).toBe('A');
+    // EnvironmentMetrics.current is milliamps (firmware getCurrent_mA()).
+    expect(storedUnit('envCurrent')).toBe('mA');
   });
 
   it('stores device metrics through the shared path', async () => {

--- a/src/server/migrations/148_fix_env_current_unit.test.ts
+++ b/src/server/migrations/148_fix_env_current_unit.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Migration 148 tests — relabel historical envCurrent telemetry rows 'A' -> 'mA'.
+ */
+import Database from 'better-sqlite3';
+import { describe, expect, it, vi } from 'vitest';
+import { migration, runMigration148Postgres, runMigration148Mysql } from './148_fix_env_current_unit.js';
+
+function makeTelemetryTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE telemetry (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      nodeId TEXT NOT NULL,
+      nodeNum INTEGER NOT NULL,
+      telemetryType TEXT NOT NULL,
+      timestamp INTEGER NOT NULL,
+      value REAL NOT NULL,
+      unit TEXT,
+      createdAt INTEGER NOT NULL
+    )
+  `);
+}
+
+function insertRow(db: Database.Database, telemetryType: string, value: number, unit: string | null): void {
+  db.prepare(
+    `INSERT INTO telemetry (nodeId, nodeNum, telemetryType, timestamp, value, unit, createdAt)
+     VALUES ('!1', 1, ?, 100, ?, ?, 100)`
+  ).run(telemetryType, value, unit);
+}
+
+describe('Migration 148 — fix envCurrent unit', () => {
+  describe('SQLite', () => {
+    it("relabels envCurrent 'A' rows to 'mA' without touching the value", () => {
+      const db = new Database(':memory:');
+      makeTelemetryTable(db);
+      insertRow(db, 'envCurrent', 0.12, 'A');
+
+      migration.up(db);
+
+      const row = db.prepare(`SELECT value, unit FROM telemetry WHERE telemetryType = 'envCurrent'`).get() as {
+        value: number;
+        unit: string;
+      };
+      expect(row.unit).toBe('mA');
+      expect(row.value).toBeCloseTo(0.12, 5);
+      db.close();
+    });
+
+    it('leaves other telemetry types and already-correct units untouched', () => {
+      const db = new Database(':memory:');
+      makeTelemetryTable(db);
+      insertRow(db, 'envVoltage', 3.7, 'V');
+      insertRow(db, 'ch1Current', 250, 'mA');
+      insertRow(db, 'envCurrent', 42, 'mA'); // already correct — must not double-touch
+
+      migration.up(db);
+
+      const units = db
+        .prepare(`SELECT telemetryType, unit FROM telemetry ORDER BY id`)
+        .all() as Array<{ telemetryType: string; unit: string }>;
+      expect(units).toEqual([
+        { telemetryType: 'envVoltage', unit: 'V' },
+        { telemetryType: 'ch1Current', unit: 'mA' },
+        { telemetryType: 'envCurrent', unit: 'mA' },
+      ]);
+      db.close();
+    });
+
+    it('is idempotent', () => {
+      const db = new Database(':memory:');
+      makeTelemetryTable(db);
+      insertRow(db, 'envCurrent', 1, 'A');
+
+      migration.up(db);
+      expect(() => migration.up(db)).not.toThrow();
+
+      const count = db
+        .prepare(`SELECT COUNT(*) AS n FROM telemetry WHERE telemetryType = 'envCurrent' AND unit = 'mA'`)
+        .get() as { n: number };
+      expect(count.n).toBe(1);
+      db.close();
+    });
+  });
+
+  describe('PostgreSQL', () => {
+    it("issues a guarded UPDATE relabeling 'A' -> 'mA'", async () => {
+      const client = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+      await runMigration148Postgres(client as any);
+      const sql = client.query.mock.calls.map((c: any[]) => String(c[0])).join('\n');
+      expect(sql).toMatch(/UPDATE telemetry SET "unit" = 'mA'/);
+      expect(sql).toMatch(/"telemetryType" = 'envCurrent'/);
+      expect(sql).toMatch(/"unit" = 'A'/);
+    });
+  });
+
+  describe('MySQL', () => {
+    it("issues a guarded UPDATE relabeling 'A' -> 'mA'", async () => {
+      const pool = { query: vi.fn().mockResolvedValue([{ affectedRows: 1 }, []]) };
+      await runMigration148Mysql(pool as any);
+      const sql = pool.query.mock.calls.map((c: any[]) => String(c[0])).join('\n');
+      expect(sql).toMatch(/UPDATE telemetry SET unit = 'mA'/);
+      expect(sql).toMatch(/telemetryType = 'envCurrent'/);
+      expect(sql).toMatch(/unit = 'A'/);
+    });
+  });
+});

--- a/src/server/migrations/148_fix_env_current_unit.ts
+++ b/src/server/migrations/148_fix_env_current_unit.ts
@@ -1,0 +1,60 @@
+/**
+ * Migration 148: Fix the stored unit on historical `envCurrent` telemetry rows.
+ *
+ * The EnvironmentMetrics `current` field is populated by the firmware
+ * INA219/INA260 drivers from `getCurrent_mA()` — it is milliamps, matching the
+ * per-channel PowerMetrics currents (unit 'mA'). The canonical unit map
+ * (`src/server/utils/telemetryKeys.ts`) mislabeled it 'A', and the unit is
+ * stored per-row at ingest, so every historical `envCurrent` row carries the
+ * wrong unit. Charts read the stored unit verbatim, so old rows kept showing
+ * "(A)" even after the map was corrected.
+ *
+ * The stored *value* is already correct (raw mA, no scaling applied at ingest),
+ * so this migration only rewrites the `unit` label — it never touches `value`.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL: the `unit = 'A'` guard means a
+ * re-run (e.g. after a crash between the migration and its ledger write) matches
+ * zero rows once the labels are already 'mA'.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 148';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): relabeling envCurrent rows 'A' -> 'mA'...`);
+    const result = db
+      .prepare(`UPDATE telemetry SET unit = 'mA' WHERE telemetryType = 'envCurrent' AND unit = 'A'`)
+      .run();
+    logger.info(`${LABEL} complete (SQLite): ${result.changes} row(s) updated`);
+  },
+
+  down: (db: Database): void => {
+    logger.info(`${LABEL} down (SQLite): reverting envCurrent rows 'mA' -> 'A'`);
+    db.prepare(`UPDATE telemetry SET unit = 'A' WHERE telemetryType = 'envCurrent' AND unit = 'mA'`).run();
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration148Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): relabeling envCurrent rows 'A' -> 'mA'...`);
+  const result = await client.query(
+    `UPDATE telemetry SET "unit" = 'mA' WHERE "telemetryType" = 'envCurrent' AND "unit" = 'A'`
+  );
+  logger.info(`${LABEL} complete (PostgreSQL): ${result.rowCount ?? 0} row(s) updated`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration148Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): relabeling envCurrent rows 'A' -> 'mA'...`);
+  const [result] = await pool.query(
+    `UPDATE telemetry SET unit = 'mA' WHERE telemetryType = 'envCurrent' AND unit = 'A'`
+  );
+  const affected = (result as { affectedRows?: number }).affectedRows ?? 0;
+  logger.info(`${LABEL} complete (MySQL): ${affected} row(s) updated`);
+}

--- a/src/server/mqttIngestion.test.ts
+++ b/src/server/mqttIngestion.test.ts
@@ -1143,7 +1143,7 @@ describe('ingestServiceEnvelope — TELEMETRY_APP key normalization (#3314)', ()
     expect(rowByType('humidity')).toMatchObject({ value: 55, unit: '%' });
     expect(rowByType('pressure')).toMatchObject({ value: 1013.2, unit: 'hPa' });
     expect(rowByType('envVoltage')).toMatchObject({ value: 4.1, unit: 'V' });
-    expect(rowByType('envCurrent')).toMatchObject({ value: 0.25, unit: 'A' });
+    expect(rowByType('envCurrent')).toMatchObject({ value: 0.25, unit: 'mA' });
 
     // None of the old dotted forms should appear.
     const types = telemetryRows().map((r: any) => r.telemetryType);

--- a/src/server/utils/telemetryKeys.ts
+++ b/src/server/utils/telemetryKeys.ts
@@ -45,7 +45,11 @@ const ENVIRONMENT_UNITS: Record<string, string> = {
   distance: 'mm',
   weight: 'kg',
   envVoltage: 'V',
-  envCurrent: 'A',
+  // Firmware INA219/INA260 populate EnvironmentMetrics.current from
+  // getCurrent_mA() — the value is milliamps, matching the per-channel
+  // PowerMetrics currents below (ch{N}Current: 'mA'). See migration that
+  // backfills historical rows stored with the wrong 'A' unit.
+  envCurrent: 'mA',
 };
 
 const AIR_QUALITY_UNITS: Record<string, string> = {


### PR DESCRIPTION
## Problem

A user with an INA219 power sensor reported that the **Environment Current** telemetry chart shows values labeled **(A)** — Amps — when the readings (~40–225) are really milliamps.

## Root cause

Meshtastic firmware populates `EnvironmentMetrics.current` from the INA219/INA260 driver's `getCurrent_mA()`, so the field is **milliamps**. MeshMonitor's `CANONICAL_TELEMETRY_UNITS` map labeled `envCurrent` as `'A'` — the lone outlier, since the newer per-channel PowerMetrics currents (`ch{N}Current`) right below it were already `'mA'`. `UnifiedTelemetryPage` even had its own map already using `'mA'`, so the fleet page and the per-node chart disagreed with each other.

The stored **value** was always correct raw mA (no scaling at ingest); only the **label** was wrong.

## Fix

- Change `envCurrent` unit `'A'` → `'mA'` in `CANONICAL_TELEMETRY_UNITS` (fixes all new rows).
- **Migration 148** relabels historical rows — the `unit` is stored per-row at ingest and charts read it verbatim, so old rows kept showing `(A)`. The UPDATE is guarded (`WHERE unit = 'A'`), idempotent, runs across SQLite/PostgreSQL/MySQL, and **never touches `value`**.
- Update two tests that pinned the old `'A'`; add a migration 148 test (relabel, other-rows-untouched, idempotency, PG/MySQL SQL shape).

## Mesh impact

None — display-only correction. No packets, no notifications, no timers.

## Testing

- `tsc -p tsconfig.server.json` clean
- Migration 148 + canonical + MQTT + registry tests: **85 passed, 0 failed**
- `lint:ci` ratchet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G