### PR TITLE
fix(map): gate 3D neighbor/traceroute lines to visible nodes, matching 2D (#4808)

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -360,6 +360,14 @@ export default function DashboardMap({
     }));
   }, [nodesWithPosition, effectiveMaxAge]);
 
+  // Visible node numbers for gating the 3D neighbor/traceroute lines to the
+  // rendered markers, matching 2D — also keeps a null-sourceId dashboard from
+  // pulling every source's edges (#4808).
+  const visible3DNodeNums = useMemo(
+    () => new Set(nodesWithPosition.map(({ node }) => Number(node.nodeNum))),
+    [nodesWithPosition],
+  );
+
   // #3636: measurement endpoints — nearest-node snapping picks from these.
   const measurePoints: MeasurePoint[] = nodesWithPosition.map(({ node, pos }) => ({
     id: String(node.nodeId ?? node.user?.id ?? node.nodeNum),
@@ -684,6 +692,7 @@ export default function DashboardMap({
             showNeighbors={showNeighborInfo}
             showTraceroutes={showPaths || showRoute}
             lookbackHours={effectiveMaxAge}
+            visibleNodeNums={visible3DNodeNums}
             onUnsupported={() => setViewMode('2d')}
           />
           {showTileSelector && (

--- a/src/components/MapAnalysis/use3DNeighborLines.test.ts
+++ b/src/components/MapAnalysis/use3DNeighborLines.test.ts
@@ -154,4 +154,25 @@ describe('use3DNeighborLines', () => {
     expect(mockUseNeighbors).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
     expect(mockUseMeshCoreNeighbors).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
   });
+
+  describe('visibleNodeNums gate (#4808)', () => {
+    it('keeps an edge when BOTH endpoints are visible', () => {
+      const { result } = renderHook(() =>
+        use3DNeighborLines(makeParams({ visibleNodeNums: new Set([1, 2]) })),
+      );
+      expect(result.current.lines.some((l) => l.key === 'mt:1')).toBe(true);
+    });
+
+    it('drops an edge when an endpoint is NOT visible (the 2D-hidden node)', () => {
+      const { result } = renderHook(() =>
+        use3DNeighborLines(makeParams({ visibleNodeNums: new Set([1]) })), // node 2 hidden
+      );
+      expect(result.current.lines.some((l) => l.key === 'mt:1')).toBe(false);
+    });
+
+    it('is a no-op when the gate is omitted (MapAnalysis behavior — all edges)', () => {
+      const { result } = renderHook(() => use3DNeighborLines(makeParams()));
+      expect(result.current.lines.some((l) => l.key === 'mt:1')).toBe(true);
+    });
+  });
 });

--- a/src/components/MapAnalysis/use3DNeighborLines.ts
+++ b/src/components/MapAnalysis/use3DNeighborLines.ts
@@ -93,10 +93,18 @@ export interface Use3DNeighborLinesParams {
   sources: string[];
   /** `config.timeSlider`. */
   timeSlider: TimeSliderWindow;
+  /**
+   * Restrict edges to those whose BOTH endpoints are in this set of visible
+   * node numbers (#4808). Undefined/null = no gate (MapAnalysis behavior:
+   * every node's edges). The non-MapAnalysis surfaces pass their rendered-
+   * marker set so 3D lines don't dangle to nodes hidden by the 2D map's
+   * age/transport/estimated/incomplete filters.
+   */
+  visibleNodeNums?: Set<number> | null;
 }
 
 export function use3DNeighborLines(params: Use3DNeighborLinesParams): NeighborLines3D {
-  const { layer } = params;
+  const { layer, visibleNodeNums } = params;
   const { data: sources = [] } = useDashboardSources();
   const sourceIds =
     params.sources.length === 0
@@ -181,6 +189,13 @@ export function use3DNeighborLines(params: Use3DNeighborLinesParams): NeighborLi
     // --- Meshtastic edges — mirrors layers/NeighborLinksLayer.tsx L115-175.
     const mtItems = (mtData as { items?: NeighborEdge[] } | undefined)?.items ?? [];
     for (const e of mtItems.filter((edge) => inWindow(edge.timestamp ?? 0))) {
+      // Visibility gate (#4808): drop edges to nodes the 2D map hid.
+      if (
+        visibleNodeNums &&
+        (!visibleNodeNums.has(Number(e.nodeNum)) || !visibleNodeNums.has(Number(e.neighborNum)))
+      ) {
+        continue;
+      }
       const aKey = `${e.sourceId}:${Number(e.nodeNum)}`;
       const bKey = `${e.sourceId}:${Number(e.neighborNum)}`;
       const a = positionByKey.get(aKey) ?? positionByNode.get(Number(e.nodeNum));
@@ -266,5 +281,6 @@ export function use3DNeighborLines(params: Use3DNeighborLinesParams): NeighborLi
     ts.enabled,
     ts.windowStartMs,
     ts.windowEndMs,
+    visibleNodeNums,
   ]);
 }

--- a/src/components/MapAnalysis/use3DTracerouteLines.test.ts
+++ b/src/components/MapAnalysis/use3DTracerouteLines.test.ts
@@ -9,7 +9,7 @@ import type { AnalyzedSegment } from '../../hooks/useTracerouteAnalysis';
 import { getSegmentSnrOpacity, weightByOccurrence } from '../../utils/mapHelpers';
 
 // Mutable mock state, same convention as layers/TraceroutePathsLayer.test.tsx.
-const mockState: { segments: AnalyzedSegment[] } = { segments: [] };
+const mockState: { segments: AnalyzedSegment[]; lastAnalysisArgs?: unknown } = { segments: [] };
 
 vi.mock('../../contexts/SettingsContext', () => ({
   useSettings: () => ({
@@ -45,7 +45,10 @@ vi.mock('../../hooks/useTracerouteAnalysis', async () => {
   );
   return {
     ...actual,
-    useTracerouteAnalysis: () => ({ segments: mockState.segments, summary: null }),
+    useTracerouteAnalysis: (args: unknown) => {
+      mockState.lastAnalysisArgs = args;
+      return { segments: mockState.segments, summary: null };
+    },
   };
 });
 
@@ -169,5 +172,20 @@ describe('use3DTracerouteLines', () => {
     );
     expect(result.current.lines).toEqual([]);
     expect(result.current.selectionByKey.size).toBe(0);
+  });
+
+  describe('visibleNodeNums gate (#4808)', () => {
+    it('feeds the caller gate into useTracerouteAnalysis so segments are limited to visible nodes', () => {
+      renderHook(() => use3DTracerouteLines(makeParams({ visibleNodeNums: new Set([1, 2]) })));
+      // nodeFilter is '' (→ null "all"), so the combined gate is the caller set.
+      expect((mockState.lastAnalysisArgs as { visibleNodeNums?: Set<number> }).visibleNodeNums).toEqual(
+        new Set([1, 2]),
+      );
+    });
+
+    it('leaves useTracerouteAnalysis ungated (null) when no caller gate is passed (MapAnalysis)', () => {
+      renderHook(() => use3DTracerouteLines(makeParams()));
+      expect((mockState.lastAnalysisArgs as { visibleNodeNums?: Set<number> | null }).visibleNodeNums).toBeNull();
+    });
   });
 });

--- a/src/components/MapAnalysis/use3DTracerouteLines.ts
+++ b/src/components/MapAnalysis/use3DTracerouteLines.ts
@@ -69,6 +69,14 @@ export interface Use3DTracerouteLinesParams {
   selected: SelectedTarget | null;
   /** Free-text node search term; empty = no filter. */
   nodeFilter: string;
+  /**
+   * Restrict segments to those whose endpoints are visible node numbers
+   * (#4808). Undefined/null = no extra gate (MapAnalysis behavior); the
+   * non-MapAnalysis surfaces pass their rendered-marker set so 3D route
+   * segments don't dangle to nodes hidden by the 2D map's filters. Combined
+   * (intersected) with any `nodeFilter`-derived set.
+   */
+  visibleNodeNums?: Set<number> | null;
 }
 
 /**
@@ -130,10 +138,15 @@ export function use3DTracerouteLines(params: Use3DTracerouteLinesParams): Tracer
     return map;
   }, [nodes]);
 
-  const visibleNodeNums = useMemo(
-    () => visibleNodeNumSet((nodes ?? []) as SearchableNode[], nodeFilter),
-    [nodes, nodeFilter],
-  );
+  const explicitVisible = params.visibleNodeNums;
+  const visibleNodeNums = useMemo(() => {
+    const filterSet = visibleNodeNumSet((nodes ?? []) as SearchableNode[], nodeFilter);
+    // No caller gate → keep the filter-derived set (null = all), exactly as
+    // before (#4808). With a caller gate, intersect the two.
+    if (!explicitVisible) return filterSet;
+    if (!filterSet) return explicitVisible;
+    return new Set([...filterSet].filter((n) => explicitVisible.has(n)));
+  }, [nodes, nodeFilter, explicitVisible]);
 
   const ts = params.timeSlider;
   const timeWindow = useMemo(

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1727,6 +1727,13 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     maxNodeAgeHours,
   ]);
 
+  // Visible node numbers for gating the 3D neighbor/traceroute lines to the
+  // rendered markers, matching 2D (#4808).
+  const visible3DNodeNums = useMemo(
+    () => new Set(visibleMapNodes.map((n) => n.nodeNum)),
+    [visibleMapNodes],
+  );
+
   const nodeMarkers: NodeMarkerDescriptor[] = visibleMapNodes
     .map(node => {
       const markerKey = String(node.user?.id ?? node.nodeNum);
@@ -2967,6 +2974,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                   showNeighbors={!!currentSourceId && showNeighborInfo}
                   showTraceroutes={!!currentSourceId && (showPaths || showRoute)}
                   lookbackHours={effectiveMapMaxAge}
+                  visibleNodeNums={visible3DNodeNums}
                   onUnsupported={() => setViewMode('2d')}
                 />
                 {shouldShowData() && showTileSelector && (

--- a/src/components/map/Map3DView.tsx
+++ b/src/components/map/Map3DView.tsx
@@ -29,6 +29,13 @@ export interface Map3DViewProps {
   showTraceroutes: boolean;
   /** Fetch lookback window in hours for the neighbor/traceroute data. */
   lookbackHours: number;
+  /**
+   * Visible node numbers (the host's rendered-marker set). When provided, the
+   * neighbor/traceroute lines are gated so both endpoints are visible — 3D
+   * lines then match the 2D map instead of dangling to nodes hidden by its
+   * age/transport/estimated filters (#4808). Omit for MapAnalysis (all nodes).
+   */
+  visibleNodeNums?: Set<number>;
   /** Seed for the exaggeration slider (default `1.3`). */
   initialExaggeration?: number;
   /** Fired with the new exaggeration value whenever the slider changes. */
@@ -60,6 +67,7 @@ export function Map3DView({
   showNeighbors,
   showTraceroutes,
   lookbackHours,
+  visibleNodeNums,
   initialExaggeration,
   onExaggerationChange,
   onUnsupported,
@@ -73,6 +81,7 @@ export function Map3DView({
     layer: { enabled: showNeighbors, lookbackHours },
     sources: sourceIds,
     timeSlider,
+    visibleNodeNums,
   });
   const tracerouteLines = use3DTracerouteLines({
     layer: { enabled: showTraceroutes, lookbackHours },
@@ -80,6 +89,7 @@ export function Map3DView({
     timeSlider,
     selected: null,
     nodeFilter: '',
+    visibleNodeNums,
   });
 
   const lines: Line3DFeature[] = useMemo(


### PR DESCRIPTION
Part of #4808. Follow-up to the marker-parity PR (#4815). Fixes the **"3D shows far more routes than 2D"** report.

## Root cause

The 3D neighbor/traceroute line hooks resolved endpoints from the **full unified node set with no visibility gate**, so they drew edges to nodes the 2D map had hidden (age / transport / estimated-position / incomplete filters). The neighbor hook had *no* gate; the traceroute hook had one but was fed `nodeFilter: ''` → resolves to "all".

(The "far more **nodes**" half was the marker opacity, already fixed in #4815 — same set, 3D just wasn't dimming aged nodes.)

## Fix

- `use3DNeighborLines` / `use3DTracerouteLines` take an optional **`visibleNodeNums: Set<number>`**. An edge/segment is kept only if **both endpoints are visible**. Omitted = no-op, so **MapAnalysis is unchanged and its parity tests stay green**.
- Since `visibleMapNodes`/`nodesWithPosition` are already transport/age/estimated-filtered, this one gate also covers the **RF/UDP/MQTT toggles** for free and drops the cross-source edges a **null-sourceId dashboard** used to pull in (the unguarded empty-`sourceIds` fan-out).
- `NodesTab` + `DashboardMap` pass their rendered-marker node-num set through `Map3DView`'s new `visibleNodeNums` prop.

## Scope note

Meshtastic-only for now — MeshCore neighbor edges (publicKey-keyed) aren't gated yet; noted for a small follow-up (these surfaces are Meshtastic).

## Verification

Deterministic unit tests (this is data logic, not a rendering question, so jsdom is the right harness):
- neighbor edge with a hidden endpoint → dropped; both-visible → kept; ungated (MapAnalysis) path → unchanged.
- traceroute hook feeds the combined gate into `useTracerouteAnalysis` when set, `null` when not.

312 map/analysis tests pass; tsc + lint-ratchet clean.

## Still open on #4808 (next PR)
Click **popups** on 3D markers (React-portal `DashboardNodePopup` into a MapLibre popup), MeshCore edge gating, and MapAnalysis hop-color/opacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G