### PR TITLE
fix(packet-monitor): drop exact-duplicate receptions from the packet log (#4811)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -74,6 +74,7 @@ import {
   recordMqttEcho,
   matchesMqttEcho,
 } from './services/mqttProxyBridge.js';
+import { isDuplicatePacketLog, packetLogDedupKey } from './services/packetLogDedup.js';
 import { NodeDbMaintenanceService } from './services/nodeDbMaintenanceService.js';
 import { AutoAnnounceService } from './services/autoAnnounceService.js';
 import { AdminTransactionService } from './services/adminTransactionService.js';
@@ -862,6 +863,11 @@ class MeshtasticManager implements ISourceManager {
 
   private autoAckCooldowns: Map<number, number> = new Map(); // nodeNum -> lastResponseTimestamp; bounded, see pruneAutoAckCooldowns (#4399)
   private autoAckProcessedPackets: Set<number> = new Set(); // packetIds already auto-acked (dedup guard)
+  // Packet Monitor recently-seen guard (#4811): key -> expiry ms. Suppresses the
+  // firmware's exact-duplicate deliveries and reconnect replays from the packet
+  // log while preserving distinct relay/transport copies. Per-source (one map
+  // per manager instance).
+  private recentPacketLogKeys: Map<string, number> = new Map();
   private autoResponderCooldowns: Map<string, number> = new Map(); // "triggerIndex:nodeNum" -> lastResponseTimestamp
   private autoResponderProcessedPackets: Set<number> = new Set(); // packetIds already auto-responded (dedup guard)
 
@@ -5834,6 +5840,20 @@ class MeshtasticManager implements ISourceManager {
         // above) arrived over the air, so it is a reception, not our own 'tx'.
         const spoof = this.assessLocalSpoof(meshPacket);
 
+        // Drop exact-duplicate receptions the firmware delivers twice, or that a
+        // reconnect replays, from the Packet Monitor (#4811). The key folds in
+        // relay_node + transport, so a rebroadcast via a different relay or the
+        // same packet over LoRa vs MQTT keeps its own row. Only guard when we
+        // have a real packet id (0/absent = unknown, never collapse). Genuine
+        // local TX is logged on a different path and is never deduped here.
+        const dedupPacketId = meshPacket.id ? Number(meshPacket.id) : 0;
+        if (dedupPacketId && isDuplicatePacketLog(
+          this.recentPacketLogKeys,
+          packetLogDedupKey(fromNum, dedupPacketId, meshPacket.relayNode, meshPacket.transportMechanism),
+          Date.now()
+        )) {
+          logger.debug(`📦 Skipping duplicate packet-log entry for id ${dedupPacketId} from ${fromNum}`);
+        } else {
         void packetLogService.logPacket({
           packet_id: meshPacket.id ?? undefined,
           timestamp: Date.now(), // Use server time in ms for consistent ordering (rxTime preserved in metadata.rx_time)
@@ -5868,6 +5888,7 @@ class MeshtasticManager implements ISourceManager {
           transport_mechanism: meshPacket.transportMechanism ?? TransportMechanism.LORA,
           sourceId: this.sourceId,
         });
+        } // end else (not a duplicate packet-log entry)
         } // end else (not internal packet)
       }
     } catch (error) {

--- a/src/server/services/packetLogDedup.test.ts
+++ b/src/server/services/packetLogDedup.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  packetLogDedupKey,
+  isDuplicatePacketLog,
+  PACKET_LOG_DEDUP_TTL_MS,
+} from './packetLogDedup';
+
+/**
+ * Packet Monitor recently-seen guard (issue #4811). Verifies that exact
+ * duplicate deliveries collapse while genuinely-distinct relay/transport copies
+ * of the same packet id survive, and that entries expire after the TTL.
+ */
+describe('packetLogDedupKey', () => {
+  it('distinguishes different relays and transports of the same packet id', () => {
+    const a = packetLogDedupKey(10, 999, 1, 0);
+    const b = packetLogDedupKey(10, 999, 2, 0); // different relay
+    const c = packetLogDedupKey(10, 999, 1, 1); // different transport
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).toBe(packetLogDedupKey(10, 999, 1, 0)); // identical tuple
+  });
+
+  it('folds absent relay/transport to a stable token', () => {
+    expect(packetLogDedupKey(10, 999, null, undefined)).toBe(packetLogDedupKey(10, 999, undefined, null));
+  });
+});
+
+describe('isDuplicatePacketLog', () => {
+  it('records a first sighting (not a duplicate) then flags the repeat', () => {
+    const seen = new Map<string, number>();
+    const key = packetLogDedupKey(10, 999, 1, 0);
+    expect(isDuplicatePacketLog(seen, key, 1_000)).toBe(false);
+    expect(isDuplicatePacketLog(seen, key, 1_500)).toBe(true);
+    expect(isDuplicatePacketLog(seen, key, 1_600)).toBe(true);
+  });
+
+  it('does NOT collapse distinct relay/transport copies of one id', () => {
+    const seen = new Map<string, number>();
+    const now = 1_000;
+    expect(isDuplicatePacketLog(seen, packetLogDedupKey(10, 999, 1, 0), now)).toBe(false);
+    // Same id/sender, different relay -> distinct reception, kept.
+    expect(isDuplicatePacketLog(seen, packetLogDedupKey(10, 999, 2, 0), now)).toBe(false);
+    // Same id/sender/relay, different transport (LoRa vs MQTT) -> kept.
+    expect(isDuplicatePacketLog(seen, packetLogDedupKey(10, 999, 1, 1), now)).toBe(false);
+  });
+
+  it('lets the same tuple through again after the TTL expires', () => {
+    const seen = new Map<string, number>();
+    const key = packetLogDedupKey(10, 999, 1, 0);
+    expect(isDuplicatePacketLog(seen, key, 1_000)).toBe(false);
+    // Just after expiry it is no longer a duplicate (pruned), and re-recorded.
+    const afterExpiry = 1_000 + PACKET_LOG_DEDUP_TTL_MS + 1;
+    expect(isDuplicatePacketLog(seen, key, afterExpiry)).toBe(false);
+    expect(isDuplicatePacketLog(seen, key, afterExpiry + 1)).toBe(true);
+  });
+
+  it('prunes expired entries so the map does not grow unbounded', () => {
+    const seen = new Map<string, number>();
+    isDuplicatePacketLog(seen, packetLogDedupKey(10, 1, 0, 0), 1_000);
+    isDuplicatePacketLog(seen, packetLogDedupKey(10, 2, 0, 0), 1_000);
+    expect(seen.size).toBe(2);
+    // A later call past the TTL prunes both stale entries before recording.
+    isDuplicatePacketLog(seen, packetLogDedupKey(10, 3, 0, 0), 1_000 + PACKET_LOG_DEDUP_TTL_MS + 1);
+    expect(seen.size).toBe(1);
+  });
+});

