### PR TITLE
feat(automation): note the firmware 2.8 MeshBeacon alternative on Auto Announce (#4731)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2397,6 +2397,7 @@
   "automation.auto_welcome.mark_welcomed_failed": "Failed to mark nodes as welcomed",
   "automation.auto_announce.title": "Auto Announce",
   "automation.auto_announce.description": "When enabled, automatically broadcast an announcement message to a selected channel at the configured interval. Use tokens like {VERSION}, {DURATION}, {FEATURES}, {NODECOUNT}, and {DIRECTCOUNT} for dynamic content.",
+  "automation.auto_announce.native_notice": "Heads up: firmware 2.8's MeshBeacon module can broadcast a periodic message natively (see the MeshBeacon settings). It's more limited than Auto Announce, though — it's zero-hop (only direct neighbors hear it), capped at a minimum one-hour interval, and currently only on the Meshtastic development branch, not a released firmware — so it isn't a full replacement.",
   "automation.auto_announce.channel": "Channel",
   "automation.auto_announce.channel_description": "Select which channel to broadcast the announcement",
   "automation.auto_announce.schedule": "Schedule",

--- a/src/components/AutoAnnounceSection.test.tsx
+++ b/src/components/AutoAnnounceSection.test.tsx
@@ -860,3 +860,45 @@ describe.skip('AutoAnnounceSection Component', () => {
     });
   });
 });
+
+// Standalone suite — the legacy describe above is `.skip`ped (it broke in the
+// SaveBar refactor). This runs independently so #4731's notice is actually
+// covered. Module-level mocks (react-i18next, useCsrfFetch, ToastContainer,
+// useSaveBar, useSourceQuery) apply here too.
+describe('AutoAnnounceSection — firmware 2.8 MeshBeacon notice (#4731)', () => {
+  const props = {
+    enabled: true,
+    intervalHours: 6,
+    message: 'hi',
+    channelIndexes: [0],
+    announceOnStart: false,
+    useSchedule: false,
+    schedule: '0 */6 * * *',
+    channels: [] as Channel[],
+    baseUrl: '',
+    onEnabledChange: vi.fn(),
+    onIntervalChange: vi.fn(),
+    onMessageChange: vi.fn(),
+    onChannelIndexesChange: vi.fn(),
+    onAnnounceOnStartChange: vi.fn(),
+    onUseScheduleChange: vi.fn(),
+    onScheduleChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    (global.fetch as any) = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ lastAnnouncementTime: Date.now() }),
+    });
+  });
+
+  it('renders the notice, worded to the verified firmware behavior', () => {
+    render(<AutoAnnounceSection {...props} />);
+    const notice = screen.getByText(/firmware 2\.8's MeshBeacon module/i);
+    expect(notice).toBeInTheDocument();
+    expect(notice.textContent).toMatch(/zero-hop/i);
+    expect(notice.textContent).toMatch(/development branch/i);
+    // Must NOT claim a native "Auto Welcome" exists (the firmware has none).
+    expect(notice.textContent || '').not.toMatch(/auto[- ]?welcome/i);
+  });
+});

--- a/src/components/AutoAnnounceSection.tsx
+++ b/src/components/AutoAnnounceSection.tsx
@@ -379,6 +379,22 @@ const AutoAnnounceSection: React.FC<AutoAnnounceSectionProps> = ({
           {t('automation.auto_announce.description')}
         </p>
 
+        {/* #4731: point users at the firmware-native alternative, worded to the
+            verified 2.8 behavior — MeshBeacon is a periodic broadcaster (overlaps
+            Auto Announce), NOT the "Auto Welcome" the reporter assumed, and it is
+            dev-branch/unreleased + zero-hop + >=1h interval. Do not overstate it. */}
+        <div style={{
+          padding: '0.75rem 1rem',
+          backgroundColor: 'var(--color-surface)',
+          borderRadius: '0.5rem',
+          color: 'var(--color-text-subtle)',
+          fontSize: '0.9rem',
+          lineHeight: '1.5',
+          marginBottom: '1rem',
+        }}>
+          {t('automation.auto_announce.native_notice', "Heads up: firmware 2.8's MeshBeacon module can broadcast a periodic message natively (see the MeshBeacon settings). It's more limited than Auto Announce, though — it's zero-hop (only direct neighbors hear it), capped at a minimum one-hour interval, and currently only on the Meshtastic development branch, not a released firmware — so it isn't a full replacement.")}
+        </div>
+
         {lastAnnouncementTime && (
           <div style={{
             marginBottom: '1rem',


### PR DESCRIPTION
Addresses #4731.

## The issue's premise didn't hold — so I verified the firmware first
#4731 asked for a notice that Meshtastic 2.8 has a **native "Auto Welcome"** feature. I had the meshtastic-expert check the actual `meshtastic/firmware` source:

- **There is no native "Auto Welcome" automation, and no "Automation" config section.** No firmware path triggers on a newly-heard node to send a welcome text.
- The only feature in this space is the **MeshBeacon module** — a *periodic broadcaster*. That overlaps our **Auto Announce**, not Auto Welcome. The reporter conflated the two.
- MeshBeacon is **development-branch only** (not in any released firmware), **zero-hop** (direct neighbors only), and floored at a **1-hour** minimum interval.

## What this ships
- **Auto Announce section**: an informational (not deprecation) notice pointing at the MeshBeacon alternative, worded to the verified limits so it isn't oversold.
- **Auto Welcome section**: **no notice** — a "2.8 does this natively" claim there would be false and misleading.
- **MeshBeacon config**: already correctly caveated ("only on the development branch for 2.8") — untouched.

## Notice copy
> Heads up: firmware 2.8's MeshBeacon module can broadcast a periodic message natively (see the MeshBeacon settings). It's more limited than Auto Announce, though — it's zero-hop (only direct neighbors hear it), capped at a minimum one-hour interval, and currently only on the Meshtastic development branch, not a released firmware — so it isn't a full replacement.

## Tests
Added a **standalone** test suite (the legacy `AutoAnnounceSection` describe is `.skip`ped from an older SaveBar refactor) asserting the notice renders, mentions the real limits, and **never** claims a native Auto Welcome exists. Build + `lint:ci` clean; en.json valid.

## Mesh impact
None — a static informational UI string; sends nothing, arms no timers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)