### PR TITLE
feat(airtime): count CLIENT_BASE as infrastructure for neighbor averaging (#4822)

### DIFF
--- a/src/server/utils/airtimeCutoff.test.ts
+++ b/src/server/utils/airtimeCutoff.test.ts
@@ -51,8 +51,19 @@ describe('averageStrongestNeighborUtilization', () => {
     role: 2, hopsAway: 0, rssi: -60, channelUtilization: 40, ...over,
   });
 
-  it('treats Router/Router-Client/Repeater/Router-Late as infrastructure', () => {
-    expect([...INFRASTRUCTURE_ROLES].sort((a, b) => a - b)).toEqual([2, 3, 4, 11]);
+  it('treats Router/Router-Client/Repeater/Router-Late/Client-Base as infrastructure', () => {
+    expect([...INFRASTRUCTURE_ROLES].sort((a, b) => a - b)).toEqual([2, 3, 4, 11, 12]);
+  });
+
+  it('treats Client Base (role 12) as infrastructure and excludes Sensor (role 6)', () => {
+    // Client Base (12) retransmits like Router Late, so it must count. Sensor (6)
+    // — the role the issue text mistook for CLIENT_BASE — must NOT count.
+    const r = averageStrongestNeighborUtilization([
+      n({ role: 6, rssi: -40, channelUtilization: 99 }),  // sensor → excluded
+      n({ role: 12, rssi: -60, channelUtilization: 22 }), // client base → included
+    ]);
+    expect(r.sampleCount).toBe(1);
+    expect(r.value).toBe(22);
   });
 
   it('averages the channelUtilization of the top-3 strongest-RSSI infra neighbours', () => {

--- a/src/server/utils/airtimeCutoff.ts
+++ b/src/server/utils/airtimeCutoff.ts
@@ -31,9 +31,10 @@ export const NEIGHBOR_UTIL_SAMPLE_COUNT = 3;
 /**
  * Device roles considered routing "infrastructure" (Meshtastic
  * Config.DeviceConfig.Role): Router (2), Router Client (3, deprecated),
- * Repeater (4, deprecated), Router Late (11).
+ * Repeater (4, deprecated), Router Late (11), Client Base (12). Client Base
+ * retransmits like Router Late, so it counts as infrastructure too.
  */
-export const INFRASTRUCTURE_ROLES: ReadonlySet<number> = new Set([2, 3, 4, 11]);
+export const INFRASTRUCTURE_ROLES: ReadonlySet<number> = new Set([2, 3, 4, 11, 12]);
 
 /** A node considered as a possible infrastructure neighbour. */
 export interface NeighborUtilCandidate {


### PR DESCRIPTION
## Summary

Adds `CLIENT_BASE` to the `INFRASTRUCTURE_ROLES` set in `src/server/utils/airtimeCutoff.ts`. This set decides which 0-hop neighbours count as routing "infrastructure" for the **Nearby infrastructure** airtime-cutoff measurement source (`averageStrongestNeighborUtilization`).

`CLIENT_BASE` retransmits packets like `ROUTER_LATE`, so it belongs alongside Router (2), Router Client (3), Repeater (4), and Router Late (11).

## Enum value correction

The issue says "CLIENT_BASE (role 6)" and "add 6" — **that is wrong**. Role 6 is `SENSOR`. The real `CLIENT_BASE` value in the Meshtastic `Config.DeviceConfig.Role` enum is **12**.

I verified this against three independent places in the repo before changing anything:
- `src/constants/index.ts` — `CLIENT_BASE: 12`, `SENSOR: 6`
- `src/components/configuration/constants.ts` — `'CLIENT_BASE': 12`, `'SENSOR': 6`
- `src/server/services/deviceBackupService.ts` — `12: 'CLIENT_BASE'`

So the change adds **12**, not 6.

## Changes

- `INFRASTRUCTURE_ROLES` set: `[2, 3, 4, 11]` → `[2, 3, 4, 11, 12]`, with the doc comment updated to list Client Base (12).
- Tests: updated the set-membership assertion and added a case proving a `CLIENT_BASE` (12) node is treated as infrastructure while a `SENSOR` (6) node — the role the issue text confused for it — is excluded.

## Verification

- `airtimeCutoff.test.ts`: 18 passed.
- `npx tsc --noEmit -p tsconfig.server.json`: only the pre-existing unrelated `satellite.js` module-not-found error (dependency not installed locally).
- `npm run lint:ci` (in-repo failures only): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)