### PR TITLE
fix(automation): accept !hex node IDs in deviceReboot target field (#4826)

### DIFF
--- a/src/components/automations/AutomationBuilder.nodeNum.test.tsx
+++ b/src/components/automations/AutomationBuilder.nodeNum.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * AutomationBuilder — the deviceReboot "Remote target node #" field (#4826).
+ *
+ * The field used `kind: 'number'`, whose `<input type="number">` silently
+ * dropped a hex node id (`!3ca956de`) — the browser rejects the non-numeric
+ * value, so it reverted to blank on save. It is now `kind: 'nodeNum'`, a text
+ * input that accepts BOTH a decimal and a `!hex` id, stores the decimal node
+ * number, and surfaces a validation message for genuinely invalid input.
+ *
+ * @vitest-environment jsdom
+ */
+import { useState } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AutomationBuilder from './AutomationBuilder';
+import type { WorkflowForm } from './compile';
+
+// Override the global i18n mock so t(key, default) returns the English default.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string | Record<string, unknown>) =>
+      typeof defaultValue === 'string' ? defaultValue : key,
+    i18n: { changeLanguage: vi.fn(), language: 'en' },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+}));
+
+const PLACEHOLDER = 'blank = locally-connected node; 1017730782 or !3ca956de';
+const INVALID_MSG = 'Enter a node number as a decimal (1017730782) or a hex id (!3ca956de).';
+
+function baseForm(targetNodeNum?: unknown): WorkflowForm {
+  return {
+    trigger: { type: 'trigger.schedule', params: { cron: '0 0 * * *' } },
+    rules: [
+      {
+        conditions: [],
+        actions: [{ type: 'action.deviceReboot', params: targetNodeNum === undefined ? {} : { targetNodeNum } }],
+      },
+    ],
+    combine: null,
+  };
+}
+
+/** Stateful harness so the controlled input round-trips onChange like the real page. */
+function Harness({ initial }: { initial?: unknown }) {
+  const [form, setForm] = useState<WorkflowForm>(() => baseForm(initial));
+  return (
+    <>
+      <AutomationBuilder
+        form={form}
+        variables={[]}
+        sources={[]}
+        channels={[]}
+        scripts={[]}
+        regions={[]}
+        onChange={setForm}
+      />
+      <output data-testid="stored">{JSON.stringify(form.rules[0].actions[0].params.targetNodeNum)}</output>
+    </>
+  );
+}
+
+const input = () => screen.getByPlaceholderText(PLACEHOLDER) as HTMLInputElement;
+const stored = () => screen.getByTestId('stored').textContent;
+
+describe('AutomationBuilder — deviceReboot target node (#4826)', () => {
+  it('stores !3ca956de as the decimal node number 1017730782', () => {
+    render(<Harness />);
+    fireEvent.change(input(), { target: { value: '!3ca956de' } });
+    expect(stored()).toBe('1017730782');
+    // The input keeps showing what the user typed.
+    expect(input().value).toBe('!3ca956de');
+    expect(screen.queryByText(INVALID_MSG)).toBeNull();
+  });
+
+  it('still accepts a bare decimal node number', () => {
+    render(<Harness />);
+    fireEvent.change(input(), { target: { value: '1017730782' } });
+    expect(stored()).toBe('1017730782');
+    expect(screen.queryByText(INVALID_MSG)).toBeNull();
+  });
+
+  it('shows a validation message for invalid input and does not silently drop it', () => {
+    render(<Harness />);
+    fireEvent.change(input(), { target: { value: '!nope' } });
+    expect(screen.getByText(INVALID_MSG)).toBeInTheDocument();
+    // The raw text survives in the field rather than vanishing.
+    expect(input().value).toBe('!nope');
+  });
+
+  it('renders a persisted decimal value on mount (round-trips through save/reload)', () => {
+    render(<Harness initial={1017730782} />);
+    expect(input().value).toBe('1017730782');
+    expect(screen.queryByText(INVALID_MSG)).toBeNull();
+  });
+
+  it('clearing the field stores a blank value', () => {
+    render(<Harness initial={1017730782} />);
+    fireEvent.change(input(), { target: { value: '' } });
+    expect(stored()).toBe('""');
+    expect(screen.queryByText(INVALID_MSG)).toBeNull();
+  });
+});

