### PR TITLE
feat(map): 3D node markers match 2D — color, type glyphs, age dimming (#4808)

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -18,7 +18,8 @@ import type { PathOptions } from 'leaflet';
 import L from 'leaflet';
 import { createNodeIcon } from '../../utils/mapIcons';
 import { markerAgeOpacity } from '../../utils/markerAgeOpacity';
-import { getNodeTypeCategory } from '../../utils/nodeTypeCategory';
+import { getNodeTypeCategory, categoryGlyphFamily } from '../../utils/nodeTypeCategory';
+import { getHopColor } from '../../utils/mapIcons';
 import { NodeMarkersLayer, type NodeMarkerDescriptor } from '../map/layers/NodeMarkersLayer';
 import type { CustomTileset } from '../../config/tilesets';
 import DashboardWaypoints from './DashboardWaypoints';
@@ -340,16 +341,24 @@ export default function DashboardMap({
   // #4704: node markers for the 3D surface — same visible+positioned node list
   // the 2D markers use, mapped to the shape `Base3DMap` expects. Computed
   // unconditionally (cheap map, no hooks); only consumed when `effective3D`.
-  const node3DFeatures: Node3DFeature[] = useMemo(
-    () =>
-      nodesWithPosition.map(({ node, pos }) => ({
-        key: unifiedNodeKey(node) ?? String(node.nodeNum ?? node.nodeId ?? node.user?.id),
-        lat: pos.lat,
-        lng: pos.lng,
-        label: node.shortName ?? node.user?.shortName ?? undefined,
-      })),
-    [nodesWithPosition],
-  );
+  const node3DFeatures: Node3DFeature[] = useMemo(() => {
+    // Computed once per recompute (not per render) — age dimming is approximate,
+    // and pinning it to a dep-free `now` avoids re-setData churn (#4808).
+    const now = Date.now();
+    const cutoffMs = (now / 1000 - effectiveMaxAge * 60 * 60) * 1000;
+    return nodesWithPosition.map(({ node, pos }) => ({
+      key: unifiedNodeKey(node) ?? String(node.nodeNum ?? node.nodeId ?? node.user?.id),
+      lat: pos.lat,
+      lng: pos.lng,
+      label: node.shortName ?? node.user?.shortName ?? undefined,
+      // Match the 2D marker (#4808): hop color + glyph-family category + age dim.
+      color: getHopColor(node.hopsAway ?? 999),
+      category: categoryGlyphFamily(getNodeTypeCategory(node)),
+      opacity: node.isFavorite
+        ? 1
+        : markerAgeOpacity(now, cutoffMs, node.lastHeard != null ? node.lastHeard * 1000 : null),
+    }));
+  }, [nodesWithPosition, effectiveMaxAge]);
 
   // #3636: measurement endpoints — nearest-node snapping picks from these.
   const measurePoints: MeasurePoint[] = nodesWithPosition.map(({ node, pos }) => ({

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -6,6 +6,7 @@ import { useSettings } from '../../contexts/SettingsContext';
 import { useMapAnalysisCtx } from './MapAnalysisContext';
 import { useSource } from '../../contexts/SourceContext';
 import { useAnalysisNodes } from './useAnalysisNodes';
+import { getNodeTypeCategory, categoryGlyphFamily } from '../../utils/nodeTypeCategory';
 import MeasureDistanceController from '../MeasureDistanceController';
 import type { MeasurePoint } from '../../utils/measureDistance';
 import LinkProfileController from './LinkProfileController';
@@ -165,6 +166,11 @@ export default function MapAnalysisCanvas() {
       lat: a.latLng[0],
       lng: a.latLng[1],
       label: a.node.shortName ?? undefined,
+      // Node-type glyph, consistent with the other 3D surfaces (#4808). Hop
+      // color + age dimming here depend on MapAnalysis's own hop-shading / age
+      // model and are handled in the follow-up; markers default to the disc's
+      // color/opacity until then.
+      category: categoryGlyphFamily(getNodeTypeCategory(a.node)),
     })),
     [analysisNodes],
   );

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -7,7 +7,7 @@ import type { Marker as LeafletMarker } from 'leaflet';
 import { DeviceInfo } from '../types/device';
 import { TabType } from '../types/ui';
 import { nodePassesTransportFilter, transportCutoffSec } from '../utils/nodeTransport';
-import { getNodeTypeCategory } from '../utils/nodeTypeCategory';
+import { getNodeTypeCategory, categoryGlyphFamily } from '../utils/nodeTypeCategory';
 import { effectiveMapMaxAgeHours } from '../utils/mapAge';
 import { ageFilterStops, nearestAgeStopIndex, formatAgeStop } from '../utils/mapAgeSteps';
 import { downsamplePositionHistory, MAX_RENDERED_POSITION_POINTS } from '../utils/positionHistoryDownsample';
@@ -1694,15 +1694,38 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     for (const node of visibleMapNodes) {
       const pos = nodePositions.get(node.nodeNum);
       if (!pos) continue;
+      // Match the 2D marker (#4808): hop-based color + glyph-family category.
+      const isLocalNode = node.user?.id === currentNodeId;
+      const hops = isLocalNode ? 0 : getEffectiveHops(node, nodeHopsCalculation, traceroutes, currentNodeNum);
       out.push({
         key: String(node.user?.id ?? node.nodeNum),
         lat: pos[0],
         lng: pos[1],
         label: node.user?.shortName ?? undefined,
+        color: getHopColor(hops),
+        category: categoryGlyphFamily(getNodeTypeCategory(node)),
+        opacity: calculateNodeOpacity(
+          node.lastHeard,
+          nodeDimmingEnabled,
+          nodeDimmingStartHours,
+          nodeDimmingMinOpacity,
+          maxNodeAgeHours,
+        ),
       });
     }
     return out;
-  }, [visibleMapNodes, nodePositions]);
+  }, [
+    visibleMapNodes,
+    nodePositions,
+    currentNodeId,
+    nodeHopsCalculation,
+    traceroutes,
+    currentNodeNum,
+    nodeDimmingEnabled,
+    nodeDimmingStartHours,
+    nodeDimmingMinOpacity,
+    maxNodeAgeHours,
+  ]);
 
   const nodeMarkers: NodeMarkerDescriptor[] = visibleMapNodes
     .map(node => {

--- a/src/components/map/Base3DMap.test.tsx
+++ b/src/components/map/Base3DMap.test.tsx
@@ -206,8 +206,12 @@ describe('Base3DMap', () => {
       .find((l: any) => l.id === 'nodes-marker');
     expect(markerLayer).toBeDefined();
     expect(markerLayer.type).toBe('symbol');
-    expect(markerLayer.layout['icon-image']).toBe('node-marker-icon');
+    // icon-image is now data-driven (#4808): standard→SDF disc, glyph families→
+    // a per-(family,color) raster, resolved from the `iconImage` feature prop.
+    expect(markerLayer.layout['icon-image']).toEqual(['get', 'iconImage']);
     expect(markerLayer.paint['icon-color']).toEqual(['get', 'color']);
+    // #4808 marker parity: per-hop color + age-dim opacity are data-driven.
+    expect(markerLayer.paint['icon-opacity']).toEqual(['get', 'opacity']);
     // Must NOT be a circle layer (the buried-marker regression).
     expect(map.addLayer).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'circle' }));
     expect(map.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: 'nodes-label', type: 'symbol' }));

