### PR TITLE
fix(ingest): stop re-recording NodeDB dump as duplicate position/telemetry history (#4809)

### DIFF
--- a/src/server/meshtasticManager.nodedbHistoryGate.test.ts
+++ b/src/server/meshtasticManager.nodedbHistoryGate.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression test for issue #4809 — NodeDB config-sync re-inserting remote
+ * nodes' position/telemetry as duplicate history.
+ *
+ * On every config sync the node dumps its whole NodeDB as FromRadio.node_info
+ * records, each embedding that node's last-known position and device_metrics.
+ * processNodeInfoProtobuf used to write those as telemetry-history rows for
+ * EVERY node (with a null packetId that bypasses dedup), so each resync
+ * re-inserted the entire database as fresh graph points — badly amplified by
+ * Meshtastic 2.8's larger warm NodeDB.
+ *
+ * The fix records NodeInfo-embedded position/device-metric history for the
+ * LOCAL node only (its telemetry never arrives as a live POSITION_APP/
+ * TELEMETRY_APP packet over the PhoneAPI). Remote nodes' history comes from
+ * those live, packetId-deduped packets instead. These tests drive the REAL
+ * processNodeInfoProtobuf and assert on the telemetry-batch it emits.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const insertTelemetryBatch = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    settings: {
+      getSettingForSource: vi.fn().mockResolvedValue(null),
+      getSetting: vi.fn().mockResolvedValue(null),
+    },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    ignoredNodes: { isIgnoredCached: vi.fn().mockReturnValue(false) },
+    telemetry: {
+      insertTelemetry: vi.fn(),
+      insertTelemetryBatch: (...args: unknown[]) => insertTelemetryBatch(...args),
+    },
+    upsertNodeAsync: vi.fn().mockResolvedValue(undefined),
+    getLatestTelemetryForTypeAsync: vi.fn().mockResolvedValue(null),
+    updateNodeMobilityAsync: vi.fn().mockResolvedValue(null),
+    clearKeyRepairStateAsync: vi.fn().mockResolvedValue(undefined),
+    logKeyRepairAttemptAsync: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn() },
+}));
+
+const LOCAL = 0x0a0a0a0a;
+const REMOTE = 0x22222222;
+
+// A valid fix with a stable payload time, plus device metrics.
+const position = { latitudeI: 407_000_000, longitudeI: -740_000_000, time: 1_600_000_100, altitude: 10 };
+const deviceMetrics = { batteryLevel: 80, voltage: 4.0 };
+
+function nodeInfo(num: number) {
+  return {
+    num,
+    user: { id: `!${num.toString(16).padStart(8, '0')}`, longName: 'N', shortName: 'N' },
+    position,
+    deviceMetrics,
+    // deliberately NO snr — snr_remote has its own throttle and would otherwise
+    // add a row for every node, muddying the position/device-metric assertion.
+  };
+}
+
+describe('MeshtasticManager — NodeDB history gate (#4809)', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module = await import('./meshtasticManager.js');
+    manager = module.fallbackManager;
+    manager.localNodeInfo = { nodeNum: LOCAL };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT write position/device-metric history for a REMOTE node', async () => {
+    await manager.processNodeInfoProtobuf(nodeInfo(REMOTE));
+    // With no snr row, the batch would be empty, so it is never flushed.
+    expect(insertTelemetryBatch).not.toHaveBeenCalled();
+  });
+
+  it('DOES write position + device-metric history for the LOCAL node', async () => {
+    await manager.processNodeInfoProtobuf(nodeInfo(LOCAL));
+    expect(insertTelemetryBatch).toHaveBeenCalledTimes(1);
+    const rows = insertTelemetryBatch.mock.calls[0][0] as Array<{ telemetryType: string }>;
+    const types = rows.map((r) => r.telemetryType);
+    expect(types).toContain('latitude');
+    expect(types).toContain('longitude');
+    expect(types).toContain('batteryLevel');
+    expect(types).toContain('voltage');
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -9017,6 +9017,22 @@ class MeshtasticManager implements ISourceManager {
       }
 
       // Add position information if available
+      // History rows sourced from the NodeDB config-sync dump are written ONLY for
+      // the local node (issue #4809). The node sends its entire NodeDB as
+      // FromRadio.node_info records on every config sync, each embedding that
+      // node's last-known position/device_metrics. For remote nodes that same
+      // history already arrives as live POSITION_APP/TELEMETRY_APP packets, which
+      // carry a packetId and are deduped; the embedded NodeInfo copies do not, so
+      // they bypass dedup and re-insert the whole database as duplicate graph
+      // points on every resync (badly amplified by Meshtastic 2.8's larger warm
+      // NodeDB and its nodes-only refresh). The LOCAL node is the sole exception:
+      // TCP clients never receive their own node's POSITION_APP/TELEMETRY_APP over
+      // the PhoneAPI, so NodeInfo is its only telemetry-history source. The node
+      // *row* (current position, last-known fields, SNR trend) still updates for
+      // every node below — only the duplicate history writes are gated.
+      const isLocalNode = this.localNodeInfo != null
+        && this.localNodeInfo.nodeNum === Number(nodeInfo.num);
+
       let positionTelemetryData: { timestamp: number; latitude: number; longitude: number; altitude?: number; precisionBits?: number; channel?: number; groundSpeed?: number; groundTrack?: number } | null = null;
       if (nodeInfo.position && (nodeInfo.position.latitudeI || nodeInfo.position.longitudeI)) {
         const coords = meshtasticProtobufService.convertCoordinates(
@@ -9088,19 +9104,24 @@ class MeshtasticManager implements ISourceManager {
             }
           }
 
-          // Always record position telemetry for history (regardless of whether the
-          // current-position columns were updated), using the actual incoming coordinates.
-          const timestamp = nodeInfo.position.time ? Number(nodeInfo.position.time) * 1000 : Date.now();
-          positionTelemetryData = {
-            timestamp,
-            latitude: coords.latitude,
-            longitude: coords.longitude,
-            altitude: nodeInfo.position.altitude,
-            precisionBits,
-            channel: channelIndex,
-            groundSpeed: nodeInfo.position.groundSpeed ?? nodeInfo.position.ground_speed,
-            groundTrack: nodeInfo.position.groundTrack ?? nodeInfo.position.ground_track
-          };
+          // Record position telemetry history for the LOCAL node only (issue #4809).
+          // Remote nodes' position history comes from live POSITION_APP packets
+          // (deduped by packetId); re-recording the NodeDB-dump copy here duplicated
+          // the whole database on every config resync. The current-position columns
+          // above still update for every node, so the map is unaffected.
+          if (isLocalNode) {
+            const timestamp = nodeInfo.position.time ? Number(nodeInfo.position.time) * 1000 : Date.now();
+            positionTelemetryData = {
+              timestamp,
+              latitude: coords.latitude,
+              longitude: coords.longitude,
+              altitude: nodeInfo.position.altitude,
+              precisionBits,
+              channel: channelIndex,
+              groundSpeed: nodeInfo.position.groundSpeed ?? nodeInfo.position.ground_speed,
+              groundTrack: nodeInfo.position.groundTrack ?? nodeInfo.position.ground_track
+            };
+          }
         } else {
           logger.warn(`⚠️ Invalid position coordinates for node ${nodeId}: lat=${coords.latitude}, lon=${coords.longitude}. Skipping position save.`);
         }
@@ -9110,7 +9131,7 @@ class MeshtasticManager implements ISourceManager {
       // This allows the local node's telemetry to be captured, since TCP clients
       // only receive TELEMETRY_APP packets from OTHER nodes via mesh, not from the local node
       let deviceMetricsTelemetryData: any = null;
-      if (nodeInfo.deviceMetrics) {
+      if (nodeInfo.deviceMetrics && isLocalNode) {
         const deviceMetrics = nodeInfo.deviceMetrics;
         const timestamp = nodeInfo.lastHeard ? Number(nodeInfo.lastHeard) * 1000 : Date.now();
 


### PR DESCRIPTION
Closes #4809.

## Root cause

Users on Meshtastic 2.8 nightly report "fake retransmits" of Position and
Telemetry — duplicate graph points, telemetry rows, and churned node data. It is
**not** a firmware replay. The 2.8 `NodeDatabase`/`NodeInfoLite` format is
on-disk only and never crosses the PhoneAPI.

What actually happens: on every config sync the node dumps its **entire NodeDB**
to MeshMonitor as `FromRadio.node_info` records, each **embedding** that node's
last-known `position` and `device_metrics`. `processNodeInfoProtobuf` recorded
those as telemetry-history rows **for every node**, with `packetId = null`. The
only telemetry dedup is a partial unique index (`WHERE packetId IS NOT NULL`,
migration 032), so null-packetId rows bypass dedup entirely and every row
inserts. **2.8 amplifies it**: the new warm NodeDB keeps far more nodes resident
and is re-dumped on reconnect and via the nodes-only refresh (nonce 69421), so
each resync re-injects the whole database as O(nodes) duplicate rows.

## Fix

Gate the NodeInfo-embedded position and device-metric **history** writes to the
**local node** only. That is the sole node with no alternative source — TCP
clients never receive their own node's `POSITION_APP`/`TELEMETRY_APP` over the
PhoneAPI. Every **remote** node's history already arrives as live,
packetId-deduped `POSITION_APP`/`TELEMETRY_APP` packets (which also drive
mobility detection — `processPositionMessageProtobuf` at meshtasticManager.ts),
so the NodeInfo copy was pure duplication.

The node **row** — current position, last-known fields, and the already-throttled
SNR trend (`snr_remote`, "save only if changed or ≥10 min") — still updates for
**all** nodes, so the map and nodes list are unaffected.

## Not in scope

The NodeInfo path does not write to `packet_log`, so this does not touch the
Packet Monitor. Packet Monitor duplication is a separate matter (the log has no
id-dedup) tracked independently.

## Testing

- New `meshtasticManager.nodedbHistoryGate.test.ts` drives the real
  `processNodeInfoProtobuf`: a REMOTE node with position + device metrics writes
  no history batch; the LOCAL node writes latitude/longitude/batteryLevel/voltage.
- Full suite: **15,329 passed, 0 failed** (2 suites fail to collect locally only,
  from a missing `satellite.js` install in this checkout — GNSS untouched; CI
  installs fresh). Server `tsc` and in-repo `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)