### PR TITLE
fix(waypoints): persist the virtual flag on edit (PATCH) (#4795)

### DIFF
--- a/src/server/routes/waypoints.test.ts
+++ b/src/server/routes/waypoints.test.ts
@@ -361,6 +361,61 @@ describe('Waypoint routes', () => {
       expect(fields).not.toHaveProperty('channel');
     });
 
+    it('PATCH threads the virtual flag through update as isVirtual (#4795)', async () => {
+      mockManager();
+      mockWaypointService.update.mockResolvedValue({
+        sourceId: harness.sourceA, waypointId: 5, latitude: 30, longitude: -90,
+        name: '', description: '', isVirtual: true, channel: 0,
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      const res = await agent
+        .patch(`/api/sources/${harness.sourceA}/waypoints/5`)
+        .send({ virtual: true });
+
+      expect(res.status).toBe(200);
+      expect(mockWaypointService.update).toHaveBeenCalledWith(
+        harness.sourceA,
+        5,
+        42,
+        expect.objectContaining({ isVirtual: true }),
+      );
+    });
+
+    it('PATCH threads virtual:false through update — the reported bug (#4795)', async () => {
+      mockManager();
+      mockWaypointService.update.mockResolvedValue({
+        sourceId: harness.sourceA, waypointId: 5, latitude: 30, longitude: -90,
+        name: '', description: '', isVirtual: false, channel: 0,
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      await agent
+        .patch(`/api/sources/${harness.sourceA}/waypoints/5`)
+        .send({ virtual: false });
+
+      expect(mockWaypointService.update).toHaveBeenCalledWith(
+        harness.sourceA,
+        5,
+        42,
+        expect.objectContaining({ isVirtual: false }),
+      );
+    });
+
+    it('PATCH omits isVirtual from the update when virtual is absent (#4795)', async () => {
+      mockManager();
+      mockWaypointService.update.mockResolvedValue({
+        sourceId: harness.sourceA, waypointId: 5, latitude: 30, longitude: -90,
+        name: '', description: '', isVirtual: false, channel: 4,
+      });
+
+      const agent = await harness.loginAs(harness.admin);
+      await agent.patch(`/api/sources/${harness.sourceA}/waypoints/5`).send({ name: 'edit' });
+
+      const fields = mockWaypointService.update.mock.calls[0][3];
+      expect(fields).not.toHaveProperty('isVirtual');
+    });
+
     it('sends the delete tombstone on the waypoint\'s own channel', async () => {
       const { broadcastWaypointDelete } = mockManager();
       vi.spyOn(databaseService.waypoints, 'getAsync').mockResolvedValue({

--- a/src/server/routes/waypoints.ts
+++ b/src/server/routes/waypoints.ts
@@ -255,6 +255,12 @@ router.patch(
       if (body.locked_to !== undefined) {
         fields.lockedTo = body.locked_to === null ? null : Number(body.locked_to);
       }
+      // #4795: the "Virtual — do not broadcast" flag was settable only at
+      // create time; PATCH silently dropped it, so the checkbox never persisted
+      // on edit. Mirror the POST handler's Boolean coercion.
+      if (body.virtual !== undefined) {
+        fields.isVirtual = Boolean(body.virtual);
+      }
       if (body.channel !== undefined) {
         const parsed = parseChannel(body.channel);
         if (parsed && typeof parsed === 'object' && 'error' in parsed) {

--- a/src/server/services/waypointService.test.ts
+++ b/src/server/services/waypointService.test.ts
@@ -434,6 +434,33 @@ describe('broadcast channel (#4341)', () => {
     expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ channel: 2 }));
   });
 
+  it('update keeps the stored isVirtual when the field is omitted (#4795)', async () => {
+    mockGet.mockResolvedValueOnce(eligibleRow({ isVirtual: true }));
+    mockUpsert.mockImplementationOnce(async (v: any) => ({ ...v }));
+
+    await waypointService.update('s1', 7, 0, { name: 'renamed' });
+
+    expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ isVirtual: true }));
+  });
+
+  it('update sets isVirtual=true when supplied (#4795)', async () => {
+    mockGet.mockResolvedValueOnce(eligibleRow({ isVirtual: false }));
+    mockUpsert.mockImplementationOnce(async (v: any) => ({ ...v }));
+
+    await waypointService.update('s1', 7, 0, { isVirtual: true });
+
+    expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ isVirtual: true }));
+  });
+
+  it('update clears isVirtual=false when supplied — the reported bug (#4795)', async () => {
+    mockGet.mockResolvedValueOnce(eligibleRow({ isVirtual: true }));
+    mockUpsert.mockImplementationOnce(async (v: any) => ({ ...v }));
+
+    await waypointService.update('s1', 7, 0, { isVirtual: false });
+
+    expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ isVirtual: false }));
+  });
+
   it('upsertFromMesh records the channel the packet arrived on', async () => {
     mockUpsert.mockImplementationOnce(async (v: any) => ({ ...v }));
 

--- a/src/server/services/waypointService.ts
+++ b/src/server/services/waypointService.ts
@@ -108,6 +108,7 @@ export interface UpdateInput {
   lockedTo?: number | null;
   channel?: number | null;
   rebroadcastIntervalS?: number | null;
+  isVirtual?: boolean;
 }
 
 /**
@@ -297,7 +298,11 @@ class WaypointService {
       description: (fields.description ?? existing.description).slice(0, 100),
       iconCodepoint,
       iconEmoji,
-      isVirtual: existing.isVirtual,
+      // Editable on PATCH (#4795): undefined => keep the existing flag, same as
+      // every other optional field here. A false value (unchecked "virtual")
+      // makes the waypoint eligible for the existing rebroadcast scheduler;
+      // update() itself sends nothing over the mesh.
+      isVirtual: fields.isVirtual === undefined ? existing.isVirtual : fields.isVirtual,
       channel:
         fields.channel === undefined
           ? existing.channel


### PR DESCRIPTION
Fixes #4795.

## Problem

Editing a waypoint never persisted the **"Virtual — do not broadcast"** checkbox. Close and reopen the editor and it's unchecked again, whatever you picked. (Reported by NullVoid on Discord, v4.14.2-rc5.)

## Root cause — two gaps

1. **PATCH route** (`waypoints.ts`) built its `fields` object from the body but **never read `body.virtual`** — the field was silently dropped. The POST handler reads `Boolean(body.virtual)`; PATCH had no equivalent.
2. **`waypointService.update`** hard-coded `isVirtual: existing.isVirtual`, so even if the field *had* reached it, the value would be ignored.

So the flag was only ever settable at create time.

## Fix

- PATCH route reads `body.virtual` into `fields.isVirtual`, mirroring POST's Boolean coercion.
- `UpdateInput` gains `isVirtual?: boolean`; `update()` writes it, keeping the existing value when omitted (the same undefined-means-keep convention every other optional field uses).

## Mesh impact

None. `update()` emits only an internal event and sends nothing over the air. Unchecking "virtual" simply makes the waypoint eligible for the **existing** rebroadcast scheduler (which already caps itself to one eligible waypoint per tick) — no new send path, no new timer.

## Tests

- **Service**: `update()` persists `isVirtual` true→false (the reported bug) and false→true, and preserves it when the field is omitted.
- **Route**: PATCH threads `virtual: true` and `virtual: false` through to `update` as `isVirtual`, and omits the field entirely when `virtual` is absent.
- Full waypoint suite green (63 tests). tsc clean, lint ratchet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G