--- a/src/components/map/Base3DMap.tsx
+++ b/src/components/map/Base3DMap.tsx
@@ -5,6 +5,7 @@ import './maplibreWorker';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import type { Basemap3DSource } from '../../config/basemap3d';
 import { NODE_MARKER_IMAGE_ID, NODE_MARKER_IMAGE_SIZE, createNodeMarkerImage } from './nodeMarkerIcon';
+import { glyphIconId, parseGlyphIconId, rasterizeGlyphIcon } from './nodeGlyphIcons';
 import './Base3DMap.css';
 
 /** A single node marker fed into the MapLibre `nodes` GeoJSON source. */
@@ -13,7 +14,19 @@ export interface Node3DFeature {
   lat: number;
   lng: number;
   label?: string;
+  /** Hop-based marker color (`getHopColor`), matching the 2D map (#4808). */
   color?: string;
+  /**
+   * Node-type category from `getNodeTypeCategory` (#4808). Selects the marker
+   * glyph (repeater tower, sensor, room server, companion, or the plain disc).
+   */
+  category?: string;
+  /**
+   * Marker opacity [0,1] from the 2D age-dimming (`calculateNodeOpacity` /
+   * `ageOpacity`), so old nodes fade in 3D exactly as they do in 2D (#4808).
+   * Defaults to 1 (fully opaque).
+   */
+  opacity?: number;
 }
 
 /**
@@ -133,11 +146,25 @@ function isWebGlAvailable(): boolean {
 function toNodesFeatureCollection(nodes: Node3DFeature[]): GeoJSON.FeatureCollection {
   return {
     type: 'FeatureCollection',
-    features: nodes.map((n) => ({
-      type: 'Feature',
-      geometry: { type: 'Point', coordinates: [n.lng, n.lat] },
-      properties: { key: n.key, label: n.label ?? '', color: n.color ?? '#3fb1ce' },
-    })),
+    features: nodes.map((n) => {
+      const color = n.color ?? '#3fb1ce';
+      const category = n.category ?? 'standard';
+      // `standard` (no glyph) uses the shared SDF disc, tinted by icon-color;
+      // glyph families select a pre-colored raster generated on demand (#4808).
+      const iconImage = category === 'standard' ? NODE_MARKER_IMAGE_ID : glyphIconId(category, color);
+      return {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [n.lng, n.lat] },
+        properties: {
+          key: n.key,
+          label: n.label ?? '',
+          color,
+          category,
+          iconImage,
+          opacity: n.opacity ?? 1,
+        },
+      };
+    }),
   };
 }
 
@@ -396,15 +423,36 @@ export function Base3DMap({
           sdf: true,
         });
       }
+      // Per-node-type glyph icons (#4808): the `standard` family uses the SDF
+      // disc above; glyph families (repeater/sensor/roomServer/companion) use a
+      // full-color raster of the 2D role-glyph marker, generated lazily the
+      // first time the layer asks for a `"<family>_<color>"` id that isn't
+      // registered yet. A Set guards against duplicate in-flight rasterizations
+      // while the async image loads (styleimagemissing fires every frame).
+      const pendingGlyphIcons = new Set<string>();
+      map.on('styleimagemissing', (e) => {
+        const id = e.id;
+        if (map.hasImage(id) || pendingGlyphIcons.has(id)) return;
+        const parsed = parseGlyphIconId(id);
+        if (!parsed) return;
+        pendingGlyphIcons.add(id);
+        void rasterizeGlyphIcon(parsed.family, parsed.color)
+          .then((imgData) => {
+            pendingGlyphIcons.delete(id);
+            if (imgData && !map.hasImage(id)) map.addImage(id, imgData);
+          })
+          .catch(() => pendingGlyphIcons.delete(id));
+      });
       map.addLayer({
         id: NODES_MARKER_LAYER_ID,
         type: 'symbol',
         source: NODES_SOURCE_ID,
         layout: {
-          'icon-image': NODE_MARKER_IMAGE_ID,
-          // 64px source image scaled to ~a 6px-radius dot, matching the old
-          // circle-radius of 6.
-          'icon-size': 0.25,
+          // `standard` → the tinted SDF disc; glyph families → the pre-colored
+          // raster keyed by `iconImage` (see toNodesFeatureCollection).
+          'icon-image': ['get', 'iconImage'],
+          // 64px source image scaled down; glyph markers read at this size.
+          'icon-size': 0.35,
           // Always draw every dot — dots must never be dropped by symbol
           // collision the way a label legitimately can be.
           'icon-allow-overlap': true,
@@ -419,6 +467,8 @@ export function Base3DMap({
           'icon-color': ['get', 'color'],
           'icon-halo-color': '#ffffff',
           'icon-halo-width': 1.5,
+          // Fade aged nodes exactly as the 2D map does (#4808).
+          'icon-opacity': ['get', 'opacity'],
         },
       });
       map.addLayer({
@@ -435,6 +485,7 @@ export function Base3DMap({
           'text-color': '#f8fafc',
           'text-halo-color': '#0f172a',
           'text-halo-width': 1,
+          'text-opacity': ['get', 'opacity'],
         },
       });
 

--- a/src/components/map/Base3DMap.tsx
+++ b/src/components/map/Base3DMap.tsx
@@ -332,6 +332,11 @@ export function Base3DMap({
       return;
     }
 
+    // Guards the async glyph rasterization below: if the component unmounts
+    // while a rasterize promise is in flight, its `addImage` must not run
+    // against the already-removed map (MapLibre throws) (#4808).
+    let mapRemoved = false;
+
     let map: maplibregl.Map;
     try {
       map = new maplibregl.Map({
@@ -439,7 +444,7 @@ export function Base3DMap({
         void rasterizeGlyphIcon(parsed.family, parsed.color)
           .then((imgData) => {
             pendingGlyphIcons.delete(id);
-            if (imgData && !map.hasImage(id)) map.addImage(id, imgData);
+            if (!mapRemoved && imgData && !map.hasImage(id)) map.addImage(id, imgData);
           })
           .catch(() => pendingGlyphIcons.delete(id));
       });
@@ -524,6 +529,7 @@ export function Base3DMap({
     });
 
     return () => {
+      mapRemoved = true;
       setLoaded(false);
       onMapReadyRef.current?.(null);
       map.remove();

--- a/src/components/map/nodeGlyphIcons.test.ts
+++ b/src/components/map/nodeGlyphIcons.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { glyphIconId, parseGlyphIconId, GLYPH_ICON_SIZE } from './nodeGlyphIcons';
+
+describe('nodeGlyphIcons id helpers (#4808)', () => {
+  it('composes a "<family>_<color>" id', () => {
+    expect(glyphIconId('repeater', '#0000FF')).toBe('repeater_#0000FF');
+    expect(glyphIconId('sensor', '#22c55e')).toBe('sensor_#22c55e');
+  });
+
+  it('round-trips an id back into family + color', () => {
+    const id = glyphIconId('roomServer', '#990066');
+    expect(parseGlyphIconId(id)).toEqual({ family: 'roomServer', color: '#990066' });
+  });
+
+  it('splits on the FIRST underscore only, so the hex color survives intact', () => {
+    // Colors carry a `#` but no `_`; the split must not be greedy.
+    expect(parseGlyphIconId('companion_#FF0000')).toEqual({ family: 'companion', color: '#FF0000' });
+  });
+
+  it('returns null for an id with no underscore (e.g. the SDF disc id)', () => {
+    expect(parseGlyphIconId('node-marker-icon')).toBeNull();
+  });
+
+  it('exposes a positive source size', () => {
+    expect(GLYPH_ICON_SIZE).toBeGreaterThan(0);
+  });
+});

--- a/src/components/map/nodeGlyphIcons.ts
+++ b/src/components/map/nodeGlyphIcons.ts
@@ -1,0 +1,66 @@
+/**
+ * Per-node-type marker glyph icons for the 3D map (#4808).
+ *
+ * The 2D map draws distinct role glyphs (repeater tower, sensor, room server,
+ * companion) over a white disc, hop-colored, via `roleGlyphMarkerSvg`. MapLibre
+ * SDF icons are single-color (they can only be tinted one flat color), so they
+ * can't reproduce the white-disc + colored-glyph look. Instead we rasterize the
+ * full-color SVG marker to a normal RGBA image, one per (glyph family, hop
+ * color) pair, and register it lazily through MapLibre's `styleimagemissing`
+ * event — so only the combinations actually on screen are ever generated.
+ *
+ * Icon id format is `"<family>_<hexColor>"` (e.g. `"repeater_#0000FF"`). The
+ * `standard` family has no glyph and keeps the shared SDF disc instead, so it
+ * never routes through here.
+ */
+import { roleGlyphMarkerSvg } from '../../utils/roleGlyphSvg';
+import type { NodeTypeCategory } from '../../utils/nodeTypeCategory';
+
+/** Source resolution of a generated glyph image (device px). */
+export const GLYPH_ICON_SIZE = 64;
+
+/** Compose the icon id used both in the GeoJSON `iconImage` prop and addImage. */
+export function glyphIconId(family: string, color: string): string {
+  return `${family}_${color}`;
+}
+
+/** Split a `"<family>_<color>"` icon id back into its parts (color may contain no `_`). */
+export function parseGlyphIconId(id: string): { family: string; color: string } | null {
+  const i = id.indexOf('_');
+  if (i < 0) return null;
+  return { family: id.slice(0, i), color: id.slice(i + 1) };
+}
+
+/**
+ * Rasterize the full-color role-glyph marker SVG to an ImageData, ready for
+ * `map.addImage`. Browser-only (uses Image + canvas); returns null for a family
+ * with no glyph or if the 2D context/rasterization is unavailable.
+ */
+export async function rasterizeGlyphIcon(
+  family: string,
+  color: string,
+  size: number = GLYPH_ICON_SIZE,
+): Promise<ImageData | null> {
+  const svg = roleGlyphMarkerSvg(family as NodeTypeCategory, color, size);
+  if (!svg) return null;
+  const url = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+  const img = new Image();
+  img.width = size;
+  img.height = size;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error('glyph svg load failed'));
+      img.src = url;
+    });
+  } catch {
+    return null;
+  }
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  ctx.drawImage(img, 0, 0, size, size);
+  return ctx.getImageData(0, 0, size, size);
+}