--- a/src/components/automations/AutomationBuilder.tsx
+++ b/src/components/automations/AutomationBuilder.tsx
@@ -5,7 +5,7 @@
  * → THEN actions) → an optional FINALLY combine step (ANY/ALL/NONE). Compiles to
  * the graph model in compile.ts.
  */
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TRIGGERS, CONDITIONS, ACTIONS, BLOCK_BY_TYPE, fieldsFor, fieldVisible, fieldPlaceholder, type BlockDef, type FieldDef } from './catalog';
 import type { WorkflowForm, FormBlock, Rule } from './compile';
@@ -15,6 +15,7 @@ import NodeMultiFieldInput, { type NodeMultiOption } from './NodeMultiFieldInput
 import TokenTextField from './TokenTextField';
 import type { GeofenceShape } from '../auto-responder/types';
 import { UiIcon } from '../icons';
+import { parseNodeNumInput } from '../../utils/nodeHelpers';
 
 export interface VariableOption { name: string; type: string; }
 export interface SourceOption {
@@ -94,6 +95,56 @@ function defaultParams(type: string, triggerType: string): Record<string, unknow
   return params;
 }
 
+/**
+ * Node-number field that accepts a decimal (`1018373854`) OR a Meshtastic hex id
+ * (`!3ca956de`), storing the decimal node number either way (#4826). A plain
+ * `<input type="number">` silently dropped `!hex`, so this is a text input that
+ * parses on change and surfaces a validation message rather than vanishing.
+ */
+function NodeNumFieldInput({ value, onChange, placeholder }: {
+  value: unknown; onChange: (v: unknown) => void; placeholder?: string;
+}) {
+  const { t } = useTranslation();
+  const [text, setText] = useState<string>(() =>
+    value === undefined || value === null || value === '' ? '' : String(value));
+
+  // Re-sync when the parent value changes to something this input didn't produce
+  // (e.g. loading a different automation into a reused builder instance). Guarded
+  // against clobbering in-progress hex typing: `!3ca956de` canonicalises to the
+  // same decimal the parent stores back, so no reset fires mid-edit.
+  useEffect(() => {
+    const incoming = value === undefined || value === null || value === '' ? '' : String(value);
+    const parsedNow = parseNodeNumInput(text);
+    const canonical = parsedNow.ok
+      ? (parsedNow.value === null ? '' : String(parsedNow.value))
+      : text;
+    if (incoming !== canonical) setText(incoming);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- #4826 sync on external value only; `text` is intentionally excluded to avoid a self-reset loop.
+  }, [value]);
+
+  const parsed = parseNodeNumInput(text);
+  const handle = (raw: string) => {
+    setText(raw);
+    const r = parseNodeNumInput(raw);
+    // Valid → store the decimal node number (or '' for a blank/clear). Invalid →
+    // keep the raw text in the param so it survives and server-side validation flags it.
+    onChange(r.ok ? (r.value === null ? '' : r.value) : raw);
+  };
+
+  return (
+    <>
+      <input className="ae-input" value={text} placeholder={placeholder}
+        onChange={(e) => handle(e.target.value)} />
+      {!parsed.ok && (
+        <div className="ae-field-error">
+          {t('automation.nodeNum.invalid',
+            'Enter a node number as a decimal (1017730782) or a hex id (!3ca956de).')}
+        </div>
+      )}
+    </>
+  );
+}
+
 export interface FieldInputProps {
   field: FieldDef; value: unknown; onChange: (v: unknown) => void; variables: VariableOption[]; sources: SourceOption[]; channels: UnifiedChannelOption[]; scripts: ScriptOption[]; regions: string[]; nodes: NodeMultiOption[]; triggerType: string;
 }