--- a/src/server/services/packetLogDedup.ts
+++ b/src/server/services/packetLogDedup.ts
@@ -1,0 +1,55 @@
+/**
+ * Recently-seen guard for the Packet Monitor (issue #4811).
+ *
+ * The packet_log table has no de-duplication, so a packet the firmware delivers
+ * twice (a 2.8-nightly symptom) or that a reconnect/replay re-inserts produces
+ * genuinely-identical duplicate rows — pure clutter.
+ *
+ * The key deliberately includes `relayNode` and `transportMechanism` so that
+ * legitimately-distinct receptions of the same packet id — a rebroadcast heard
+ * via a different relay, or the same packet arriving over both LoRa and MQTT —
+ * keep their own key and are NOT collapsed. Those carry different SNR / hop /
+ * transport data and are exactly what a packet monitor is for. Only an exact
+ * (sender, id, relay, transport) repeat within the TTL window is dropped.
+ *
+ * In-memory and TTL-bounded; the store lives per-source on the manager, so no
+ * schema change and no cross-source leakage.
+ */
+
+/** How long a (from,id,relay,transport) tuple suppresses a repeat. */
+export const PACKET_LOG_DEDUP_TTL_MS = 30_000;
+
+/**
+ * Build the dedup key. `relayNode`/`transportMechanism` are folded in so distinct
+ * relay/transport copies of one packet id survive; absent values collapse to a
+ * stable empty token.
+ */
+export function packetLogDedupKey(
+  fromNum: number,
+  packetId: number,
+  relayNode: number | null | undefined,
+  transportMechanism: number | null | undefined
+): string {
+  return `${fromNum}:${packetId}:${relayNode ?? ''}:${transportMechanism ?? ''}`;
+}
+
+/**
+ * Prune expired entries, then test-and-record `key`. Returns true when `key` was
+ * already present (unexpired) — i.e. this is a duplicate that should NOT be
+ * logged again. Mutates `seen` in place.
+ */
+export function isDuplicatePacketLog(
+  seen: Map<string, number>,
+  key: string,
+  now: number,
+  ttlMs: number = PACKET_LOG_DEDUP_TTL_MS
+): boolean {
+  // Prune expired entries. The map is bounded by traffic within the TTL window,
+  // so this stays cheap.
+  for (const [k, expiresAt] of seen) {
+    if (expiresAt <= now) seen.delete(k);
+  }
+  if (seen.has(key)) return true;
+  seen.set(key, now + ttlMs);
+  return false;
+}


### PR DESCRIPTION
Closes #4811.

## Problem

The Packet Monitor (`packet_log`) has **no de-duplication of any kind** — no
unique index on `packet_id`, no recently-seen guard before logging. Every
MeshPacket the firmware hands us becomes a new row. On Meshtastic 2.8 nightly
this shows as duplicate Position/Telemetry entries, because the firmware can
deliver the **same packet id twice** with identical rx metadata, and
reconnect/replay re-inserts packets.

## What must NOT be collapsed

Multi-relay and multi-transport (LoRa + MQTT) copies of the same packet id are
**legitimately distinct** receptions carrying different `rx_snr`/`rx_rssi`/
`relay_node`/`hop_*`/`transport_mechanism`. A packet monitor should keep them —
so a blunt unique index on `(from, id)` would be wrong.

## Fix

A short-TTL (30s), in-memory, **per-source** recently-seen guard before
`logPacket`, keyed on `(fromNum, packetId, relayNode, transportMechanism)`. The
relay + transport in the key mean distinct relay/transport copies keep their own
row; only an exact `(sender, id, relay, transport)` repeat inside the window is
dropped. Packets with no real id (0/absent) are never collapsed, and genuine
local TX (a different log path) is not touched.

The dedup logic lives in a small pure module (`packetLogDedup.ts`) so it is unit
tested directly; the manager holds one `Map` per source.

## Testing

- `packetLogDedup.test.ts` (6): key distinctness across relay/transport, first vs
  repeat, distinct copies preserved, TTL expiry, pruning.
- Full suite: **15,333 passed, 0 failed** (2 suites fail to collect locally only,
  missing `satellite.js` in this checkout — GNSS untouched; CI installs fresh).
  Server `tsc` and in-repo `lint:ci` clean.

Companion to #4810 (the NodeDB telemetry-duplication half of the same report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)