### PR TITLE
fix(map): load MapLibre v6 worker so 3D node markers render (#4800)

### DIFF
--- a/src/components/map/Base3DMap.test.tsx
+++ b/src/components/map/Base3DMap.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, StrictMode } from 'react';
 import { render, fireEvent, cleanup, screen } from '@testing-library/react';
 import { Base3DMap, type Node3DFeature, type Line3DFeature } from './Base3DMap';
+import { createNodeMarkerImage } from './nodeMarkerIcon';
 import type { Basemap3DSource } from '../../config/basemap3d';
 
 // ---------------------------------------------------------------------------
@@ -39,6 +40,11 @@ const { FakeMap, FakeNavigationControl, FakeAttributionControl } = vi.hoisted(()
       this.layerIds.add(layer.id);
     });
     setTerrain = vi.fn();
+    images = new Set<string>();
+    addImage = vi.fn((id: string) => {
+      this.images.add(id);
+    });
+    hasImage = vi.fn((id: string) => this.images.has(id));
     getSource = vi.fn((id: string) => this.sources[id]);
     getLayer = vi.fn((id: string) => (this.layerIds.has(id) ? {} : undefined));
     removeLayer = vi.fn((id: string) => {
@@ -109,7 +115,13 @@ vi.mock('maplibre-gl', () => ({
   Map: FakeMap,
   NavigationControl: FakeNavigationControl,
   AttributionControl: FakeAttributionControl,
+  setWorkerUrl: vi.fn(),
 }));
+
+// Base3DMap imports the worker-URL side-effect module (#4800). Its Vite
+// `?worker&url` import + setWorkerUrl call are build/runtime concerns irrelevant
+// to these jsdom layer-config tests, so stub it out entirely.
+vi.mock('./maplibreWorker', () => ({}));
 
 // ---------------------------------------------------------------------------
 
@@ -186,7 +198,18 @@ describe('Base3DMap', () => {
     expect(map.setTerrain).toHaveBeenCalledWith({ source: 'terrain-dem', exaggeration: 1.3 });
     expect(map.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: 'terrain-hillshade', type: 'hillshade' }));
     expect(map.addSource).toHaveBeenCalledWith('nodes', expect.objectContaining({ type: 'geojson' }));
-    expect(map.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: 'nodes-circle', type: 'circle' }));
+    // Node dots are a `symbol` layer, not `circle` (#4800): circle layers don't
+    // drape onto 3D terrain, so they were buried under exaggerated terrain.
+    expect(map.addImage).toHaveBeenCalledWith('node-marker-icon', expect.anything(), { sdf: true });
+    const markerLayer = map.addLayer.mock.calls
+      .map((c: unknown[]) => c[0] as any)
+      .find((l: any) => l.id === 'nodes-marker');
+    expect(markerLayer).toBeDefined();
+    expect(markerLayer.type).toBe('symbol');
+    expect(markerLayer.layout['icon-image']).toBe('node-marker-icon');
+    expect(markerLayer.paint['icon-color']).toEqual(['get', 'color']);
+    // Must NOT be a circle layer (the buried-marker regression).
+    expect(map.addLayer).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'circle' }));
     expect(map.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: 'nodes-label', type: 'symbol' }));
   });
 
@@ -207,7 +230,7 @@ describe('Base3DMap', () => {
       map.triggerLoad();
     });
 
-    const clickHandler = map.layerHandlers['click:nodes-circle'];
+    const clickHandler = map.layerHandlers['click:nodes-marker'];
     expect(clickHandler).toBeDefined();
     clickHandler({ features: [{ properties: { key: 'node-1' } }] });
 
@@ -348,9 +371,9 @@ describe('Base3DMap', () => {
       expect(dashed.map(([layer]) => layer.paint['line-dasharray'])).toEqual(
         expect.arrayContaining([[2, 2], [3, 2]]),
       );
-      // Line layers must be inserted below the node circle layer.
+      // Line layers must be inserted below the node marker layer.
       for (const [, beforeId] of calls) {
-        expect(beforeId).toBe('nodes-circle');
+        expect(beforeId).toBe('nodes-marker');
       }
     });
 
