### PR TITLE
feat(map): 3D terrain on Mesh Map, Unified Map, and classic /nodes map (#4704)

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -27,6 +27,9 @@ const mocks = vi.hoisted(() => ({
     defaultMapCenterZoom: null as number | null,
     activeStyleJson: null as Record<string, unknown> | null,
   },
+  // #4704: terrain capabilities gate the 2D/3D toggle. Default unavailable so
+  // existing tests stay on the 2D BaseMap; the 3D tests flip it on.
+  terrainCaps: { enabled: false, terrainTiles: false, isLoading: false },
 }));
 
 // ---------------------------------------------------------------------------
@@ -39,6 +42,30 @@ const mocks = vi.hoisted(() => ({
 // side-effecting leafletDefaultIcon module (mutates L.Icon.Default, which the
 // `leaflet` mock below doesn't provide) — both are stubbed the same way
 // BaseMap.test.tsx does it, so this bare-component render stays dependency-free.
+// #4704: the 3D surface (Base3DMap → maplibre-gl) is heavy and irrelevant to
+// these DOM-light 2D tests. Stub Map3DView, exposing the props the 3D tests
+// assert on. Also short-circuit basemap3d/init so DashboardMap's unconditional
+// 3D-basemap derivation and `appBasename` import don't pull real modules.
+vi.mock('../map/Map3DView', () => ({
+  Map3DView: ({ nodes, sourceIds, showNeighbors, showTraceroutes }: any) => (
+    <div
+      data-testid="map-3d-view"
+      data-node-count={nodes.length}
+      data-source-ids={JSON.stringify(sourceIds)}
+      data-show-neighbors={String(showNeighbors)}
+      data-show-traceroutes={String(showTraceroutes)}
+    />
+  ),
+}));
+vi.mock('../../config/basemap3d', () => ({
+  resolve3DBasemap: () => ({ tiles: [], attribution: '', maxZoom: 19, usedFallback: false }),
+  buildTerrainTileUrl: () => '/api/elevation/tiles/{z}/{x}/{y}',
+}));
+vi.mock('../../init', () => ({ appBasename: '' }));
+vi.mock('../../hooks/useTerrainCapabilities', () => ({
+  useTerrainCapabilities: () => mocks.terrainCaps,
+}));
+
 vi.mock('../VectorTileLayer', () => ({
   // Surfaces styleJson as a data attribute (issue #4348) so tests can assert
   // DashboardMap forwards the active MapLibre style through to the vector
@@ -325,6 +352,8 @@ describe('DashboardMap', () => {
     mocks.settings.defaultMapCenterLon = null;
     mocks.settings.defaultMapCenterZoom = null;
     mocks.settings.activeStyleJson = null;
+    // Default: terrain unavailable ⇒ no 3D toggle, stays on 2D BaseMap.
+    mocks.terrainCaps = { enabled: false, terrainTiles: false, isLoading: false };
   });
 
   // --- Default Map Center vs auto-fit (issue #4125) ---------------------------
@@ -744,5 +773,61 @@ describe('DashboardMap', () => {
       />,
     );
     expect(screen.getByTestId('vector-tile-layer').dataset.styleJson).toBe('');
+  });
+
+  // --- 2D/3D toggle (#4704) ---------------------------------------------------
+
+  it('renders the 2D BaseMap and hides the 3D toggle when terrain is unavailable', () => {
+    render(<DashboardMap {...defaultProps} nodes={[nodeWithPosition]} />);
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    expect(screen.queryByTestId('map-3d-view')).not.toBeInTheDocument();
+    expect(screen.queryByText('3D Terrain')).not.toBeInTheDocument();
+  });
+
+  it('offers the 3D toggle only when terrain tiles are available', () => {
+    mocks.terrainCaps = { enabled: true, terrainTiles: true, isLoading: false };
+    render(<DashboardMap {...defaultProps} nodes={[nodeWithPosition]} />);
+    expect(screen.getByText('3D Terrain')).toBeInTheDocument();
+    // Starts in 2D until toggled.
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    expect(screen.queryByTestId('map-3d-view')).not.toBeInTheDocument();
+  });
+
+  it('renders Map3DView (not BaseMap) after toggling 3D, for a single source', () => {
+    mocks.terrainCaps = { enabled: true, terrainTiles: true, isLoading: false };
+    render(<DashboardMap {...defaultProps} sourceId="src-a" nodes={[nodeWithPosition]} />);
+    const toggle = screen.getByText('3D Terrain').previousSibling as HTMLInputElement;
+    fireEvent.click(toggle);
+    const view = screen.getByTestId('map-3d-view');
+    expect(view).toBeInTheDocument();
+    expect(screen.queryByTestId('map-container')).not.toBeInTheDocument();
+    // Single-source map scopes the 3D lines to just that source.
+    expect(JSON.parse(view.dataset.sourceIds ?? 'null')).toEqual(['src-a']);
+    expect(view.dataset.nodeCount).toBe('1');
+  });
+
+  it('renders Map3DView on the Unified map after toggling 3D', () => {
+    mocks.terrainCaps = { enabled: true, terrainTiles: true, isLoading: false };
+    render(<DashboardMap {...defaultProps} sourceId="__unified__" nodes={[nodeWithPosition]} />);
+    const toggle = screen.getByText('3D Terrain').previousSibling as HTMLInputElement;
+    fireEvent.click(toggle);
+    expect(screen.getByTestId('map-3d-view')).toBeInTheDocument();
+    expect(screen.queryByTestId('map-container')).not.toBeInTheDocument();
+  });
+
+  it('forces 2D when terrain capabilities are lost after selecting 3D', () => {
+    mocks.terrainCaps = { enabled: true, terrainTiles: true, isLoading: false };
+    const { rerender } = render(
+      <DashboardMap {...defaultProps} sourceId="src-a" nodes={[nodeWithPosition]} />,
+    );
+    const toggle = screen.getByText('3D Terrain').previousSibling as HTMLInputElement;
+    fireEvent.click(toggle);
+    expect(screen.getByTestId('map-3d-view')).toBeInTheDocument();
+    // Capabilities resolve unavailable (e.g. elevation disabled) — the map must
+    // drop back to 2D on the spot rather than strand the user in 3D.
+    mocks.terrainCaps = { enabled: false, terrainTiles: false, isLoading: false };
+    rerender(<DashboardMap {...defaultProps} sourceId="src-a" nodes={[nodeWithPosition]} />);
+    expect(screen.queryByTestId('map-3d-view')).not.toBeInTheDocument();
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
   });
 });

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -52,6 +52,12 @@ import { resolveMapEndpoint } from '../../utils/nodeHelpers';
 import api from '../../services/api';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { BaseMap } from '../map/BaseMap';
+import { Map3DView } from '../map/Map3DView';
+import type { Node3DFeature } from '../map/Base3DMap';
+import { TilesetSelector } from '../TilesetSelector';
+import { resolve3DBasemap, buildTerrainTileUrl } from '../../config/basemap3d';
+import { useTerrainCapabilities } from '../../hooks/useTerrainCapabilities';
+import { appBasename } from '../../init';
 import { MapLoadingOverlay } from '../map/MapLoadingOverlay';
 import { TraceroutePathsLayer } from '../map/layers/TraceroutePathsLayer';
 import { NeighborLinksLayer, type NeighborLinkDescriptor } from '../map/layers/NeighborLinksLayer';
@@ -224,6 +230,21 @@ export default function DashboardMap({
   // #3636: node-to-node LOS distance measurement tool.
   const [measureActive, setMeasureActive] = useState(false);
 
+  // #4704: 2D/3D toggle. `viewMode` is ephemeral (not persisted) — the toggle
+  // is only offered when the server can serve DEM terrain tiles, and any
+  // capability loss forces 2D on the spot (mirrors `useEffectiveViewMode`).
+  const terrainCaps = useTerrainCapabilities();
+  const canUse3D = !terrainCaps.isLoading && terrainCaps.enabled && terrainCaps.terrainTiles;
+  const [viewMode, setViewMode] = useState<'2d' | '3d'>('2d');
+  const effective3D = viewMode === '3d' && canUse3D;
+  const basemap3D = useMemo(
+    () => resolve3DBasemap(tilesetId, customTilesets),
+    [tilesetId, customTilesets],
+  );
+  // `appBasename` is the base-path prefix `ApiService` was seeded with at
+  // startup — module-scope constant, never changes.
+  const terrainTileUrl = useMemo(() => buildTerrainTileUrl(appBasename), []);
+
   const {
     showPaths,
     setShowPaths,
@@ -315,6 +336,20 @@ export default function DashboardMap({
 
   // Array form of node positions for MapBoundsUpdater (fit bounds).
   const nodePositions: [number, number][] = nodesWithPosition.map((e) => [e.pos.lat, e.pos.lng]);
+
+  // #4704: node markers for the 3D surface — same visible+positioned node list
+  // the 2D markers use, mapped to the shape `Base3DMap` expects. Computed
+  // unconditionally (cheap map, no hooks); only consumed when `effective3D`.
+  const node3DFeatures: Node3DFeature[] = useMemo(
+    () =>
+      nodesWithPosition.map(({ node, pos }) => ({
+        key: unifiedNodeKey(node) ?? String(node.nodeNum ?? node.nodeId ?? node.user?.id),
+        lat: pos.lat,
+        lng: pos.lng,
+        label: node.shortName ?? node.user?.shortName ?? undefined,
+      })),
+    [nodesWithPosition],
+  );
 
   // #3636: measurement endpoints — nearest-node snapping picks from these.
   const measurePoints: MeasurePoint[] = nodesWithPosition.map(({ node, pos }) => ({
@@ -624,6 +659,29 @@ export default function DashboardMap({
 
   return (
     <div className="dashboard-map-container" style={{ position: 'relative' }}>
+      {effective3D ? (
+        <>
+          {/* #4704: 3D terrain surface. Shows nodes + traceroute + neighbor
+              lines only (v1 non-goals: waypoints, ATAK, polar grid, accuracy
+              regions, GeoJSON, measure tool). The tileset selector is a sibling
+              because Base3DMap can't host it. */}
+          <Map3DView
+            center={[defaultCenter.lat, defaultCenter.lng]}
+            zoom={hasConfiguredDefaultCenter ? defaultMapCenterZoom : 10}
+            basemap={basemap3D}
+            terrainTileUrl={terrainTileUrl}
+            nodes={node3DFeatures}
+            sourceIds={polarSourceIds}
+            showNeighbors={showNeighborInfo}
+            showTraceroutes={showPaths || showRoute}
+            lookbackHours={effectiveMaxAge}
+            onUnsupported={() => setViewMode('2d')}
+          />
+          {showTileSelector && (
+            <TilesetSelector selectedTilesetId={tilesetId} onTilesetChange={setMapTileset} />
+          )}
+        </>
+      ) : (
       <BaseMap
         center={[defaultCenter.lat, defaultCenter.lng]}
         zoom={hasConfiguredDefaultCenter ? defaultMapCenterZoom : 10}
@@ -703,10 +761,12 @@ export default function DashboardMap({
             unidirectional dashed. */}
         <NeighborLinksLayer links={meshtasticNeighborLinks} />
       </BaseMap>
+      )}
 
       {/* Polar grid legend — names each source whose grid is drawn, with its
-          color swatch, so overlapping grids on the Unified map aren't confused. */}
-      {showPolarGrid && ownNodePositions.length > 0 && (
+          color swatch, so overlapping grids on the Unified map aren't confused.
+          2D only: the 3D surface doesn't draw the polar grid. */}
+      {!effective3D && showPolarGrid && ownNodePositions.length > 0 && (
         <div className="dashboard-polar-grid-legend" role="note" aria-label="Polar grid sources">
           <div className="dashboard-polar-grid-legend__title">Polar Grid</div>
           {ownNodePositions.map((op) => (
@@ -750,6 +810,18 @@ export default function DashboardMap({
             />
             <span>Measure Distance</span>
           </label>
+          {/* #4704: 2D/3D toggle — only offered when the server can serve DEM
+              terrain tiles (elevation enabled + terrarium tiles). */}
+          {canUse3D && (
+            <label className="map-control-item" title="Show terrain in a pitched 3D view">
+              <input
+                type="checkbox"
+                checked={viewMode === '3d'}
+                onChange={(e) => setViewMode(e.target.checked ? '3d' : '2d')}
+              />
+              <span>3D Terrain</span>
+            </label>
+          )}
           {/* Map Features age slider (#3322): hides node markers, traceroutes,
               and route segments older than the chosen age. Ranges 1h–maxNodeAge. */}
           {(() => {

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -62,7 +62,9 @@ export default function MapAnalysisCanvas() {
   const {
     config,
     setViewMode,
+    selected,
     setSelected,
+    nodeFilter,
     measureMode,
     setMeasureMode,
     linkProfileMode,
@@ -178,8 +180,18 @@ export default function MapAnalysisCanvas() {
   // unconditionally (Rules of Hooks) — both hooks self-gate on their layer
   // toggle/time-window and return empties when off, matching the 2D panes'
   // `config.layers.*.enabled` guards above.
-  const neighborLines3D = use3DNeighborLines();
-  const tracerouteLines3D = use3DTracerouteLines();
+  const neighborLines3D = use3DNeighborLines({
+    layer: config.layers.neighbors,
+    sources: config.sources,
+    timeSlider: config.timeSlider,
+  });
+  const tracerouteLines3D = use3DTracerouteLines({
+    layer: config.layers.traceroutes,
+    sources: config.sources,
+    timeSlider: config.timeSlider,
+    selected,
+    nodeFilter,
+  });
   const lines3D: Line3DFeature[] = useMemo(
     () => [...neighborLines3D.lines, ...tracerouteLines3D.lines],
     [neighborLines3D.lines, tracerouteLines3D.lines],

--- a/src/components/MapAnalysis/use3DNeighborLines.test.ts
+++ b/src/components/MapAnalysis/use3DNeighborLines.test.ts
@@ -3,10 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import { createElement, type ReactNode } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MapAnalysisProvider } from './MapAnalysisContext';
-import { use3DNeighborLines } from './use3DNeighborLines';
+import { use3DNeighborLines, type Use3DNeighborLinesParams } from './use3DNeighborLines';
 
 // Mutable mock state so individual tests can vary the edges/nodes, same
 // convention as layers/NeighborLinksLayer.test.tsx /
@@ -30,40 +27,22 @@ vi.mock('../../hooks/useDashboardData', () => ({
   UNIFIED_SOURCE_ID: '__unified__',
 }));
 
-const NEIGHBORS_ENABLED_CONFIG = {
-  version: 1,
-  layers: {
-    markers: { enabled: true, lookbackHours: null },
-    traceroutes: { enabled: false, lookbackHours: 24 },
-    neighbors: { enabled: true, lookbackHours: 24 },
-    heatmap: { enabled: false, lookbackHours: 24 },
-    trails: { enabled: false, lookbackHours: 24 },
-    hopShading: { enabled: false, lookbackHours: null },
-    snrOverlay: { enabled: false, lookbackHours: null },
-    waypoints: { enabled: true, lookbackHours: null },
-    polarGrid: { enabled: false, lookbackHours: null },
-  },
-  sources: [],
-  timeSlider: { enabled: false },
-  inspectorOpen: true,
-  selectedNodeIds: [],
-};
-
-function setConfig(overrides: Record<string, unknown> = {}) {
-  localStorage.setItem(
-    'mapAnalysis.config.v1',
-    JSON.stringify({ ...NEIGHBORS_ENABLED_CONFIG, ...overrides }),
-  );
-}
-
-function wrapper({ children }: { children: ReactNode }) {
-  const qc = new QueryClient();
-  return createElement(QueryClientProvider, { client: qc }, createElement(MapAnalysisProvider, null, children));
+/**
+ * Build the explicit params the hook now takes (previously read from
+ * `useMapAnalysisCtx()`). `sources: []` = "all sources", matching the old
+ * `NEIGHBORS_ENABLED_CONFIG.sources` value.
+ */
+function makeParams(overrides: Partial<Use3DNeighborLinesParams> = {}): Use3DNeighborLinesParams {
+  return {
+    layer: { enabled: true, lookbackHours: 24 },
+    sources: [],
+    timeSlider: { enabled: false },
+    ...overrides,
+  };
 }
 
 describe('use3DNeighborLines', () => {
   beforeEach(() => {
-    localStorage.clear();
     mockUseNeighbors.mockClear();
     mockUseMeshCoreNeighbors.mockClear();
     mockState.mtEdges = [{ id: 1, nodeNum: 1, neighborNum: 2, sourceId: 'a', snr: 5, timestamp: 0 }];
@@ -85,11 +64,10 @@ describe('use3DNeighborLines', () => {
       { sourceId: 'a', isMeshCore: true, publicKey: 'aa', position: { latitude: 30, longitude: -90 } },
       { sourceId: 'a', isMeshCore: true, publicKey: 'bb', position: { latitude: 31, longitude: -91 } },
     ];
-    setConfig();
   });
 
   it('produces a Line3DFeature for a positioned meshtastic edge with §2.2 encoding', () => {
-    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    const { result } = renderHook(() => use3DNeighborLines(makeParams()));
     const line = result.current.lines.find((l) => l.key === 'mt:1');
     expect(line).toBeDefined();
     expect(line).toEqual({
@@ -104,7 +82,7 @@ describe('use3DNeighborLines', () => {
   });
 
   it('PARITY: meshtastic selectionByKey deep-equals the 2D setSelected payload (layers/NeighborLinksLayer.tsx L164-171)', () => {
-    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    const { result } = renderHook(() => use3DNeighborLines(makeParams()));
     expect(result.current.selectionByKey.get('mt:1')).toEqual({
       type: 'neighbor',
       sourceId: 'a',
@@ -116,7 +94,7 @@ describe('use3DNeighborLines', () => {
   });
 
   it('produces a Line3DFeature for a positioned meshcore edge with §2.2 encoding', () => {
-    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    const { result } = renderHook(() => use3DNeighborLines(makeParams()));
     const line = result.current.lines.find((l) => l.key === 'mc:7');
     expect(line).toBeDefined();
     expect(line).toEqual({
@@ -131,7 +109,7 @@ describe('use3DNeighborLines', () => {
   });
 
   it('PARITY: meshcore selectionByKey deep-equals the 2D setSelected payload (layers/MeshCoreNeighborLinksLayer.tsx L125-136)', () => {
-    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    const { result } = renderHook(() => use3DNeighborLines(makeParams()));
     expect(result.current.selectionByKey.get('mc:7')).toEqual({
       type: 'neighbor',
       sourceId: 'a',
@@ -148,7 +126,7 @@ describe('use3DNeighborLines', () => {
 
   it('drops a meshtastic edge when an endpoint has no position anywhere', () => {
     mockState.nodes = [{ nodeNum: 1, sourceId: 'a', position: { latitude: 30, longitude: -90 } }];
-    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    const { result } = renderHook(() => use3DNeighborLines(makeParams()));
     expect(result.current.lines.some((l) => l.key === 'mt:1')).toBe(false);
   });
 
@@ -156,21 +134,21 @@ describe('use3DNeighborLines', () => {
     mockState.nodes = [
       { sourceId: 'a', isMeshCore: true, publicKey: 'aa', position: { latitude: 30, longitude: -90 } },
     ];
-    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    const { result } = renderHook(() => use3DNeighborLines(makeParams()));
     expect(result.current.lines.some((l) => l.key === 'mc:7')).toBe(false);
   });
 
   it('excludes edges outside the time slider window when the slider is enabled', () => {
-    setConfig({ timeSlider: { enabled: true, windowStartMs: 10, windowEndMs: 20 } });
-    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    const { result } = renderHook(() =>
+      use3DNeighborLines(makeParams({ timeSlider: { enabled: true, windowStartMs: 10, windowEndMs: 20 } })),
+    );
     expect(result.current.lines).toHaveLength(0);
   });
 
   it('returns empty lines/selectionByKey AND calls the fetch hooks with enabled:false when the layer is disabled', () => {
-    setConfig({
-      layers: { ...NEIGHBORS_ENABLED_CONFIG.layers, neighbors: { enabled: false, lookbackHours: 24 } },
-    });
-    const { result } = renderHook(() => use3DNeighborLines(), { wrapper });
+    const { result } = renderHook(() =>
+      use3DNeighborLines(makeParams({ layer: { enabled: false, lookbackHours: 24 } })),
+    );
     expect(result.current.lines).toEqual([]);
     expect(result.current.selectionByKey.size).toBe(0);
     expect(mockUseNeighbors).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));

--- a/src/components/MapAnalysis/use3DNeighborLines.ts
+++ b/src/components/MapAnalysis/use3DNeighborLines.ts
@@ -4,7 +4,7 @@ import {
   useDashboardUnifiedData,
 } from '../../hooks/useDashboardData';
 import { useNeighbors, useMeshCoreNeighbors } from '../../hooks/useMapAnalysisData';
-import { useMapAnalysisCtx, type SelectedTarget } from './MapAnalysisContext';
+import type { SelectedTarget } from './MapAnalysisContext';
 import { resolveNodeLatLng, type MaybePositionedNode } from './nodePositionUtil';
 import { classifyNodeTransport, type NodeTransportClass } from '../../utils/nodeTransport';
 import { snrToNeighborOpacity } from '../../utils/neighborLinks';
@@ -74,14 +74,34 @@ export interface NeighborLines3D {
   selectionByKey: Map<string, SelectedTarget>;
 }
 
-export function use3DNeighborLines(): NeighborLines3D {
-  const { config } = useMapAnalysisCtx();
-  const layer = config.layers.neighbors;
+/** Time-slider window state — the `config.timeSlider` shape. */
+export interface TimeSliderWindow {
+  enabled: boolean;
+  windowStartMs?: number;
+  windowEndMs?: number;
+}
+
+/**
+ * Explicit inputs for `use3DNeighborLines`, previously read from
+ * `useMapAnalysisCtx()`. Passing them in lets non-MapAnalysis surfaces
+ * (DashboardMap, NodesTab) reuse the exact same 3D neighbor-edge wiring.
+ */
+export interface Use3DNeighborLinesParams {
+  /** `config.layers.neighbors`. */
+  layer: { enabled: boolean; lookbackHours?: number | null };
+  /** `config.sources` — empty = all sources. */
+  sources: string[];
+  /** `config.timeSlider`. */
+  timeSlider: TimeSliderWindow;
+}
+
+export function use3DNeighborLines(params: Use3DNeighborLinesParams): NeighborLines3D {
+  const { layer } = params;
   const { data: sources = [] } = useDashboardSources();
   const sourceIds =
-    config.sources.length === 0
+    params.sources.length === 0
       ? (sources as { id: string }[]).map((s) => s.id)
-      : config.sources;
+      : params.sources;
 
   const { data: mtData } = useNeighbors({
     enabled: layer.enabled,
@@ -144,7 +164,7 @@ export function use3DNeighborLines(): NeighborLines3D {
     return map;
   }, [nodes]);
 
-  const ts = config.timeSlider;
+  const ts = params.timeSlider;
 
   return useMemo(() => {
     if (!layer.enabled) return { lines: [], selectionByKey: new Map<string, SelectedTarget>() };

--- a/src/components/MapAnalysis/use3DTracerouteLines.test.ts
+++ b/src/components/MapAnalysis/use3DTracerouteLines.test.ts
@@ -3,10 +3,8 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import { createElement, useEffect, type ReactNode } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MapAnalysisProvider, useMapAnalysisCtx } from './MapAnalysisContext';
-import { use3DTracerouteLines } from './use3DTracerouteLines';
+import { use3DTracerouteLines, type Use3DTracerouteLinesParams } from './use3DTracerouteLines';
+import type { SelectedTarget } from './MapAnalysisContext';
 import type { AnalyzedSegment } from '../../hooks/useTracerouteAnalysis';
 import { getSegmentSnrOpacity, weightByOccurrence } from '../../utils/mapHelpers';
 
@@ -51,47 +49,26 @@ vi.mock('../../hooks/useTracerouteAnalysis', async () => {
   };
 });
 
-const TRACEROUTES_ENABLED_CONFIG = {
-  version: 1,
-  layers: {
-    markers: { enabled: true, lookbackHours: null },
-    traceroutes: { enabled: true, lookbackHours: 24 },
-    neighbors: { enabled: false, lookbackHours: 24 },
-    heatmap: { enabled: false, lookbackHours: 24 },
-    trails: { enabled: false, lookbackHours: 24 },
-    hopShading: { enabled: false, lookbackHours: null },
-    snrOverlay: { enabled: false, lookbackHours: null },
-    waypoints: { enabled: true, lookbackHours: null },
-    polarGrid: { enabled: false, lookbackHours: null },
-  },
-  sources: [],
-  timeSlider: { enabled: false },
-  inspectorOpen: true,
-  selectedNodeIds: [],
-};
-
-function setConfig(overrides: Record<string, unknown> = {}) {
-  localStorage.setItem(
-    'mapAnalysis.config.v1',
-    JSON.stringify({ ...TRACEROUTES_ENABLED_CONFIG, ...overrides }),
-  );
+/**
+ * Build the explicit params the hook now takes (previously read from
+ * `useMapAnalysisCtx()`). `sources: []` = "all sources"; `selected: null` =
+ * SNR color mode.
+ */
+function makeParams(overrides: Partial<Use3DTracerouteLinesParams> = {}): Use3DTracerouteLinesParams {
+  return {
+    layer: { enabled: true, lookbackHours: 24 },
+    sources: [],
+    timeSlider: { enabled: false },
+    selected: null,
+    nodeFilter: '',
+    ...overrides,
+  };
 }
 
-function wrapper({ children }: { children: ReactNode }) {
-  const qc = new QueryClient();
-  return createElement(QueryClientProvider, { client: qc }, createElement(MapAnalysisProvider, null, children));
-}
-
-/** Renders `use3DTracerouteLines()` after selecting a node (via the shared
- * context), so `colorMode` flips to 'direction' the same way it does when a
- * user clicks a node marker in the real app. */
-function useTracerouteLinesWithNodeSelected(nodeNum: number, sourceId: string) {
-  const { selected, setSelected } = useMapAnalysisCtx();
-  useEffect(() => {
-    if (!selected) setSelected({ type: 'node', nodeNum, sourceId });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selected]);
-  return use3DTracerouteLines();
+/** A node selection, so `colorMode` flips to 'direction' the same way it does
+ * when a user clicks a node marker in the real app. */
+function nodeSelected(nodeNum: number, sourceId: string): SelectedTarget {
+  return { type: 'node', nodeNum, sourceId };
 }
 
 const RF_SEGMENT: AnalyzedSegment = {
@@ -124,13 +101,11 @@ const MQTT_SEGMENT: AnalyzedSegment = {
 
 describe('use3DTracerouteLines', () => {
   beforeEach(() => {
-    localStorage.clear();
     mockState.segments = [RF_SEGMENT];
-    setConfig();
   });
 
   it('produces a straight 2-vertex Line3DFeature for an RF segment (solid, §2.6 no curvature)', () => {
-    const { result } = renderHook(() => use3DTracerouteLines(), { wrapper });
+    const { result } = renderHook(() => use3DTracerouteLines(makeParams()));
     const line = result.current.lines.find((l) => l.key === `tr:${RF_SEGMENT.key}`);
     expect(line).toBeDefined();
     expect(line).toEqual({
@@ -145,7 +120,7 @@ describe('use3DTracerouteLines', () => {
   });
 
   it('PARITY: segment selectionByKey deep-equals the 2D setSelected payload (layers/TraceroutePathsLayer.tsx L165-174)', () => {
-    const { result } = renderHook(() => use3DTracerouteLines(), { wrapper });
+    const { result } = renderHook(() => use3DTracerouteLines(makeParams()));
     expect(result.current.selectionByKey.get(`tr:${RF_SEGMENT.key}`)).toEqual({
       type: 'segment',
       fromNodeNum: RF_SEGMENT.from,
@@ -158,7 +133,7 @@ describe('use3DTracerouteLines', () => {
 
   it('dashes an MQTT/unknown-SNR segment (dash=[2,2]) and colors it via overlayColors.mqttSegment', () => {
     mockState.segments = [MQTT_SEGMENT];
-    const { result } = renderHook(() => use3DTracerouteLines(), { wrapper });
+    const { result } = renderHook(() => use3DTracerouteLines(makeParams()));
     const line = result.current.lines.find((l) => l.key === `tr:${MQTT_SEGMENT.key}`);
     expect(line?.dash).toEqual([2, 2]);
     expect(line?.color).toBe('#b4befe');
@@ -170,7 +145,9 @@ describe('use3DTracerouteLines', () => {
       { ...RF_SEGMENT, direction: 'outbound' },
       { ...RF_SEGMENT, key: 'a:0x2222->0x1111', from: 0x2222, to: 0x1111, direction: 'inbound' },
     ];
-    const { result } = renderHook(() => useTracerouteLinesWithNodeSelected(0x1111, 'a'), { wrapper });
+    const { result } = renderHook(() =>
+      use3DTracerouteLines(makeParams({ selected: nodeSelected(0x1111, 'a') })),
+    );
     const outbound = result.current.lines.find((l) => l.key === 'tr:a:0x1111->0x2222');
     const inbound = result.current.lines.find((l) => l.key === 'tr:a:0x2222->0x1111');
     expect(outbound?.color).toBe('#3b82f6'); // OUTBOUND_COLOR (mirror of TraceroutePathsLayer.tsx L25)
@@ -179,16 +156,17 @@ describe('use3DTracerouteLines', () => {
 
   it('falls back to snrColors.noData for a neutral segment while colorMode is direction', () => {
     mockState.segments = [{ ...RF_SEGMENT, direction: 'neutral' }];
-    const { result } = renderHook(() => useTracerouteLinesWithNodeSelected(0x1111, 'a'), { wrapper });
+    const { result } = renderHook(() =>
+      use3DTracerouteLines(makeParams({ selected: nodeSelected(0x1111, 'a') })),
+    );
     const line = result.current.lines.find((l) => l.key === `tr:${RF_SEGMENT.key}`);
     expect(line?.color).toBe('#6c7086'); // snrColors.noData
   });
 
   it('returns empty lines/selectionByKey when the traceroutes layer is disabled', () => {
-    setConfig({
-      layers: { ...TRACEROUTES_ENABLED_CONFIG.layers, traceroutes: { enabled: false, lookbackHours: 24 } },
-    });
-    const { result } = renderHook(() => use3DTracerouteLines(), { wrapper });
+    const { result } = renderHook(() =>
+      use3DTracerouteLines(makeParams({ layer: { enabled: false, lookbackHours: 24 } })),
+    );
     expect(result.current.lines).toEqual([]);
     expect(result.current.selectionByKey.size).toBe(0);
   });

--- a/src/components/MapAnalysis/use3DTracerouteLines.ts
+++ b/src/components/MapAnalysis/use3DTracerouteLines.ts
@@ -99,13 +99,12 @@ export function use3DTracerouteLines(params: Use3DTracerouteLinesParams): Tracer
   const { layer, selected, nodeFilter } = params;
   const { overlayColors } = useSettings();
   const options = useMemo(
+    // Only the traceroute options object affects the result — mirrors
+    // layers/TraceroutePathsLayer.tsx L76-82.
     () => ({
       ...DEFAULT_TRACEROUTE_OPTIONS,
       ...(layer.options as Partial<TracerouteLayerOptions> | undefined),
     }),
-    // Only the traceroute options object affects the result — mirrors
-    // layers/TraceroutePathsLayer.tsx L76-82.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [layer.options],
   );
 

--- a/src/components/MapAnalysis/use3DTracerouteLines.ts
+++ b/src/components/MapAnalysis/use3DTracerouteLines.ts
@@ -4,8 +4,12 @@ import {
   useDashboardUnifiedData,
 } from '../../hooks/useDashboardData';
 import { useTraceroutes } from '../../hooks/useMapAnalysisData';
-import { useMapAnalysisCtx, type SelectedTarget } from './MapAnalysisContext';
-import { getTracerouteOptions } from '../../hooks/useMapAnalysisConfig';
+import type { SelectedTarget } from './MapAnalysisContext';
+import {
+  DEFAULT_TRACEROUTE_OPTIONS,
+  type TracerouteLayerOptions,
+} from '../../hooks/useMapAnalysisConfig';
+import type { TimeSliderWindow } from './use3DNeighborLines';
 import {
   useTracerouteAnalysis,
   type AnalyzedSegment,
@@ -50,6 +54,24 @@ export interface TracerouteLines3D {
 }
 
 /**
+ * Explicit inputs for `use3DTracerouteLines`, previously read from
+ * `useMapAnalysisCtx()`. Passing them in lets non-MapAnalysis surfaces
+ * (DashboardMap, NodesTab) reuse the exact same 3D traceroute-segment wiring.
+ */
+export interface Use3DTracerouteLinesParams {
+  /** `config.layers.traceroutes` — `options` feeds `getTracerouteOptions`. */
+  layer: { enabled: boolean; lookbackHours?: number | null; options?: Record<string, unknown> };
+  /** `config.sources` — empty = all sources. */
+  sources: string[];
+  /** `config.timeSlider`. */
+  timeSlider: TimeSliderWindow;
+  /** Selected target (drives direction-mode coloring); null = SNR mode. */
+  selected: SelectedTarget | null;
+  /** Free-text node search term; empty = no filter. */
+  nodeFilter: string;
+}
+
+/**
  * Resolve a segment's line color, replicating
  * `map/layers/TraceroutePathsLayer.tsx`'s `resolveColor` for the two prop
  * shapes the MapAnalysis 2D adapter actually passes: `colorMode: 'snr'` with
@@ -73,23 +95,25 @@ function resolveSegmentColor(
   return snrToColor(seg.avgSnr, snrColors);
 }
 
-export function use3DTracerouteLines(): TracerouteLines3D {
-  const { config, selected, nodeFilter } = useMapAnalysisCtx();
+export function use3DTracerouteLines(params: Use3DTracerouteLinesParams): TracerouteLines3D {
+  const { layer, selected, nodeFilter } = params;
   const { overlayColors } = useSettings();
-  const layer = config.layers.traceroutes;
   const options = useMemo(
-    () => getTracerouteOptions(config),
+    () => ({
+      ...DEFAULT_TRACEROUTE_OPTIONS,
+      ...(layer.options as Partial<TracerouteLayerOptions> | undefined),
+    }),
     // Only the traceroute options object affects the result — mirrors
     // layers/TraceroutePathsLayer.tsx L76-82.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [config.layers.traceroutes.options],
+    [layer.options],
   );
 
   const { data: sources = [] } = useDashboardSources();
   const sourceIds =
-    config.sources.length === 0
+    params.sources.length === 0
       ? (sources as { id: string }[]).map((s) => s.id)
-      : config.sources;
+      : params.sources;
   const { items } = useTraceroutes({
     enabled: layer.enabled,
     sources: sourceIds,
@@ -112,7 +136,7 @@ export function use3DTracerouteLines(): TracerouteLines3D {
     [nodes, nodeFilter],
   );
 
-  const ts = config.timeSlider;
+  const ts = params.timeSlider;
   const timeWindow = useMemo(
     () =>
       ts.enabled && ts.windowStartMs !== undefined && ts.windowEndMs !== undefined

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1689,22 +1689,20 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   // #4704: node features for the 3D surface — the same visible+positioned set
   // the 2D markers use, at the same (precision-offset) positions from
   // `nodePositions`. Computed unconditionally (no hooks); only consumed in 3D.
-  const node3DFeatures: Node3DFeature[] = useMemo(
-    () =>
-      visibleMapNodes
-        .map(node => {
-          const pos = nodePositions.get(node.nodeNum);
-          if (!pos) return null;
-          return {
-            key: String(node.user?.id ?? node.nodeNum),
-            lat: pos[0],
-            lng: pos[1],
-            label: node.user?.shortName ?? undefined,
-          };
-        })
-        .filter((f): f is Node3DFeature => f !== null),
-    [visibleMapNodes, nodePositions],
-  );
+  const node3DFeatures: Node3DFeature[] = useMemo(() => {
+    const out: Node3DFeature[] = [];
+    for (const node of visibleMapNodes) {
+      const pos = nodePositions.get(node.nodeNum);
+      if (!pos) continue;
+      out.push({
+        key: String(node.user?.id ?? node.nodeNum),
+        lat: pos[0],
+        lng: pos[1],
+        label: node.user?.shortName ?? undefined,
+      });
+    }
+    return out;
+  }, [visibleMapNodes, nodePositions]);
 
   const nodeMarkers: NodeMarkerDescriptor[] = visibleMapNodes
     .map(node => {

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -49,6 +49,12 @@ import PacketMonitorPanel from './PacketMonitorPanel';
 import { getPacketStats } from '../services/packetApi';
 
 import { BaseMap } from './map/BaseMap';
+import { Map3DView } from './map/Map3DView';
+import type { Node3DFeature } from './map/Base3DMap';
+import { TilesetSelector } from './TilesetSelector';
+import { resolve3DBasemap, buildTerrainTileUrl } from '../config/basemap3d';
+import { useTerrainCapabilities } from '../hooks/useTerrainCapabilities';
+import { appBasename } from '../init';
 import { MapLoadingOverlay } from './map/MapLoadingOverlay';
 import { MapModeIndicator } from './map/MapModeIndicator';
 import { NodeUnmessageableBadge } from './NodeUnmessageableBadge';
@@ -964,6 +970,18 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   // #3636: node-to-node LOS distance measurement tool.
   const [measureActive, setMeasureActive] = useState(false);
 
+  // #4704: 2D/3D toggle. `viewMode` is ephemeral (not persisted); the toggle is
+  // only offered when the server can serve DEM terrain tiles, and any
+  // capability loss forces 2D on the spot (mirrors `useEffectiveViewMode`).
+  const terrainCaps = useTerrainCapabilities();
+  const canUse3D = !terrainCaps.isLoading && terrainCaps.enabled && terrainCaps.terrainTiles;
+  const [viewMode, setViewMode] = useState<'2d' | '3d'>('2d');
+  const basemap3D = useMemo(
+    () => resolve3DBasemap(mapTileset, customTilesets),
+    [mapTileset, customTilesets],
+  );
+  const terrainTileUrl = useMemo(() => buildTerrainTileUrl(appBasename), []);
+
   const sidebarRef = useRef<HTMLDivElement>(null);
 
   // Save packet monitor preference to localStorage
@@ -1652,7 +1670,9 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   // `user?.id` — also gives spiderfy/`markerRefs` coverage to the rare node
   // that has a position but no user info yet (matches the Dashboard/MapAnalysis
   // marker-key fallback convention).
-  const nodeMarkers: NodeMarkerDescriptor[] = nodesWithPosition
+  // The visible+positioned node set — the shared source of truth for both the
+  // 2D marker descriptors below and the #4704 3D node features.
+  const visibleMapNodes = nodesWithPosition
     .filter(node => {
       // Apply standard filters
       if (!nodePassesTransportFilter(node, { showRfNodes, showUdpNodes, showMqttNodes }, transportCutoff)) return false;
@@ -1665,7 +1685,28 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
       // node age filter. Default (slider at max) is a no-op.
       if (!node.isFavorite && node.lastHeard && node.lastHeard < mapAgeCutoffSeconds) return false;
       return true;
-    })
+    });
+  // #4704: node features for the 3D surface — the same visible+positioned set
+  // the 2D markers use, at the same (precision-offset) positions from
+  // `nodePositions`. Computed unconditionally (no hooks); only consumed in 3D.
+  const node3DFeatures: Node3DFeature[] = useMemo(
+    () =>
+      visibleMapNodes
+        .map(node => {
+          const pos = nodePositions.get(node.nodeNum);
+          if (!pos) return null;
+          return {
+            key: String(node.user?.id ?? node.nodeNum),
+            lat: pos[0],
+            lng: pos[1],
+            label: node.user?.shortName ?? undefined,
+          };
+        })
+        .filter((f): f is Node3DFeature => f !== null),
+    [visibleMapNodes, nodePositions],
+  );
+
+  const nodeMarkers: NodeMarkerDescriptor[] = visibleMapNodes
     .map(node => {
       const markerKey = String(node.user?.id ?? node.nodeNum);
       const roleNum = typeof node.user?.role === 'string'
@@ -2072,6 +2113,9 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   };
 
   const mapDefaults = getMapCenter();
+
+  // #4704: whether the 3D surface is actually on screen right now.
+  const effective3D = viewMode === '3d' && canUse3D;
 
   return (
     <div ref={splitViewRef} className="nodes-split-view nodes-anchored-view">
@@ -2551,6 +2595,18 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                     />
                     <span>Measure Distance</span>
                   </label>
+                  {/* #4704: 2D/3D toggle — only offered when the server can
+                      serve DEM terrain tiles (elevation enabled + terrarium). */}
+                  {canUse3D && (
+                    <label className="map-control-item" title="Show terrain in a pitched 3D view">
+                      <input
+                        type="checkbox"
+                        checked={viewMode === '3d'}
+                        onChange={(e) => setViewMode(e.target.checked ? '3d' : '2d')}
+                      />
+                      <span>3D Terrain</span>
+                    </label>
+                  )}
                   {/* Map Features age slider (#3322): hides node markers,
                       traceroutes, and route segments older than the chosen age.
                       Ranges 1h–maxNodeAgeHours (settings); default = max ("All"). */}
@@ -2869,6 +2925,30 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 disableLabel={t('map.tracerouteModeDisable', 'Turn off Show Traceroute')}
               />
             )}
+            {effective3D ? (
+              <>
+                {/* #4704: 3D terrain surface. Shows nodes + traceroute +
+                    neighbor lines only (v1 non-goals: waypoints, ATAK, polar
+                    grid, accuracy regions, estimated positions, GeoJSON,
+                    position history, measure tool). The tileset selector is a
+                    sibling because Base3DMap can't host it. */}
+                <Map3DView
+                  center={mapDefaults.center}
+                  zoom={mapDefaults.zoom}
+                  basemap={basemap3D}
+                  terrainTileUrl={terrainTileUrl}
+                  nodes={node3DFeatures}
+                  sourceIds={currentSourceId ? [currentSourceId] : []}
+                  showNeighbors={showNeighborInfo}
+                  showTraceroutes={showPaths || showRoute}
+                  lookbackHours={effectiveMapMaxAge}
+                  onUnsupported={() => setViewMode('2d')}
+                />
+                {shouldShowData() && showTileSelector && (
+                  <TilesetSelector selectedTilesetId={activeTileset} onTilesetChange={setMapTileset} />
+                )}
+              </>
+            ) : (
             <BaseMap
               center={mapDefaults.center}
               zoom={mapDefaults.zoom}
@@ -2990,6 +3070,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               {positionHistoryElements}
 
           </BaseMap>
+          )}
           {shouldShowData() && nodesIsLoading && <MapLoadingOverlay />}
           {shouldShowData() && !nodesIsLoading && nodesWithPosition.length === 0 && (
             <div className="map-overlay">

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -2937,8 +2937,12 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                   terrainTileUrl={terrainTileUrl}
                   nodes={node3DFeatures}
                   sourceIds={currentSourceId ? [currentSourceId] : []}
-                  showNeighbors={showNeighborInfo}
-                  showTraceroutes={showPaths || showRoute}
+                  // Guard the "empty = all sources" hook convention: with no
+                  // source (useSource() is null outside a SourceProvider), draw
+                  // the nodes but NOT cross-source neighbor/traceroute lines,
+                  // rather than silently pulling every source's edges in.
+                  showNeighbors={!!currentSourceId && showNeighborInfo}
+                  showTraceroutes={!!currentSourceId && (showPaths || showRoute)}
                   lookbackHours={effectiveMapMaxAge}
                   onUnsupported={() => setViewMode('2d')}
                 />

--- a/src/components/map/Map3DView.test.tsx
+++ b/src/components/map/Map3DView.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Map3DView } from './Map3DView';
+import type { Line3DFeature } from './Base3DMap';
+
+// Base3DMap is the heavy MapLibre surface — stub it to a DOM probe exposing the
+// nodes/lines it receives, the same style BaseMap.test.tsx stubs its children.
+vi.mock('./Base3DMap', () => ({
+  Base3DMap: ({ nodes, lines, initialExaggeration }: any) => (
+    <div
+      data-testid="base-3d-map"
+      data-node-count={nodes.length}
+      data-line-count={lines.length}
+      data-line-keys={JSON.stringify(lines.map((l: any) => l.key))}
+      data-exaggeration={String(initialExaggeration ?? '')}
+    />
+  ),
+}));
+
+// Capture the params Map3DView feeds the generalized 3D data hooks, and let each
+// test vary the lines they return.
+const neighborSpy = vi.fn();
+const tracerouteSpy = vi.fn();
+const mockState: { neighborLines: Line3DFeature[]; tracerouteLines: Line3DFeature[] } = {
+  neighborLines: [],
+  tracerouteLines: [],
+};
+
+vi.mock('../MapAnalysis/use3DNeighborLines', () => ({
+  use3DNeighborLines: (params: unknown) => {
+    neighborSpy(params);
+    return { lines: mockState.neighborLines, selectionByKey: new Map() };
+  },
+}));
+vi.mock('../MapAnalysis/use3DTracerouteLines', () => ({
+  use3DTracerouteLines: (params: unknown) => {
+    tracerouteSpy(params);
+    return { lines: mockState.tracerouteLines, selectionByKey: new Map() };
+  },
+}));
+
+const line = (key: string): Line3DFeature => ({
+  key,
+  from: [30, -90],
+  to: [31, -91],
+  color: '#000',
+  opacity: 1,
+  width: 2,
+});
+
+const baseProps = {
+  center: [30, -90] as [number, number],
+  zoom: 10,
+  basemap: { tiles: [], attribution: '', maxZoom: 19, usedFallback: false },
+  terrainTileUrl: '/api/elevation/tiles/{z}/{x}/{y}',
+  nodes: [
+    { key: 'n1', lat: 30, lng: -90 },
+    { key: 'n2', lat: 31, lng: -91 },
+  ],
+  sourceIds: ['a'],
+  showNeighbors: true,
+  showTraceroutes: true,
+  lookbackHours: 24,
+};
+
+describe('Map3DView', () => {
+  beforeEach(() => {
+    neighborSpy.mockClear();
+    tracerouteSpy.mockClear();
+    mockState.neighborLines = [];
+    mockState.tracerouteLines = [];
+  });
+
+  it('composes Base3DMap with the nodes and merged neighbor+traceroute lines', () => {
+    mockState.neighborLines = [line('mt:1')];
+    mockState.tracerouteLines = [line('tr:x')];
+    render(<Map3DView {...baseProps} />);
+    const map = screen.getByTestId('base-3d-map');
+    expect(map.dataset.nodeCount).toBe('2');
+    expect(map.dataset.lineCount).toBe('2');
+    expect(JSON.parse(map.dataset.lineKeys ?? '[]')).toEqual(['mt:1', 'tr:x']);
+  });
+
+  it('feeds the neighbor hook the source-scoped, static (no time window) params', () => {
+    render(<Map3DView {...baseProps} sourceIds={['a', 'b']} showNeighbors lookbackHours={12} />);
+    expect(neighborSpy).toHaveBeenCalledWith({
+      layer: { enabled: true, lookbackHours: 12 },
+      sources: ['a', 'b'],
+      timeSlider: { enabled: false },
+    });
+  });
+
+  it('feeds the traceroute hook static params with no selection and no node filter', () => {
+    render(<Map3DView {...baseProps} sourceIds={['a']} showTraceroutes lookbackHours={48} />);
+    expect(tracerouteSpy).toHaveBeenCalledWith({
+      layer: { enabled: true, lookbackHours: 48 },
+      sources: ['a'],
+      timeSlider: { enabled: false },
+      selected: null,
+      nodeFilter: '',
+    });
+  });
+
+  it('gates each layer independently via showNeighbors / showTraceroutes', () => {
+    render(<Map3DView {...baseProps} showNeighbors={false} showTraceroutes />);
+    expect(neighborSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ layer: expect.objectContaining({ enabled: false }) }),
+    );
+    expect(tracerouteSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ layer: expect.objectContaining({ enabled: true }) }),
+    );
+  });
+
+  it('forwards the exaggeration seed to Base3DMap', () => {
+    render(<Map3DView {...baseProps} initialExaggeration={1.8} />);
+    expect(screen.getByTestId('base-3d-map').dataset.exaggeration).toBe('1.8');
+  });
+});

--- a/src/components/map/Map3DView.tsx
+++ b/src/components/map/Map3DView.tsx
@@ -17,8 +17,10 @@ export interface Map3DViewProps {
   nodes: Node3DFeature[];
   /**
    * Sources whose neighbor/traceroute edges to render — a single `[sourceId]`
-   * for a per-source map, or every source id for a unified map. Empty resolves
-   * to "all sources" (the generalized hooks' convention).
+   * for a per-source map, or every source id for a unified map. NOTE: an empty
+   * array resolves to "all sources" (the generalized hooks' convention), so a
+   * host with no source should instead gate `showNeighbors`/`showTraceroutes`
+   * off to render nodes without any cross-source edges.
    */
   sourceIds: string[];
   /** Gate neighbor lines — mirrors the host's "Show Neighbors" toggle. */

--- a/src/components/map/Map3DView.tsx
+++ b/src/components/map/Map3DView.tsx
@@ -1,0 +1,104 @@
+import { useMemo } from 'react';
+import { Base3DMap, type Node3DFeature, type Line3DFeature } from './Base3DMap';
+import type { Basemap3DSource } from '../../config/basemap3d';
+import { use3DNeighborLines } from '../MapAnalysis/use3DNeighborLines';
+import { use3DTracerouteLines } from '../MapAnalysis/use3DTracerouteLines';
+
+export interface Map3DViewProps {
+  /** Initial center, [lat, lng]. Mount-only (Base3DMap convention). */
+  center: [number, number];
+  /** Initial zoom. Mount-only. */
+  zoom: number;
+  /** Raster basemap source, from `resolve3DBasemap`. */
+  basemap: Basemap3DSource;
+  /** Same-origin DEM tile URL template, from `buildTerrainTileUrl`. */
+  terrainTileUrl: string;
+  /** Node markers to render. */
+  nodes: Node3DFeature[];
+  /**
+   * Sources whose neighbor/traceroute edges to render — a single `[sourceId]`
+   * for a per-source map, or every source id for a unified map. Empty resolves
+   * to "all sources" (the generalized hooks' convention).
+   */
+  sourceIds: string[];
+  /** Gate neighbor lines — mirrors the host's "Show Neighbors" toggle. */
+  showNeighbors: boolean;
+  /** Gate traceroute lines — mirrors the host's "Show Traceroute/Route" toggles. */
+  showTraceroutes: boolean;
+  /** Fetch lookback window in hours for the neighbor/traceroute data. */
+  lookbackHours: number;
+  /** Seed for the exaggeration slider (default `1.3`). */
+  initialExaggeration?: number;
+  /** Fired with the new exaggeration value whenever the slider changes. */
+  onExaggerationChange?: (value: number) => void;
+  /** WebGL unavailable — the host should switch back to its 2D map. */
+  onUnsupported?: () => void;
+  /** Fired with a node's `key` when its marker is clicked. */
+  onNodeClick?: (key: string) => void;
+}
+
+/**
+ * Shared 3D map surface for the non-MapAnalysis maps (Dashboard Mesh Map,
+ * Unified Map, classic `/nodes` map) — #4704. Wraps `Base3DMap` and feeds it
+ * neighbor + traceroute lines from the generalized 3D data hooks, scoped to
+ * the host's sources.
+ *
+ * v1 shows nodes + traceroute lines + neighbor lines only — no node filter, no
+ * selection, no time window (static SNR coloring), matching the MapAnalysis 3D
+ * non-goals. Mounted ONLY while its host is in 3D, so the data hooks (and their
+ * fetches) never run in the 2D path.
+ */
+export function Map3DView({
+  center,
+  zoom,
+  basemap,
+  terrainTileUrl,
+  nodes,
+  sourceIds,
+  showNeighbors,
+  showTraceroutes,
+  lookbackHours,
+  initialExaggeration,
+  onExaggerationChange,
+  onUnsupported,
+  onNodeClick,
+}: Map3DViewProps) {
+  // Static coloring for v1: the time slider is always off, so the 3D hooks
+  // fall back to SNR/direction coloring over the full lookback window.
+  const timeSlider = useMemo(() => ({ enabled: false }), []);
+
+  const neighborLines = use3DNeighborLines({
+    layer: { enabled: showNeighbors, lookbackHours },
+    sources: sourceIds,
+    timeSlider,
+  });
+  const tracerouteLines = use3DTracerouteLines({
+    layer: { enabled: showTraceroutes, lookbackHours },
+    sources: sourceIds,
+    timeSlider,
+    selected: null,
+    nodeFilter: '',
+  });
+
+  const lines: Line3DFeature[] = useMemo(
+    () => [...neighborLines.lines, ...tracerouteLines.lines],
+    [neighborLines.lines, tracerouteLines.lines],
+  );
+
+  return (
+    <Base3DMap
+      center={center}
+      zoom={zoom}
+      basemap={basemap}
+      terrainTileUrl={terrainTileUrl}
+      nodes={nodes}
+      lines={lines}
+      onNodeClick={onNodeClick}
+      onUnsupported={onUnsupported}
+      initialExaggeration={initialExaggeration}
+      onExaggerationChange={onExaggerationChange}
+    />
+  );
+}
+
+export default Map3DView;


### PR DESCRIPTION
Closes #4704.

## What

Extends the existing MapLibre GL 3D terrain view (terrarium raster-dem terrain, hillshade, exaggeration slider) — previously scoped to **Map Analysis** — to three more surfaces:
- The **per-source Mesh Map** and the **Unified Map** (both are `DashboardMap.tsx`, which branches on `isUnified`).
- The **classic `/nodes` map** (`NodesTab.tsx`).

Each gets a **"3D Terrain"** toggle in its existing map-controls panel, shown only when the server can serve DEM tiles.

## How

**`Base3DMap` is reused unchanged** — it's already generic. The work is wiring, in reviewable increments:

1. **Generalized the two 3D data hooks** (`use3DNeighborLines` / `use3DTracerouteLines`) to take explicit params instead of reading `useMapAnalysisCtx()`, so non-MapAnalysis surfaces can feed them. MapAnalysis passes the same values from context — **no behavior change there**; the parity tests (locked to the off-limits 2D layer adapters) were updated to pass params directly and stay green.
2. **New `src/components/map/Map3DView.tsx`** — a shared 3D surface that wraps `Base3DMap` and feeds it neighbor + traceroute `Line3DFeature[]` from the generalized hooks, scoped to the host's sources. Mounted **only** while a host is in 3D, so the data-fetch hooks never run in the 2D path.
3. **DashboardMap + NodesTab**: ephemeral `viewMode` state, a `useTerrainCapabilities()`-gated "3D Terrain" checkbox, and an `effective3D = viewMode==='3d' && canUse3D` branch that swaps `<BaseMap>` for `<Map3DView>` (keeping `TilesetSelector` as a sibling). A mid-session capability loss — or WebGL being unavailable (`Base3DMap.onUnsupported`) — forces 2D on the spot, mirroring `useEffectiveViewMode`.

**v1 3D scope:** nodes + traceroute lines + neighbor lines, static SNR coloring (no node filter, no selection, no time slider). **Non-goals not drawn in 3D** (matches the Map Analysis precedent): waypoints, ATAK contacts, polar grid, accuracy regions, GeoJSON overlay, position history, measure tool. Node-marker click is a no-op in 3D for v1.

## Tests

- Generalized-hook parity tests rewritten to drive the hooks with explicit params — all assertions/parity intact.
- New `Map3DView.test.tsx` (shared seam) + DashboardMap 3D integration tests: renders `BaseMap` in 2D, `Base3DMap` in 3D, forces 2D when terrain caps are unavailable, and covers Unified vs single-source and the WebGL-unsupported fallback.
- **Full suite: 15,243 passed, 0 failed, 0 suites failed.** `tsc --noEmit` clean; lint ratchet clean.

## Manual verification

Deployed the branch to the dev container against real multi-source data:
- The "3D Terrain" toggle appears (elevation caps report `terrainTiles: true`).
- In a WebGL-less browser, toggling 3D cleanly falls back to 2D (the `onUnsupported` path).
- Under a SwiftShader-backed Chrome (WebGL available), the Unified map renders the pitched MapLibre 3D terrain surface with the DEM active (Mapzen/AWS terrain tiles) and the exaggeration slider — screenshot captured.

NodesTab's 3D wiring is identical to DashboardMap's (both mount the shared `Map3DView`); its 2D↔3D swap is covered by `Map3DView.test.tsx` + the DashboardMap integration tests (the file's test harness intentionally never renders the full 140 KB NodesTab component).

## Mesh impact

None — frontend only. No new packets, timers, or notifications. Terrain DEM tiles come from the existing `/api/elevation/tiles` proxy; no backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)