### PR TITLE
feat(nodes): add Uptime sort option to the map-view node list (#4814)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -333,6 +333,7 @@
   "nodes.sort_short_name": "Sort: Short Name",
   "nodes.sort_id": "Sort: ID",
   "nodes.sort_updated": "Sort: Updated",
+  "nodes.sort_uptime": "Sort: Uptime",
   "nodes.sort_signal": "Sort: Signal",
   "nodes.sort_charge": "Sort: Charge",
   "nodes.sort_hardware": "Sort: Hardware",

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1483,6 +1483,12 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
           aVal = a.deviceMetrics?.batteryLevel ?? -1;
           bVal = b.deviceMetrics?.batteryLevel ?? -1;
           break;
+        case 'uptime':
+          // Never-reported uptime sorts to the bottom. Top-level uptimeSeconds is
+          // enriched by /api/nodes (#4814), with the device-metrics copy as fallback.
+          aVal = a.uptimeSeconds ?? a.deviceMetrics?.uptimeSeconds ?? -1;
+          bVal = b.uptimeSeconds ?? b.deviceMetrics?.uptimeSeconds ?? -1;
+          break;
         case 'hwModel':
           aVal = a.user?.hwModel ?? 0;
           bVal = b.user?.hwModel ?? 0;
@@ -2227,6 +2233,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 <option value="shortName">{t('nodes.sort_short_name')}</option>
                 <option value="id">{t('nodes.sort_id')}</option>
                 <option value="lastHeard">{t('nodes.sort_updated')}</option>
+                <option value="uptime">{t('nodes.sort_uptime')}</option>
                 <option value="snr">{t('nodes.sort_signal')}</option>
                 <option value="battery">{t('nodes.sort_charge')}</option>
                 <option value="hwModel">{t('nodes.sort_hardware')}</option>

--- a/src/hooks/useProcessedNodes.test.ts
+++ b/src/hooks/useProcessedNodes.test.ts
@@ -642,6 +642,28 @@ describe('sortNodes helper', () => {
     expect(sorted[2].snr).toBe(-5);
   });
 
+  it('should sort by uptime, nodes without uptime last (#4814)', () => {
+    const uptimeNodes: DeviceInfo[] = [
+      { nodeNum: 1, user: { longName: 'Short', shortName: 'S', id: '!s' }, uptimeSeconds: 60 } as DeviceInfo,
+      { nodeNum: 2, user: { longName: 'None', shortName: 'N', id: '!n' } } as DeviceInfo, // never reported
+      { nodeNum: 3, user: { longName: 'Long', shortName: 'L', id: '!l' }, uptimeSeconds: 86400 } as DeviceInfo,
+    ];
+    const desc = sortNodes(uptimeNodes, 'uptime', 'desc');
+    expect(desc.map(n => n.user?.longName)).toEqual(['Long', 'Short', 'None']);
+
+    const asc = sortNodes(uptimeNodes, 'uptime', 'asc');
+    // Never-reported (-1 fallback) sorts below the real 60s value.
+    expect(asc.map(n => n.user?.longName)).toEqual(['None', 'Short', 'Long']);
+  });
+
+  it('falls back to deviceMetrics.uptimeSeconds when the top-level field is absent (#4814)', () => {
+    const nodes: DeviceInfo[] = [
+      { nodeNum: 1, user: { id: '!a', longName: 'A', shortName: 'A' }, deviceMetrics: { uptimeSeconds: 500 } } as DeviceInfo,
+      { nodeNum: 2, user: { id: '!b', longName: 'B', shortName: 'B' }, uptimeSeconds: 100 } as DeviceInfo,
+    ];
+    expect(sortNodes(nodes, 'uptime', 'desc').map(n => n.user?.longName)).toEqual(['A', 'B']);
+  });
+
   it('should not mutate original array', () => {
     const original = [...testNodes];
     sortNodes(testNodes, 'longName', 'asc');

--- a/src/hooks/useProcessedNodes.ts
+++ b/src/hooks/useProcessedNodes.ts
@@ -86,6 +86,13 @@ export function sortNodes(nodes: DeviceInfo[], field: SortField, direction: Sort
         aVal = a.deviceMetrics?.batteryLevel || -1;
         bVal = b.deviceMetrics?.batteryLevel || -1;
         break;
+      case 'uptime':
+        // Nodes that have never reported uptime sort to the bottom (-1). Top-level
+        // uptimeSeconds is enriched by /api/nodes (#4814); fall back to the
+        // device-metrics copy if a caller passes an un-enriched node.
+        aVal = a.uptimeSeconds ?? a.deviceMetrics?.uptimeSeconds ?? -1;
+        bVal = b.uptimeSeconds ?? b.deviceMetrics?.uptimeSeconds ?? -1;
+        break;
       case 'hwModel':
         aVal = a.user?.hwModel || 0;
         bVal = b.user?.hwModel || 0;

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -257,6 +257,12 @@ export interface DeviceInfo {
     airUtilTx?: number;
     uptimeSeconds?: number;
   };
+  /**
+   * Latest uptime (seconds) enriched onto the node list from telemetry by the
+   * /api/nodes route (#4814) to back the "Sort: Uptime" option. Not a node
+   * column — device-metrics telemetry is its only source.
+   */
+  uptimeSeconds?: number;
   hopsAway?: number;
   lastHeard?: number;
   snr?: number;

--- a/src/server/routes/nodesRoutes.ts
+++ b/src/server/routes/nodesRoutes.ts
@@ -25,7 +25,7 @@ import { fallbackManager } from '../meshtasticManager.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { resolveSourceManager } from '../utils/resolveSourceManager.js';
 import { isMeshCoreManager, getPrimaryMeshtasticManager } from '../sourceManagerTypes.js';
-import { filterNodesByChannelPermission, enhanceNodeForClient, checkNodeChannelAccess } from '../utils/nodeEnhancer.js';
+import { filterNodesByChannelPermission, enhanceNodeForClient, checkNodeChannelAccess, attachUptimeToNodes } from '../utils/nodeEnhancer.js';
 import { pivotPositionHistory } from '../utils/positionHistoryPivot.js';
 import { resolveRequestSourceId } from '../utils/sourceResolver.js';
 import { requireSourceId } from '../utils/requireSourceId.js';
@@ -79,6 +79,13 @@ router.get('/nodes', optionalAuth(), async (req, res) => {
     // source can't see another source's nodes (#3745).
     const filteredNodes = await filterNodesByChannelPermission(allNodes, (req as any).user, nodesSourceId);
     const enhancedNodes = await Promise.all(filteredNodes.map(node => enhanceNodeForClient(node, (req as any).user, estimatedPositions)));
+
+    // Enrich each node with its latest uptime from telemetry (#4814). Uptime is
+    // not a node column — it lives only in device-metrics telemetry — so the node
+    // list needs it attached here to support the "Sort: Uptime" option. One
+    // grouped query for all nodes, mirroring the v1 /nodes route.
+    const uptimeMap = await databaseService.telemetry.getLatestTelemetryValueForAllNodes('uptimeSeconds', nodesSourceId);
+    attachUptimeToNodes(enhancedNodes, uptimeMap);
 
     // Append MeshCore contacts/localNodes so the aggregate dashboard map can
     // render them alongside Meshtastic nodes. MeshCore stores lastSeen in ms;

--- a/src/server/utils/nodeEnhancer.test.ts
+++ b/src/server/utils/nodeEnhancer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { enhanceNodeForClient, filterNodesByChannelPermission, checkNodeChannelAccess, maskNodeLocationByChannel, maskTelemetryByChannel, maskTraceroutesByChannel } from './nodeEnhancer.js';
+import { enhanceNodeForClient, filterNodesByChannelPermission, checkNodeChannelAccess, maskNodeLocationByChannel, maskTelemetryByChannel, maskTraceroutesByChannel, attachUptimeToNodes } from './nodeEnhancer.js';
 
 // Mock the auth middleware
 vi.mock('../auth/authMiddleware.js', () => ({
@@ -682,5 +682,30 @@ describe('nodeEnhancer: maskTraceroutesByChannel', () => {
     expect(result).toHaveLength(2);
     expect((result[0] as any).toNodeId).toBe('!B');
     expect((result[1] as any).toNodeId).toBe('!D');
+  });
+});
+
+describe('attachUptimeToNodes (#4814)', () => {
+  it('attaches uptime by node user.id and leaves un-reported nodes undefined', () => {
+    const nodes: Array<{ user?: { id?: string }; uptimeSeconds?: number }> = [
+      { user: { id: '!a' } },
+      { user: { id: '!b' } },
+      { user: { id: '!c' } }, // no uptime in map
+      {}, // no user at all
+    ];
+    const uptimeMap = new Map<string, number>([['!a', 3600], ['!b', 120]]);
+
+    attachUptimeToNodes(nodes, uptimeMap);
+
+    expect(nodes[0].uptimeSeconds).toBe(3600);
+    expect(nodes[1].uptimeSeconds).toBe(120);
+    expect(nodes[2].uptimeSeconds).toBeUndefined();
+    expect(nodes[3].uptimeSeconds).toBeUndefined();
+  });
+
+  it('preserves a genuine 0 uptime (just booted) rather than dropping it', () => {
+    const nodes: Array<{ user?: { id?: string }; uptimeSeconds?: number }> = [{ user: { id: '!a' } }];
+    attachUptimeToNodes(nodes, new Map([['!a', 0]]));
+    expect(nodes[0].uptimeSeconds).toBe(0);
   });
 });

--- a/src/server/utils/nodeEnhancer.ts
+++ b/src/server/utils/nodeEnhancer.ts
@@ -422,3 +422,21 @@ export async function checkNodeChannelAccess(
   const channelDbId = channelNum - CHANNEL_DB_OFFSET;
   return channelDbPermissions[channelDbId]?.viewOnMap === true;
 }
+
+/**
+ * Attach latest device uptime onto client node objects for the node list's
+ * "Sort: Uptime" option (#4814). Uptime is not a node column — it lives only in
+ * device-metrics telemetry — so the route fetches one grouped map keyed by node
+ * id and this attaches it. Nodes without a reported uptime are left untouched
+ * (undefined), so the sort pushes them to the bottom. Mutates `nodes` in place.
+ */
+export function attachUptimeToNodes<T extends { user?: { id?: string }; uptimeSeconds?: number }>(
+  nodes: T[],
+  uptimeMap: Map<string, number>,
+): void {
+  for (const node of nodes) {
+    const id = node.user?.id;
+    const uptime = id ? uptimeMap.get(id) : undefined;
+    if (uptime !== undefined) node.uptimeSeconds = uptime;
+  }
+}

--- a/src/types/device.ts
+++ b/src/types/device.ts
@@ -29,6 +29,13 @@ export interface DeviceInfo {
     /** Radio noise floor in dBm, from LocalStats telemetry (#3396). */
     noiseFloor?: number;
   };
+  /**
+   * Latest device uptime in seconds, enriched onto the node list from telemetry
+   * by the /api/nodes route (#4814). Not a node column — lives only in
+   * device-metrics telemetry — so it is attached at serialization time to back
+   * the "Sort: Uptime" option. Undefined when the node has never reported it.
+   */
+  uptimeSeconds?: number;
   hopsAway?: number;
   lastMessageHops?: number; // Hops from most recent packet (hopStart - hopLimit)
   viaMqtt?: boolean;

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -28,7 +28,7 @@ export type TabType =
 // omitted — see comment above.
 export const VALID_TABS: TabType[] = ['nodes', 'channels', 'messages', 'info', 'settings', 'automation', 'dashboard', 'configuration', 'notifications', 'users', 'audit', 'security', 'admin', 'packetmonitor', 'mqtt-config'];
 
-export type SortField = 'longName' | 'shortName' | 'id' | 'lastHeard' | 'snr' | 'battery' | 'hwModel' | 'hops';
+export type SortField = 'longName' | 'shortName' | 'id' | 'lastHeard' | 'snr' | 'battery' | 'hwModel' | 'hops' | 'uptime';
 
 export type SortDirection = 'asc' | 'desc';
 


### PR DESCRIPTION
Closes #4814. Requested by @wilhel1812.

## Summary

Adds an **"Uptime"** option to the map-view node-list sort dropdown, so users can
surface long-running infrastructure nodes (descending) or recently-rebooted ones
(ascending).

## Why it needed backend work

Uptime is **not** a node column — it lives only in device-metrics telemetry — so
the `/api/nodes` list never carried it. This enriches each node with a top-level
`uptimeSeconds` from the latest telemetry via a new, testable `attachUptimeToNodes`
helper (one grouped query, mirroring what the `/api/v1/nodes` route already does).
`uptimeSeconds` is added to both the server and client `DeviceInfo` types.

## Frontend

- `SortField` gains `'uptime'`. Both sort implementations handle it — the shared
  `sortNodes` (useProcessedNodes) and NodesTab's own switch — with never-reported
  nodes sorting to the bottom and a `deviceMetrics.uptimeSeconds` fallback.
- New "Sort: Uptime" dropdown option + `nodes.sort_uptime` locale string.

## Performance note

The enrichment runs on `/api/nodes`, which is polled (30s with WebSocket, 5s
fallback), adding one grouped telemetry query per poll — the same cost the v1
route already pays. Flagging it since `/api/nodes` is the hot endpoint; happy to
denormalize a `uptimeSeconds` node column instead if preferred.

## Testing

- `nodeEnhancer.test.ts`: `attachUptimeToNodes` attaches by node id, skips
  un-reported / user-less nodes, and preserves a genuine 0 (just-booted).
- `useProcessedNodes.test.ts`: uptime sort desc/asc order + never-reported-last +
  deviceMetrics fallback.
- Full suite: **15,348 passed, 0 failed** (2 suites fail to collect locally only,
  missing `satellite.js` — GNSS untouched; CI installs fresh). Both `tsc` configs
  and in-repo `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)