### PR TITLE
fix(meshcore): preserve hop hash width in Trace Path

### DIFF
--- a/src/server/meshcoreManager.tracePathHashWidth.test.ts
+++ b/src/server/meshcoreManager.tracePathHashWidth.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for MeshCoreManager.traceContactPath()'s per-hop hash-width handling
+ * (#4786).
+ *
+ * traceContactPath() previously flattened a cached out_path into raw bytes
+ * without telling the native backend how wide each hop hash is, so a
+ * discovered 2-byte path (e.g. "0d34") was always sent as 1-byte hops and
+ * the device timed out waiting for a nonexistent second hop. It now infers
+ * the width from the cached path, validates it is uniform across hops, and
+ * rejects widths the device's trace-path command cannot encode (3 bytes).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+const PK = 'a3' + 'f'.repeat(62);
+
+function makeManager(opts: {
+  outPath: string;
+  pathLen?: number;
+  response?: { success: boolean; data?: unknown; error?: string };
+}): { manager: MeshCoreManager; bridgeCalls: { cmd: string; params: Record<string, any> }[] } {
+  const m = new MeshCoreManager('test-source');
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  (m as any).connected = true;
+  (m as any).contacts = new Map([
+    [
+      PK,
+      {
+        publicKey: PK,
+        name: 'Repeater One',
+        outPath: opts.outPath,
+        pathLen: opts.pathLen ?? 1,
+      },
+    ],
+  ]);
+
+  const bridgeCalls: { cmd: string; params: Record<string, any> }[] = [];
+  (m as any).sendBridgeCommand = async (cmd: string, params: Record<string, any>) => {
+    bridgeCalls.push({ cmd, params });
+    return {
+      id: '1',
+      ...(opts.response ?? {
+        success: true,
+        data: { pathLen: params.path?.length ?? 0, flags: 0, pathSnrs: [], lastSnr: 0 },
+      }),
+    };
+  };
+
+  return { manager: m, bridgeCalls };
+}
+
+describe('MeshCoreManager — traceContactPath hop hash width (#4786)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends a 1-byte path with path_hash_bytes=1', async () => {
+    const { manager, bridgeCalls } = makeManager({ outPath: '11,22', pathLen: 2 });
+    const result = await manager.traceContactPath(PK);
+
+    expect(result).not.toBeNull();
+    expect(bridgeCalls).toHaveLength(1);
+    expect(bridgeCalls[0].cmd).toBe('trace_path');
+    expect(bridgeCalls[0].params.path_hash_bytes).toBe(1);
+    expect(Array.from(bridgeCalls[0].params.path as Uint8Array)).toEqual([0x11, 0x22]);
+  });
+
+  it('sends a single 2-byte hop ("0d34") as one hop with path_hash_bytes=2, not two 1-byte hops', async () => {
+    const { manager, bridgeCalls } = makeManager({ outPath: '0d34', pathLen: 1 });
+    const result = await manager.traceContactPath(PK);
+
+    expect(result).not.toBeNull();
+    expect(bridgeCalls).toHaveLength(1);
+    expect(bridgeCalls[0].params.path_hash_bytes).toBe(2);
+    expect(Array.from(bridgeCalls[0].params.path as Uint8Array)).toEqual([0x0d, 0x34]);
+  });
+
+  it('sends multiple 2-byte hops with path_hash_bytes=2 and preserves hop order', async () => {
+    const { manager, bridgeCalls } = makeManager({ outPath: '0d34,7fa2', pathLen: 2 });
+    const result = await manager.traceContactPath(PK);
+
+    expect(result).not.toBeNull();
+    expect(bridgeCalls[0].params.path_hash_bytes).toBe(2);
+    expect(Array.from(bridgeCalls[0].params.path as Uint8Array)).toEqual([0x0d, 0x34, 0x7f, 0xa2]);
+  });
+
+  it('rejects a 3-byte cached path without transmitting (device trace command cannot encode it)', async () => {
+    const { manager, bridgeCalls } = makeManager({ outPath: '0d34ff', pathLen: 1 });
+    const result = await manager.traceContactPath(PK);
+
+    expect(result).toBeNull();
+    expect(bridgeCalls).toHaveLength(0);
+  });
+
+  it('rejects a cached path with mixed-width hops without transmitting', async () => {
+    const { manager, bridgeCalls } = makeManager({ outPath: '11,0d34', pathLen: 2 });
+    const result = await manager.traceContactPath(PK);
+
+    expect(result).toBeNull();
+    expect(bridgeCalls).toHaveLength(0);
+  });
+
+  it('rejects an empty/malformed cached path without transmitting', async () => {
+    const { manager, bridgeCalls } = makeManager({ outPath: 'zz,--', pathLen: 1 });
+    const result = await manager.traceContactPath(PK);
+
+    expect(result).toBeNull();
+    expect(bridgeCalls).toHaveLength(0);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -4307,12 +4307,29 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       logger.warn(`[MeshCore] Trace-path: no known path for ${publicKey.substring(0, 16)}…`);
       return null;
     }
-    // Expand each comma-separated hop token into its constituent bytes so
-    // multi-byte hops (e.g. "a3f2") yield [0xa3, 0xf2] rather than being
-    // truncated to a single byte by parseInt. 1-byte paths are unaffected.
+    const pathHops = parsePathHops(contact.outPath);
+    if (pathHops.length === 0) {
+      logger.warn(`[MeshCore] Trace-path: cached path for ${publicKey.substring(0, 16)}… is empty or malformed`);
+      return null;
+    }
+    const hashBytes = pathHashBytesOf(pathHops);
+    if (pathHops.some((h) => h.length !== hashBytes * 2)) {
+      logger.warn(`[MeshCore] Trace-path: cached path for ${publicKey.substring(0, 16)}… has mixed-width hops, aborting`);
+      return null;
+    }
+    // CMD_SEND_TRACE_PATH's flags byte only encodes power-of-two hop widths
+    // (device: `1 << (flags & 0x03)`), so 1- and 2-byte hops are
+    // representable but the 3-byte width MeshMonitor also supports elsewhere
+    // is not (#4786).
+    if (hashBytes !== 1 && hashBytes !== 2) {
+      logger.warn(`[MeshCore] Trace-path: ${hashBytes}-byte hop hash width for ${publicKey.substring(0, 16)}… is not supported by the device's trace-path command (only 1 or 2 bytes/hop)`);
+      return null;
+    }
+    // Expand each hop token into its constituent bytes so multi-byte hops
+    // (e.g. "a3f2") yield [0xa3, 0xf2] rather than being truncated to a
+    // single byte by parseInt. 1-byte paths are unaffected.
     const pathBytes = Uint8Array.from(
-      contact.outPath.split(',').flatMap((h) => {
-        const tok = h.trim();
+      pathHops.flatMap((tok) => {
         const bytes: number[] = [];
         for (let i = 0; i + 2 <= tok.length; i += 2) {
           bytes.push(parseInt(tok.slice(i, i + 2), 16));
@@ -4323,6 +4340,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     try {
       const response = await this.sendBridgeCommand('trace_path', {
         path: pathBytes,
+        path_hash_bytes: hashBytes,
       }, 60000);
       if (!response.success) {
         logger.warn(`[MeshCore] trace_path failed for ${publicKey}: ${response.error}`);

--- a/src/server/meshcoreNativeBackend.tracePath.test.ts
+++ b/src/server/meshcoreNativeBackend.tracePath.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for MeshCoreNativeBackend's `trace_path` dispatch (#4786).
+ *
+ * The pinned `meshcore.js` fork hardcodes the CMD_SEND_TRACE_PATH flags byte
+ * to 0, so a discovered 2-byte-hop path gets sent as two 1-byte hops and the
+ * device replies to a nonexistent second hop, timing out. The fork's own
+ * TraceData(0x89) push parser has a matching bug: it reads `pathSnrs` as
+ * `pathLen` bytes (the raw hash-byte count) instead of the hop count
+ * (`pathLen >> path_sz`), which would desync a multi-byte reply even with
+ * the outgoing flags fixed.
+ *
+ * MeshCoreNativeBackend now bypasses both by hand-building the outgoing
+ * frame with the correct flags byte and installing a corrected TraceData
+ * parser for the duration of the request (same pattern as `request_owner`/
+ * `request_regions`'s manual frame handling elsewhere in this file).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { MeshCoreNativeBackend, __setMeshCoreModule } from './meshcoreNativeBackend.js';
+
+const ResponseCodes = {
+  Ok: 0, Err: 1, ContactsStart: 2, Contact: 3, EndOfContacts: 4,
+  SelfInfo: 5, Sent: 6, ContactMsgRecv: 7, ChannelMsgRecv: 8,
+  CurrTime: 9, NoMoreMessages: 10, Stats: 24,
+};
+const PushCodes = {
+  Advert: 0x80, PathUpdated: 0x81, MsgWaiting: 0x83, NewAdvert: 0x8a,
+  BinaryResponse: 0x8c, TraceData: 0x89,
+};
+const CommandCodes = { SendTracePath: 36 };
+const StatsTypes = { Core: 0, Radio: 1, Packets: 2 };
+const SelfAdvertTypes = { ZeroHop: 0, Flood: 1 };
+const BinaryRequestTypes = { GetTelemetryData: 0x03 };
+const AdvType = { None: 0, Chat: 1, Repeater: 2, Room: 3 };
+const TxtTypes = { Plain: 0, CliData: 1, SignedPlain: 2 };
+
+class MockConnection extends EventEmitter {
+  sentFrames: Uint8Array[] = [];
+  async connect() { /* no-op */ }
+  async close() { /* no-op */ }
+  async getSelfInfo() {
+    return { type: AdvType.Chat, publicKey: Uint8Array.from(Array(32).fill(0)), name: 'TestNode' };
+  }
+  sendToRadioFrame(frame: Uint8Array) {
+    // Keep the original reference (a Buffer in practice) rather than copying
+    // into a plain Uint8Array, so tests can use Buffer helpers like
+    // readUInt32LE() on the captured frame.
+    this.sentFrames.push(frame);
+  }
+}
+
+function installMockModule(): void {
+  __setMeshCoreModule({
+    NodeJSSerialConnection: MockConnection as any,
+    TCPConnection: MockConnection as any,
+    Constants: {
+      ResponseCodes, PushCodes, CommandCodes, StatsTypes, SelfAdvertTypes,
+      BinaryRequestTypes, AdvType, TxtTypes,
+    } as any,
+    CayenneLpp: { parse: () => [] } as any,
+    Packet: {} as any,
+  });
+}
+
+async function connectedBackend(): Promise<{ backend: MeshCoreNativeBackend; conn: MockConnection }> {
+  const backend = new MeshCoreNativeBackend('src-trace', {
+    connectionType: 'serial',
+    serialPort: '/dev/ttyUSB0',
+  });
+  await backend.connect();
+  const conn = (backend as any).connection as MockConnection;
+  return { backend, conn };
+}
+
+/**
+ * Encode a raw wire-format TraceData(0x89) push body the way
+ * onTraceDataPush() reads it: [reserved][pathLen][flags][tag:4 LE][auth:4 LE]
+ * [pathHashes:pathLen][pathSnrs:hopCount][lastSnr] (the leading push-code
+ * byte itself is consumed by the connection's own frame dispatcher before
+ * onTraceDataPush() runs, so this builds only the body it reads).
+ */
+function buildTraceDataBody(opts: {
+  pathHashes: number[]; pathSz: number; tag: number; snrs: number[]; lastSnr: number;
+}): Uint8Array {
+  const tagBytes = [
+    opts.tag & 0xff, (opts.tag >>> 8) & 0xff, (opts.tag >>> 16) & 0xff, (opts.tag >>> 24) & 0xff,
+  ];
+  return Uint8Array.from([
+    0, // reserved
+    opts.pathHashes.length,
+    opts.pathSz,
+    ...tagBytes,
+    0, 0, 0, 0, // auth
+    ...opts.pathHashes,
+    ...opts.snrs,
+    opts.lastSnr & 0xff,
+  ]);
+}
+
+/** Minimal BufferReader compatible with what onTraceDataPush() expects. */
+function readerFor(body: Uint8Array) {
+  let p = 0;
+  return {
+    readByte: () => body[p++],
+    readUInt8: () => body[p++],
+    readInt8: () => {
+      const b = body[p++];
+      return (b << 24) >> 24;
+    },
+    readUInt32LE: () => {
+      const v = body[p] | (body[p + 1] << 8) | (body[p + 2] << 16) | (body[p + 3] << 24);
+      p += 4;
+      return v >>> 0;
+    },
+    readBytes: (n: number) => {
+      const out = body.slice(p, p + n);
+      p += n;
+      return out;
+    },
+  };
+}
+
+describe('MeshCoreNativeBackend — trace_path (#4786)', () => {
+  beforeEach(() => installMockModule());
+  afterEach(() => __setMeshCoreModule(null));
+
+  it('sends flags=0 (path_sz=0) for a 1-byte path, unchanged from before the fix', async () => {
+    const { backend, conn } = await connectedBackend();
+    const promise = backend.sendCommand('trace_path', {
+      path: Uint8Array.from([0x0d]),
+      path_hash_bytes: 1,
+    });
+
+    // Let the frame land, then reply.
+    await new Promise((r) => setImmediate(r));
+    const frame = conn.sentFrames.at(-1)!;
+    expect(frame[0]).toBe(36); // CMD_SEND_TRACE_PATH
+    expect(frame[9]).toBe(0); // flags: path_sz=0 → 1 byte/hop
+    expect(Array.from(frame.slice(10))).toEqual([0x0d]);
+
+    const tag = (frame as Buffer).readUInt32LE(1);
+    const body = buildTraceDataBody({ pathHashes: [0x0d], pathSz: 0, tag, snrs: [40], lastSnr: 28 });
+    (conn as any).onTraceDataPush(readerFor(body));
+
+    const res = await promise;
+    expect(res.success).toBe(true);
+    expect(res.data.pathSnrs).toEqual([40]);
+    expect(res.data.lastSnr).toBe(7); // 28 → int8 28 / 4
+  });
+
+  it('sends flags=1 (path_sz=1) for a 2-byte path and correctly parses a 1-hop SNR reply — the reported bug', async () => {
+    const { backend, conn } = await connectedBackend();
+    // "0d34" as one 2-byte hop.
+    const promise = backend.sendCommand('trace_path', {
+      path: Uint8Array.from([0x0d, 0x34]),
+      path_hash_bytes: 2,
+    });
+
+    await new Promise((r) => setImmediate(r));
+    const frame = conn.sentFrames.at(-1)!;
+    expect(frame[0]).toBe(36);
+    expect(frame[9]).toBe(1); // flags: path_sz=1 → 2 bytes/hop (was always 0 before the fix)
+    expect(Array.from(frame.slice(10))).toEqual([0x0d, 0x34]);
+
+    const tag = (frame as Buffer).readUInt32LE(1);
+    // One 2-byte hop → pathHashes has 2 bytes, but pathSnrs has only 1 entry
+    // (one hop). Before the fix, meshcore.js would read 2 bytes for pathSnrs
+    // here and consume the lastSnr byte too, corrupting the whole parse.
+    const body = buildTraceDataBody({
+      pathHashes: [0x0d, 0x34], pathSz: 1, tag, snrs: [44], lastSnr: 232 /* -6dB *4, as unsigned byte */,
+    });
+    (conn as any).onTraceDataPush(readerFor(body));
+
+    const res = await promise;
+    expect(res.success).toBe(true);
+    expect(res.data.pathLen).toBe(2);
+    // Exactly one hop's SNR, not two mis-split bytes.
+    expect(res.data.pathSnrs).toEqual([44]);
+    // lastSnr correctly read from its own trailing byte, not stolen by an
+    // over-long pathSnrs read.
+    expect(res.data.lastSnr).toBe(-6);
+  });
+
+  it('ignores a TraceData push whose tag does not match this request', async () => {
+    const { backend, conn } = await connectedBackend();
+    const promise = backend.sendCommand('trace_path', {
+      path: Uint8Array.from([0x0d, 0x34]),
+      path_hash_bytes: 2,
+    }, 200);
+
+    await new Promise((r) => setImmediate(r));
+    const foreignBody = buildTraceDataBody({
+      pathHashes: [0xaa, 0xbb], pathSz: 1, tag: 0xdeadbeef, snrs: [10], lastSnr: 4,
+    });
+    (conn as any).onTraceDataPush(readerFor(foreignBody));
+
+    const res = await promise;
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/timeout/i);
+  });
+
+  it('rejects a hop hash width the device trace command cannot encode', async () => {
+    const { backend } = await connectedBackend();
+    const res = await backend.sendCommand('trace_path', {
+      path: Uint8Array.from([0x0d, 0x34, 0x56]),
+      path_hash_bytes: 3,
+    });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/unsupported hop hash width/i);
+  });
+
+  it('rejects an Err response', async () => {
+    const { backend, conn } = await connectedBackend();
+    const promise = backend.sendCommand('trace_path', {
+      path: Uint8Array.from([0x0d]),
+      path_hash_bytes: 1,
+    });
+    await new Promise((r) => setImmediate(r));
+    conn.emit(ResponseCodes.Err);
+
+    const res = await promise;
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/rejected/i);
+  });
+
+  it('restores the connection\'s original onTraceDataPush after the request settles', async () => {
+    const { backend, conn } = await connectedBackend();
+    const sentinel = () => {};
+    (conn as any).onTraceDataPush = sentinel;
+
+    const promise = backend.sendCommand('trace_path', {
+      path: Uint8Array.from([0x0d]),
+      path_hash_bytes: 1,
+    });
+    await new Promise((r) => setImmediate(r));
+    // Mid-flight the handler is swapped out for the corrected parser.
+    expect((conn as any).onTraceDataPush).not.toBe(sentinel);
+
+    const frame = conn.sentFrames.at(-1)!;
+    const tag = (frame as Buffer).readUInt32LE(1);
+    const body = buildTraceDataBody({ pathHashes: [0x0d], pathSz: 0, tag, snrs: [4], lastSnr: 0 });
+    (conn as any).onTraceDataPush(readerFor(body));
+    await promise;
+
+    expect((conn as any).onTraceDataPush).toBe(sentinel);
+  });
+});

--- a/src/server/meshcoreNativeBackend.tracePath.test.ts
+++ b/src/server/meshcoreNativeBackend.tracePath.test.ts
@@ -244,4 +244,49 @@ describe('MeshCoreNativeBackend — trace_path (#4786)', () => {
 
     expect((conn as any).onTraceDataPush).toBe(sentinel);
   });
+
+  it('serializes two queued trace_path calls so each gets its own corrected parser and reply, with no cross-contamination', async () => {
+    // Regression coverage for a race a reviewer flagged: the onTraceDataPush
+    // patch/restore now lives INSIDE the runExclusiveRadioOp executor, so a
+    // second call queued behind the first can only patch/send/restore after
+    // the first has fully released the lock (including its own restore).
+    // Patching outside that lock (the pre-fix shape) let a queued call's
+    // synchronous dispatch-time patch land before the in-flight call's own
+    // send/reply window, since only sends were actually serialized.
+    const { backend, conn } = await connectedBackend();
+
+    const promiseA = backend.sendCommand('trace_path', {
+      path: Uint8Array.from([0x0d, 0x34]),
+      path_hash_bytes: 2,
+    });
+    const promiseB = backend.sendCommand('trace_path', {
+      path: Uint8Array.from([0xaa, 0xbb]),
+      path_hash_bytes: 2,
+    });
+
+    // B is queued behind the lock — only A's frame has gone out so far.
+    await new Promise((r) => setImmediate(r));
+    expect(conn.sentFrames).toHaveLength(1);
+    const frameA = conn.sentFrames[0]!;
+    const tagA = (frameA as Buffer).readUInt32LE(1);
+
+    const bodyA = buildTraceDataBody({ pathHashes: [0x0d, 0x34], pathSz: 1, tag: tagA, snrs: [44], lastSnr: 8 });
+    (conn as any).onTraceDataPush(readerFor(bodyA));
+    const resA = await promiseA;
+    expect(resA.success).toBe(true);
+    expect(resA.data.pathSnrs).toEqual([44]);
+
+    // Only now does B's executor run: send its frame, patch its own parser.
+    await new Promise((r) => setImmediate(r));
+    expect(conn.sentFrames).toHaveLength(2);
+    const frameB = conn.sentFrames[1]!;
+    const tagB = (frameB as Buffer).readUInt32LE(1);
+    expect(tagB).not.toBe(tagA);
+
+    const bodyB = buildTraceDataBody({ pathHashes: [0xaa, 0xbb], pathSz: 1, tag: tagB, snrs: [99], lastSnr: 4 });
+    (conn as any).onTraceDataPush(readerFor(bodyB));
+    const resB = await promiseB;
+    expect(resB.success).toBe(true);
+    expect(resB.data.pathSnrs).toEqual([99]);
+  });
 });

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -22,12 +22,36 @@ import { isRfBridgeCommand, MESHCORE_RECEIVE_ONLY_MESSAGE } from './constants/me
 // upstream package; a workspace clone can be aliased via package.json.
 type AnyConnection = any;
 
+/** meshcore.js's internal BufferReader surface, as used by our corrected
+ * TraceData(0x89) push parser (see the `trace_path` dispatch case). */
+interface TraceDataBufferReader {
+  readByte(): number;
+  readUInt8(): number;
+  readUInt32LE(): number;
+  readBytes(count: number): Uint8Array;
+  readInt8(): number;
+}
+
+/** Parsed CMD_SEND_TRACE_PATH reply, correcting the pinned meshcore.js's
+ * `pathSnrs` over-read for multi-byte hop hashes (#4786). */
+interface TraceDataResponse {
+  reserved: number;
+  pathLen: number;
+  flags: number;
+  tag: number;
+  authCode: number;
+  pathHashes: Uint8Array;
+  pathSnrs: Uint8Array;
+  lastSnr: number;
+}
+
 interface MeshCoreJsModule {
   NodeJSSerialConnection: new (path: string) => AnyConnection;
   TCPConnection: new (host: string, port: number) => AnyConnection;
   Constants: {
     ResponseCodes: Record<string, number>;
     PushCodes: Record<string, number>;
+    CommandCodes: Record<string, number>;
     StatsTypes: { Core: number; Radio: number; Packets: number };
     SelfAdvertTypes: { ZeroHop: number; Flood: number };
     BinaryRequestTypes: { GetTelemetryData: number };
@@ -1329,14 +1353,85 @@ export class MeshCoreNativeBackend extends EventEmitter {
           throw new Error('trace_path requires a non-empty path');
         }
         const path = pathBytes instanceof Uint8Array ? pathBytes : Uint8Array.from(pathBytes);
-        const result = await c.tracePath(path, params.extra_timeout as number | undefined);
-        return {
-          ok: true,
-          pathLen: result.pathLen,
-          flags: result.flags,
-          pathSnrs: Array.from(result.pathSnrs as Uint8Array),
-          lastSnr: result.lastSnr,
+        // CMD_SEND_TRACE_PATH's flags byte packs the per-hop hash width as
+        // `1 << (flags & 0x03)` bytes (companion_radio/MyMesh.cpp), so only
+        // 1- and 2-byte hops are representable (path_sz 0/1); the caller
+        // rejects other widths before reaching here.
+        const hashBytes = Number(params.path_hash_bytes) || 1;
+        if (hashBytes !== 1 && hashBytes !== 2) {
+          throw new Error(`trace_path: unsupported hop hash width ${hashBytes} (device only supports 1 or 2 bytes/hop)`);
+        }
+        if (path.length % hashBytes !== 0) {
+          throw new Error(`trace_path: path length ${path.length} is not a multiple of hop hash width ${hashBytes}`);
+        }
+        const pathSz = hashBytes === 2 ? 1 : 0;
+
+        // The pinned meshcore.js's sendCommandSendTracePath() hardcodes
+        // flags=0, so any cached path wider than 1 byte/hop gets misread by
+        // the firmware as twice as many 1-byte hops and the trace times out
+        // (#4786). Build the frame ourselves so we can set the real width:
+        // [SendTracePath][tag:4 LE][auth:4 LE][flags][path bytes].
+        const tag = Math.floor(Math.random() * 0x1_0000_0000);
+        const frame = Buffer.alloc(1 + 4 + 4 + 1 + path.length);
+        frame.writeUInt8(K.CommandCodes.SendTracePath, 0);
+        frame.writeUInt32LE(tag, 1);
+        frame.writeUInt32LE(0, 5); // auth
+        frame.writeUInt8(pathSz, 9);
+        Buffer.from(path).copy(frame, 10);
+
+        // The library's own onTraceDataPush() also mis-parses multi-byte
+        // replies: it reads `pathSnrs` as `pathLen` bytes (the raw hash byte
+        // count) instead of the hop count (`pathLen >> path_sz`), so for
+        // 2-byte hops it reads into `lastSnr` and desyncs the payload.
+        // Install a corrected parser on the connection for the life of this
+        // request only; runExclusiveRadioOp below guarantees no concurrent
+        // trace_path can observe the swap.
+        const originalOnTraceDataPush = c.onTraceDataPush;
+        c.onTraceDataPush = (bufferReader: TraceDataBufferReader) => {
+          const reserved = bufferReader.readByte();
+          const respPathLen = bufferReader.readUInt8();
+          const respFlags = bufferReader.readUInt8();
+          const respPathSz = respFlags & 0x03;
+          const respTag = bufferReader.readUInt32LE();
+          const authCode = bufferReader.readUInt32LE();
+          const pathHashes = bufferReader.readBytes(respPathLen);
+          const hopCount = respPathSz > 0 ? respPathLen >> respPathSz : respPathLen;
+          const pathSnrs = bufferReader.readBytes(hopCount);
+          const lastSnr = bufferReader.readInt8() / 4;
+          c.emit(K.PushCodes.TraceData, {
+            reserved, pathLen: respPathLen, flags: respFlags, tag: respTag, authCode, pathHashes, pathSnrs, lastSnr,
+          });
         };
+
+        try {
+          const result = await this.runExclusiveRadioOp(() => new Promise<TraceDataResponse>((resolve, reject) => {
+            const onTraceData = (response: TraceDataResponse) => {
+              if (response.tag !== tag) return;
+              cleanup();
+              resolve(response);
+            };
+            const onErr = () => {
+              cleanup();
+              reject(new Error('Device rejected trace-path request'));
+            };
+            function cleanup() {
+              c.off(K.PushCodes.TraceData, onTraceData);
+              c.off(K.ResponseCodes.Err, onErr);
+            }
+            c.on(K.PushCodes.TraceData, onTraceData);
+            c.once(K.ResponseCodes.Err, onErr);
+            void c.sendToRadioFrame(frame);
+          }));
+          return {
+            ok: true,
+            pathLen: result.pathLen,
+            flags: result.flags,
+            pathSnrs: Array.from(result.pathSnrs as Uint8Array),
+            lastSnr: result.lastSnr,
+          };
+        } finally {
+          c.onTraceDataPush = originalOnTraceDataPush;
+        }
       }
 
       case 'share_contact': {

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -1379,59 +1379,74 @@ export class MeshCoreNativeBackend extends EventEmitter {
         frame.writeUInt8(pathSz, 9);
         Buffer.from(path).copy(frame, 10);
 
-        // The library's own onTraceDataPush() also mis-parses multi-byte
-        // replies: it reads `pathSnrs` as `pathLen` bytes (the raw hash byte
-        // count) instead of the hop count (`pathLen >> path_sz`), so for
-        // 2-byte hops it reads into `lastSnr` and desyncs the payload.
-        // Install a corrected parser on the connection for the life of this
-        // request only; runExclusiveRadioOp below guarantees no concurrent
-        // trace_path can observe the swap.
-        const originalOnTraceDataPush = c.onTraceDataPush;
-        c.onTraceDataPush = (bufferReader: TraceDataBufferReader) => {
-          const reserved = bufferReader.readByte();
-          const respPathLen = bufferReader.readUInt8();
-          const respFlags = bufferReader.readUInt8();
-          const respPathSz = respFlags & 0x03;
-          const respTag = bufferReader.readUInt32LE();
-          const authCode = bufferReader.readUInt32LE();
-          const pathHashes = bufferReader.readBytes(respPathLen);
-          const hopCount = respPathSz > 0 ? respPathLen >> respPathSz : respPathLen;
-          const pathSnrs = bufferReader.readBytes(hopCount);
-          const lastSnr = bufferReader.readInt8() / 4;
-          c.emit(K.PushCodes.TraceData, {
-            reserved, pathLen: respPathLen, flags: respFlags, tag: respTag, authCode, pathHashes, pathSnrs, lastSnr,
-          });
-        };
-
-        try {
-          const result = await this.runExclusiveRadioOp(() => new Promise<TraceDataResponse>((resolve, reject) => {
-            const onTraceData = (response: TraceDataResponse) => {
-              if (response.tag !== tag) return;
-              cleanup();
-              resolve(response);
-            };
-            const onErr = () => {
-              cleanup();
-              reject(new Error('Device rejected trace-path request'));
-            };
-            function cleanup() {
-              c.off(K.PushCodes.TraceData, onTraceData);
-              c.off(K.ResponseCodes.Err, onErr);
-            }
-            c.on(K.PushCodes.TraceData, onTraceData);
-            c.once(K.ResponseCodes.Err, onErr);
-            void c.sendToRadioFrame(frame);
-          }));
-          return {
-            ok: true,
-            pathLen: result.pathLen,
-            flags: result.flags,
-            pathSnrs: Array.from(result.pathSnrs as Uint8Array),
-            lastSnr: result.lastSnr,
+        // Guarantees the swap below can't bleed into a queued trace_path (or
+        // any other radio op waiting on this connection's lock): a call
+        // queued behind this one only starts its own executor — and its own
+        // patch/restore — after cleanup() has already restored this call's
+        // handler. Patching outside runExclusiveRadioOp would let a second
+        // call's synchronous dispatch-time patch land before this call's own
+        // send/reply window, which is only serialized against *sends*, not
+        // against arbitrary property writes on `c`.
+        const timeoutMs = Number(params.timeout_ms) || 45_000;
+        const result = await this.runExclusiveRadioOp(() => new Promise<TraceDataResponse>((resolve, reject) => {
+          // The library's own onTraceDataPush() also mis-parses multi-byte
+          // replies: it reads `pathSnrs` as `pathLen` bytes (the raw hash
+          // byte count) instead of the hop count (`pathLen >> path_sz`), so
+          // for 2-byte hops it reads into `lastSnr` and desyncs the payload.
+          // Install a corrected parser for exactly this request's window.
+          const originalOnTraceDataPush = c.onTraceDataPush;
+          c.onTraceDataPush = (bufferReader: TraceDataBufferReader) => {
+            const reserved = bufferReader.readByte();
+            const respPathLen = bufferReader.readUInt8();
+            const respFlags = bufferReader.readUInt8();
+            const respPathSz = respFlags & 0x03;
+            const respTag = bufferReader.readUInt32LE();
+            const authCode = bufferReader.readUInt32LE();
+            const pathHashes = bufferReader.readBytes(respPathLen);
+            const hopCount = respPathSz > 0 ? respPathLen >> respPathSz : respPathLen;
+            const pathSnrs = bufferReader.readBytes(hopCount);
+            const lastSnr = bufferReader.readInt8() / 4;
+            c.emit(K.PushCodes.TraceData, {
+              reserved, pathLen: respPathLen, flags: respFlags, tag: respTag, authCode, pathHashes, pathSnrs, lastSnr,
+            });
           };
-        } finally {
-          c.onTraceDataPush = originalOnTraceDataPush;
-        }
+
+          // Own timeout (mirrors request_owner/request_regions above): a
+          // trace that never gets Sent/TraceData/Err back must still settle
+          // this promise, or runExclusiveRadioOp's chain — and every other
+          // radio op queued on this connection — would stall forever behind
+          // it. Kept comfortably under sendCommand's outer timeout so this
+          // fires first and always releases the lock via cleanup().
+          const timer = setTimeout(() => {
+            cleanup();
+            reject(new Error('trace_path timed out'));
+          }, timeoutMs);
+          const onTraceData = (response: TraceDataResponse) => {
+            if (response.tag !== tag) return;
+            cleanup();
+            resolve(response);
+          };
+          const onErr = () => {
+            cleanup();
+            reject(new Error('Device rejected trace-path request'));
+          };
+          function cleanup() {
+            clearTimeout(timer);
+            c.off(K.PushCodes.TraceData, onTraceData);
+            c.off(K.ResponseCodes.Err, onErr);
+            c.onTraceDataPush = originalOnTraceDataPush;
+          }
+          c.on(K.PushCodes.TraceData, onTraceData);
+          c.once(K.ResponseCodes.Err, onErr);
+          void c.sendToRadioFrame(frame);
+        }));
+        return {
+          ok: true,
+          pathLen: result.pathLen,
+          flags: result.flags,
+          pathSnrs: Array.from(result.pathSnrs as Uint8Array),
+          lastSnr: result.lastSnr,
+        };
       }
 
       case 'share_contact': {


### PR DESCRIPTION
## Summary

Fixes #4786.

`MeshCoreManager.traceContactPath()` flattened a cached `out_path` into raw bytes but never told the device how wide each hop hash is. The pinned `meshcore.js`'s `CMD_SEND_TRACE_PATH` always ships `flags=0`, so a discovered 2-byte hop (e.g. `0d34`) gets read by the companion firmware as two 1-byte hops (`0d` then `34`); the trace then waits on a nonexistent second hop and times out.

- `traceContactPath()` now infers the per-hop hash width from the cached path, rejects mixed-width or malformed cached paths, and rejects 3-byte paths specifically — the device's `CMD_SEND_TRACE_PATH` flags byte only encodes `1 << (flags & 0x03)` bytes/hop (companion_radio/`MyMesh.cpp`), so 1 and 2 bytes are representable but 3 is not. This matches the issue's note that the 3-byte limitation is a separate, out-of-scope firmware/protocol issue.
- `MeshCoreNativeBackend`'s `trace_path` case bypasses the pinned `meshcore.js`'s `tracePath()`/`sendCommandSendTracePath()` (which hardcodes `flags=0`) by hand-building the `CMD_SEND_TRACE_PATH` frame with the correct flags byte — the same manual-frame pattern already used in this file for `request_owner`/`request_regions`.
- While tracing the wire format against the pinned `meshcore.js` fork and `companion_radio/MyMesh.cpp`, I found a second, related bug: the library's own `onTraceDataPush()` reads `pathSnrs` as `pathLen` bytes (the raw path-hash byte count) instead of the hop count (`pathLen >> path_sz`), so a multi-byte-hop reply would desync the whole parse even with the outgoing flags fixed. The `trace_path` case installs a corrected parser on the connection for the life of each request (restored afterward) rather than depending on an upstream `meshcore.js` change.

No changes were needed to the pinned `meshcore.js` dependency — both bugs are worked around entirely within MeshMonitor's own native backend.

## Test plan

- [x] New `meshcoreNativeBackend.tracePath.test.ts`: verifies the outgoing frame's flags byte for 1-byte (`0`) and 2-byte (`1`) paths, verifies the corrected TraceData response parser recovers the right hop-SNR array length and `lastSnr` for a 2-byte-hop reply (the reported bug), tag-mismatch is ignored, unsupported (3-byte) width is rejected, `Err` is surfaced as a rejection, and the connection's original `onTraceDataPush` is restored after the request settles.
- [x] New `meshcoreManager.tracePathHashWidth.test.ts`: verifies 1-byte and 2-byte cached paths are sent with the correct `path_hash_bytes`/byte array, and that 3-byte, mixed-width, and malformed cached paths are rejected without transmitting.
- [x] `npx tsc --noEmit` (both `tsconfig.server.json` and full `tsconfig.json`) — clean.
- [x] `npm run lint:ci` — clean (no baseline growth; the fix introduced no new `@typescript-eslint/no-explicit-any` by adding two local wire-format interfaces instead).
- [x] Full `meshcoreManager*.test.ts` + `meshcoreNativeBackend*.test.ts` suite: 578/578 passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQ6WW1S8zHUwmXa8BTQ6c8)_