### PR TITLE
fix(notifications): resolve the token user in notification handlers

### DIFF
--- a/src/server/auth/authMiddleware.ts
+++ b/src/server/auth/authMiddleware.ts
@@ -518,6 +518,26 @@ export function requireAdmin() {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       if (!req.session.userId) {
+        // No session — accept a Bearer API token before rejecting, the same
+        // way requireAuth and requirePermission do (#4259). Without this the
+        // admin-only routes are the one part of the API a token can never
+        // reach, so anything automating them has to hold a password and drive
+        // a login instead. The admin check below still applies: the token
+        // inherits its creating user's rights, so a non-admin's token gets the
+        // same 403 a non-admin session would.
+        const tokenUser = await resolveBearerUser(req);
+        if (tokenUser) {
+          if (!tokenUser.isAdmin) {
+            logger.debug(`❌ Token user ${tokenUser.username} denied admin access`);
+            return res.status(403).json({
+              error: 'Admin access required',
+              code: 'FORBIDDEN_ADMIN'
+            });
+          }
+          req.user = tokenUser;
+          return next();
+        }
+
         return res.status(401).json({
           error: 'Authentication required',
           code: 'UNAUTHORIZED'

--- a/src/server/auth/bearerLegacyAuth.test.ts
+++ b/src/server/auth/bearerLegacyAuth.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
-import { requireAuth, requirePermission } from './authMiddleware.js';
+import { requireAdmin, requireAuth, requirePermission } from './authMiddleware.js';
 
 let harness: RouteTestHarness;
 
@@ -27,6 +27,11 @@ beforeEach(async () => {
       // requireAuth-gated route (session-or-token, no anonymous fallback).
       app.get('/rt/whoami', requireAuth(), (req, res) =>
         res.json({ userId: req.user?.id, username: req.user?.username }),
+      );
+      // requireAdmin-gated route — the last legacy guard that read only the
+      // session, leaving admin-only endpoints unreachable by any API token.
+      app.post('/rt/admin-only', requireAdmin(), (req, res) =>
+        res.json({ ok: true, userId: req.user?.id }),
       );
     },
   });
@@ -118,5 +123,61 @@ describe('Bearer tokens on requireAuth-gated legacy routes (#4259)', () => {
       .set('Authorization', 'Bearer mm_v1_notarealtoken00');
     expect(res.status).toBe(401);
     expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+});
+
+describe('Bearer tokens on requireAdmin-gated legacy routes', () => {
+  it('accepts an admin token in place of a session', async () => {
+    const token = await harness.tokenFor(harness.admin);
+    const res = await request(harness.app)
+      .post('/rt/admin-only')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, userId: harness.admin.id });
+  });
+
+  it('rejects a NON-admin token with 403, not 401', async () => {
+    // The distinction matters: 401 would say "authenticate", which the caller
+    // already did. The token is valid, its user simply is not an admin -- the
+    // same answer a non-admin session gets.
+    const token = await harness.tokenFor(harness.limited);
+    const res = await request(harness.app)
+      .post('/rt/admin-only')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('FORBIDDEN_ADMIN');
+  });
+
+  it('rejects with 401 when neither session nor token is present', async () => {
+    const res = await request(harness.app).post('/rt/admin-only').send({});
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('rejects an invalid token with 401 (no anonymous fallback)', async () => {
+    const res = await request(harness.app)
+      .post('/rt/admin-only')
+      .set('Authorization', 'Bearer mm_v1_notarealtoken00')
+      .send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('still works with an admin session cookie (no regression)', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.post('/rt/admin-only').send({});
+    expect(res.status).toBe(200);
+  });
+
+  it('still rejects a non-admin session with 403 (no regression)', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post('/rt/admin-only').send({});
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('FORBIDDEN_ADMIN');
   });
 });

--- a/src/server/auth/bearerLegacyAuth.test.ts
+++ b/src/server/auth/bearerLegacyAuth.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import { pushRouter } from '../routes/notificationRoutes.js';
 import { requireAdmin, requireAuth, requirePermission } from './authMiddleware.js';
 
 let harness: RouteTestHarness;
@@ -33,6 +34,10 @@ beforeEach(async () => {
       app.post('/rt/admin-only', requireAdmin(), (req, res) =>
         res.json({ ok: true, userId: req.user?.id }),
       );
+      // The REAL notification router. Its handlers read the user id
+      // themselves, so a guard that accepts a token is not enough -- the
+      // handler has to look at req.user too.
+      app.use('/rt/push', pushRouter);
     },
   });
 });
@@ -179,5 +184,28 @@ describe('Bearer tokens on requireAdmin-gated legacy routes', () => {
     const res = await agent.post('/rt/admin-only').send({});
     expect(res.status).toBe(403);
     expect(res.body.code).toBe('FORBIDDEN_ADMIN');
+  });
+});
+
+describe('Bearer tokens reach notification handlers, not just their guards', () => {
+  it('GET /preferences resolves the token user instead of 401ing', async () => {
+    // The guard (requireAuth) already accepted Bearer tokens; the handler then
+    // read req.session.userId and rejected anyway. That combination is what
+    // made per-user notification preferences unreachable by automation.
+    const token = await harness.tokenFor(harness.admin);
+    const res = await request(harness.app)
+      .get('/rt/push/preferences')
+      .query({ sourceId: harness.sourceA })
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).not.toBe(401);
+  });
+
+  it('still 401s with neither session nor token', async () => {
+    const res = await request(harness.app)
+      .get('/rt/push/preferences')
+      .query({ sourceId: harness.sourceA });
+
+    expect(res.status).toBe(401);
   });
 });

