### PR TITLE
feat(map): add satellite + labels (hybrid) tile option (#4728)

### DIFF
--- a/src/components/map/BaseMap.test.tsx
+++ b/src/components/map/BaseMap.test.tsx
@@ -23,12 +23,13 @@ vi.mock('react-leaflet', () => ({
       {children}
     </div>
   ),
-  TileLayer: (props: { url?: string; maxZoom?: number; zIndex?: number }) => (
+  TileLayer: (props: { url?: string; maxZoom?: number; zIndex?: number; attribution?: string }) => (
     <div
       data-testid="raster-tile"
       data-url={props.url}
       data-maxzoom={String(props.maxZoom)}
       data-zindex={props.zIndex === undefined ? '' : String(props.zIndex)}
+      data-attribution={props.attribution}
     />
   ),
   useMap: () => ({ invalidateSize: vi.fn() }),
@@ -114,6 +115,11 @@ describe('BaseMap', () => {
     expect(base.getAttribute('data-zindex')).toBe(''); // base uses the leaflet default
     expect(overlay.getAttribute('data-url')).toContain('World_Reference_Overlay');
     expect(Number(overlay.getAttribute('data-zindex'))).toBeGreaterThan(0);
+
+    // The overlay's data sources differ from the imagery, so it carries its own
+    // attribution (Garmin/USGS/NPS) rather than reusing the base's credit.
+    expect(overlay.getAttribute('data-attribution')).not.toBe(base.getAttribute('data-attribution'));
+    expect(overlay.getAttribute('data-attribution')).toContain('Garmin');
 
     expect(screen.queryByTestId('vector-tile')).not.toBeInTheDocument();
   });

--- a/src/components/map/BaseMap.test.tsx
+++ b/src/components/map/BaseMap.test.tsx
@@ -23,8 +23,13 @@ vi.mock('react-leaflet', () => ({
       {children}
     </div>
   ),
-  TileLayer: (props: { url?: string; maxZoom?: number }) => (
-    <div data-testid="raster-tile" data-url={props.url} data-maxzoom={String(props.maxZoom)} />
+  TileLayer: (props: { url?: string; maxZoom?: number; zIndex?: number }) => (
+    <div
+      data-testid="raster-tile"
+      data-url={props.url}
+      data-maxzoom={String(props.maxZoom)}
+      data-zindex={props.zIndex === undefined ? '' : String(props.zIndex)}
+    />
   ),
   useMap: () => ({ invalidateSize: vi.fn() }),
   useMapEvents: () => ({ invalidateSize: vi.fn() }),
@@ -94,6 +99,30 @@ describe('BaseMap', () => {
     const rasterTile = screen.getByTestId('raster-tile');
     expect(rasterTile).toBeInTheDocument();
     expect(rasterTile.getAttribute('data-url')).toBe(OSM_URL);
+  });
+
+  // 3c. Hybrid overlay branch: a raster tileset with an `overlayUrl` renders a
+  // SECOND transparent TileLayer on top of the base, at a higher zIndex so the
+  // labels/roads sit above the imagery.
+  it('renders a second overlay TileLayer above the base when the tileset has an overlayUrl (esriHybrid)', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} tilesetId="esriHybrid" />);
+    const tiles = screen.getAllByTestId('raster-tile');
+    expect(tiles).toHaveLength(2);
+
+    const [base, overlay] = tiles;
+    expect(base.getAttribute('data-url')).toContain('World_Imagery');
+    expect(base.getAttribute('data-zindex')).toBe(''); // base uses the leaflet default
+    expect(overlay.getAttribute('data-url')).toContain('World_Reference_Overlay');
+    expect(Number(overlay.getAttribute('data-zindex'))).toBeGreaterThan(0);
+
+    expect(screen.queryByTestId('vector-tile')).not.toBeInTheDocument();
+  });
+
+  it('renders only the base raster tile (no overlay) for a tileset without overlayUrl', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} tilesetId="esriSatellite" />);
+    const tiles = screen.getAllByTestId('raster-tile');
+    expect(tiles).toHaveLength(1);
+    expect(tiles[0].getAttribute('data-url')).toContain('World_Imagery');
   });
 
   // 3b. Raster tile-layer keying (tile-loading regression fix): the raster

--- a/src/components/map/BaseMap.tsx
+++ b/src/components/map/BaseMap.tsx
@@ -148,12 +148,28 @@ export function BaseMap({
             />
           )
           : (
-            <TileLayer
-              key={`raster-${tileset.maxZoom}`}
-              url={tileset.url}
-              attribution={tileset.attribution}
-              maxZoom={tileset.maxZoom}
-            />
+            <>
+              <TileLayer
+                key={`raster-${tileset.maxZoom}`}
+                url={tileset.url}
+                attribution={tileset.attribution}
+                maxZoom={tileset.maxZoom}
+              />
+              {/* Optional transparent label/road overlay drawn on top of the
+                  base raster (e.g. the satellite+labels hybrid). Keyed like the
+                  base by maxZoom so same-ceiling swaps refresh in place; a
+                  higher zIndex keeps it above the base tiles. Absent when the
+                  tileset defines no overlayUrl. */}
+              {tileset.overlayUrl && (
+                <TileLayer
+                  key={`raster-overlay-${tileset.maxZoom}`}
+                  url={tileset.overlayUrl}
+                  attribution={tileset.attribution}
+                  maxZoom={tileset.maxZoom}
+                  zIndex={10}
+                />
+              )}
+            </>
           )}
         {resizeTrigger !== undefined && <MapResizeHandler trigger={resizeTrigger} />}
         {children}

--- a/src/components/map/BaseMap.tsx
+++ b/src/components/map/BaseMap.tsx
@@ -164,7 +164,7 @@ export function BaseMap({
                 <TileLayer
                   key={`raster-overlay-${tileset.maxZoom}`}
                   url={tileset.overlayUrl}
-                  attribution={tileset.attribution}
+                  attribution={tileset.overlayAttribution ?? tileset.attribution}
                   maxZoom={tileset.maxZoom}
                   zIndex={10}
                 />

--- a/src/config/overlayColors.test.ts
+++ b/src/config/overlayColors.test.ts
@@ -45,14 +45,15 @@ describe('overlayColors', () => {
   });
 
   describe('tilesetSchemeMap completeness', () => {
-    it('maps all 6 built-in tilesets', () => {
-      expect(Object.keys(tilesetSchemeMap)).toHaveLength(6);
+    it('maps all 7 built-in tilesets', () => {
+      expect(Object.keys(tilesetSchemeMap)).toHaveLength(7);
       expect(tilesetSchemeMap).toHaveProperty('osm');
       expect(tilesetSchemeMap).toHaveProperty('osmHot');
       expect(tilesetSchemeMap).toHaveProperty('cartoDark');
       expect(tilesetSchemeMap).toHaveProperty('cartoLight');
       expect(tilesetSchemeMap).toHaveProperty('openTopo');
       expect(tilesetSchemeMap).toHaveProperty('esriSatellite');
+      expect(tilesetSchemeMap).toHaveProperty('esriHybrid');
     });
   });
 

--- a/src/config/overlayColors.ts
+++ b/src/config/overlayColors.ts
@@ -102,6 +102,7 @@ export const tilesetSchemeMap: Record<string, OverlayScheme> = {
   cartoLight: 'light',
   openTopo: 'light',
   esriSatellite: 'dark',
+  esriHybrid: 'dark',
 };
 
 /** Get the overlay scheme for a tileset ID. Custom tilesets default to 'dark'. */

--- a/src/config/tilesets.test.ts
+++ b/src/config/tilesets.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TILESETS,
+  getTilesetById,
+  getAllTilesets,
+  type CustomTileset,
+} from './tilesets';
+
+describe('tilesets — hybrid overlay support', () => {
+  it('exposes the esriHybrid tileset with an ESRI reference-label overlayUrl', () => {
+    const hybrid = TILESETS.esriHybrid;
+    expect(hybrid).toBeDefined();
+    expect(hybrid.name).toBe('Satellite + Labels');
+    // Base is the same imagery as the plain satellite tileset...
+    expect(hybrid.url).toContain('World_Imagery');
+    // ...with a transparent reference overlay stacked on top.
+    expect(hybrid.overlayUrl).toBeDefined();
+    expect(hybrid.overlayUrl).toContain('World_Reference_Overlay');
+    expect(hybrid.overlayUrl).toMatch(/\{z\}.*\{y\}.*\{x\}/); // ESRI z/y/x order
+  });
+
+  it('plain esriSatellite has no overlayUrl (kept as a distinct option)', () => {
+    expect(TILESETS.esriSatellite.overlayUrl).toBeUndefined();
+  });
+
+  it('getTilesetById resolves esriHybrid with its overlayUrl intact', () => {
+    const t = getTilesetById('esriHybrid');
+    expect(t.id).toBe('esriHybrid');
+    expect(t.overlayUrl).toContain('World_Reference_Overlay');
+  });
+
+  it('getTilesetById passes overlayUrl through for custom tilesets', () => {
+    const custom: CustomTileset = {
+      id: 'custom-hybrid',
+      name: 'My Hybrid',
+      url: 'https://base/{z}/{x}/{y}.png',
+      overlayUrl: 'https://labels/{z}/{x}/{y}.png',
+      attribution: '',
+      maxZoom: 18,
+      description: '',
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const resolved = getTilesetById('custom-hybrid', [custom]);
+    expect(resolved.overlayUrl).toBe('https://labels/{z}/{x}/{y}.png');
+    expect(getAllTilesets([custom]).find(t => t.id === 'custom-hybrid')?.overlayUrl)
+      .toBe('https://labels/{z}/{x}/{y}.png');
+  });
+});

--- a/src/config/tilesets.test.ts
+++ b/src/config/tilesets.test.ts
@@ -17,6 +17,11 @@ describe('tilesets — hybrid overlay support', () => {
     expect(hybrid.overlayUrl).toBeDefined();
     expect(hybrid.overlayUrl).toContain('World_Reference_Overlay');
     expect(hybrid.overlayUrl).toMatch(/\{z\}.*\{y\}.*\{x\}/); // ESRI z/y/x order
+    // The overlay credits its own sources (Garmin/USGS/NPS), distinct from the
+    // imagery attribution — ESRI serves them as separate services.
+    expect(hybrid.overlayAttribution).toBeDefined();
+    expect(hybrid.overlayAttribution).toContain('Garmin');
+    expect(hybrid.overlayAttribution).not.toBe(hybrid.attribution);
   });
 
   it('plain esriSatellite has no overlayUrl (kept as a distinct option)', () => {

--- a/src/config/tilesets.ts
+++ b/src/config/tilesets.ts
@@ -20,6 +20,7 @@ export interface CustomTileset {
   isVector?: boolean;
   overlayScheme?: 'light' | 'dark';
   overlayUrl?: string;
+  overlayAttribution?: string;
 }
 
 export interface TilesetConfig {
@@ -34,6 +35,11 @@ export interface TilesetConfig {
   /** Optional transparent raster overlay drawn on top of the base tiles (e.g.
    *  labels/roads over satellite imagery). Raster tilesets only. */
   readonly overlayUrl?: string;
+  /** Attribution for the overlay layer. The overlay's data sources usually
+   *  differ from the base (e.g. ESRI's reference overlay credits Garmin/USGS/NPS,
+   *  not the imagery providers), so it needs its own credit. Falls back to
+   *  `attribution` when omitted. Only meaningful alongside `overlayUrl`. */
+  readonly overlayAttribution?: string;
 }
 
 export const TILESETS: Readonly<Record<PredefinedTilesetId, TilesetConfig>> = {
@@ -91,6 +97,7 @@ export const TILESETS: Readonly<Record<PredefinedTilesetId, TilesetConfig>> = {
     url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
     overlayUrl: 'https://services.arcgisonline.com/arcgis/rest/services/Reference/World_Reference_Overlay/MapServer/tile/{z}/{y}/{x}',
     attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+    overlayAttribution: 'Labels &copy; Esri &mdash; Sources: Esri, Garmin, USGS, NPS',
     maxZoom: 18,
     description: 'Satellite imagery with place names and road labels'
   }

--- a/src/config/tilesets.ts
+++ b/src/config/tilesets.ts
@@ -3,7 +3,7 @@
  */
 
 // Type-safe tileset IDs using string literal union (predefined only)
-export type PredefinedTilesetId = 'osm' | 'osmHot' | 'cartoDark' | 'cartoLight' | 'openTopo' | 'esriSatellite';
+export type PredefinedTilesetId = 'osm' | 'osmHot' | 'cartoDark' | 'cartoLight' | 'openTopo' | 'esriSatellite' | 'esriHybrid';
 
 // Custom tilesets can have any string ID (must start with 'custom-')
 export type TilesetId = PredefinedTilesetId | string;
@@ -19,6 +19,7 @@ export interface CustomTileset {
   updatedAt: number;
   isVector?: boolean;
   overlayScheme?: 'light' | 'dark';
+  overlayUrl?: string;
 }
 
 export interface TilesetConfig {
@@ -30,6 +31,9 @@ export interface TilesetConfig {
   readonly description: string;
   readonly isCustom?: boolean;
   readonly isVector?: boolean;
+  /** Optional transparent raster overlay drawn on top of the base tiles (e.g.
+   *  labels/roads over satellite imagery). Raster tilesets only. */
+  readonly overlayUrl?: string;
 }
 
 export const TILESETS: Readonly<Record<PredefinedTilesetId, TilesetConfig>> = {
@@ -80,6 +84,15 @@ export const TILESETS: Readonly<Record<PredefinedTilesetId, TilesetConfig>> = {
     attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
     maxZoom: 18,
     description: 'Satellite imagery'
+  },
+  esriHybrid: {
+    id: 'esriHybrid',
+    name: 'Satellite + Labels',
+    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+    overlayUrl: 'https://services.arcgisonline.com/arcgis/rest/services/Reference/World_Reference_Overlay/MapServer/tile/{z}/{y}/{x}',
+    attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+    maxZoom: 18,
+    description: 'Satellite imagery with place names and road labels'
   }
 } as const;
 


### PR DESCRIPTION
Closes #4728.

## What

Adds a **"Satellite + Labels"** map tileset. ESRI's existing satellite tileset (`World_Imagery`) shows pure imagery with no place names or road labels; users asked for a hybrid. This layers ESRI's free, no-API-key transparent `World_Reference_Overlay` (same license as the satellite tiles already in use) on top of the imagery.

## Approach

Went with the issue's **approach B (data-driven)** rather than hardcoding a satellite-specific branch:

- `TilesetConfig` + `CustomTileset` gain an optional `overlayUrl`.
- `BaseMap`'s raster branch renders a **second transparent `TileLayer`** (at a higher `zIndex`) when `overlayUrl` is set — keyed by `maxZoom` like the base so in-place URL swaps still work.
- A new `esriHybrid` entry (`World_Imagery` base + `World_Reference_Overlay` overlay) is added to `TILESETS`.
- Plain **"Satellite"** stays a separate option; `TilesetSelector` enumerates the new entry automatically (no change).
- `overlayColors`: `esriHybrid → 'dark'` scheme so overlay lines stay bright over dark imagery, matching plain satellite.

Custom tilesets can carry `overlayUrl` too, so future overlay combos need no code.

## Tests

- `tilesets.test.ts` (new): locks the `esriHybrid` entry and `overlayUrl` passthrough for custom tilesets.
- `BaseMap.test.tsx`: mock captures `zIndex`; new cases assert a hybrid tileset renders 2 raster layers (overlay on top) while a non-hybrid renders 1. Existing keying-regression tests unchanged.
- `overlayColors.test.ts`: completeness count 6 → 7.

All 295 map/config tests pass.

## Manual verification

Deployed to the dev container and selected "Satellite + Labels" on the Unified map: ESRI satellite imagery with place names (Fort Lauderdale, Boynton Beach, Key Biscayne, …) and road shields (I-95, US-27, US-441) rendering over the imagery, exactly as intended.

## Mesh impact

None — no packets, notifications, or timers. The only IO is fetching public ESRI overlay tiles (same host family already in use for satellite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)