@@ -107,6 +158,9 @@ export function FieldInput({ field, value, onChange, variables, sources, channel
     case 'number':
       control = <input className="ae-input" type="number" value={(value ?? '') as string} placeholder={placeholder}
         onChange={(e) => onChange(e.target.value === '' ? '' : Number(e.target.value))} />;
+      break;
+    case 'nodeNum':
+      control = <NodeNumFieldInput value={value} onChange={onChange} placeholder={placeholder} />;
       break;
     case 'textarea':
       control = field.tokens

--- a/src/components/automations/AutomationsPage.css
+++ b/src/components/automations/AutomationsPage.css
@@ -77,6 +77,7 @@
 .ae-textarea--code { font-family: var(--font-mono, monospace); font-size: 0.82rem; min-height: 280px; }
 .ae-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 0.6rem 1rem; }
 .ae-help-text { font-size: 0.76rem; color: var(--color-text-subtle); margin-top: 0.25rem; }
+.ae-field-error { font-size: 0.76rem; color: var(--color-error); margin-top: 0.25rem; }
 
 /* Token-highlighting text field: a backdrop renders the chrome + highlighted
    {{ }} tokens; a transparent input/textarea sits on top for editing. Both share

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -7,7 +7,7 @@
  */
 import { HOP_COUNT_EMOJIS, HOP_EMOJI_MAX, MQTT_SOURCE_EMOJI } from '../../utils/hopEmoji';
 
-export type FieldKind = 'text' | 'number' | 'textarea' | 'select' | 'checkbox' | 'variable' | 'emoji' | 'fieldselect' | 'sourceMulti' | 'sendSourceMulti' | 'channelMulti' | 'geofence' | 'scriptselect' | 'regionSelect' | 'nodeMulti';
+export type FieldKind = 'text' | 'number' | 'nodeNum' | 'textarea' | 'select' | 'checkbox' | 'variable' | 'emoji' | 'fieldselect' | 'sourceMulti' | 'sendSourceMulti' | 'channelMulti' | 'geofence' | 'scriptselect' | 'regionSelect' | 'nodeMulti';
 
 export interface FieldOpt { value: string; label: string; }
 export interface FieldGroup { label: string; options: FieldOpt[]; }
@@ -617,7 +617,7 @@ export const ACTIONS: BlockDef[] = [
     description: 'Reboot the physical device — e.g. reinitialize a flaky BLE bridge or MQTT proxy on a daily schedule.',
     fields: [
       { name: 'sourceIds', label: 'Reboot which node(s)', kind: 'sendSourceMulti', help: 'The connected node(s) to reboot. Leave none to use the source that triggered the automation — but a source IS required for source-less triggers like Schedules and System events. (MQTT sources have no physical device and are excluded.)' },
-      { name: 'targetNodeNum', label: 'Remote target node #', kind: 'number', advanced: true, placeholder: 'blank = locally-connected node', help: 'Meshtastic remote-admin reboot: leave blank to reboot the locally-connected node; set a node number to reboot a remote node over the mesh (uses the session-passkey admin mechanism — the target must have granted admin access). Ignored by MeshCore.' },
+      { name: 'targetNodeNum', label: 'Remote target node #', kind: 'nodeNum', advanced: true, placeholder: 'blank = locally-connected node; 1017730782 or !3ca956de', help: 'Meshtastic remote-admin reboot: leave blank to reboot the locally-connected node; set a node number to reboot a remote node over the mesh (uses the session-passkey admin mechanism — the target must have granted admin access). Accepts a decimal node number or a hex id (!3ca956de). Ignored by MeshCore.' },
       { name: 'seconds', label: 'Reboot delay (seconds)', kind: 'number', advanced: true, placeholder: '10', help: 'Meshtastic: how long the device waits before rebooting (default 10s). Ignored by MeshCore.' },
     ],
   },

--- a/src/utils/nodeHelpers.test.ts
+++ b/src/utils/nodeHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getEffectivePosition, getRoleName, getHardwareModelName, getNodeName, getNodeShortName, formatSenderLabel, hasValidEffectivePosition, isNodeComplete, resolveMapEndpoint, formatLocationSource } from './nodeHelpers';
+import { getEffectivePosition, getRoleName, getHardwareModelName, getNodeName, getNodeShortName, formatSenderLabel, hasValidEffectivePosition, isNodeComplete, resolveMapEndpoint, formatLocationSource, parseNodeNumInput } from './nodeHelpers';
 import { setDiscardInvalidPositionsDisplay } from './positionDisplayConfig';
 import { ROLE_NAMES, HARDWARE_MODELS } from '../constants/index.js';
 import type { DeviceInfo } from '../types/device';
