### PR TITLE
fix(map): render 3D node markers as symbols so they sit on the terrain (#4800)

### DIFF
--- a/src/components/map/Base3DMap.test.tsx
+++ b/src/components/map/Base3DMap.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, StrictMode } from 'react';
 import { render, fireEvent, cleanup, screen } from '@testing-library/react';
 import { Base3DMap, type Node3DFeature, type Line3DFeature } from './Base3DMap';
+import { createNodeMarkerImage } from './nodeMarkerIcon';
 import type { Basemap3DSource } from '../../config/basemap3d';
 
 // ---------------------------------------------------------------------------
@@ -39,6 +40,11 @@ const { FakeMap, FakeNavigationControl, FakeAttributionControl } = vi.hoisted(()
       this.layerIds.add(layer.id);
     });
     setTerrain = vi.fn();
+    images = new Set<string>();
+    addImage = vi.fn((id: string) => {
+      this.images.add(id);
+    });
+    hasImage = vi.fn((id: string) => this.images.has(id));
     getSource = vi.fn((id: string) => this.sources[id]);
     getLayer = vi.fn((id: string) => (this.layerIds.has(id) ? {} : undefined));
     removeLayer = vi.fn((id: string) => {
@@ -186,7 +192,18 @@ describe('Base3DMap', () => {
     expect(map.setTerrain).toHaveBeenCalledWith({ source: 'terrain-dem', exaggeration: 1.3 });
     expect(map.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: 'terrain-hillshade', type: 'hillshade' }));
     expect(map.addSource).toHaveBeenCalledWith('nodes', expect.objectContaining({ type: 'geojson' }));
-    expect(map.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: 'nodes-circle', type: 'circle' }));
+    // Node dots are a `symbol` layer, not `circle` (#4800): circle layers don't
+    // drape onto 3D terrain, so they were buried under exaggerated terrain.
+    expect(map.addImage).toHaveBeenCalledWith('node-marker-icon', expect.anything(), { sdf: true });
+    const markerLayer = map.addLayer.mock.calls
+      .map((c: unknown[]) => c[0] as any)
+      .find((l: any) => l.id === 'nodes-marker');
+    expect(markerLayer).toBeDefined();
+    expect(markerLayer.type).toBe('symbol');
+    expect(markerLayer.layout['icon-image']).toBe('node-marker-icon');
+    expect(markerLayer.paint['icon-color']).toEqual(['get', 'color']);
+    // Must NOT be a circle layer (the buried-marker regression).
+    expect(map.addLayer).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'circle' }));
     expect(map.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: 'nodes-label', type: 'symbol' }));
   });
 
@@ -207,7 +224,7 @@ describe('Base3DMap', () => {
       map.triggerLoad();
     });
 
-    const clickHandler = map.layerHandlers['click:nodes-circle'];
+    const clickHandler = map.layerHandlers['click:nodes-marker'];
     expect(clickHandler).toBeDefined();
     clickHandler({ features: [{ properties: { key: 'node-1' } }] });
 
@@ -348,9 +365,9 @@ describe('Base3DMap', () => {
       expect(dashed.map(([layer]) => layer.paint['line-dasharray'])).toEqual(
         expect.arrayContaining([[2, 2], [3, 2]]),
       );
-      // Line layers must be inserted below the node circle layer.
+      // Line layers must be inserted below the node marker layer.
       for (const [, beforeId] of calls) {
-        expect(beforeId).toBe('nodes-circle');
+        expect(beforeId).toBe('nodes-marker');
       }
     });
 
