### PR TITLE
fix(source-pages): keep sign-in reachable when landing on a source without connection permission

### DIFF
--- a/src/pages/MeshCoreSourcePage.test.tsx
+++ b/src/pages/MeshCoreSourcePage.test.tsx
@@ -158,6 +158,20 @@ describe('MeshCoreSourcePage', () => {
     expect(fetchUrls.some((u) => u.includes('/meshcore/status'))).toBe(false);
   });
 
+  it('regression #4828: still shows the sign-in button when logged out and lacking connection:read', async () => {
+    // A logged-out visitor landing directly on a source (e.g. via the
+    // default-landing-page setting) must still be able to sign in — the
+    // permission-denied message must not black out the whole page.
+    authValue.authStatus = { authenticated: false, user: null };
+    authValue.hasPermission = () => false;
+    renderPage();
+    expect(
+      await screen.findByText('You do not have permission to view this MeshCore source.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'source.topbar.sign_in' })).toBeInTheDocument();
+    authValue.authStatus = { authenticated: true, user: { isAdmin: false } };
+  });
+
   it('shows Disconnected after snapshot returns connected=false', async () => {
     authValue.hasPermission = () => true;
     renderPage();

--- a/src/pages/MeshCoreSourcePage.tsx
+++ b/src/pages/MeshCoreSourcePage.tsx
@@ -6,9 +6,12 @@
  * hook at the per-source `/api/sources/:id/meshcore/*` routes. Permission
  * gating uses `hasPermission(resource, action, { sourceId })` with the
  * sourcey per-source resources (`connection`, `nodes`, `messages`,
- * `configuration`). When the user lacks `connection:read` the entire
- * surface is hidden — and the hook is left disabled so no probe requests
- * fire.
+ * `configuration`). When the user lacks `connection:read` the MeshCore
+ * surface is replaced with a permission-denied message — but the top bar
+ * (and its sign-in button/LoginModal) always renders, so a logged-out user
+ * landing here (e.g. via the default-landing-page setting, #4828) can still
+ * sign in instead of being stuck on a dead end. The hook is left disabled
+ * so no probe requests fire while the surface is hidden.
  */
 
 import { useState } from 'react';
@@ -45,18 +48,6 @@ function MeshCoreSourceInner() {
     return (
       <div className="meshcore-tab">
         <p>{t('meshcore.no_source', 'No source selected.')}</p>
-      </div>
-    );
-  }
-
-  // No connection-read permission means the entire surface is hidden, just
-  // like a Meshtastic source the user can't read. The hook is never mounted,
-  // so no `/meshcore/status` probe fires.
-  if (!canReadConnection) {
-    return (
-      <div className="meshcore-tab">
-        <h2>{t('meshcore.title')}</h2>
-        <p>{t('meshcore.no_permission', 'You do not have permission to view this MeshCore source.')}</p>
       </div>
     );
   }
@@ -122,7 +113,14 @@ function MeshCoreSourceInner() {
         </div>
       </header>
 
-      <MeshCorePage baseUrl={appBasename} sourceId={sourceId} onStatusChange={setMcStatus} />
+      {canReadConnection ? (
+        <MeshCorePage baseUrl={appBasename} sourceId={sourceId} onStatusChange={setMcStatus} />
+      ) : (
+        <div className="meshcore-tab">
+          <h2>{t('meshcore.title')}</h2>
+          <p>{t('meshcore.no_permission', 'You do not have permission to view this MeshCore source.')}</p>
+        </div>
+      )}
 
       <LoginModal isOpen={showLogin} onClose={() => setShowLogin(false)} />
     </div>

--- a/src/pages/ReticulumSourcePage.test.tsx
+++ b/src/pages/ReticulumSourcePage.test.tsx
@@ -156,6 +156,20 @@ describe('ReticulumSourcePage', () => {
     expect(fetchUrls.some((u) => u.includes('/reticulum/interfaces'))).toBe(false);
   });
 
+  it('regression #4828: still shows the sign-in button when logged out and lacking nodes:read', async () => {
+    // A logged-out visitor landing directly on a source (e.g. via the
+    // default-landing-page setting) must still be able to sign in — the
+    // permission-denied message must not black out the whole page.
+    authValue.authStatus = { authenticated: false, user: null };
+    authValue.hasPermission = () => false;
+    renderPage();
+    expect(
+      await screen.findByText('You do not have permission to view this Reticulum source.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'source.topbar.sign_in' })).toBeInTheDocument();
+    authValue.authStatus = { authenticated: true, user: { isAdmin: false } };
+  });
+
   it('shows Disconnected after status returns connected=false', async () => {
     authValue.hasPermission = () => true;
     renderPage();

--- a/src/pages/ReticulumSourcePage.tsx
+++ b/src/pages/ReticulumSourcePage.tsx
@@ -7,8 +7,12 @@
  * the reticulum data routes (`/api/sources/:id/reticulum/destinations`,
  * `/interfaces`) require (build spec §2) — rather than `connection`, since
  * that's the actual gate the underlying routes enforce. When the user lacks
- * it the entire surface is hidden and `useReticulum` is left disabled so no
- * probe requests fire.
+ * it the Reticulum surface is replaced with a permission-denied message —
+ * but the top bar (and its sign-in button/LoginModal) always renders, so a
+ * logged-out user landing here (e.g. via the default-landing-page setting,
+ * #4828) can still sign in instead of being stuck on a dead end.
+ * `useReticulum` is left disabled while the surface is hidden so no probe
+ * requests fire.
  */
 
 import { useState } from 'react';
@@ -47,17 +51,6 @@ function ReticulumSourceInner() {
     return (
       <div className={styles.gate}>
         <p>{t('reticulum.no_source', 'No source selected.')}</p>
-      </div>
-    );
-  }
-
-  // No nodes-read permission means the entire surface is hidden. The hook
-  // is never mounted, so no `/reticulum/status` probe fires.
-  if (!canReadNodes) {
-    return (
-      <div className={styles.gate}>
-        <h2>{t('reticulum.title', 'Reticulum')}</h2>
-        <p>{t('reticulum.no_permission', 'You do not have permission to view this Reticulum source.')}</p>
       </div>
     );
   }
@@ -113,7 +106,14 @@ function ReticulumSourceInner() {
         </div>
       </header>
 
-      <ReticulumPage baseUrl={appBasename} sourceId={sourceId} onStatusChange={setRnsStatus} />
+      {canReadNodes ? (
+        <ReticulumPage baseUrl={appBasename} sourceId={sourceId} onStatusChange={setRnsStatus} />
+      ) : (
+        <div className={styles.gate}>
+          <h2>{t('reticulum.title', 'Reticulum')}</h2>
+          <p>{t('reticulum.no_permission', 'You do not have permission to view this Reticulum source.')}</p>
+        </div>
+      )}
 
       <LoginModal isOpen={showLogin} onClose={() => setShowLogin(false)} />
     </div>


### PR DESCRIPTION
## Summary

- `MeshCoreSourcePage` and `ReticulumSourcePage` returned early with only a "You do not have permission to view this ... source." message when the viewer lacked `connection:read` / `nodes:read`, before the top bar (which hosts the sign-in button and `LoginModal`) ever rendered.
- A logged-out visitor whose **Default Landing Page** setting points at a MeshCore/Reticulum source hit this dead end immediately after logging out, with no way to reach the login form — exactly the trap reported in #4828.
- Both pages now always render the top bar; only the content area below it swaps between the source UI and the permission-denied message, so the sign-in button (and `LoginModal`) stays reachable regardless of permission state.

## Root cause

`DashboardPage`'s default-landing-page redirect effect (`src/pages/DashboardPage.tsx`) fires unconditionally whenever `defaultLandingPage` is a source UUID — it doesn't check auth state before navigating to `/source/<id>/`. That's fine in principle (App.tsx, the Meshtastic source view, doesn't hard-gate the whole page on permission either), but `MeshCoreSourcePage`/`ReticulumSourcePage` did hard-gate: an early `return` before the header meant a logged-out user redirected there had literally no UI element to click to sign in.

## Test plan

- [x] `npx vitest run src/pages/MeshCoreSourcePage.test.tsx src/pages/ReticulumSourcePage.test.tsx` — all 14 tests pass, including two new regression tests asserting the sign-in button is present and clickable while logged out and lacking the relevant read permission.
- [x] `npm run lint:ci` — clean, no new violations.
- [x] `npx tsc --noEmit` — clean.

Fixes #4828

---

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRkEgK7bRUivKYES1MXpQt)_