### PR TITLE
fix(auth): accept Bearer API tokens on requireAdmin routes

### DIFF
--- a/src/server/auth/authMiddleware.ts
+++ b/src/server/auth/authMiddleware.ts
@@ -518,6 +518,26 @@ export function requireAdmin() {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       if (!req.session.userId) {
+        // No session — accept a Bearer API token before rejecting, the same
+        // way requireAuth and requirePermission do (#4259). Without this the
+        // admin-only routes are the one part of the API a token can never
+        // reach, so anything automating them has to hold a password and drive
+        // a login instead. The admin check below still applies: the token
+        // inherits its creating user's rights, so a non-admin's token gets the
+        // same 403 a non-admin session would.
+        const tokenUser = await resolveBearerUser(req);
+        if (tokenUser) {
+          if (!tokenUser.isAdmin) {
+            logger.debug(`❌ Token user ${tokenUser.username} denied admin access`);
+            return res.status(403).json({
+              error: 'Admin access required',
+              code: 'FORBIDDEN_ADMIN'
+            });
+          }
+          req.user = tokenUser;
+          return next();
+        }
+
         return res.status(401).json({
           error: 'Authentication required',
           code: 'UNAUTHORIZED'

--- a/src/server/auth/bearerLegacyAuth.test.ts
+++ b/src/server/auth/bearerLegacyAuth.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
-import { requireAuth, requirePermission } from './authMiddleware.js';
+import { requireAdmin, requireAuth, requirePermission } from './authMiddleware.js';
 
 let harness: RouteTestHarness;
 
@@ -27,6 +27,11 @@ beforeEach(async () => {
       // requireAuth-gated route (session-or-token, no anonymous fallback).
       app.get('/rt/whoami', requireAuth(), (req, res) =>
         res.json({ userId: req.user?.id, username: req.user?.username }),
+      );
+      // requireAdmin-gated route — the last legacy guard that read only the
+      // session, leaving admin-only endpoints unreachable by any API token.
+      app.post('/rt/admin-only', requireAdmin(), (req, res) =>
+        res.json({ ok: true, userId: req.user?.id }),
       );
     },
   });
@@ -118,5 +123,61 @@ describe('Bearer tokens on requireAuth-gated legacy routes (#4259)', () => {
       .set('Authorization', 'Bearer mm_v1_notarealtoken00');
     expect(res.status).toBe(401);
     expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+});
+
+describe('Bearer tokens on requireAdmin-gated legacy routes', () => {
+  it('accepts an admin token in place of a session', async () => {
+    const token = await harness.tokenFor(harness.admin);
+    const res = await request(harness.app)
+      .post('/rt/admin-only')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, userId: harness.admin.id });
+  });
+
+  it('rejects a NON-admin token with 403, not 401', async () => {
+    // The distinction matters: 401 would say "authenticate", which the caller
+    // already did. The token is valid, its user simply is not an admin -- the
+    // same answer a non-admin session gets.
+    const token = await harness.tokenFor(harness.limited);
+    const res = await request(harness.app)
+      .post('/rt/admin-only')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('FORBIDDEN_ADMIN');
+  });
+
+  it('rejects with 401 when neither session nor token is present', async () => {
+    const res = await request(harness.app).post('/rt/admin-only').send({});
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('rejects an invalid token with 401 (no anonymous fallback)', async () => {
+    const res = await request(harness.app)
+      .post('/rt/admin-only')
+      .set('Authorization', 'Bearer mm_v1_notarealtoken00')
+      .send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('still works with an admin session cookie (no regression)', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.post('/rt/admin-only').send({});
+    expect(res.status).toBe(200);
+  });
+
+  it('still rejects a non-admin session with 403 (no regression)', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post('/rt/admin-only').send({});
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('FORBIDDEN_ADMIN');
   });
 });


### PR DESCRIPTION
Fixes #4783.

`requireAuth` and `requirePermission` have honored `Authorization: Bearer` since #4259, but `requireAdmin` was left reading only `req.session.userId`. That makes every admin-gated endpoint the one part of the API an API token can never reach — `POST /api/apprise/configure`, `PUT /api/apprise/enabled`, `PUT /api/push/vapid-subject`, `POST /api/push/test`, `GET /api/device/security-keys`, and the rest.

A valid admin token currently gets `401 UNAUTHORIZED`, which is misleading: the caller did authenticate. Anything automating those endpoints has to hold the admin password and drive the login + CSRF flow instead of using the token mechanism the rest of the API already accepts.

## The change

Mirrors the `requireAuth` fallback: when there is no session, resolve a Bearer token and use it.

The admin check still applies. Tokens inherit their creating user's rights, so a non-admin's token gets the same `403 FORBIDDEN_ADMIN` a non-admin session gets — **not** a 401. That distinction is deliberate and is one of the tests.

20 lines in one function; no new imports, no signature changes, no behaviour change for any session-authenticated caller.

## Tests

Added to `src/server/auth/bearerLegacyAuth.test.ts`, beside the existing #4259 cases, using the same harness with real tokens through real bcrypt:

- admin token accepted in place of a session
- non-admin token → 403 `FORBIDDEN_ADMIN`, not 401
- no session and no token → 401
- invalid token → 401 (no anonymous fallback)
- admin **session** still works (regression)
- non-admin **session** still 403 (regression)

The two token-path tests were confirmed to fail without the change; the four regression cases pass either way, which is the point of including them.

## Verification

- `npm run test:run` — 15199 passed, 0 failed (1050 files)
- `npm run typecheck` — clean
- `npm run lint` — lint ratchet OK, no new violations
- `npm run build` and `npm run build:server` — clean

## Mesh impact checklist

Not applicable, and I checked rather than assumed: this is authentication middleware. It sends no packets, fires no notifications, and arms no timers — the request path is unchanged except for which callers are allowed through. No airtime cost, no scheduling, no per-node scaling.

## Response envelope

Left as bare `{ error, code }` to match the identical `FORBIDDEN_ADMIN` branch a few lines below in the same function, and the sibling guards. Converting one branch to `fail()` while its twin stays bare seemed worse than consistency; happy to convert the whole function if you would prefer.