### PR TITLE
fix(messages): fix invisible links on sent message bubbles

### DIFF
--- a/src/styles/messages.css
+++ b/src/styles/messages.css
@@ -86,7 +86,7 @@
   color: var(--color-chat-bubble-sent-text, var(--color-accent-text));
 }
 
-.message-bubble.mine a.message-link {
+.message-bubble.mine .message-text a.message-link {
   color: var(--color-chat-bubble-sent-text, var(--color-accent-text));
   text-decoration: underline;
 }


### PR DESCRIPTION
## Summary
- Sent-message ("mine") links rendered invisible because `.message-bubble .message-text a.message-link` had the same CSS specificity as the mine-specific override and won the cascade tie by coming later in the stylesheet, setting link color to `var(--color-accent)` — the same token used for the sent bubble's own background.
- Fixes it by scoping the mine-specific link color rule under `.message-text` too, giving it strictly higher specificity so it always wins regardless of declaration order.

## Root cause
`src/styles/messages.css`:
- `.message-bubble.mine` background: `var(--color-chat-bubble-sent-bg, var(--color-accent))`
- `.message-bubble.mine a.message-link` (specificity 0,3,1) sets link color to the sent-text token — correct intent
- `.message-bubble .message-text a.message-link` (specificity 0,3,1, declared later) sets link color to `var(--color-accent)` — same specificity, later in source, so it wins for `.mine` bubbles too
- No theme defines `--color-chat-bubble-sent-bg`/`--color-chat-bubble-sent-text`, so both bubble background and (incorrectly-won) link color resolve to the same `--color-accent` value, making links you sent invisible in every theme.

## Fix
Changed the mine-specific selector to `.message-bubble.mine .message-text a.message-link` (specificity 0,4,1), which now reliably beats the generic rule.

## Test plan
- [x] Reviewed CSS specificity math for both rules to confirm the mine-specific selector now always wins
- [ ] Manually verify in the running dev container: send a link-only message on the `gauntlet` channel and confirm it's visible and legible against the sent-bubble background, in both light and dark themes

Fixes #4819

---
_Generated by [Claude Code](https://claude.ai/code/session_019rS8b4qqW9fUCaUmEidZCq)_