### PR TITLE
fix(mobile): keep the bottom nav tappable under the search modal (#4774)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3245,6 +3245,16 @@ function App() {
     }
   }, [setActiveTab, setSelectedDMNode, setSelectedChannel]);
 
+  // On mobile the search modal opens over the bottom nav. Once the nav is
+  // reachable again (#4774), tapping another nav item changes the active tab,
+  // and the transient modal should get out of the way rather than linger over
+  // the destination view. Closing on tab change makes search behave like the
+  // rest of the tab bar. Opening search does not change activeTab, so this does
+  // not fight the open action.
+  useEffect(() => {
+    setIsSearchOpen(false);
+  }, [activeTab]);
+
   // Ctrl+K / Cmd+K keyboard shortcut to toggle search modal
   const canSearch = hasPermission('messages', 'read') ||
     Array.from({ length: 8 }, (_, i) =>

--- a/src/components/SearchModal/SearchModal.css
+++ b/src/components/SearchModal/SearchModal.css
@@ -289,6 +289,10 @@
      when the bar is not mounted. The keyboard inset is still handled by the
      base .search-modal-overlay padding-bottom (issue #2994). */
   .search-modal-overlay {
+    /* --source-nav-bar-height is offsetHeight, which ALREADY includes the nav's
+       safe-area padding-bottom, so it is used as-is. Only the static fallback
+       adds env(safe-area-inset-bottom). Do NOT add env() to the real-height
+       branch or the inset is counted twice. */
     bottom: var(
       --source-nav-bar-height,
       calc(var(--app-nav-bar-height, 56px) + env(safe-area-inset-bottom, 0px))

--- a/src/components/SearchModal/SearchModal.css
+++ b/src/components/SearchModal/SearchModal.css
@@ -281,13 +281,18 @@
 
 @media (max-width: 768px) {
   /* Stop the overlay above the bottom navigation bar so the nav stays visible
-     and tappable instead of being covered (the overlay and the nav share
-     z-index 10001, and the overlay paints later). The nav reserves
-     --app-nav-bar-height + safe-area-inset-bottom, so clearing exactly that
-     docks the modal right above it (#4774). The keyboard inset is still handled
-     by the base .search-modal-overlay padding-bottom (issue #2994). */
+     AND tappable instead of being covered. The overlay outranks the nav in
+     z-index, so any strip where it overlaps the nav swallows the nav's taps
+     (visible but not clickable, #4774). SourceNav publishes its REAL height as
+     --source-nav-bar-height (which already includes the safe-area inset), so we
+     clear exactly the rendered nav; the static estimate is only a fallback for
+     when the bar is not mounted. The keyboard inset is still handled by the
+     base .search-modal-overlay padding-bottom (issue #2994). */
   .search-modal-overlay {
-    bottom: calc(var(--app-nav-bar-height, 56px) + env(safe-area-inset-bottom, 0px));
+    bottom: var(
+      --source-nav-bar-height,
+      calc(var(--app-nav-bar-height, 56px) + env(safe-area-inset-bottom, 0px))
+    );
   }
 
   .search-modal {

--- a/src/components/nav/SourceNav.heightPublish.test.tsx
+++ b/src/components/nav/SourceNav.heightPublish.test.tsx
@@ -117,6 +117,42 @@ describe('SourceNav publishes its measured bottom-bar height (#4774)', () => {
     unmount();
     expect(document.documentElement.style.getPropertyValue(PROP)).toBe('');
   });
+
+  it('clears the property when the viewport crosses out of the bottom-bar breakpoint mid-mount', () => {
+    // Drive the matchMedia 'change' path directly: a phone rotated to a wide
+    // landscape (or a resized window) toggles matches without a ResizeObserver
+    // fire, and the published height must be withdrawn.
+    let matches = true;
+    const changeListeners: Array<() => void> = [];
+    const mql = {
+      get matches() {
+        return matches;
+      },
+      media: '',
+      onchange: null,
+      addEventListener: (ev: string, cb: () => void) => {
+        if (ev === 'change') changeListeners.push(cb);
+      },
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    };
+    Object.defineProperty(window, 'matchMedia', { writable: true, value: vi.fn(() => mql) });
+
+    const { container } = render(
+      <SourceNav sections={sections} activeId="nodes" collapsed mobileVariant="bottom-bar" />,
+    );
+    const nav = container.querySelector('[data-source-nav]') as HTMLElement;
+    Object.defineProperty(nav, 'offsetHeight', { configurable: true, value: 64 });
+    roCallback?.();
+    expect(document.documentElement.style.getPropertyValue(PROP)).toBe('64px');
+
+    // Viewport widens past the breakpoint: matches flips and the mq fires.
+    matches = false;
+    changeListeners.forEach(cb => cb());
+    expect(document.documentElement.style.getPropertyValue(PROP)).toBe('');
+  });
 });
 
 describe('SearchModal overlay consumes the published nav height (#4774)', () => {

--- a/src/components/nav/SourceNav.heightPublish.test.tsx
+++ b/src/components/nav/SourceNav.heightPublish.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+/**
+ * #4774 regression: the mobile bottom bar must publish its REAL rendered height
+ * so the search modal overlay docks above the actual nav rather than a static
+ * 56px estimate. When the nav was taller than the estimate (safe-area inset,
+ * large system text, or the expanded state) the overlay (which outranks the nav
+ * in z-index) covered the nav's top strip and swallowed its taps: the nav was
+ * visible but not clickable until the modal was closed.
+ *
+ * These cover both halves:
+ *   - the publisher (SourceNav sets --source-nav-bar-height to offsetHeight when
+ *     it is the bottom bar, and removes it otherwise / on unmount), and
+ *   - the consumer (SearchModal.css reads that variable for the overlay bottom).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { render, cleanup } from '@testing-library/react';
+import { SourceNav, type SourceNavSection } from './SourceNav';
+
+const sections: SourceNavSection[] = [
+  { items: [{ id: 'nodes', label: 'Nodes', icon: 'nodes', onClick: () => {} }] },
+];
+
+const PROP = '--source-nav-bar-height';
+
+/** Capture the ResizeObserver callback so the test can drive a "resize". */
+let roCallback: (() => void) | null = null;
+
+function setViewportMatches(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+beforeEach(() => {
+  roCallback = null;
+  // Minimal ResizeObserver stub: remember the callback, no auto-fire.
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    constructor(cb: () => void) {
+      roCallback = cb;
+    }
+    observe() {}
+    disconnect() {}
+  };
+  document.documentElement.style.removeProperty(PROP);
+});
+
+afterEach(() => {
+  cleanup();
+  document.documentElement.style.removeProperty(PROP);
+  delete (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver;
+});
+
+describe('SourceNav publishes its measured bottom-bar height (#4774)', () => {
+  it('sets --source-nav-bar-height to the real offsetHeight when it is the bottom bar', () => {
+    setViewportMatches(true); // below the 768px breakpoint
+    const { container } = render(
+      <SourceNav sections={sections} activeId="nodes" collapsed mobileVariant="bottom-bar" />,
+    );
+    const nav = container.querySelector('[data-source-nav]') as HTMLElement;
+    expect(nav).toBeTruthy();
+    // jsdom does no layout, so force a realistic height that exceeds the 56px
+    // static estimate — this is exactly the condition that caused the overlap.
+    Object.defineProperty(nav, 'offsetHeight', { configurable: true, value: 72 });
+
+    // A resize (rotation, tab-set change) is what re-measures on a real device.
+    roCallback?.();
+
+    expect(document.documentElement.style.getPropertyValue(PROP)).toBe('72px');
+  });
+
+  it('does NOT publish when the viewport is above the bottom-bar breakpoint', () => {
+    setViewportMatches(false); // desktop / rail layout
+    const { container } = render(
+      <SourceNav sections={sections} activeId="nodes" collapsed mobileVariant="bottom-bar" />,
+    );
+    const nav = container.querySelector('[data-source-nav]') as HTMLElement;
+    Object.defineProperty(nav, 'offsetHeight', { configurable: true, value: 500 });
+    roCallback?.();
+
+    expect(document.documentElement.style.getPropertyValue(PROP)).toBe('');
+  });
+
+  it('does NOT publish for the rail variant even on a narrow viewport', () => {
+    setViewportMatches(true);
+    const { container } = render(
+      <SourceNav sections={sections} activeId="nodes" collapsed mobileVariant="rail" />,
+    );
+    const nav = container.querySelector('[data-source-nav]') as HTMLElement;
+    Object.defineProperty(nav, 'offsetHeight', { configurable: true, value: 500 });
+    roCallback?.();
+
+    expect(document.documentElement.style.getPropertyValue(PROP)).toBe('');
+  });
+
+  it('removes the property on unmount so a stale value cannot linger', () => {
+    setViewportMatches(true);
+    const { container, unmount } = render(
+      <SourceNav sections={sections} activeId="nodes" collapsed mobileVariant="bottom-bar" />,
+    );
+    const nav = container.querySelector('[data-source-nav]') as HTMLElement;
+    Object.defineProperty(nav, 'offsetHeight', { configurable: true, value: 60 });
+    roCallback?.();
+    expect(document.documentElement.style.getPropertyValue(PROP)).toBe('60px');
+
+    unmount();
+    expect(document.documentElement.style.getPropertyValue(PROP)).toBe('');
+  });
+});
+
+describe('SearchModal overlay consumes the published nav height (#4774)', () => {
+  const css = readFileSync(resolve('src/components/SearchModal/SearchModal.css'), 'utf-8');
+
+  it('the mobile overlay bottom reads --source-nav-bar-height with the static fallback', () => {
+    const mobile = css.slice(css.indexOf('@media (max-width: 768px)'));
+    const m = mobile.match(/\.search-modal-overlay\s*\{([^}]*)\}/);
+    expect(m).not.toBeNull();
+    const bottom = m![1].match(/bottom:\s*([^;]+)/)?.[1].replace(/\s+/g, ' ').trim();
+    expect(bottom).toBeDefined();
+    // Real measured height first, static estimate only as fallback.
+    expect(bottom).toMatch(/var\(\s*--source-nav-bar-height/);
+    expect(bottom).toMatch(/--app-nav-bar-height/); // fallback preserved
+  });
+});

--- a/src/components/nav/SourceNav.tsx
+++ b/src/components/nav/SourceNav.tsx
@@ -167,6 +167,9 @@ export const SourceNav: React.FC<SourceNavProps> = ({
       el.removeEventListener('scroll', measure);
       observer?.disconnect();
       bottomBarMq?.removeEventListener?.('change', onResize);
+      // Intentionally unconditional: removeProperty is a no-op when we never
+      // published (rail / desktop), so clearing on every teardown is safe and
+      // guarantees a stale height can never outlive this nav.
       document.documentElement.style.removeProperty('--source-nav-bar-height');
     };
   }, [sections, collapsed, mobileVariant]);

--- a/src/components/nav/SourceNav.tsx
+++ b/src/components/nav/SourceNav.tsx
@@ -120,17 +120,54 @@ export const SourceNav: React.FC<SourceNavProps> = ({
       });
     };
 
+    // Publish the bar's REAL rendered height so overlays that dock above it
+    // (the search modal) clear the actual nav, not the static
+    // `--app-nav-bar-height: 56px` estimate. A taller bar (safe-area inset,
+    // large system text, or the expanded state) overflowed that estimate, and
+    // because the search overlay outranks the nav in z-index its hit-box then
+    // covered the visible-but-untappable top strip of the nav (#4774). Only the
+    // bottom-bar layout (below the 768px breakpoint) docks, so the property is
+    // published only then and removed otherwise, leaving the static fallback in
+    // place. offsetHeight already includes the safe-area padding-bottom.
+    const bottomBarMq =
+      typeof window !== 'undefined' && window.matchMedia
+        ? window.matchMedia('(max-width: 768px), (max-height: 500px) and (orientation: landscape)')
+        : null;
+    let publishedHeight = -1;
+    const publishHeight = () => {
+      const active = mobileVariant === 'bottom-bar' && !!bottomBarMq?.matches;
+      if (active) {
+        const h = el.offsetHeight;
+        if (h !== publishedHeight) {
+          publishedHeight = h;
+          document.documentElement.style.setProperty('--source-nav-bar-height', `${h}px`);
+        }
+      } else if (publishedHeight !== -1) {
+        publishedHeight = -1;
+        document.documentElement.style.removeProperty('--source-nav-bar-height');
+      }
+    };
+
+    const onResize = () => {
+      measure();
+      publishHeight();
+    };
+
     measure();
+    publishHeight();
     el.addEventListener('scroll', measure, { passive: true });
     // Tab set and viewport both change the answer: permissions can add or drop
     // entries, and rotation changes how many fit.
     const observer =
-      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(measure) : null;
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(onResize) : null;
     observer?.observe(el);
+    bottomBarMq?.addEventListener?.('change', onResize);
 
     return () => {
       el.removeEventListener('scroll', measure);
       observer?.disconnect();
+      bottomBarMq?.removeEventListener?.('change', onResize);
+      document.documentElement.style.removeProperty('--source-nav-bar-height');
     };
   }, [sections, collapsed, mobileVariant]);
 


### PR DESCRIPTION
Fixes #4774 (the regression reopened after #4776).

## Problem

#4776 stopped the mobile search overlay from *visually* covering the bottom nav, but Wilhelm reported the nav was still **un-tappable** — buttons visible, taps ignored until the modal's close button was pressed.

## Root cause (confirmed on a live mobile viewport)

The overlay reserves a **static** `--app-nav-bar-height` (56px), but the nav's *actual* rendered height varies — safe-area inset, large system text, or the expanded state push it past 56px. When the nav is taller than the reserved strip, its top pokes above the overlay's bottom edge, and since the overlay (`z-index: 10001`) outranks the nav (`z-index: 900`), that strip **swallows the taps**. "Visible but not clickable."

I reproduced this by forcing the reserved strip below the nav height and hit-testing: `elementFromPoint` over the nav returned `search-modal-body` (the overlay), not the nav.

A z-index bump was rejected — there are legitimate full-screen modals at z 10000–10002 and 100000 that the nav *should* sit under.

## Fix

Root-cause: make the overlay reserve the nav's **real** height.

- **`SourceNav.tsx`** publishes its measured `offsetHeight` as `--source-nav-bar-height` via its existing `ResizeObserver`, gated to the mobile bottom-bar layout and removed otherwise / on unmount. (`offsetHeight` already includes the safe-area inset.)
- **`SearchModal.css`** reads that variable for the overlay's mobile `bottom`, falling back to the old static estimate when the bar isn't mounted — so it always docks above the actual nav.
- **`App.tsx`** closes the search modal on active-tab change, so tapping another nav item lands you on that view instead of leaving the modal lingering over it (the tab-bar mental model from the issue's UX note).

## Verification (built container, 390px viewport)

| Check | Result |
|-------|--------|
| Nav publishes real height | `--source-nav-bar-height: 53px` ✓ |
| Overlay docks at nav top, no overlap, nav hit-testable (natural) | ✓ |
| Nav forced to **96px** → ResizeObserver re-publishes → overlay follows → still tappable | ✓ |
| Tapping a different nav tab closes the modal + navigates | ✓ |

## Tests

- New `SourceNav.heightPublish.test.tsx`: publishes on bottom-bar, not on rail/desktop, removes on unmount; plus a CSS-source guard that the overlay consumes the variable.
- Existing SourceNav / SearchModal / bottom-bar-clearance suites still green (50 tests). tsc clean, lint ratchet clean.

## Notes / scope

- Sibling dockers (`SaveBar.css`, `nodes.css`) share the same static-56px reservation and have the same latent risk; left as-is to keep this focused on the reported regression.
- Tapping the *already-active* tab doesn't close the modal (no `activeTab` change); the × button and any other tab do. Minor, not the reported bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G