--- a/src/components/map/nodeGlyphIcons.ts
+++ b/src/components/map/nodeGlyphIcons.ts
@@ -24,7 +24,11 @@ export function glyphIconId(family: string, color: string): string {
   return `${family}_${color}`;
 }
 
-/** Split a `"<family>_<color>"` icon id back into its parts (color may contain no `_`). */
+/**
+ * Split a `"<family>_<color>"` icon id back into its parts, on the FIRST `_`.
+ * Safe because family names contain no `_` (a hex color has `#` but no `_`); if
+ * a future family name introduces one, switch this to a fixed separator.
+ */
 export function parseGlyphIconId(id: string): { family: string; color: string } | null {
   const i = id.indexOf('_');
   if (i < 0) return null;


### PR DESCRIPTION
Part of #4808 (3D visual parity). Follow-up to #4800, which made the 3D markers render at all. This PR brings the 3D node **markers** up to parity with the 2D map.

## What's included

- **Per-hop color** — markers tinted by `getHopColor(hops)`, same as 2D (green=direct → red=6+ hops, grey=unknown). Wired into the `node3DFeatures` builders in `NodesTab` + `DashboardMap` (`icon-color` was already data-driven).
- **Node-type glyphs** — repeater tower, sensor, room server, companion, reusing the 2D `roleGlyphMarkerSvg` via `getNodeTypeCategory` → `categoryGlyphFamily`. MapLibre SDF icons are single-color, so rather than the SDF disc these glyph families use a **full-color raster** of the 2D glyph, generated **lazily per `(family, color)`** via MapLibre's `styleimagemissing` event (only on-screen combinations are ever built). The `standard` family keeps the tinted SDF disc.
- **Age dimming** — markers fade with node age (`icon-opacity`/`text-opacity`), matching 2D `calculateNodeOpacity`/`markerAgeOpacity`.
- `MapAnalysisCanvas` gets the glyph category for icon consistency.

## Why the age-dimming matters (the "3D shows far more nodes" report)

The 3D node **set** is provably identical to 2D on each surface (same `visibleMapNodes`/`nodesWithPosition`). The reason 3D *looked* like it had far more nodes: 2D fades aged-out nodes toward invisibility, while the 3D markers had **no opacity** and drew them at full strength. Adding the opacity closes that gap.

## Verification

Verified in a real headless-WebGL render (SwiftShader), since jsdom/CI can't render MapLibre:
- Per-hop colors reach the source and render (`color: #FF0000/#9ca3af/#990066…`).
- Each glyph family rasterizes and renders (repeater/sensor/roomServer/companion) — screenshot shared with maintainer.
- Per-node age opacity reaches the source (`opacity: 0.56, 0.48, …`).

Tests: Base3DMap / Map3DView / MapAnalysisCanvas + new `nodeGlyphIcons` suites green (73). tsc + lint-ratchet clean.

## Explicitly out of scope (fast-follow)

1. **Click popups** on 3D markers (`DashboardNodePopup` needs `SettingsContext` → React-portal-into-MapLibre wiring).
2. **Neighbor/traceroute LINE parity** — the *real* "far more routes" cause: the 3D line hooks (`use3DNeighborLines`/`use3DTracerouteLines`) resolve endpoints from the **full unified node set with no visibility/transport gate**, and DashboardMap doesn't guard the empty-`sourceIds`→all-sources case. That's the line-selection pipeline, a separate subsystem from these marker changes.
3. MapAnalysis hop-color + opacity (ride its own hop-shading/age model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G