### PR TITLE
fix(map): 3D parity follow-ups — MeshCore edge gating + MapAnalysis hop color/opacity (#4808)

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -368,6 +368,19 @@ export default function DashboardMap({
     [nodesWithPosition],
   );
 
+  // MeshCore analogue of `visible3DNodeNums` (#4808 follow-up): MeshCore nodes
+  // have no nodeNum (the numeric set holds NaN for them), so their neighbor
+  // edges are gated by the set of visible MeshCore public keys instead.
+  const visible3DMeshCoreKeys = useMemo(
+    () =>
+      new Set(
+        nodesWithPosition
+          .filter(({ node }) => node.isMeshCore && typeof node.publicKey === 'string' && node.publicKey.length > 0)
+          .map(({ node }) => node.publicKey as string),
+      ),
+    [nodesWithPosition],
+  );
+
   // key → { node, pos } for resolving a clicked 3D marker back to its node so
   // the shared DashboardNodePopup can render on the 3D map too (#4808).
   const node3DByKey = useMemo(() => {
@@ -703,6 +716,7 @@ export default function DashboardMap({
             showTraceroutes={showPaths || showRoute}
             lookbackHours={effectiveMaxAge}
             visibleNodeNums={visible3DNodeNums}
+            visibleMeshCoreKeys={visible3DMeshCoreKeys}
             renderPopup={(key) => {
               const entry = node3DByKey.get(key);
               return entry ? (

--- a/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
@@ -9,6 +9,7 @@ import { MemoryRouter } from 'react-router-dom';
 import MapAnalysisCanvas from './MapAnalysisCanvas';
 import { MapAnalysisProvider, useMapAnalysisCtx, type MapViewState } from './MapAnalysisContext';
 import { getHopColor } from '../../utils/mapIcons';
+import { MIN_MARKER_OPACITY } from '../../utils/markerAgeOpacity';
 
 // Stub react-leaflet — Vitest's jsdom doesn't provide all the DOM bits Leaflet needs.
 vi.mock('react-leaflet', () => ({
@@ -433,6 +434,23 @@ describe('MapAnalysisCanvas', () => {
       // fully opaque, matching layers/NodeMarkersLayer.tsx's finalOpacity.
       expect(nodeBtn).toHaveAttribute('data-color', getHopColor(999));
       expect(nodeBtn).toHaveAttribute('data-opacity', '1');
+    });
+
+    it('fades a 3D node to the floor opacity when the time slider is on and the node has no lastHeard (#4808 follow-up)', () => {
+      localStorage.setItem(
+        'mapAnalysis.config.v1',
+        JSON.stringify({
+          version: 1,
+          viewMode: '3d',
+          // Window is enabled; the mock node carries no lastHeard, so the age
+          // fade drops it to the floor — the same MIN_MARKER_OPACITY branch the
+          // 2D layers/NodeMarkersLayer.tsx takes for a timestamp-less node.
+          timeSlider: { enabled: true, windowStartMs: 10, windowEndMs: 20 },
+        }),
+      );
+      render(<MapAnalysisCanvas />, { wrapper });
+      const nodeBtn = screen.getByTestId('base-3d-node-mt:1');
+      expect(nodeBtn).toHaveAttribute('data-opacity', String(MIN_MARKER_OPACITY));
     });
 
     it('clicking a 3D node marker resolves the node and does not throw for an unknown key', () => {

--- a/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.test.tsx
@@ -8,6 +8,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import MapAnalysisCanvas from './MapAnalysisCanvas';
 import { MapAnalysisProvider, useMapAnalysisCtx, type MapViewState } from './MapAnalysisContext';
+import { getHopColor } from '../../utils/mapIcons';
 
 // Stub react-leaflet — Vitest's jsdom doesn't provide all the DOM bits Leaflet needs.
 vi.mock('react-leaflet', () => ({
@@ -179,7 +180,7 @@ vi.mock('../map/Base3DMap', () => ({
     zoom: number;
     pitch?: number;
     bearing?: number;
-    nodes: Array<{ key: string; lat: number; lng: number; label?: string }>;
+    nodes: Array<{ key: string; lat: number; lng: number; label?: string; color?: string; opacity?: number }>;
     basemap: { tiles: string[]; usedFallback: boolean };
     terrainTileUrl: string;
     onNodeClick?: (key: string) => void;
@@ -207,6 +208,8 @@ vi.mock('../map/Base3DMap', () => ({
           key={n.key}
           type="button"
           data-testid={`base-3d-node-${n.key}`}
+          data-color={n.color}
+          data-opacity={n.opacity}
           onClick={() => props.onNodeClick?.(n.key)}
         >
           {n.label}
@@ -419,6 +422,17 @@ describe('MapAnalysisCanvas', () => {
       // label mapped from node.shortName ('A').
       const nodeBtn = screen.getByTestId('base-3d-node-mt:1');
       expect(nodeBtn).toHaveTextContent('A');
+    });
+
+    it('tints the 3D node with the 2D hop color and full opacity by default (#4808 follow-up)', () => {
+      persist3d();
+      render(<MapAnalysisCanvas />, { wrapper });
+      const nodeBtn = screen.getByTestId('base-3d-node-mt:1');
+      // hop-shading off + no hop data ⇒ hops=999 ⇒ the same neutral color the
+      // 2D marker uses (getHopColor(999)); no time slider + empty selection ⇒
+      // fully opaque, matching layers/NodeMarkersLayer.tsx's finalOpacity.
+      expect(nodeBtn).toHaveAttribute('data-color', getHopColor(999));
+      expect(nodeBtn).toHaveAttribute('data-opacity', '1');
     });
 
     it('clicking a 3D node marker resolves the node and does not throw for an unknown key', () => {

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -7,6 +7,11 @@ import { useMapAnalysisCtx } from './MapAnalysisContext';
 import { useSource } from '../../contexts/SourceContext';
 import { useAnalysisNodes } from './useAnalysisNodes';
 import { getNodeTypeCategory, categoryGlyphFamily } from '../../utils/nodeTypeCategory';
+import { getHopColor } from '../../utils/mapIcons';
+import { markerAgeOpacity, MIN_MARKER_OPACITY } from '../../utils/markerAgeOpacity';
+import { isNodeEmphasized, selectionOpacity } from '../../utils/nodeIdentity';
+import { useHopCounts } from '../../hooks/useMapAnalysisData';
+import { useDashboardSources } from '../../hooks/useDashboardData';
 import MeasureDistanceController from '../MeasureDistanceController';
 import type { MeasurePoint } from '../../utils/measureDistance';
 import LinkProfileController from './LinkProfileController';
@@ -98,6 +103,24 @@ export default function MapAnalysisCanvas() {
   // #3636: measurement endpoints, from the same visible+positioned node list
   // the markers layer uses so the two never disagree.
   const analysisNodes = useAnalysisNodes();
+
+  // Hop counts for 3D hop-shading — the same source the 2D markers layer
+  // (`layers/NodeMarkersLayer.tsx`) uses, gated on the same toggle so the
+  // fetch only runs when hop-shading is on (#4808 follow-up).
+  const { data: hopSources = [] } = useDashboardSources();
+  const hopSourceIds = (hopSources as Array<{ id: string }>).map((s) => s.id);
+  const hopCounts = useHopCounts({
+    enabled: config.layers.hopShading.enabled,
+    sources: config.sources.length === 0 ? hopSourceIds : config.sources,
+  });
+  const hopByKey = useMemo(() => {
+    const m = new Map<string, number>();
+    const entries =
+      (hopCounts.data as { entries?: Array<{ sourceId: string; nodeNum: number; hops: number }> } | undefined)
+        ?.entries ?? [];
+    for (const e of entries) m.set(`${e.sourceId}:${Number(e.nodeNum)}`, e.hops);
+    return m;
+  }, [hopCounts.data]);
   const measurePoints: MeasurePoint[] = useMemo(
     () => analysisNodes.map((a) => ({
       id: a.key,
@@ -160,19 +183,39 @@ export default function MapAnalysisCanvas() {
 
   // Same shared `useAnalysisNodes()` data the 2D markers layer/picker use
   // (see `analysisNodes` above), mapped to the shape `Base3DMap` expects.
+  // #4808 follow-up: mirror the 2D markers layer's hop color + opacity so the
+  // 3D markers match. Hop color from `/api/analysis/hopCounts` (999 = no data /
+  // shading off ⇒ neutral); opacity is the time-slider age fade times the
+  // selection dim — the exact `finalOpacity` computation in
+  // `layers/NodeMarkersLayer.tsx`.
+  const ts3D = config.timeSlider;
+  const fadeByAge3D = ts3D.enabled && ts3D.windowStartMs != null && ts3D.windowEndMs != null;
+  const windowStartMs3D = ts3D.windowStartMs ?? 0;
+  const windowEndMs3D = ts3D.windowEndMs ?? 0;
   const node3DFeatures: Node3DFeature[] = useMemo(
-    () => analysisNodes.map((a) => ({
-      key: a.key,
-      lat: a.latLng[0],
-      lng: a.latLng[1],
-      label: a.node.shortName ?? undefined,
-      // Node-type glyph, consistent with the other 3D surfaces (#4808). Hop
-      // color + age dimming here depend on MapAnalysis's own hop-shading / age
-      // model and are handled in the follow-up; markers default to the disc's
-      // color/opacity until then.
-      category: categoryGlyphFamily(getNodeTypeCategory(a.node)),
-    })),
-    [analysisNodes],
+    () => analysisNodes.map((a) => {
+      const sourceId = a.node.sourceId ?? '';
+      const hopVal = hopByKey.get(`${sourceId}:${Number(a.node.nodeNum)}`);
+      const hops = config.layers.hopShading.enabled && hopVal !== undefined ? hopVal : 999;
+      // A missing lastHeard sits at the floor when fading, matching the 2D
+      // layer's raw-slider-window behavior.
+      const markerOpacity = !fadeByAge3D
+        ? 1
+        : a.node.lastHeard != null
+          ? markerAgeOpacity(windowEndMs3D, windowStartMs3D, a.node.lastHeard * 1000)
+          : MIN_MARKER_OPACITY;
+      const emphasized = isNodeEmphasized(a.key, config.selectedNodeIds);
+      return {
+        key: a.key,
+        lat: a.latLng[0],
+        lng: a.latLng[1],
+        label: a.node.shortName ?? undefined,
+        color: getHopColor(hops),
+        category: categoryGlyphFamily(getNodeTypeCategory(a.node)),
+        opacity: selectionOpacity(markerOpacity, emphasized),
+      };
+    }),
+    [analysisNodes, hopByKey, config.layers.hopShading.enabled, config.selectedNodeIds, fadeByAge3D, windowStartMs3D, windowEndMs3D],
   );
   const basemap3D = useMemo(
     () => resolve3DBasemap(mapTileset, customTilesets),

--- a/src/components/MapAnalysis/use3DNeighborLines.test.ts
+++ b/src/components/MapAnalysis/use3DNeighborLines.test.ts
@@ -175,4 +175,34 @@ describe('use3DNeighborLines', () => {
       expect(result.current.lines.some((l) => l.key === 'mt:1')).toBe(true);
     });
   });
+
+  describe('visibleMeshCoreKeys gate (#4808 follow-up)', () => {
+    it('keeps a meshcore edge when BOTH endpoint keys are visible', () => {
+      const { result } = renderHook(() =>
+        use3DNeighborLines(makeParams({ visibleMeshCoreKeys: new Set(['aa', 'bb']) })),
+      );
+      expect(result.current.lines.some((l) => l.key === 'mc:7')).toBe(true);
+    });
+
+    it('drops a meshcore edge when an endpoint key is NOT visible (the 2D-hidden node)', () => {
+      const { result } = renderHook(() =>
+        use3DNeighborLines(makeParams({ visibleMeshCoreKeys: new Set(['aa']) })), // 'bb' hidden
+      );
+      expect(result.current.lines.some((l) => l.key === 'mc:7')).toBe(false);
+    });
+
+    it('gates meshcore by key WITHOUT affecting meshtastic edges (independent sets)', () => {
+      const { result } = renderHook(() =>
+        // MeshCore fully hidden, Meshtastic ungated: mt edge survives, mc dropped.
+        use3DNeighborLines(makeParams({ visibleMeshCoreKeys: new Set<string>() })),
+      );
+      expect(result.current.lines.some((l) => l.key === 'mt:1')).toBe(true);
+      expect(result.current.lines.some((l) => l.key === 'mc:7')).toBe(false);
+    });
+
+    it('is a no-op when the gate is omitted (MapAnalysis behavior — all meshcore edges)', () => {
+      const { result } = renderHook(() => use3DNeighborLines(makeParams()));
+      expect(result.current.lines.some((l) => l.key === 'mc:7')).toBe(true);
+    });
+  });
 });

--- a/src/components/MapAnalysis/use3DNeighborLines.ts
+++ b/src/components/MapAnalysis/use3DNeighborLines.ts
@@ -108,6 +108,12 @@ export interface Use3DNeighborLinesParams {
    * pass the set of visible MeshCore public keys here; both endpoints of a
    * MeshCore edge must be present or the edge is dropped. Undefined/null = no
    * gate (MapAnalysis behavior).
+   *
+   * Keys are BARE `publicKey` strings (no `sourceId:` prefix), matching the
+   * bare `nodeNum` semantics of `visibleNodeNums`. On a unified map the same
+   * physical node can appear on multiple sources under one publicKey, so an
+   * edge passes the gate whenever its key is visible on ANY source — the
+   * intended unified-visibility behavior, symmetric with the Meshtastic set.
    */
   visibleMeshCoreKeys?: Set<string> | null;
 }

--- a/src/components/MapAnalysis/use3DNeighborLines.ts
+++ b/src/components/MapAnalysis/use3DNeighborLines.ts
@@ -101,10 +101,19 @@ export interface Use3DNeighborLinesParams {
    * age/transport/estimated/incomplete filters.
    */
   visibleNodeNums?: Set<number> | null;
+  /**
+   * MeshCore analogue of `visibleNodeNums` (#4808 follow-up). MeshCore nodes
+   * carry no Meshtastic nodeNum — their stable identity is `publicKey` — so
+   * the numeric set cannot gate MeshCore edges. Hosts that gate visibility
+   * pass the set of visible MeshCore public keys here; both endpoints of a
+   * MeshCore edge must be present or the edge is dropped. Undefined/null = no
+   * gate (MapAnalysis behavior).
+   */
+  visibleMeshCoreKeys?: Set<string> | null;
 }
 
 export function use3DNeighborLines(params: Use3DNeighborLinesParams): NeighborLines3D {
-  const { layer, visibleNodeNums } = params;
+  const { layer, visibleNodeNums, visibleMeshCoreKeys } = params;
   const { data: sources = [] } = useDashboardSources();
   const sourceIds =
     params.sources.length === 0
@@ -231,6 +240,14 @@ export function use3DNeighborLines(params: Use3DNeighborLinesParams): NeighborLi
     // --- MeshCore edges — mirrors layers/MeshCoreNeighborLinksLayer.tsx L79-140.
     const mcItems = (mcData as { items?: MeshCoreNeighborEdge[] } | undefined)?.items ?? [];
     for (const e of mcItems.filter((edge) => inWindow(edge.timestamp))) {
+      // Visibility gate (#4808 follow-up): drop MeshCore edges to nodes the 2D
+      // map hid. Keyed by publicKey since MeshCore nodes have no nodeNum.
+      if (
+        visibleMeshCoreKeys &&
+        (!visibleMeshCoreKeys.has(e.publicKey) || !visibleMeshCoreKeys.has(e.neighborPublicKey))
+      ) {
+        continue;
+      }
       const aKey = `${e.sourceId}:${e.publicKey}`;
       const bKey = `${e.sourceId}:${e.neighborPublicKey}`;
       const a = mcPositionByKey.get(aKey);
@@ -282,5 +299,6 @@ export function use3DNeighborLines(params: Use3DNeighborLinesParams): NeighborLi
     ts.windowStartMs,
     ts.windowEndMs,
     visibleNodeNums,
+    visibleMeshCoreKeys,
   ]);
 }

--- a/src/components/map/Map3DView.tsx
+++ b/src/components/map/Map3DView.tsx
@@ -37,6 +37,13 @@ export interface Map3DViewProps {
    * age/transport/estimated filters (#4808). Omit for MapAnalysis (all nodes).
    */
   visibleNodeNums?: Set<number>;
+  /**
+   * Visible MeshCore public keys (#4808 follow-up). Gates MeshCore neighbor
+   * edges the same way `visibleNodeNums` gates Meshtastic edges; MeshCore
+   * nodes have no nodeNum so they need a separate key set. Omit for surfaces
+   * with no MeshCore nodes (NodesTab) or no gate (MapAnalysis).
+   */
+  visibleMeshCoreKeys?: Set<string>;
   /** Seed for the exaggeration slider (default `1.3`). */
   initialExaggeration?: number;
   /** Fired with the new exaggeration value whenever the slider changes. */
@@ -71,6 +78,7 @@ export function Map3DView({
   showTraceroutes,
   lookbackHours,
   visibleNodeNums,
+  visibleMeshCoreKeys,
   initialExaggeration,
   onExaggerationChange,
   onUnsupported,
@@ -86,6 +94,7 @@ export function Map3DView({
     sources: sourceIds,
     timeSlider,
     visibleNodeNums,
+    visibleMeshCoreKeys,
   });
   const tracerouteLines = use3DTracerouteLines({
     layer: { enabled: showTraceroutes, lookbackHours },


### PR DESCRIPTION
## Summary

The two deferred #4808 3D↔2D parity closers, one commit each:

### 1. Gate 3D MeshCore neighbor edges to visible nodes
The #4817 line-visibility gate only covered **Meshtastic** edges. `visibleNodeNums` is a `Set<number>`, but MeshCore nodes carry no `nodeNum` (they collapse to `NaN` in that set), so MeshCore neighbor edges couldn't be gated and dangled to nodes the 2D map had hidden by age/transport/estimated filters.

- New parallel `visibleMeshCoreKeys: Set<string>` (visible publicKeys) on `use3DNeighborLines`, gating the MeshCore edge loop.
- Threaded through `Map3DView`; built in `DashboardMap` from the rendered MeshCore markers.
- No-op when omitted → NodesTab (Meshtastic-only) and MapAnalysis (no gate) unaffected.

### 2. MapAnalysis 3D markers match 2D hop color + age opacity
MapAnalysis's 3D markers defaulted to the disc's color/opacity while the other 3D surfaces (#4815) already matched 2D. Mirror `layers/NodeMarkersLayer`'s model on the 3D builder:
- Hop color from `/api/analysis/hopCounts` (gated on the hop-shading toggle; `999` = neutral when off/absent).
- Same `finalOpacity` — time-slider age fade × selection dim.

## Testing
- `use3DNeighborLines.test.ts`: +4 MeshCore-gate tests mirroring the `visibleNodeNums` gate (15 pass).
- `MapAnalysisCanvas.test.tsx`: +1 test asserting the 3D node carries the 2D hop color + full default opacity (36 pass).
- Broader sweep: 348 tests across MapAnalysis + Map3DView + DashboardMap pass. `tsc` clean on touched files; `lint:ci` clean.
- Reuses already-tested pure helpers (`getHopColor`, `markerAgeOpacity`, `selectionOpacity`, `isNodeEmphasized`).

Closes out the #4808 epic (markers #4815, lines #4817, click-popups #4825, these follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G