@@ -699,5 +722,48 @@ describe('Base3DMap', () => {
       );
       expect(onMapReady).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('createNodeMarkerImage (#4800 SDF node dot)', () => {
+  const alphaAt = (img: { width: number; data: Uint8ClampedArray }, x: number, y: number) =>
+    img.data[(y * img.width + x) * 4 + 3];
+
+  it('returns a square RGBA buffer of the requested size', () => {
+    const img = createNodeMarkerImage(64);
+    expect(img.width).toBe(64);
+    expect(img.height).toBe(64);
+    expect(img.data.length).toBe(64 * 64 * 4);
+  });
+
+  it('defaults to the module marker size when called with no argument', () => {
+    const img = createNodeMarkerImage();
+    expect(img.width).toBe(64);
+  });
+
+  it('keeps RGB solid white so icon-color can tint it per node', () => {
+    const img = createNodeMarkerImage(32);
+    for (let i = 0; i < img.data.length; i += 4) {
+      expect(img.data[i]).toBe(255);
+      expect(img.data[i + 1]).toBe(255);
+      expect(img.data[i + 2]).toBe(255);
+    }
+  });
+
+  it('encodes the disc in alpha: opaque center, transparent corner, edge near 191', () => {
+    const size = 64;
+    const img = createNodeMarkerImage(size);
+    // Center is well inside the disc → saturated.
+    expect(alphaAt(img, size / 2, size / 2)).toBe(255);
+    // Corner is far outside → fully transparent.
+    expect(alphaAt(img, 0, 0)).toBe(0);
+    // A pixel one row out from the exact disc edge straddles MapLibre's 191
+    // threshold — inside is brighter, outside is dimmer.
+    const center = (size - 1) / 2;
+    const radius = size / 2 - 6;
+    const justInside = alphaAt(img, Math.round(center + radius - 1), Math.round(center));
+    const justOutside = alphaAt(img, Math.round(center + radius + 1), Math.round(center));
+    expect(justInside).toBeGreaterThan(191);
+    expect(justOutside).toBeLessThan(191);
   });
 });

--- a/src/components/map/Base3DMap.tsx
+++ b/src/components/map/Base3DMap.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 // maplibre-gl v6 is ESM-only and dropped its default export (#4650).
 import * as maplibregl from 'maplibre-gl';
+import './maplibreWorker';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import type { Basemap3DSource } from '../../config/basemap3d';
+import { NODE_MARKER_IMAGE_ID, NODE_MARKER_IMAGE_SIZE, createNodeMarkerImage } from './nodeMarkerIcon';
 import './Base3DMap.css';
 
 /** A single node marker fed into the MapLibre `nodes` GeoJSON source. */
@@ -55,9 +57,9 @@ export interface Base3DMapProps {
   basemap: Basemap3DSource;
   /** Same-origin DEM tile URL template, from `buildTerrainTileUrl`. */
   terrainTileUrl: string;
-  /** Node markers to render as a GeoJSON `circle` + `symbol` label layer. */
+  /** Node markers to render as a GeoJSON `symbol` icon + `symbol` label layer. */
   nodes: Node3DFeature[];
-  /** Fired when a node's circle marker is clicked, with its `key`. */
+  /** Fired when a node's marker is clicked, with its `key`. */
   onNodeClick?: (key: string) => void;
   /** Line segments (neighbor links, traceroute paths, …) to render below the node layers. */
   lines?: Line3DFeature[];
@@ -101,7 +103,7 @@ const BASEMAP_LAYER_ID = 'basemap-raster-layer';
 const TERRAIN_SOURCE_ID = 'terrain-dem';
 const HILLSHADE_LAYER_ID = 'terrain-hillshade';
 const NODES_SOURCE_ID = 'nodes';
-const NODES_CIRCLE_LAYER_ID = 'nodes-circle';
+const NODES_MARKER_LAYER_ID = 'nodes-marker';
 const NODES_LABEL_LAYER_ID = 'nodes-label';
 const LINES_SOURCE_ID = 'lines';
 const LINES_LAYER_PREFIX = 'lines-';
@@ -251,7 +253,7 @@ export function Base3DMap({
   const nextLineLayerIndexRef = useRef(0);
 
   // Adds one MapLibre `line` layer for a dash group, filtered to its
-  // features via `dashKey`, inserted below the node circle/label layers so
+  // features via `dashKey`, inserted below the node marker/label layers so
   // markers stay clickable on top. Stable identity (empty deps, refs only)
   // so it can be an effect dep without forcing extra reconciliation runs.
   const addLineLayer = useCallback((map: maplibregl.Map, dashKey: string, dash: number[], layerId: string) => {
@@ -268,7 +270,7 @@ export function Base3DMap({
           ...(dash.length ? { 'line-dasharray': dash } : {}),
         },
       },
-      NODES_CIRCLE_LAYER_ID,
+      NODES_MARKER_LAYER_ID,
     );
     map.on('click', layerId, (e) => {
       const feature = e.features?.[0];
@@ -383,15 +385,40 @@ export function Base3DMap({
         type: 'geojson',
         data: toNodesFeatureCollection(nodes),
       });
+      // Node dots are a `symbol` layer, NOT a `circle` layer: MapLibre circle
+      // layers render at elevation 0 and do not drape onto 3D terrain, so with
+      // exaggerated terrain the dots were buried under the surface and vanished
+      // (#4800). Symbol layers are elevated onto the terrain, so the dot is a
+      // symbol using a generated SDF disc icon — tinted per-node via icon-color
+      // and outlined via icon-halo, reproducing the 2D circle marker's look.
+      if (!map.hasImage(NODE_MARKER_IMAGE_ID)) {
+        map.addImage(NODE_MARKER_IMAGE_ID, createNodeMarkerImage(NODE_MARKER_IMAGE_SIZE), {
+          sdf: true,
+        });
+      }
       map.addLayer({
-        id: NODES_CIRCLE_LAYER_ID,
-        type: 'circle',
+        id: NODES_MARKER_LAYER_ID,
+        type: 'symbol',
         source: NODES_SOURCE_ID,
+        layout: {
+          'icon-image': NODE_MARKER_IMAGE_ID,
+          // 64px source image scaled to ~a 6px-radius dot, matching the old
+          // circle-radius of 6.
+          'icon-size': 0.25,
+          // Always draw every dot — dots must never be dropped by symbol
+          // collision the way a label legitimately can be.
+          'icon-allow-overlap': true,
+          'icon-ignore-placement': true,
+          // Billboard the dot toward the camera (as the 2D circle's default
+          // viewport alignment did) rather than laying it flat on the tilted
+          // terrain surface.
+          'icon-rotation-alignment': 'viewport',
+          'icon-pitch-alignment': 'viewport',
+        },
         paint: {
-          'circle-radius': 6,
-          'circle-color': ['get', 'color'],
-          'circle-stroke-width': 1.5,
-          'circle-stroke-color': '#ffffff',
+          'icon-color': ['get', 'color'],
+          'icon-halo-color': '#ffffff',
+          'icon-halo-width': 1.5,
         },
       });
       map.addLayer({
@@ -411,22 +438,22 @@ export function Base3DMap({
         },
       });
 
-      map.on('click', NODES_CIRCLE_LAYER_ID, (e) => {
+      map.on('click', NODES_MARKER_LAYER_ID, (e) => {
         const feature = e.features?.[0];
         const key = feature?.properties?.key;
         if (typeof key === 'string') {
           onNodeClickRef.current?.(key);
         }
       });
-      map.on('mouseenter', NODES_CIRCLE_LAYER_ID, () => {
+      map.on('mouseenter', NODES_MARKER_LAYER_ID, () => {
         map.getCanvas().style.cursor = 'pointer';
       });
-      map.on('mouseleave', NODES_CIRCLE_LAYER_ID, () => {
+      map.on('mouseleave', NODES_MARKER_LAYER_ID, () => {
         map.getCanvas().style.cursor = '';
       });
 
       // Lines source + one line layer per distinct dash pattern (spec §2.1/§3.1),
-      // inserted below the node circle/label layers so markers stay clickable
+      // inserted below the node marker/label layers so markers stay clickable
       // on top. Zero dash groups when `lines` is omitted/empty ⇒ no line
       // layers added, matching pre-Phase-3 behavior.
       map.addSource(LINES_SOURCE_ID, {

--- a/src/components/map/maplibreWorker.ts
+++ b/src/components/map/maplibreWorker.ts
@@ -1,0 +1,39 @@
+/**
+ * Point MapLibre GL at a Vite-bundled worker URL (#4800).
+ *
+ * MapLibre v6 (#4650) is ESM-only and ships its tiling/layout worker as a
+ * separate module, `maplibre-gl-worker.mjs`. It builds that worker's URL
+ * *dynamically* (a dev-vs-prod filename ternary), so Vite cannot statically
+ * analyse the `new Worker(new URL(...), { type: 'module' })` call and never
+ * emits the worker as a build asset. At runtime the browser then requests
+ * `<base>/assets/maplibre-gl-worker.mjs`, gets a 404, and the worker never
+ * starts.
+ *
+ * The worker is where GeoJSON sources are parsed into tiles and where symbol /
+ * circle layers are laid out, so with a dead worker every GeoJSON source and
+ * every symbol/circle layer silently renders nothing — while raster layers
+ * (basemap, terrain-dem, hillshade) keep working because they don't use it.
+ * That is exactly the 3D-map bug: terrain renders, nodes and labels never do.
+ *
+ * `?worker&url` makes Vite bundle the worker as its own chunk — resolving its
+ * internal `./maplibre-gl-shared.mjs` import — and hand back a base-aware URL,
+ * which we register via `setWorkerUrl` before any map is constructed. Importing
+ * this module for its side effect at the top of the (single) map-constructing
+ * component guarantees it runs first.
+ */
+import * as maplibregl from 'maplibre-gl';
+// Vite virtual import: bundles the worker + its deps, returns the emitted URL.
+import maplibreWorkerUrl from 'maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url';
+
+// Vite builds with `base: '/'`, so the emitted URL is root-relative
+// (`/assets/…`). But the app is served under a runtime base path (e.g.
+// `/meshmonitor`) taken from the server-injected `<base>` tag — the same source
+// `src/init.ts` uses. Without the prefix the worker 404s under a subpath
+// deployment (#4800). Only rewrite a root-relative URL; leave absolute ones be.
+const baseHref = document.querySelector('base')?.getAttribute('href') || '/';
+const basePrefix = baseHref === '/' ? '' : baseHref.replace(/\/$/, '');
+const workerUrl = maplibreWorkerUrl.startsWith('/')
+  ? `${basePrefix}${maplibreWorkerUrl}`
+  : maplibreWorkerUrl;
+
+maplibregl.setWorkerUrl(workerUrl);

--- a/src/components/map/nodeMarkerIcon.ts
+++ b/src/components/map/nodeMarkerIcon.ts
@@ -1,0 +1,59 @@
+/**
+ * Node marker icon for the 3D map (#4800).
+ *
+ * Lives in its own module (not `Base3DMap.tsx`) so the component file exports
+ * only its component — a non-component export there trips
+ * `react-refresh/only-export-components`.
+ */
+
+/** Id of the generated SDF disc image used as the node marker icon. */
+export const NODE_MARKER_IMAGE_ID = 'node-marker-icon';
+
+/**
+ * Source resolution of the marker image (device px); the symbol layer scales it
+ * down via `icon-size`. 64px gives a crisp dot after downscaling.
+ */
+export const NODE_MARKER_IMAGE_SIZE = 64;
+
+/**
+ * Build a signed-distance-field (SDF) disc image for the node marker symbol.
+ *
+ * MapLibre `circle` layers do NOT drape onto 3D terrain — they render at
+ * elevation 0, so with exaggerated terrain the surface rises above them and the
+ * node dots vanish under the mesh (the reported bug). `symbol` layers, by
+ * contrast, are elevated onto the terrain surface, so the dot is drawn as a
+ * symbol using this icon instead of a circle layer.
+ *
+ * The image is an SDF: RGB is solid white and the disc is encoded in the alpha
+ * channel. That lets one shared image be tinted per-node via `icon-color` and
+ * outlined via `icon-halo-color`/`icon-halo-width`, reproducing the 2D circle
+ * marker's coloured-fill-plus-white-ring look. Per MapLibre's SDF convention
+ * the shape edge sits at alpha 191 (0.75 x 255): alpha climbs toward 255 inside
+ * the disc and falls toward 0 outside, over a short linear ramp so the halo has
+ * a gradient to render against.
+ *
+ * Pure and canvas-free so it is deterministic and unit-testable (jsdom has no
+ * canvas); the returned object is accepted directly by `map.addImage`.
+ */
+export function createNodeMarkerImage(
+  size: number = NODE_MARKER_IMAGE_SIZE,
+): { width: number; height: number; data: Uint8ClampedArray } {
+  const data = new Uint8ClampedArray(size * size * 4);
+  const center = (size - 1) / 2;
+  // Leave a ring of padding so the halo has room and the disc never clips.
+  const radius = size / 2 - 6;
+  const EDGE = 191; // 0.75 * 255 — MapLibre's SDF edge threshold
+  const RAMP = 16; // alpha units per pixel of signed distance
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const dist = radius - Math.hypot(x - center, y - center); // > 0 inside
+      const alpha = Math.max(0, Math.min(255, Math.round(EDGE + dist * RAMP)));
+      const i = (y * size + x) * 4;
+      data[i] = 255; // R — white, recolored per-node by icon-color
+      data[i + 1] = 255; // G
+      data[i + 2] = 255; // B
+      data[i + 3] = alpha;
+    }
+  }
+  return { width: size, height: size, data };
+}

--- a/src/test/maplibreWorkerUrlStub.ts
+++ b/src/test/maplibreWorkerUrlStub.ts
@@ -1,0 +1,6 @@
+// Test stub for the Vite `?worker&url` virtual import used by
+// `src/components/map/maplibreWorker.ts` (#4800). That suffix is a build-only
+// Vite feature Vitest cannot resolve, and it targets a v6 dist file the test
+// environment need not have. jsdom map tests mock `maplibre-gl` entirely, so
+// the real worker URL is irrelevant here — an empty string is enough.
+export default '';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,6 +47,11 @@ export default defineConfig({
   ],
   // Always build for root - runtime HTML rewriting will handle BASE_URL
   base: '/',
+  // MapLibre v6 loads its bundled worker with `{ type: 'module' }`, so Vite must
+  // emit worker chunks in ES format rather than the default IIFE (#4800).
+  worker: {
+    format: 'es',
+  },
   server: {
     host: true,
     port: 5173,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -157,6 +157,13 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      // The MapLibre worker URL is a build-only Vite `?worker&url` virtual
+      // import (maplibreWorker.ts, #4800) that Vitest cannot resolve; stub it so
+      // any test importing Base3DMap can collect. jsdom tests mock maplibre-gl.
+      'maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url': path.resolve(
+        __dirname,
+        'src/test/maplibreWorkerUrlStub.ts',
+      ),
       // Force the ESM build of the spiderfier under Vitest. Its package `main`
       // is a UMD bundle whose named `OverlappingMarkerSpiderfier` export isn't a
       // constructor when Vitest externalizes it, so any test that mounts a


### PR DESCRIPTION
Fixes #4800. Supersedes #4803 (which fixed only the second of the two bugs below and was closed).

## Symptom

3D terrain mode renders the terrain surface but **zero node markers** (and no labels).

## Root cause — two bugs, and the first hid the second

**1. The MapLibre v6 worker never loads (the real root cause).**
MapLibre v6 (#4650, ESM-only) loads its tiling/layout worker as a separate `maplibre-gl-worker.mjs`, building that URL *dynamically* — so Vite can't statically analyse it and never emits the file. At runtime the browser requests `<base>/assets/maplibre-gl-worker.mjs`, gets a **404**, and the worker dies. The worker is where GeoJSON sources are parsed into tiles and symbol/circle layers are laid out, so **every GeoJSON source + symbol/circle layer silently renders nothing**, while raster layers (basemap, terrain-dem, hillshade) keep working. That's exactly the bug: terrain renders, nodes never do.

**2. Circle layers don't draw on 3D terrain.**
Even with the worker alive, MapLibre `circle` layers render nothing on the terrain surface. So the node dot is drawn as a `symbol` layer instead (with a generated SDF disc icon, tinted per-node via `icon-color`, white ring via `icon-halo`).

## Fix

- **`maplibreWorker.ts`** — bundle the worker via Vite `?worker&url`, prefix the runtime base path (the app serves under `/meshmonitor`), and register it with `setWorkerUrl` before any map is built.
- **`vite.config.ts`** — `worker.format: 'es'` (v6 instantiates the worker as `{ type: 'module' }`).
- **`nodeMarkerIcon.ts`** — pure, canvas-free SDF disc generator.
- **`Base3DMap.tsx`** — import the worker setup; replace the `circle` marker layer with a `symbol` layer + `addImage`.
- **`vitest.config.ts` + stub** — resolve the build-only `?worker&url` import under Vitest.

## Verification (real WebGL render)

Since CI/jsdom has no WebGL, I verified end-to-end in a **headless SwiftShader** render of the actual v6 app. Definitive proof both changes are required:

| Build | isSourceLoaded | source features | markers rendered |
|-------|:--:|:--:|:--:|
| before (circle, no worker fix) | false | 0 | **0** |
| worker fix + circle layer | true | 450 | **0** |
| worker fix + symbol layer | true | 453 | **187** ✅ |

Screenshot of the working result (node markers + labels on the 3D terrain) was shared with the maintainer.

Tests: Base3DMap/Map3DView/MapAnalysisCanvas suites green (68). tsc + lint-ratchet clean.

## Notes
- Node dots render in the default color (`#3fb1ce`); per-node coloring in 3D is a pre-existing gap (`node3DFeatures` doesn't pass `color`), out of scope here.
- A reusable headless-SwiftShader 3D smoke harness would have caught this (jsdom mocks MapLibre, so unit tests can't); happy to contribute one separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G