@@ -713,5 +713,53 @@ describe('formatLocationSource (#4176)', () => {
   it('returns null for any unknown/out-of-range value', () => {
     expect(formatLocationSource(4)).toBeNull();
     expect(formatLocationSource(-1)).toBeNull();
+  });
+});
+
+describe('parseNodeNumInput (#4826)', () => {
+  it('parses a Meshtastic hex id (!3ca956de) to its decimal node number', () => {
+    expect(parseNodeNumInput('!3ca956de')).toEqual({ ok: true, value: 1017730782 });
+  });
+
+  it('is case-insensitive for the hex form', () => {
+    expect(parseNodeNumInput('!3CA956DE')).toEqual({ ok: true, value: 1017730782 });
+  });
+
+  it('parses a bare decimal node number', () => {
+    expect(parseNodeNumInput('1017730782')).toEqual({ ok: true, value: 1017730782 });
+  });
+
+  it('keeps an all-digit value decimal rather than treating it as hex', () => {
+    // "12345678" is valid as both; the bare-digit branch must win → decimal.
+    expect(parseNodeNumInput('12345678')).toEqual({ ok: true, value: 12345678 });
+  });
+
+  it('accepts a bare 8-hex-digit id that contains a letter', () => {
+    expect(parseNodeNumInput('3ca956de')).toEqual({ ok: true, value: 1017730782 });
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseNodeNumInput('  !3ca956de  ')).toEqual({ ok: true, value: 1017730782 });
+  });
+
+  it('treats blank input as a valid clear (null value)', () => {
+    expect(parseNodeNumInput('')).toEqual({ ok: true, value: null });
+    expect(parseNodeNumInput('   ')).toEqual({ ok: true, value: null });
+  });
+
+  it('rejects a hex id with too many digits', () => {
+    expect(parseNodeNumInput('!3ca956def')).toEqual({ ok: false, value: null });
+  });
+
+  it('rejects non-hex, non-decimal garbage', () => {
+    expect(parseNodeNumInput('nope')).toEqual({ ok: false, value: null });
+    expect(parseNodeNumInput('!xyz')).toEqual({ ok: false, value: null });
+    expect(parseNodeNumInput('12.5')).toEqual({ ok: false, value: null });
+  });
+
+  it('rejects zero and values above the unsigned 32-bit range', () => {
+    expect(parseNodeNumInput('0')).toEqual({ ok: false, value: null });
+    expect(parseNodeNumInput('!ffffffff')).toEqual({ ok: true, value: 0xffffffff });
+    expect(parseNodeNumInput('4294967296')).toEqual({ ok: false, value: null });
   });
 });

--- a/src/utils/nodeHelpers.ts
+++ b/src/utils/nodeHelpers.ts
@@ -27,6 +27,50 @@ export const parseNodeId = (nodeId: string): number | null => {
   return isNaN(num) ? null : num;
 };
 