--- a/src/server/routes/notificationRoutes.ts
+++ b/src/server/routes/notificationRoutes.ts
@@ -75,7 +75,11 @@ pushRouter.post(
         return res.status(400).json({ error: `Unknown sourceId: ${sourceId}` });
       }
 
-      const userId = req.session?.userId;
+      // requireAuth()/requireAdmin() populate req.user for BOTH a session and a
+      // Bearer API token (#4259). Reading the session directly ignored the token
+      // half, so these endpoints 401d for a valid token even though the guard had
+      // already accepted it.
+      const userId = req.user?.id ?? req.session?.userId;
       const userAgent = req.headers['user-agent'];
 
       await pushNotificationService.saveSubscription(userId, subscription, userAgent, sourceId);
@@ -117,7 +121,11 @@ pushRouter.post(
 // Test push notification (admin only)
 pushRouter.post('/test', requireAdmin(), async (req: Request, res: Response) => {
   try {
-    const userId = req.session?.userId;
+    // requireAuth()/requireAdmin() populate req.user for BOTH a session and a
+    // Bearer API token (#4259). Reading the session directly ignored the token
+    // half, so these endpoints 401d for a valid token even though the guard had
+    // already accepted it.
+    const userId = req.user?.id ?? req.session?.userId;
 
     // Get local node name for prefix
     const mgr = getPrimaryMeshtasticManager(sourceManagerRegistry) ?? fallbackManager;
@@ -154,7 +162,11 @@ pushRouter.get(
   requirePermission('messages', 'read', { sourceIdFrom: 'query' }),
   async (req: Request, res: Response) => {
   try {
-    const userId = req.session?.userId;
+    // requireAuth()/requireAdmin() populate req.user for BOTH a session and a
+    // Bearer API token (#4259). Reading the session directly ignored the token
+    // half, so these endpoints 401d for a valid token even though the guard had
+    // already accepted it.
+    const userId = req.user?.id ?? req.session?.userId;
     if (!userId) {
       return res.status(401).json({ error: 'Authentication required' });
     }
@@ -206,7 +218,11 @@ pushRouter.post(
   requirePermission('messages', 'read', { sourceIdFrom: 'body' }),
   async (req: Request, res: Response) => {
   try {
-    const userId = req.session?.userId;
+    // requireAuth()/requireAdmin() populate req.user for BOTH a session and a
+    // Bearer API token (#4259). Reading the session directly ignored the token
+    // half, so these endpoints 401d for a valid token even though the guard had
+    // already accepted it.
+    const userId = req.user?.id ?? req.session?.userId;
     if (!userId) {
       return res.status(401).json({ error: 'Authentication required' });
     }
@@ -400,7 +416,11 @@ appriseRouter.post(
   requirePermission('settings', 'write', { sourceIdFrom: 'body' }),
   async (req: Request, res: Response) => {
   try {
-    const userId = req.session?.userId;
+    // requireAuth()/requireAdmin() populate req.user for BOTH a session and a
+    // Bearer API token (#4259). Reading the session directly ignored the token
+    // half, so these endpoints 401d for a valid token even though the guard had
+    // already accepted it.
+    const userId = req.user?.id ?? req.session?.userId;
     if (!userId) {
       return res.status(401).json({ success: false, message: 'Not authenticated' });
     }


### PR DESCRIPTION
Follow-up to #4784 — the guards were only half the problem. **That PR should merge first**; this branch is based on it, so the diff here will reduce to a single commit once it lands.

`requireAuth()` and `requireAdmin()` both populate `req.user` for a Bearer API token as well as a session, but the five handlers in `notificationRoutes.ts` read `req.session?.userId` directly and 401 when it is absent. A valid token clears the guard and is then rejected by the handler it was just admitted to.

## Why this one bites harder than it looks

Per-user notification preferences are unreachable by any API token — and that is the row Apprise delivery actually reads. `resolveAppriseTargetAsync` resolves URLs from `prefs.appriseUrls` with **no global fallback**, so `POST /api/apprise/configure` on its own configures nothing that will ever be delivered.

The practical consequence: setting up Apprise notifications is a UI-only operation, and cannot be provisioned, restored after a rebuild, or kept in configuration management. I hit this deploying MeshMonitor from Ansible — every other setting in the app converges through the API; this was the one that could not.

## The change

`req.user?.id ?? req.session?.userId`, in five handlers. The session path is byte-for-byte preserved; only the token path changes, from "reject" to "resolve".

## Tests

Added to `src/server/auth/bearerLegacyAuth.test.ts` beside the existing #4259 cases. The test mounts the **real `pushRouter`** rather than a stand-in, so it exercises the actual handler rather than a re-implementation of it:

- `GET /preferences` with an admin token must not 401
- still 401s with neither session nor token

Confirmed to fail without the change.

## Verification

- `npm run test:run` — 15201 passed, 0 failed
- `npm run typecheck` — clean
- `npm run lint` — lint ratchet OK, no new violations
- Deployed to my production instance: `GET /api/push/preferences` went 401 → 200, and an Ansible role now converges the admin account's Discord/Apprise config through the API. A live `POST /api/apprise/test` delivered to Discord.

## Mesh impact checklist

Not applicable, and checked rather than assumed: this is request-scoped user resolution in HTTP handlers. No packets, no notifications *originated* by the change, no timers. It alters which callers are allowed to read and write their own preference row, nothing about what the mesh does.