### PR TITLE
feat(3d): click node markers to open node popups (#4808)

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -368,6 +368,16 @@ export default function DashboardMap({
     [nodesWithPosition],
   );
 
+  // key → { node, pos } for resolving a clicked 3D marker back to its node so
+  // the shared DashboardNodePopup can render on the 3D map too (#4808).
+  const node3DByKey = useMemo(() => {
+    const m = new Map<string, { node: (typeof nodesWithPosition)[number]['node']; pos: { lat: number; lng: number } }>();
+    for (const { node, pos } of nodesWithPosition) {
+      m.set(unifiedNodeKey(node) ?? String(node.nodeNum ?? node.nodeId ?? node.user?.id), { node, pos });
+    }
+    return m;
+  }, [nodesWithPosition]);
+
   // #3636: measurement endpoints — nearest-node snapping picks from these.
   const measurePoints: MeasurePoint[] = nodesWithPosition.map(({ node, pos }) => ({
     id: String(node.nodeId ?? node.user?.id ?? node.nodeNum),
@@ -693,6 +703,12 @@ export default function DashboardMap({
             showTraceroutes={showPaths || showRoute}
             lookbackHours={effectiveMaxAge}
             visibleNodeNums={visible3DNodeNums}
+            renderPopup={(key) => {
+              const entry = node3DByKey.get(key);
+              return entry ? (
+                <DashboardNodePopup node={entry.node} pos={entry.pos} onSourceSelect={onNodeSourceSelect} />
+              ) : null;
+            }}
             onUnsupported={() => setViewMode('2d')}
           />
           {showTileSelector && (

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -50,6 +50,7 @@ import { getPacketStats } from '../services/packetApi';
 
 import { BaseMap } from './map/BaseMap';
 import { Map3DView } from './map/Map3DView';
+import DashboardNodePopup from './Dashboard/DashboardNodePopup';
 import type { Node3DFeature } from './map/Base3DMap';
 import { TilesetSelector } from './TilesetSelector';
 import { resolve3DBasemap, buildTerrainTileUrl } from '../config/basemap3d';
@@ -1734,6 +1735,14 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     [visibleMapNodes],
   );
 
+  // key → node for resolving a clicked 3D marker back to its node so the shared
+  // DashboardNodePopup can render on the 3D map (#4808).
+  const node3DByKey = useMemo(() => {
+    const m = new Map<string, (typeof visibleMapNodes)[number]>();
+    for (const node of visibleMapNodes) m.set(String(node.user?.id ?? node.nodeNum), node);
+    return m;
+  }, [visibleMapNodes]);
+
   const nodeMarkers: NodeMarkerDescriptor[] = visibleMapNodes
     .map(node => {
       const markerKey = String(node.user?.id ?? node.nodeNum);
@@ -2975,6 +2984,13 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                   showTraceroutes={!!currentSourceId && (showPaths || showRoute)}
                   lookbackHours={effectiveMapMaxAge}
                   visibleNodeNums={visible3DNodeNums}
+                  renderPopup={(key) => {
+                    const node = node3DByKey.get(key);
+                    const pos = node ? nodePositions.get(node.nodeNum) : undefined;
+                    return node && pos ? (
+                      <DashboardNodePopup node={node} pos={{ lat: pos[0], lng: pos[1] }} />
+                    ) : null;
+                  }}
                   onUnsupported={() => setViewMode('2d')}
                 />
                 {shouldShowData() && showTileSelector && (

--- a/src/components/map/Base3DMap.test.tsx
+++ b/src/components/map/Base3DMap.test.tsx
@@ -20,7 +20,7 @@ type Listener = (...args: unknown[]) => void;
 // classes they reference must be created via `vi.hoisted` rather than plain
 // top-level `class` declarations (which are hoisted but stay in the
 // temporal dead zone until their declaration point).
-const { FakeMap, FakeNavigationControl, FakeAttributionControl } = vi.hoisted(() => {
+const { FakeMap, FakeNavigationControl, FakeAttributionControl, FakePopup } = vi.hoisted(() => {
   class FakeMap {
     static instances: FakeMap[] = [];
     /** When true, the constructor throws like a real WebGL-init failure. */
@@ -106,7 +106,38 @@ const { FakeMap, FakeNavigationControl, FakeAttributionControl } = vi.hoisted(()
     }
   }
 
-  return { FakeMap, FakeNavigationControl, FakeAttributionControl };
+  // Records the popup lifecycle so tests can assert a marker click opens one
+  // and portals content into its DOM container (#4808).
+  class FakePopup {
+    static instances: FakePopup[] = [];
+    lngLat: unknown;
+    container: HTMLElement | null = null;
+    removed = false;
+    handlers: Record<string, () => void> = {};
+    constructor(public options: unknown) {
+      FakePopup.instances.push(this);
+    }
+    setLngLat(ll: unknown) {
+      this.lngLat = ll;
+      return this;
+    }
+    setDOMContent(el: HTMLElement) {
+      this.container = el;
+      return this;
+    }
+    addTo() {
+      return this;
+    }
+    on(type: string, cb: () => void) {
+      this.handlers[type] = cb;
+      return this;
+    }
+    remove() {
+      this.removed = true;
+    }
+  }
+
+  return { FakeMap, FakeNavigationControl, FakeAttributionControl, FakePopup };
 });
 
 // maplibre-gl v6 is ESM-only with named exports (no default) — mirror that so
@@ -115,6 +146,7 @@ vi.mock('maplibre-gl', () => ({
   Map: FakeMap,
   NavigationControl: FakeNavigationControl,
   AttributionControl: FakeAttributionControl,
+  Popup: FakePopup,
   setWorkerUrl: vi.fn(),
 }));
 
@@ -239,6 +271,50 @@ describe('Base3DMap', () => {
     clickHandler({ features: [{ properties: { key: 'node-1' } }] });
 
     expect(onNodeClick).toHaveBeenCalledWith('node-1');
+  });
+
+  it('opens a popup and portals renderPopup content on marker click (#4808)', () => {
+    FakePopup.instances = [];
+    render(
+      <Base3DMap
+        center={[40.0, -105.0]}
+        zoom={12}
+        basemap={basemap}
+        terrainTileUrl={terrainTileUrl}
+        nodes={nodes}
+        renderPopup={(key) => <div data-testid="popup-body">popup:{key}</div>}
+      />,
+    );
+    const map = currentFakeMap();
+    act(() => {
+      map.triggerLoad();
+    });
+    act(() => {
+      map.layerHandlers['click:nodes-marker']({
+        features: [{ properties: { key: 'node-1' }, geometry: { type: 'Point', coordinates: [-105, 40] } }],
+        lngLat: { lng: -105, lat: 40 },
+      });
+    });
+    const popup = FakePopup.instances.at(-1);
+    expect(popup).toBeDefined();
+    expect(popup!.lngLat).toEqual([-105, 40]);
+    // Host content is portaled into the maplibre-owned container.
+    expect(popup!.container?.querySelector('[data-testid="popup-body"]')?.textContent).toBe('popup:node-1');
+  });
+
+  it('does NOT open a popup when renderPopup is omitted', () => {
+    FakePopup.instances = [];
+    render(
+      <Base3DMap center={[40.0, -105.0]} zoom={12} basemap={basemap} terrainTileUrl={terrainTileUrl} nodes={nodes} />,
+    );
+    const map = currentFakeMap();
+    act(() => {
+      map.triggerLoad();
+    });
+    act(() => {
+      map.layerHandlers['click:nodes-marker']({ features: [{ properties: { key: 'node-1' } }], lngLat: { lng: 0, lat: 0 } });
+    });
+    expect(FakePopup.instances).toHaveLength(0);
   });
 
   it('updates terrain exaggeration via setTerrain when the slider changes', () => {

--- a/src/components/map/Base3DMap.test.tsx
+++ b/src/components/map/Base3DMap.test.tsx
@@ -134,6 +134,9 @@ const { FakeMap, FakeNavigationControl, FakeAttributionControl, FakePopup } = vi
     }
     remove() {
       this.removed = true;
+      // Real maplibre fires 'close' synchronously on remove(); mirror that so
+      // tests exercise the close-listener path (#4808 rapid-click guard).
+      this.handlers.close?.();
     }
   }
 
@@ -315,6 +318,44 @@ describe('Base3DMap', () => {
       map.layerHandlers['click:nodes-marker']({ features: [{ properties: { key: 'node-1' } }], lngLat: { lng: 0, lat: 0 } });
     });
     expect(FakePopup.instances).toHaveLength(0);
+  });
+
+  it('keeps the newer popup when markers are clicked in rapid succession (#4808)', () => {
+    FakePopup.instances = [];
+    render(
+      <Base3DMap
+        center={[40.0, -105.0]}
+        zoom={12}
+        basemap={basemap}
+        terrainTileUrl={terrainTileUrl}
+        nodes={nodes}
+        renderPopup={(key) => <div data-testid="popup-body">popup:{key}</div>}
+      />,
+    );
+    const map = currentFakeMap();
+    act(() => {
+      map.triggerLoad();
+    });
+    // First marker click opens popup A.
+    act(() => {
+      map.layerHandlers['click:nodes-marker']({
+        features: [{ properties: { key: 'node-1' }, geometry: { type: 'Point', coordinates: [-105, 40] } }],
+        lngLat: { lng: -105, lat: 40 },
+      });
+    });
+    // Second marker click tears down A (firing its guarded close) and opens B.
+    act(() => {
+      map.layerHandlers['click:nodes-marker']({
+        features: [{ properties: { key: 'node-2' }, geometry: { type: 'Point', coordinates: [-104, 41] } }],
+        lngLat: { lng: -104, lat: 41 },
+      });
+    });
+    // The first popup was removed; the second survives with its own content.
+    expect(FakePopup.instances).toHaveLength(2);
+    expect(FakePopup.instances[0].removed).toBe(true);
+    const latest = FakePopup.instances.at(-1)!;
+    expect(latest.removed).toBe(false);
+    expect(latest.container?.querySelector('[data-testid="popup-body"]')?.textContent).toBe('popup:node-2');
   });
 
   it('updates terrain exaggeration via setTerrain when the slider changes', () => {

--- a/src/components/map/Base3DMap.tsx
+++ b/src/components/map/Base3DMap.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
+import type { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 // maplibre-gl v6 is ESM-only and dropped its default export (#4650).
 import * as maplibregl from 'maplibre-gl';
 import './maplibreWorker';
@@ -74,6 +76,13 @@ export interface Base3DMapProps {
   nodes: Node3DFeature[];
   /** Fired when a node's marker is clicked, with its `key`. */
   onNodeClick?: (key: string) => void;
+  /**
+   * Render the popup body for a clicked node (#4808). When provided, a marker
+   * click opens a MapLibre popup and this content is portaled into it — so it
+   * renders inside the app's provider tree and keeps its React context (e.g.
+   * SettingsContext), unlike a detached `createRoot`. Return null to suppress.
+   */
+  renderPopup?: (key: string) => ReactNode;
   /** Line segments (neighbor links, traceroute paths, …) to render below the node layers. */
   lines?: Line3DFeature[];
   /** Fired when a line is clicked, with its `key`. */
@@ -239,6 +248,7 @@ export function Base3DMap({
   terrainTileUrl,
   nodes,
   onNodeClick,
+  renderPopup,
   lines = [],
   onLineClick,
   onUnsupported,
@@ -251,6 +261,11 @@ export function Base3DMap({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const [loaded, setLoaded] = useState(false);
+  // Open node popup (#4808): the maplibre Popup owns the on-map container; React
+  // portals `renderPopup(key)` into it (see the render below). `popupRef` holds
+  // the live maplibre Popup so a new click / unmount can tear the old one down.
+  const [openPopup, setOpenPopup] = useState<{ key: string; container: HTMLDivElement } | null>(null);
+  const popupRef = useRef<maplibregl.Popup | null>(null);
   const [webglUnavailable, setWebglUnavailable] = useState(false);
   // Seed-once from initialExaggeration (spec §2.4): exaggeration only ever
   // changes via the slider below, so no prop-driven re-sync after mount.
@@ -260,6 +275,8 @@ export function Base3DMap({
   // without adding them as effect deps that would force a map/layer rebuild.
   const onNodeClickRef = useRef(onNodeClick);
   onNodeClickRef.current = onNodeClick;
+  const renderPopupRef = useRef(renderPopup);
+  renderPopupRef.current = renderPopup;
   const onLineClickRef = useRef(onLineClick);
   onLineClickRef.current = onLineClick;
   const onExaggerationChangeRef = useRef(onExaggerationChange);
@@ -497,8 +514,26 @@ export function Base3DMap({
       map.on('click', NODES_MARKER_LAYER_ID, (e) => {
         const feature = e.features?.[0];
         const key = feature?.properties?.key;
-        if (typeof key === 'string') {
-          onNodeClickRef.current?.(key);
+        if (typeof key !== 'string') return;
+        onNodeClickRef.current?.(key);
+        // Open the node popup, if the host supplies one (#4808). Tear down any
+        // previous popup, anchor a fresh one at the marker, and portal the
+        // host's content into its container (see the render below).
+        if (renderPopupRef.current) {
+          popupRef.current?.remove();
+          const container = document.createElement('div');
+          const geometry = feature?.geometry;
+          const lngLat =
+            geometry && geometry.type === 'Point'
+              ? (geometry.coordinates as [number, number])
+              : e.lngLat;
+          const popup = new maplibregl.Popup({ closeButton: true, closeOnClick: false, maxWidth: '320px' })
+            .setLngLat(lngLat)
+            .setDOMContent(container)
+            .addTo(map);
+          popup.on('close', () => setOpenPopup(null));
+          popupRef.current = popup;
+          setOpenPopup({ key, container });
         }
       });
       map.on('mouseenter', NODES_MARKER_LAYER_ID, () => {
@@ -532,6 +567,9 @@ export function Base3DMap({
       mapRemoved = true;
       setLoaded(false);
       onMapReadyRef.current?.(null);
+      popupRef.current?.remove();
+      popupRef.current = null;
+      setOpenPopup(null);
       map.remove();
       mapRef.current = null;
     };
@@ -620,6 +658,11 @@ export function Base3DMap({
   return (
     <div className={`base-3d-map ${className ?? ''}`.trim()}>
       <div ref={containerRef} className="base-3d-map-canvas" data-testid="base-3d-map-canvas" />
+      {/* Node popup content (#4808): portaled into the maplibre-owned container
+          so it renders within the app provider tree and keeps React context. */}
+      {openPopup && renderPopupRef.current
+        ? createPortal(renderPopupRef.current(openPopup.key), openPopup.container)
+        : null}
       {webglUnavailable ? (
         <div className="base-3d-map-unsupported" data-testid="base-3d-map-unsupported" role="alert">
           3D view requires WebGL, which is not available in this browser

--- a/src/components/map/Base3DMap.tsx
+++ b/src/components/map/Base3DMap.tsx
@@ -531,7 +531,15 @@ export function Base3DMap({
             .setLngLat(lngLat)
             .setDOMContent(container)
             .addTo(map);
-          popup.on('close', () => setOpenPopup(null));
+          // Guard the close listener by popup identity: a stale popup being
+          // torn down (rapid successive clicks, unmount) must not clear the
+          // state of a newer popup that has already replaced it.
+          popup.on('close', () => {
+            if (popupRef.current === popup) {
+              popupRef.current = null;
+              setOpenPopup(null);
+            }
+          });
           popupRef.current = popup;
           setOpenPopup({ key, container });
         }

--- a/src/components/map/Map3DView.tsx
+++ b/src/components/map/Map3DView.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { Base3DMap, type Node3DFeature, type Line3DFeature } from './Base3DMap';
+import type { ReactNode } from 'react';
 import type { Basemap3DSource } from '../../config/basemap3d';
 import { use3DNeighborLines } from '../MapAnalysis/use3DNeighborLines';
 import { use3DTracerouteLines } from '../MapAnalysis/use3DTracerouteLines';
@@ -44,6 +45,8 @@ export interface Map3DViewProps {
   onUnsupported?: () => void;
   /** Fired with a node's `key` when its marker is clicked. */
   onNodeClick?: (key: string) => void;
+  /** Render the popup body for a clicked node; portaled into a maplibre popup (#4808). */
+  renderPopup?: (key: string) => ReactNode;
 }
 
 /**
@@ -72,6 +75,7 @@ export function Map3DView({
   onExaggerationChange,
   onUnsupported,
   onNodeClick,
+  renderPopup,
 }: Map3DViewProps) {
   // Static coloring for v1: the time slider is always off, so the 3D hooks
   // fall back to SNR/direction coloring over the full lookback window.
@@ -106,6 +110,7 @@ export function Map3DView({
       nodes={nodes}
       lines={lines}
       onNodeClick={onNodeClick}
+      renderPopup={renderPopup}
       onUnsupported={onUnsupported}
       initialExaggeration={initialExaggeration}
       onExaggerationChange={onExaggerationChange}


### PR DESCRIPTION
## Summary

Final piece of 3D↔2D visual parity for #4808: **clicking a node marker on the 3D terrain map now opens the same node popup as the 2D maps.**

- Reuses `DashboardNodePopup` (the exact 2D card) — role, hop count, SNR, battery, distance, position source, coordinates, last-heard.
- Anchored at the clicked marker; MapLibre `Popup` with a close button, `closeOnClick: false`.
- Content is rendered with `createPortal` into the MapLibre-owned popup container so it **keeps React context** (`SettingsContext` for units/formatting) — a detached `createRoot` would lose it.
- `Base3DMap` gains an optional `renderPopup(key)` prop, threaded through `Map3DView`. `NodesTab` and `DashboardMap` supply it by resolving the node from the clicked feature key.
- Popup is torn down on unmount and before opening the next one.

Markers (#4815) and lines (#4817) landed already; this closes out the epic.

## Testing

- **Unit:** `Base3DMap.test.tsx` — 30 pass, incl. 2 new popup tests (portal opens on marker click; no popup when `renderPopup` omitted).
- **End-to-end (SwiftShader headless WebGL):** a real PointerEvent click on a rendered 3D marker opens the popup with the full node card:
  > DELRAY G2TRON · !a2e175d0 · Router · 1 hop · 11.25 dB · 101% · ~1.8 mi · Manual · 26.44821, -80.08586 · 39 minutes ago
- `tsc` clean on touched files; `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G