### PR TITLE
chore(release): 4.14.2-rc6

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor-desktop",
-  "version": "4.14.2-rc5",
+  "version": "4.14.2-rc6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor-desktop",
-      "version": "4.14.2-rc5",
+      "version": "4.14.2-rc6",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.14.2-rc5",
+  "version": "4.14.2-rc6",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.14.2-rc5",
+  "version": "4.14.2-rc6",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.14.2-rc5
-appVersion: "4.14.2-rc5"
+version: 4.14.2-rc6
+appVersion: "4.14.2-rc6"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.2-rc5",
+  "version": "4.14.2-rc6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.14.2-rc5",
+      "version": "4.14.2-rc6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.14.2-rc5",
+  "version": "4.14.2-rc6",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump to **4.14.2-rc6** across all six version files (package.json + lock, helm Chart.yaml version/appVersion, desktop/package.json + lock, tauri.conf.json).

Rolls up 11 PRs merged since rc5 — headlined by the map-improvements trio: hybrid satellite tiles (#4728), 3D terrain on the Mesh/Unified/NodesTab maps (#4704), and the GPS/GNSS constellation overlay (#4729). Full notes go on the release itself.

Release `v4.14.2-rc6` (pre-release) will be cut against main once this merges.