+/** Largest valid Meshtastic node number (unsigned 32-bit). */
+const MAX_NODE_NUM = 0xffffffff;
+
+/** Outcome of parsing free-text node-number input. */
+export interface NodeNumParseResult {
+  /** True when the input is blank (a clear) or a valid node number. */
+  ok: boolean;
+  /** Parsed decimal node number, or null for a blank/invalid input. */
+  value: number | null;
+}
+
+/**
+ * Parse a user-typed node-number field that accepts BOTH a bare decimal
+ * (`1018373854`) and a Meshtastic hex id (`!3ca956de`, or a bare 8-hex-digit
+ * `3ca956de`), returning the decimal node number in every case (#4826).
+ *
+ * A leading `!` forces hex. Bare all-digit input is decimal (so `12345678`
+ * stays decimal, not hex). Bare input that is exactly 8 hex digits and contains
+ * a letter is treated as a hex id for convenience.
+ *
+ * @returns `{ ok: true, value: null }` for blank (a clear), `{ ok: true, value }`
+ *   for a valid node number, `{ ok: false, value: null }` for invalid input.
+ */
+export const parseNodeNumInput = (raw: string): NodeNumParseResult => {
+  const s = (raw ?? '').trim();
+  if (s === '') return { ok: true, value: null };
+
+  let num: number | null = null;
+  if (s.startsWith('!')) {
+    const hex = s.slice(1);
+    if (/^[0-9a-fA-F]{1,8}$/.test(hex)) num = parseInt(hex, 16);
+  } else if (/^[0-9]+$/.test(s)) {
+    num = Number(s);
+  } else if (/^[0-9a-fA-F]{8}$/.test(s)) {
+    // Bare 8-hex-digit id (contains a letter, else the decimal branch caught it).
+    num = parseInt(s, 16);
+  }
+
+  if (num === null || !Number.isInteger(num) || num <= 0 || num > MAX_NODE_NUM) {
+    return { ok: false, value: null };
+  }
+  return { ok: true, value: num };
+};
+
 /**
  * Check if a node has an infrastructure role (Router, Repeater, etc.)
  * @param node - The device node to check


### PR DESCRIPTION
## Root cause

The Automation Engine's `deviceReboot` action has a **"Remote target node #"** field (`targetNodeNum`, #4126). It was declared `kind: 'number'` in the builder catalog, which the builder renders as `<input type="number">`. Browsers reject any non-numeric string in a number input, so typing a Meshtastic hex node id like `!3ca956de` produced an empty `e.target.value` — the field silently reverted to blank on save. Only the bare decimal form (`1017730782`) persisted.

## Fix (option A — accept both formats)

- New shared helper `parseNodeNumInput()` in `src/utils/nodeHelpers.ts` accepts **both** a bare decimal and a Meshtastic hex id (`!3ca956de`, or a bare 8-hex-digit id), returning the decimal `nodeNum` in every case. A leading `!` forces hex; bare all-digit input stays decimal (so `12345678` is decimal, not hex); range-checked to a positive unsigned-32-bit value.
- New `nodeNum` field kind + `NodeNumFieldInput` in `AutomationBuilder.tsx`: a text input (so `!` can be typed) that parses on change and **stores the decimal node number**. Genuinely invalid input keeps the raw text and shows a validation message instead of vanishing.
- `targetNodeNum` in `catalog.ts` switched from `kind: 'number'` to `kind: 'nodeNum'`; placeholder/help updated to show both formats.
- `.ae-field-error` style added.

Note: the issue stated `!3ca956de == 1018373854`, but `0x3ca956de` is actually **1017730782** — the code and tests use the correct value.

## Tests

- `parseNodeNumInput` unit tests (hex, decimal, bare-8-hex, whitespace, blank/clear, invalid, range bounds).
- `AutomationBuilder.nodeNum.test.tsx` (Testing Library): `!3ca956de` persists as `1017730782`; bare decimal still works; invalid input shows the validation message and does not silently drop; a persisted decimal round-trips on mount.
- `npx tsc --noEmit` clean (except pre-existing `satellite.js`); `lint:ci` clean.

## Mesh impact

None — UI parsing only. No new packets, timers, or notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)