### PR TITLE
feat(automation): add Run Now to fire an automation's actions immediately (#4827)

### DIFF
--- a/src/components/automations/AutomationsPage.runNow.test.tsx
+++ b/src/components/automations/AutomationsPage.runNow.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * AutomationsPage — "Run Now" button (#4827).
+ *
+ * Run Now fires an automation's REAL actions immediately (mesh sends, reboots,
+ * notifications), unlike the safe "Test" dry-run. Because it is destructive it
+ * MUST be gated behind an explicit confirmation. These prove the button asks for
+ * confirmation first, does nothing when the user cancels, and only then calls the
+ * live-execution API.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import AutomationsPage from './AutomationsPage';
+
+vi.mock('../../services/api', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    setBaseUrl: vi.fn(),
+    runAutomationNow: vi.fn(),
+  },
+}));
+
+import apiService from '../../services/api';
+
+const mockedGet = apiService.get as unknown as ReturnType<typeof vi.fn>;
+const mockedRunNow = apiService.runAutomationNow as unknown as ReturnType<typeof vi.fn>;
+
+const AUTOMATION = {
+  id: 'auto-1',
+  name: 'Nightly reboot',
+  description: null,
+  enabled: true,
+  config: JSON.stringify({ nodes: [{ id: 't1', type: 'trigger.schedule', params: { cron: '0 3 * * *' } }], edges: [] }),
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+};
+
+beforeEach(() => {
+  mockedGet.mockReset();
+  mockedRunNow.mockReset();
+  mockedGet.mockImplementation((url: string) => {
+    if (url === '/api/automations') return Promise.resolve([AUTOMATION]);
+    return Promise.resolve([]);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Open the editor for the seeded automation and wait for the Run now button. */
+async function openEditor() {
+  render(<MemoryRouter><AutomationsPage /></MemoryRouter>);
+  await userEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+  return screen.findByRole('button', { name: /Run now/i });
+}
+
+describe('AutomationsPage — Run Now', () => {
+  it('does NOT fire when the user cancels the confirmation', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const runNowBtn = await openEditor();
+    await userEvent.click(runNowBtn);
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(mockedRunNow).not.toHaveBeenCalled();
+  });
+
+  it('fires the live-execution API only after the user confirms', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockedRunNow.mockResolvedValue({ ran: true, status: 'completed', actions: [{ nodeId: 'a1', ok: true }] });
+
+    const runNowBtn = await openEditor();
+    await userEvent.click(runNowBtn);
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(mockedRunNow).toHaveBeenCalledTimes(1);
+    expect(mockedRunNow).toHaveBeenCalledWith('auto-1');
+    // The outcome is surfaced to the user.
+    expect(await screen.findByText(/Fired: completed/i)).toBeInTheDocument();
+  });
+
+  it('reports a cooldown suppression instead of claiming success', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockedRunNow.mockResolvedValue({ ran: false, reason: 'cooldown', detail: 'cooldown active — 30s remaining (automation)' });
+
+    const runNowBtn = await openEditor();
+    await userEvent.click(runNowBtn);
+
+    expect(await screen.findByText(/Did not fire: cooldown active/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -226,6 +226,8 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
   const [showTest, setShowTest] = useState(false);
   const [resettingHomes, setResettingHomes] = useState(false);
   const [resetHomesMsg, setResetHomesMsg] = useState<string | null>(null);
+  const [runningNow, setRunningNow] = useState(false);
+  const [runNowMsg, setRunNowMsg] = useState<string | null>(null);
 
   /** Compile the current editor state → graph config for the Test panel. */
   const getTestConfig = () => {
@@ -361,6 +363,42 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
     }
   };
 
+  /**
+   * Fire the SAVED automation's real actions right now (#4827). Live execution,
+   * so it is gated behind an explicit confirm — distinct from the safe "Test"
+   * dry-run. The engine runs the persisted config (not the unsaved editor draft)
+   * and honors the rule's cooldown / rate limits without touching its schedule.
+   */
+  const runNow = async () => {
+    if (isNew || !initial?.id) return;
+    const proceed = window.confirm(
+      "Run this automation now?\n\n"
+      + "This fires the SAVED automation's real actions immediately. It can send "
+      + "messages to the mesh, reboot nodes, or trigger notifications. This is NOT "
+      + "a dry run.\n\n"
+      + "It still respects the rule's cooldown and rate limits, and does not change "
+      + "its schedule.\n\nContinue?",
+    );
+    if (!proceed) return;
+    setRunningNow(true);
+    setRunNowMsg(null);
+    try {
+      const r = await apiService.runAutomationNow(initial.id);
+      if (r.ran) {
+        const n = r.actions?.length ?? 0;
+        setRunNowMsg(`Fired: ${r.status ?? 'completed'} (${n} action${n === 1 ? '' : 's'} dispatched).`);
+      } else if (r.reason === 'cooldown' || r.reason === 'ratelimited') {
+        setRunNowMsg(`Did not fire: ${r.detail ?? r.reason}.`);
+      } else {
+        setRunNowMsg(`Did not fire: ${r.reason ?? 'unknown reason'}.`);
+      }
+    } catch (e) {
+      setRunNowMsg(e instanceof Error ? e.message : 'Failed to run automation');
+    } finally {
+      setRunningNow(false);
+    }
+  };
+
   const showResetHomes = !isNew && (
     (mode === 'builder' && form.trigger.type === 'trigger.leftHome')
     || (mode === 'json' && jsonText.includes('trigger.leftHome'))
@@ -400,6 +438,16 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
       <div className="ae-btn-row" style={{ marginTop: '0.75rem' }}>
         <button className="ae-btn ae-btn--primary" disabled={saving} onClick={save}>{saving ? 'Saving…' : 'Save automation'}</button>
         <button className="ae-btn" onClick={() => setShowTest((s) => !s)}>{!showTest && <UiIcon name="play" size={15} />} {showTest ? 'Hide test' : 'Test'}</button>
+        {!isNew && (
+          <button
+            className="ae-btn"
+            disabled={runningNow}
+            onClick={runNow}
+            title="Fire this automation's real actions now (live execution, not a dry run)"
+          >
+            {runningNow ? 'Running…' : <><UiIcon name="zap" size={15} /> Run now</>}
+          </button>
+        )}
         {showResetHomes && (
           <button
             className="ae-btn"
@@ -412,6 +460,7 @@ function AutomationEditor({ automation, onClose }: { automation: Automation | 'n
         )}
       </div>
       {resetHomesMsg && <div className="ae-muted" style={{ marginTop: '0.4rem' }}>{resetHomesMsg}</div>}
+      {runNowMsg && <div className="ae-muted" style={{ marginTop: '0.4rem' }}>{runNowMsg}</div>}
 
       {showTest && <AutomationTester getConfig={getTestConfig} variables={variables} sources={sources} />}
     </div>

--- a/src/server/routes/automationRoutes.runNow.test.ts
+++ b/src/server/routes/automationRoutes.runNow.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Automation "Run Now" route (#4827).
+ *
+ * `POST /api/automations/:id/run-now` fires an automation's actions FOR REAL via
+ * the engine's real dispatch path — distinct from the safe `/:id/test` dry-run.
+ * These prove it (a) is gated on `automations:write` exactly like editing, and
+ * (b) delegates to the engine's real-execution method rather than re-implementing
+ * dispatch. The engine singleton is mocked (a non-DB service mock) so the test
+ * asserts the wiring without touching the mesh; permission enforcement runs
+ * against the harness's real auth middleware + SQLite.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+// Non-DB service mock: control what the route sees as the running engine.
+vi.mock('../services/automation/automationEngineSingleton.js', () => ({
+  getAutomationEngine: vi.fn(),
+  reloadAutomations: vi.fn().mockResolvedValue(undefined),
+}));
+
+import automationRouter from './automationRoutes.js';
+import { getAutomationEngine } from '../services/automation/automationEngineSingleton.js';
+
+const mockedGetEngine = getAutomationEngine as unknown as ReturnType<typeof vi.fn>;
+
+describe('POST /api/automations/:id/run-now', () => {
+  let harness: RouteTestHarness;
+  let runNow: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/api/automations', automationRouter),
+    });
+    runNow = vi.fn().mockResolvedValue({
+      ran: true,
+      status: 'completed',
+      actions: [{ nodeId: 'a1', ok: true }],
+      steps: [{ nodeId: 'a1', type: 'action.reboot', outcome: 'action:ok' }],
+    });
+    mockedGetEngine.mockReturnValue({ runNow });
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('rejects a user without automations:write with 403 and never fires', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post('/api/automations/auto-1/run-now');
+    expect(res.status).toBe(403);
+    expect(runNow).not.toHaveBeenCalled();
+  });
+
+  it('invokes the engine real-execution path when permitted', async () => {
+    await harness.grant(harness.limited.id, 'automations', 'write');
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post('/api/automations/auto-1/run-now');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      data: {
+        ran: true,
+        status: 'completed',
+        actions: [{ nodeId: 'a1', ok: true }],
+        steps: [{ nodeId: 'a1', type: 'action.reboot', outcome: 'action:ok' }],
+      },
+    });
+    // Delegated to the engine's real-execution method with this automation id.
+    expect(runNow).toHaveBeenCalledTimes(1);
+    expect(runNow).toHaveBeenCalledWith('auto-1');
+  });
+
+  it('surfaces a cooldown/rate-limit suppression as 200 with the verdict', async () => {
+    runNow.mockResolvedValue({ ran: false, reason: 'cooldown', detail: 'cooldown active — 30s remaining (automation)' });
+    await harness.grant(harness.limited.id, 'automations', 'write');
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post('/api/automations/auto-1/run-now');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.ran).toBe(false);
+    expect(res.body.data.reason).toBe('cooldown');
+  });
+
+  it('returns 404 when the automation does not exist', async () => {
+    runNow.mockResolvedValue({ ran: false, reason: 'not_found' });
+    await harness.grant(harness.limited.id, 'automations', 'write');
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post('/api/automations/missing/run-now');
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('AUTOMATION_NOT_FOUND');
+  });
+
+  it('returns 503 when the engine is not started', async () => {
+    mockedGetEngine.mockReturnValue(null);
+    await harness.grant(harness.limited.id, 'automations', 'write');
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post('/api/automations/auto-1/run-now');
+    expect(res.status).toBe(503);
+    expect(res.body.code).toBe('ENGINE_NOT_READY');
+    expect(runNow).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routes/automationRoutes.ts
+++ b/src/server/routes/automationRoutes.ts
@@ -22,6 +22,7 @@ import {
   NUMERIC_OPS,
 } from '../../types/automation.js';
 import { reloadAutomations, getAutomationEngine } from '../services/automation/automationEngineSingleton.js';
+import { ok, fail } from '../utils/apiResponse.js';
 import { simulateAutomation, type SimEventInput } from '../services/automation/automationSimulator.js';
 import { createMeshNodeDataProvider } from '../services/automation/meshNodeData.js';
 import { unifyChannels, sourceProtocol } from '../services/automation/channelUnify.js';
@@ -417,6 +418,31 @@ router.post('/:id/reset-homes', canWrite, async (req: Request, res: Response) =>
   } catch (error) {
     logger.error('Error resetting left-home anchors:', error);
     res.status(500).json({ error: 'Failed to reset homes' });
+  }
+});
+
+/**
+ * Manually fire an automation's actions FOR REAL right now (#4827, "Run Now"),
+ * bypassing its trigger schedule. Distinct from `/:id/test`, which is a safe
+ * dry-run: this dispatches live actions (mesh sends, reboots, notifications).
+ * Gated on `automations:write` — a real execution is at least as privileged as
+ * editing the rule. Routes through the engine's real dispatch path, so the
+ * per-automation cooldown, rate-limit and self-origin guards all still apply and
+ * the cron cadence is left untouched.
+ */
+router.post('/:id/run-now', canWrite, async (req: Request, res: Response) => {
+  try {
+    const engine = getAutomationEngine();
+    if (!engine) return fail(res, 503, 'ENGINE_NOT_READY', 'automation engine not started');
+    const result = await engine.runNow(req.params.id);
+    if (result.reason === 'not_found') return fail(res, 404, 'AUTOMATION_NOT_FOUND', 'automation not found');
+    if (result.reason === 'invalid') return fail(res, 400, 'INVALID_AUTOMATION', 'automation config is invalid');
+    // cooldown / rate-limit suppression is a legitimate outcome (the guard did its
+    // job) — return 200 with the verdict so the UI can explain why it did not fire.
+    return ok(res, result);
+  } catch (error) {
+    logger.error('Error running automation now:', error);
+    return fail(res, 500, 'RUN_NOW_FAILED', 'Failed to run automation');
   }
 });
 

--- a/src/server/services/automation/automationEngineService.test.ts
+++ b/src/server/services/automation/automationEngineService.test.ts
@@ -130,6 +130,64 @@ describe('AutomationEngineService', () => {
     expect(runs[0].status).toBe('completed');
   });
 
+  // ── runNow / "Run Now" manual fire (#4827) ──────────────────────────────────
+  describe('runNow (#4827)', () => {
+    const notifyGraph = (over: Record<string, unknown> = {}): AutomationGraph => ({
+      version: 1,
+      nodes: [
+        { id: 't', type: 'trigger.schedule', params: { cron: '0 3 * * *', ...over } },
+        { id: 'n', type: 'action.notify', params: { body: 'nightly' } },
+      ],
+      edges: [{ from: 't', to: 'n' }],
+    });
+
+    it('fires the actions for real and writes a completed run, without needing load()', async () => {
+      const { calls, deps } = recorder();
+      const a = await createEnabled('sched', notifyGraph());
+      const engine = engineWith(deps);
+      // Deliberately NOT calling engine.load(): runNow loads the row directly,
+      // proving it does not depend on the enabled trigger index / cron schedule.
+      const res = await engine.runNow(a.id);
+      expect(res.ran).toBe(true);
+      expect(res.status).toBe('completed');
+      expect(calls.map((c) => c.fn)).toEqual(['notify']);
+      const runs = await autos.listRuns(a.id);
+      expect(runs).toHaveLength(1);
+      expect(runs[0].status).toBe('completed');
+    });
+
+    it('works on a DISABLED automation (not in the running index)', async () => {
+      const { calls, deps } = recorder();
+      const a = await autos.createAutomation({ name: 'off', enabled: false, config: JSON.stringify(notifyGraph()) });
+      const engine = engineWith(deps);
+      await engine.load();
+      expect(engine.countFor('trigger.schedule')).toBe(0); // not loaded (disabled)
+      const res = await engine.runNow(a.id);
+      expect(res.ran).toBe(true);
+      expect(calls.map((c) => c.fn)).toEqual(['notify']);
+    });
+
+    it('respects the per-automation cooldown (a manual fire counts against it)', async () => {
+      const { calls, deps } = recorder();
+      const a = await createEnabled('sched-cd', notifyGraph({ cooldownSeconds: 60 }));
+      const engine = engineWith(deps);
+      expect((await engine.runNow(a.id)).ran).toBe(true); // t0 fires
+      clock += 30_000;
+      const suppressed = await engine.runNow(a.id); // within cooldown window
+      expect(suppressed.ran).toBe(false);
+      expect(suppressed.reason).toBe('cooldown');
+      clock += 31_000;
+      expect((await engine.runNow(a.id)).ran).toBe(true); // past cooldown fires again
+      expect(calls.map((c) => c.fn)).toEqual(['notify', 'notify']); // only the two fires dispatched
+    });
+
+    it('returns not_found for an unknown id', async () => {
+      const { deps } = recorder();
+      const engine = engineWith(deps);
+      expect(await engine.runNow('does-not-exist')).toEqual({ ran: false, reason: 'not_found' });
+    });
+  });
+
   it('applies the trigger pre-filter (no match → no fire)', async () => {
     const { calls, deps } = recorder();
     await createEnabled('ping', {

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -13,7 +13,7 @@
  */
 import { logger } from '../../../utils/logger.js';
 import type { DbMessage } from '../../../services/database.js';
-import type { AutomationsRepository } from '../../../db/repositories/automations.js';
+import type { AutomationsRepository, AutomationRecord } from '../../../db/repositories/automations.js';
 import type { AutomationHomeAnchorsRepository } from '../../../db/repositories/automationHomeAnchors.js';
 import { isMqttSourceType } from '../../../db/repositories/sources.js';
 import {
@@ -140,6 +140,21 @@ interface FireResult {
   steps: Array<{ nodeId: string; type: string; outcome: string; error?: string }>;
 }
 
+/**
+ * Verdict of a manual "Run Now" fire (#4827). `ran` is true only when the
+ * automation's actions actually dispatched; a `reason` explains a no-op (the
+ * rule was suppressed by its own cooldown / rate-limit guard, or could not be
+ * loaded). `status`/`actions`/`steps` mirror the real run when it fired.
+ */
+export interface RunNowResult {
+  ran: boolean;
+  reason?: 'not_found' | 'invalid' | 'cooldown' | 'ratelimited';
+  detail?: string;
+  status?: 'completed' | 'failed';
+  actions?: Array<{ nodeId: string; ok: boolean; error?: string }>;
+  steps?: Array<{ nodeId: string; type: string; outcome: string; error?: string }>;
+}
+
 /** Shallow copy of a trigger's fields with long text truncated, for trace payloads. */
 function compactEventFields(fields: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
@@ -222,37 +237,49 @@ export class AutomationEngineService {
   }
 
   /** (Re)load enabled automations and rebuild the trigger index. */
+  /**
+   * Parse + validate one automation row into a {@link LoadedAutomation}, or null
+   * if its config is unparseable / invalid / has no trigger node. Shared by
+   * {@link load} (which builds the enabled-trigger index) and {@link runNow} (a
+   * manual one-off fire that must work even for a disabled automation not in the
+   * running index).
+   */
+  private buildEntry(row: Pick<AutomationRecord, 'id' | 'name' | 'config'>): LoadedAutomation | null {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(row.config);
+    } catch {
+      logger.warn(`[AutomationEngine] automation "${row.name}" has unparseable config; skipping`);
+      return null;
+    }
+    const result = validateAutomationGraph(parsed);
+    if (!result.valid || !result.graph) {
+      logger.warn(`[AutomationEngine] automation "${row.name}" is invalid; skipping: ${result.errors.join('; ')}`);
+      return null;
+    }
+    const triggerNode = result.graph.nodes.find((n) => categoryOf(n.type) === 'trigger');
+    if (!triggerNode) return null;
+    const triggerType = triggerNode.type as TriggerType;
+    const cooldownSeconds = Number((triggerNode.params as any)?.cooldownSeconds ?? 0) || 0;
+    // No `as any` needed: params is Record<string, unknown> and parseCooldownScope
+    // takes unknown. (The cooldownSeconds line above predates the lint ratchet.)
+    const cooldownScope = parseCooldownScope(triggerNode.params?.cooldownScope);
+    // No `as any` needed: params is Record<string, unknown> and parseRateLimit
+    // takes unknown (same reasoning as the parseCooldownScope line above).
+    const rateLimit = parseRateLimit(triggerNode.params?.rateLimit);
+    return {
+      id: row.id, name: row.name, graph: result.graph, triggerNode, triggerType, cooldownSeconds, cooldownScope, rateLimit,
+    };
+  }
+
   async load(): Promise<void> {
     const rows = await this.automationsRepo.listEnabledAutomations();
     const index = new Map<TriggerType, LoadedAutomation[]>();
     for (const row of rows) {
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(row.config);
-      } catch {
-        logger.warn(`[AutomationEngine] automation "${row.name}" has unparseable config; skipping`);
-        continue;
-      }
-      const result = validateAutomationGraph(parsed);
-      if (!result.valid || !result.graph) {
-        logger.warn(`[AutomationEngine] automation "${row.name}" is invalid; skipping: ${result.errors.join('; ')}`);
-        continue;
-      }
-      const triggerNode = result.graph.nodes.find((n) => categoryOf(n.type) === 'trigger');
-      if (!triggerNode) continue;
-      const triggerType = triggerNode.type as TriggerType;
-      const cooldownSeconds = Number((triggerNode.params as any)?.cooldownSeconds ?? 0) || 0;
-      // No `as any` needed: params is Record<string, unknown> and parseCooldownScope
-      // takes unknown. (The cooldownSeconds line above predates the lint ratchet.)
-      const cooldownScope = parseCooldownScope(triggerNode.params?.cooldownScope);
-      // No `as any` needed: params is Record<string, unknown> and parseRateLimit
-      // takes unknown (same reasoning as the parseCooldownScope line above).
-      const rateLimit = parseRateLimit(triggerNode.params?.rateLimit);
-      const entry: LoadedAutomation = {
-        id: row.id, name: row.name, graph: result.graph, triggerNode, triggerType, cooldownSeconds, cooldownScope, rateLimit,
-      };
-      if (!index.has(triggerType)) index.set(triggerType, []);
-      index.get(triggerType)!.push(entry);
+      const entry = this.buildEntry(row);
+      if (!entry) continue;
+      if (!index.has(entry.triggerType)) index.set(entry.triggerType, []);
+      index.get(entry.triggerType)!.push(entry);
     }
     this.index = index;
     // Drop cooldown state for automations that are no longer loaded (deleted or
@@ -332,6 +359,40 @@ export class AutomationEngineService {
     const fr = await this.fireAutomation(a, ctx, now);
     if (traced) this.emitTrace(a, ctx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });
     return 1;
+  }
+
+  /**
+   * Manually fire an automation's actions FOR REAL right now (#4827, the "Run
+   * Now" button), bypassing its trigger (schedule / message / …) so a user can
+   * verify a scheduled rule end-to-end without waiting for its cron.
+   *
+   * Reuses the exact real dispatch path the scheduler uses ({@link fireAutomation}
+   * plus the {@link cooldownGate} / {@link rateLimitGate} checks), so the
+   * per-automation cooldown, rate-limit and self-origin guards all still apply —
+   * a manual fire counts against those windows exactly like a real one. The
+   * synthetic schedule context carries no originating node, so the self-origin
+   * guard (#3914) has nothing to drop.
+   *
+   * Does NOT disturb the cron cadence: croner computes each next fire from the
+   * wall clock, and this method never touches the cron jobs nor persists any
+   * last-fire timestamp (the cooldown map is in-memory). Loads the row directly
+   * rather than the enabled index, so it works for disabled automations too.
+   */
+  async runNow(automationId: string): Promise<RunNowResult> {
+    const row = await this.automationsRepo.getAutomation(automationId);
+    if (!row) return { ran: false, reason: 'not_found' };
+    const a = this.buildEntry(row);
+    if (!a) return { ran: false, reason: 'invalid' };
+    const now = this.now();
+    const ctx = buildScheduleContext(null, now);
+    const gate = this.cooldownGate(a, ctx, now);
+    if (!gate.ok) return { ran: false, reason: 'cooldown', detail: gate.reason };
+    const rateGate = this.rateLimitGate(a, now);
+    if (!rateGate.ok) return { ran: false, reason: 'ratelimited', detail: rateGate.reason };
+    this.markFired(a, gate.key, now);
+    this.markRateLimited(a, now);
+    const fr = await this.fireAutomation(a, ctx, now);
+    return { ran: true, status: fr.status, actions: fr.actions, steps: fr.steps };
   }
 
   /** Number of loaded automations for a trigger type (test/introspection aid). */

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2080,6 +2080,30 @@ class ApiService {
     );
     return res.data;
   }
+
+  /**
+   * Fire an automation's actions FOR REAL immediately (#4827, "Run Now"),
+   * bypassing its trigger schedule. Unlike a dry-run test this dispatches live
+   * actions; callers MUST confirm with the user first. Returns the engine's
+   * verdict — `ran: false` with a `reason` when the rule was suppressed by its
+   * own cooldown / rate-limit guard.
+   */
+  async runAutomationNow(id: string): Promise<AutomationRunNowResult> {
+    const res = await this.post<{ success: boolean; data: AutomationRunNowResult }>(
+      `/api/automations/${id}/run-now`,
+    );
+    return res.data;
+  }
+}
+
+/** Verdict returned by {@link ApiService.runAutomationNow} (#4827). */
+export interface AutomationRunNowResult {
+  ran: boolean;
+  reason?: 'not_found' | 'invalid' | 'cooldown' | 'ratelimited';
+  detail?: string;
+  status?: 'completed' | 'failed';
+  actions?: Array<{ nodeId: string; ok: boolean; error?: string }>;
+  steps?: Array<{ nodeId: string; type: string; outcome: string; error?: string }>;
 }
 
 // Channel Database types


### PR DESCRIPTION
## What & why

Resolves #4827. The Automation Engine already has a **Test** button that does a
DRY RUN (evaluates conditions/logic, no real side effects). This adds a **Run
Now** button that executes a saved automation's action(s) **for real** immediately,
bypassing the trigger schedule, so a user can verify a scheduled automation
(e.g. a cron-triggered node reboot) end-to-end without waiting for its next fire.

## Design, reuses the real dispatch path

Run Now does **not** re-implement action dispatch. It reuses the exact path the
scheduler already uses:

- New `AutomationEngineService.runNow(id)` loads the automation row directly
  (`automationsRepo.getAutomation`), builds the same `LoadedAutomation` the
  scheduler builds, extracted from `load()` into a shared `buildEntry()` helper
  runs the same `cooldownGate` / `rateLimitGate`, then calls the existing private
  `fireAutomation()`. That is the same method `onSchedule()` and `onMessage()`
  invoke, so a run-log row is written and every guard applies.
- Loading the row directly (rather than the enabled index) means Run Now also
  works on a **disabled** automation, which is exactly the "let me verify it
  before/while it's off" case.
- The fire uses a synthetic `buildScheduleContext(null, now)`, the neutral
  no-event context the cron path uses. `evaluateGraph` activates from the graph's
  trigger node by category, not by matching the context type, so this works for
  any trigger type.

Backend endpoint `POST /api/automations/:id/run-now`:
- Uses the shared `ok()` / `fail()` response envelope.
- Gated on `requirePermission('automations', 'write')`, a real execution is at
  least as privileged as editing the rule.
- Maps engine verdicts: engine-not-started → 503 `ENGINE_NOT_READY`; unknown id →
  404 `AUTOMATION_NOT_FOUND`; invalid config → 400; a cooldown/rate-limit
  suppression → **200** with the verdict (the guard did its job, surfaced to the
  user, not an error).

Frontend: `apiService.runAutomationNow(id)` + a **Run now** button (uses
`UiIcon name="zap"`, no hardcoded emoji) placed next to **Test** in the editor's
button row, shown only for saved automations. It fires only after an explicit
`window.confirm()`, and surfaces the outcome ("Fired: completed (N actions
dispatched)" or "Did not fire: <reason>").

## Mesh impact checklist

1. **Airtime / spam:** user-initiated single fire (one click = one execution).
   Because it routes through the real dispatch path, the automation's
   **cooldown**, **rate-limit** and **self-origin guard (#3914)** all still gate
   it, nothing is bypassed. The synthetic schedule context carries no originating
   node, so the self-origin guard has nothing to drop. A hand-rolled dispatch
   would have lost all of these; reuse gives them for free.
2. **Destructive/irreversible actions:** Run Now can send to the mesh or reboot
   nodes, so the UI requires an explicit confirmation dialog making clear it is
   **live execution with real side effects**, distinct from the safe Test dry-run.
   It does not fire on a single unguarded click.
3. **Schedule safety:** `runNow` never touches the cron jobs and persists **no**
   last-fire timestamp (cooldown state is in-memory, exactly what a real fire
   stamps). croner computes each next fire from the wall clock, so a manual fire
   does **not** reset or advance the cron cadence. Verified by an engine test that
   fires a disabled/unloaded automation via `runNow` without any cron job present.

## Tests

- **Route test** (`automationRoutes.runNow.test.ts`, `createRouteTestApp` harness):
  403 without `automations:write` (and engine never called); delegates to
  `engine.runNow(id)` and returns the enveloped verdict when permitted; cooldown
  suppression → 200; unknown id → 404; engine-not-started → 503.
- **Component test** (`AutomationsPage.runNow.test.tsx`): the button does nothing
  when the user cancels the confirm; only fires the live-execution API after
  confirming; reports a cooldown suppression instead of claiming success.
- **Engine unit tests** (`automationEngineService.test.ts`): `runNow` fires actions
  for real and writes a completed run without `load()`; works on a disabled
  automation; respects the per-automation cooldown; returns `not_found`.

All affected suites pass (route + component + 79 engine tests). `tsc` clean for
both `tsconfig.json` and `tsconfig.server.json` (only the pre-existing
`satellite.js` error remains). `lint:ci` ratchet passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
