### PR TITLE
fix(meshcore): honor temperature unit for MeshCore telemetry (#3659)

### DIFF
--- a/src/utils/temperature.test.ts
+++ b/src/utils/temperature.test.ts
@@ -63,11 +63,20 @@ describe('temperature utilities', () => {
       expect(isTemperatureType('co2Temperature')).toBe(true);
     });
 
+    it('matches the MeshCore temperature channel family (#3659)', () => {
+      expect(isTemperatureType('mc_temperature')).toBe(true);
+      expect(isTemperatureType('mc_temperature_ch1')).toBe(true);
+      expect(isTemperatureType('mc_temperature_ch2')).toBe(true);
+    });
+
     it('does not match non-temperature types', () => {
       expect(isTemperatureType('humidity')).toBe(false);
       expect(isTemperatureType('voltage')).toBe(false);
       expect(isTemperatureType('batteryLevel')).toBe(false);
       expect(isTemperatureType('')).toBe(false);
+      // A non-temperature MeshCore channel must not be swept in by the prefix.
+      expect(isTemperatureType('mc_humidity')).toBe(false);
+      expect(isTemperatureType('mc_voltage')).toBe(false);
     });
   });
 });

--- a/src/utils/temperature.ts
+++ b/src/utils/temperature.ts
@@ -35,5 +35,9 @@ export function getTemperatureUnit(unit: TemperatureUnit): string {
 const TEMPERATURE_TELEMETRY_TYPES = new Set(['temperature', 'soilTemperature', 'co2Temperature']);
 
 export function isTemperatureType(type: string): boolean {
-  return TEMPERATURE_TELEMETRY_TYPES.has(type);
+  // MeshCore telemetry names its temperature channels `mc_temperature`,
+  // `mc_temperature_ch1`, `mc_temperature_ch2`, … — all Celsius, all should
+  // honor the unit preference like Meshtastic's (issue #3659). Match the whole
+  // family by prefix rather than enumerating each channel.
+  return TEMPERATURE_TELEMETRY_TYPES.has(type) || type.startsWith('mc_temperature');
 }


### PR DESCRIPTION
## Summary

Fixes the reopened #3659. The earlier fix wired the `temperatureUnit` prop into
MeshCore's `<TelemetryGraphs>`, but `isTemperatureType()` in
`src/utils/temperature.ts` still only recognized `temperature`,
`soilTemperature`, and `co2Temperature` — so MeshCore's `mc_temperature`,
`mc_temperature_ch1`, `mc_temperature_ch2` channels were never converted, and
the graphs kept showing °C regardless of the Units & Formats setting.

## Fix

`isTemperatureType()` now also matches the whole `mc_temperature*` family by
prefix. A codebase scan confirms the only `mc_temperature*` types are the three
channels above, and no non-temperature MeshCore channel starts with that prefix,
so there's no false-positive risk (guarded by a test on `mc_humidity` /
`mc_voltage`).

## Testing

- `src/utils/temperature.test.ts`: added the MeshCore family (positive) and
  non-temperature `mc_*` (negative) cases — 10 passing.

Reported by mattch3886 on Discord.

🤖 Generated with [Claude Code](https://claude.com/claude-code)