@@ -699,5 +716,48 @@ describe('Base3DMap', () => {
       );
       expect(onMapReady).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('createNodeMarkerImage (#4800 SDF node dot)', () => {
+  const alphaAt = (img: { width: number; data: Uint8ClampedArray }, x: number, y: number) =>
+    img.data[(y * img.width + x) * 4 + 3];
+
+  it('returns a square RGBA buffer of the requested size', () => {
+    const img = createNodeMarkerImage(64);
+    expect(img.width).toBe(64);
+    expect(img.height).toBe(64);
+    expect(img.data.length).toBe(64 * 64 * 4);
+  });
+
+  it('defaults to the module marker size when called with no argument', () => {
+    const img = createNodeMarkerImage();
+    expect(img.width).toBe(64);
+  });
+
+  it('keeps RGB solid white so icon-color can tint it per node', () => {
+    const img = createNodeMarkerImage(32);
+    for (let i = 0; i < img.data.length; i += 4) {
+      expect(img.data[i]).toBe(255);
+      expect(img.data[i + 1]).toBe(255);
+      expect(img.data[i + 2]).toBe(255);
+    }
+  });
+
+  it('encodes the disc in alpha: opaque center, transparent corner, edge near 191', () => {
+    const size = 64;
+    const img = createNodeMarkerImage(size);
+    // Center is well inside the disc → saturated.
+    expect(alphaAt(img, size / 2, size / 2)).toBe(255);
+    // Corner is far outside → fully transparent.
+    expect(alphaAt(img, 0, 0)).toBe(0);
+    // A pixel one row out from the exact disc edge straddles MapLibre's 191
+    // threshold — inside is brighter, outside is dimmer.
+    const center = (size - 1) / 2;
+    const radius = size / 2 - 6;
+    const justInside = alphaAt(img, Math.round(center + radius - 1), Math.round(center));
+    const justOutside = alphaAt(img, Math.round(center + radius + 1), Math.round(center));
+    expect(justInside).toBeGreaterThan(191);
+    expect(justOutside).toBeLessThan(191);
   });
 });

--- a/src/components/map/Base3DMap.tsx
+++ b/src/components/map/Base3DMap.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import * as maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import type { Basemap3DSource } from '../../config/basemap3d';
+import { NODE_MARKER_IMAGE_ID, NODE_MARKER_IMAGE_SIZE, createNodeMarkerImage } from './nodeMarkerIcon';
 import './Base3DMap.css';
 
 /** A single node marker fed into the MapLibre `nodes` GeoJSON source. */
@@ -55,9 +56,9 @@ export interface Base3DMapProps {
   basemap: Basemap3DSource;
   /** Same-origin DEM tile URL template, from `buildTerrainTileUrl`. */
   terrainTileUrl: string;
-  /** Node markers to render as a GeoJSON `circle` + `symbol` label layer. */
+  /** Node markers to render as a GeoJSON `symbol` icon + `symbol` label layer. */
   nodes: Node3DFeature[];
-  /** Fired when a node's circle marker is clicked, with its `key`. */
+  /** Fired when a node's marker is clicked, with its `key`. */
   onNodeClick?: (key: string) => void;
   /** Line segments (neighbor links, traceroute paths, …) to render below the node layers. */
   lines?: Line3DFeature[];
@@ -101,7 +102,7 @@ const BASEMAP_LAYER_ID = 'basemap-raster-layer';
 const TERRAIN_SOURCE_ID = 'terrain-dem';
 const HILLSHADE_LAYER_ID = 'terrain-hillshade';
 const NODES_SOURCE_ID = 'nodes';
-const NODES_CIRCLE_LAYER_ID = 'nodes-circle';
+const NODES_MARKER_LAYER_ID = 'nodes-marker';
 const NODES_LABEL_LAYER_ID = 'nodes-label';
 const LINES_SOURCE_ID = 'lines';
 const LINES_LAYER_PREFIX = 'lines-';
@@ -251,7 +252,7 @@ export function Base3DMap({
   const nextLineLayerIndexRef = useRef(0);
 
   // Adds one MapLibre `line` layer for a dash group, filtered to its
-  // features via `dashKey`, inserted below the node circle/label layers so
+  // features via `dashKey`, inserted below the node marker/label layers so
   // markers stay clickable on top. Stable identity (empty deps, refs only)
   // so it can be an effect dep without forcing extra reconciliation runs.
   const addLineLayer = useCallback((map: maplibregl.Map, dashKey: string, dash: number[], layerId: string) => {
@@ -268,7 +269,7 @@ export function Base3DMap({
           ...(dash.length ? { 'line-dasharray': dash } : {}),
         },
       },
-      NODES_CIRCLE_LAYER_ID,
+      NODES_MARKER_LAYER_ID,
     );
     map.on('click', layerId, (e) => {
       const feature = e.features?.[0];
@@ -383,15 +384,40 @@ export function Base3DMap({
         type: 'geojson',
         data: toNodesFeatureCollection(nodes),
       });
+      // Node dots are a `symbol` layer, NOT a `circle` layer: MapLibre circle
+      // layers render at elevation 0 and do not drape onto 3D terrain, so with
+      // exaggerated terrain the dots were buried under the surface and vanished
+      // (#4800). Symbol layers are elevated onto the terrain, so the dot is a
+      // symbol using a generated SDF disc icon — tinted per-node via icon-color
+      // and outlined via icon-halo, reproducing the 2D circle marker's look.
+      if (!map.hasImage(NODE_MARKER_IMAGE_ID)) {
+        map.addImage(NODE_MARKER_IMAGE_ID, createNodeMarkerImage(NODE_MARKER_IMAGE_SIZE), {
+          sdf: true,
+        });
+      }
       map.addLayer({
-        id: NODES_CIRCLE_LAYER_ID,
-        type: 'circle',
+        id: NODES_MARKER_LAYER_ID,
+        type: 'symbol',
         source: NODES_SOURCE_ID,
+        layout: {
+          'icon-image': NODE_MARKER_IMAGE_ID,
+          // 64px source image scaled to ~a 6px-radius dot, matching the old
+          // circle-radius of 6.
+          'icon-size': 0.25,
+          // Always draw every dot — dots must never be dropped by symbol
+          // collision the way a label legitimately can be.
+          'icon-allow-overlap': true,
+          'icon-ignore-placement': true,
+          // Billboard the dot toward the camera (as the 2D circle's default
+          // viewport alignment did) rather than laying it flat on the tilted
+          // terrain surface.
+          'icon-rotation-alignment': 'viewport',
+          'icon-pitch-alignment': 'viewport',
+        },
         paint: {
-          'circle-radius': 6,
-          'circle-color': ['get', 'color'],
-          'circle-stroke-width': 1.5,
-          'circle-stroke-color': '#ffffff',
+          'icon-color': ['get', 'color'],
+          'icon-halo-color': '#ffffff',
+          'icon-halo-width': 1.5,
         },
       });
       map.addLayer({
@@ -411,22 +437,22 @@ export function Base3DMap({
         },
       });
 
-      map.on('click', NODES_CIRCLE_LAYER_ID, (e) => {
+      map.on('click', NODES_MARKER_LAYER_ID, (e) => {
         const feature = e.features?.[0];
         const key = feature?.properties?.key;
         if (typeof key === 'string') {
           onNodeClickRef.current?.(key);
         }
       });
-      map.on('mouseenter', NODES_CIRCLE_LAYER_ID, () => {
+      map.on('mouseenter', NODES_MARKER_LAYER_ID, () => {
         map.getCanvas().style.cursor = 'pointer';
       });
-      map.on('mouseleave', NODES_CIRCLE_LAYER_ID, () => {
+      map.on('mouseleave', NODES_MARKER_LAYER_ID, () => {
         map.getCanvas().style.cursor = '';
       });
 
       // Lines source + one line layer per distinct dash pattern (spec §2.1/§3.1),
-      // inserted below the node circle/label layers so markers stay clickable
+      // inserted below the node marker/label layers so markers stay clickable
       // on top. Zero dash groups when `lines` is omitted/empty ⇒ no line
       // layers added, matching pre-Phase-3 behavior.
       map.addSource(LINES_SOURCE_ID, {

--- a/src/components/map/nodeMarkerIcon.ts
+++ b/src/components/map/nodeMarkerIcon.ts
@@ -1,0 +1,59 @@
+/**
+ * Node marker icon for the 3D map (#4800).
+ *
+ * Lives in its own module (not `Base3DMap.tsx`) so the component file exports
+ * only its component — a non-component export there trips
+ * `react-refresh/only-export-components`.
+ */
+
+/** Id of the generated SDF disc image used as the node marker icon. */
+export const NODE_MARKER_IMAGE_ID = 'node-marker-icon';
+
+/**
+ * Source resolution of the marker image (device px); the symbol layer scales it
+ * down via `icon-size`. 64px gives a crisp dot after downscaling.
+ */
+export const NODE_MARKER_IMAGE_SIZE = 64;
+
+/**
+ * Build a signed-distance-field (SDF) disc image for the node marker symbol.
+ *
+ * MapLibre `circle` layers do NOT drape onto 3D terrain — they render at
+ * elevation 0, so with exaggerated terrain the surface rises above them and the
+ * node dots vanish under the mesh (the reported bug). `symbol` layers, by
+ * contrast, are elevated onto the terrain surface, so the dot is drawn as a
+ * symbol using this icon instead of a circle layer.
+ *
+ * The image is an SDF: RGB is solid white and the disc is encoded in the alpha
+ * channel. That lets one shared image be tinted per-node via `icon-color` and
+ * outlined via `icon-halo-color`/`icon-halo-width`, reproducing the 2D circle
+ * marker's coloured-fill-plus-white-ring look. Per MapLibre's SDF convention
+ * the shape edge sits at alpha 191 (0.75 x 255): alpha climbs toward 255 inside
+ * the disc and falls toward 0 outside, over a short linear ramp so the halo has
+ * a gradient to render against.
+ *
+ * Pure and canvas-free so it is deterministic and unit-testable (jsdom has no
+ * canvas); the returned object is accepted directly by `map.addImage`.
+ */
+export function createNodeMarkerImage(
+  size: number = NODE_MARKER_IMAGE_SIZE,
+): { width: number; height: number; data: Uint8ClampedArray } {
+  const data = new Uint8ClampedArray(size * size * 4);
+  const center = (size - 1) / 2;
+  // Leave a ring of padding so the halo has room and the disc never clips.
+  const radius = size / 2 - 6;
+  const EDGE = 191; // 0.75 * 255 — MapLibre's SDF edge threshold
+  const RAMP = 16; // alpha units per pixel of signed distance
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const dist = radius - Math.hypot(x - center, y - center); // > 0 inside
+      const alpha = Math.max(0, Math.min(255, Math.round(EDGE + dist * RAMP)));
+      const i = (y * size + x) * 4;
+      data[i] = 255; // R — white, recolored per-node by icon-color
+      data[i + 1] = 255; // G
+      data[i + 2] = 255; // B
+      data[i + 3] = alpha;
+    }
+  }
+  return { width: size, height: size, data };
+}


### PR DESCRIPTION
Fixes #4800.

## Problem

3D terrain mode (new in rc6, #4793) renders the terrain but shows **zero node markers**.

## Root cause (confirmed against the MapLibre style spec)

The node dots were drawn as a MapLibre **`circle`** layer. MapLibre `circle` layers do **not** drape onto 3D terrain — they render at elevation 0. With exaggerated terrain, the surface rises above them and every dot is buried under the mesh.

I verified against the MapLibre 5.x style spec that there is **no** circle elevation property (no `circle-elevation-reference` — that's Mapbox-only; the circle layer only has `circle-pitch-alignment`/`circle-pitch-scale`, neither of which elevates). `symbol` layers, by contrast, are elevated onto the terrain surface.

## Fix

Draw the node dot as a **`symbol`** layer instead of a circle layer:

- New `nodeMarkerIcon.ts` generates a **SDF disc icon** (white RGB, disc encoded in the alpha channel) — pure and canvas-free, so it's deterministic and unit-testable, and kept out of the component file so it doesn't trip `react-refresh/only-export-components`.
- On load, `map.addImage(..., { sdf: true })`, then a symbol marker layer with `icon-color: ['get','color']` (per-node tint) and `icon-halo-color/width` (the white ring) — reproducing the 2D circle's coloured-fill + white-ring look. `icon-allow-overlap` keeps every dot; viewport alignment billboards it toward the camera as the old circle did.
- Layer id `nodes-circle` → `nodes-marker`; the line-insertion `beforeId` and click/hover handlers key off the same constant, so they follow automatically.

## Tests

- Assert the marker is a **`symbol`** layer with the SDF `icon-image` + `icon-color`, assert the `addImage(..., {sdf:true})` call, and assert **no `circle` layer** is added (locks in the regression).
- Unit-test the SDF generator: dimensions, solid-white RGB, and the alpha ramp (opaque center → transparent corner → ~191 at the disc edge).
- Full `Base3DMap` suite green (28 tests). Lint ratchet clean.

## ⚠️ Validation gap — please visually confirm

**Automated visual validation could not run in my environment**: the headless browser I drive has **no WebGL** (`webgl1`/`webgl2` both false), so MapLibre never initializes and the 3D toggle reverts. The unit tests mock MapLibre entirely, so they verify layer *config*, not rendering.

The **root cause** and the **symbol-vs-circle terrain behaviour** are confirmed against the MapLibre style spec, but the on-terrain pixel result needs a check on real hardware. Please enable **3D Terrain** on the Mesh Map / `/nodes` map and confirm node dots (and labels) now appear on the terrain surface, tinted correctly, and remain clickable. Icon size (`icon-size: 0.25`) and halo width are easy one-line tweaks if the dots look too big/small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G