### PR TITLE
chore(release): 4.14.2-rc5

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor-desktop",
-  "version": "4.14.2-rc4",
+  "version": "4.14.2-rc5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor-desktop",
-      "version": "4.14.2-rc4",
+      "version": "4.14.2-rc5",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.14.2-rc4",
+  "version": "4.14.2-rc5",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.14.2-rc4",
+  "version": "4.14.2-rc5",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.14.2-rc4
-appVersion: "4.14.2-rc4"
+version: 4.14.2-rc5
+appVersion: "4.14.2-rc5"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.2-rc4",
+  "version": "4.14.2-rc5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.14.2-rc4",
+      "version": "4.14.2-rc5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.2-rc4",
+  "version": "4.14.2-rc5",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Release version bump: 4.14.2-rc5

Bumps the version across all five release files (+ desktop lock):
- `package.json` / `package-lock.json`
- `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`)
- `desktop/src-tauri/tauri.conf.json`
- `desktop/package.json` / `desktop/package-lock.json`

### Rolls up 19 commits since v4.14.2-rc4

**Features**
- maplibre-gl 5 → 6 upgrade (#4650) — validated 3D render under SwiftShader
- Non-linear map age filter, 720h cap (#4770)
- Export telemetry graphs as CSV (#4771)
- Prometheus `/api/v1/metrics` endpoint (#4757)

**Fixes**
- VN stops advertising a stale local node number (#1390)
- Three mobile/map CSS quirks (#4774, #4772, #4758)
- Refresh MQTT device-telemetry node metrics (#4755)

**Deps / docs / i18n**
- `pg` + `@types/pg`, `lucide-react` 1.31.0, several dev-dep + CI-action bumps
- Mesh-impact checklist added to agent guidance (#4778)
- Weblate translations (#4709)

No migrations or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)