### PR TITLE
feat(nodes): receive + display node Status Messages (#4818)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2871,6 +2871,7 @@
   "telemetry.show_solar": "Show solar overlay",
   "telemetry.hide_solar": "Hide solar overlay",
   "node_details.title": "Node Details",
+  "node_details.status_message": "Status",
   "node_details.expand": "Expand node details",
   "node_details.collapse": "Collapse node details",
   "node_details.hardware": "Hardware",

--- a/src/components/NodeDetailsBlock.css
+++ b/src/components/NodeDetailsBlock.css
@@ -338,3 +338,14 @@
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+/* Status Message (#4818): the node's self-broadcast status. Spans the full
+   grid width and wraps, since it can be up to 80 chars of free text. */
+.node-detail-card-status {
+  grid-column: 1 / -1;
+}
+.node-detail-status-message {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-style: italic;
+}

--- a/src/components/NodeDetailsBlock.tsx
+++ b/src/components/NodeDetailsBlock.tsx
@@ -386,6 +386,16 @@ const NodeDetailsBlock: React.FC<NodeDetailsBlockProps> = ({ node, timeFormat = 
       {!isCollapsed && (
         <>
         <div className="node-details-grid">
+          {/* Status Message (#4818) — the node's own broadcast status
+              (NODE_STATUS_APP). A node property like name/role, never a chat
+              message. Rendered verbatim (React escapes untrusted mesh text). */}
+          {node.nodeStatus && (
+            <div className="node-detail-card node-detail-card-status">
+              <div className="node-detail-label">{t('node_details.status_message', 'Status')}</div>
+              <div className="node-detail-value node-detail-status-message">{node.nodeStatus}</div>
+            </div>
+          )}
+
           {/* Hardware Model - Now First */}
           {hwModel !== undefined && (
             <div className="node-detail-card node-detail-card-hardware">

--- a/src/components/NodeStatusLine.module.css
+++ b/src/components/NodeStatusLine.module.css
@@ -1,0 +1,13 @@
+/* Status Message subtitle on a node-list row (#4818). A dedicated CSS module
+   rather than an addition to the frozen global nodes.css (whose cascade order
+   is a documented hazard, #3532) or an inline style. Clamps to one line; the
+   full text is available via the element's title attribute. */
+.statusLine {
+  font-style: italic;
+  opacity: 0.7;
+  font-size: 0.85em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -62,6 +62,7 @@ import { NodeUnmessageableBadge } from './NodeUnmessageableBadge';
 import { NodeIncompleteBadge } from './NodeIncompleteBadge';
 import { NodeDetailsButton } from './NodeDetailsButton';
 import nodeRowStyles from './NodeRowActions.module.css';
+import nodeStatusStyles from './NodeStatusLine.module.css';
 import { NeighborLinksLayer, type NeighborLinkDescriptor } from './map/layers/NeighborLinksLayer';
 import { AccuracyRegionsLayer, type AccuracyRegionDescriptor } from './map/layers/AccuracyRegionsLayer';
 import { NodeCard } from './map/popups/NodeCard';
@@ -2377,23 +2378,11 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                           <div className="node-role" title={t('nodes.node_role')}>{getRoleName(node.user.role)}</div>
                         )}
                         {/* Status Message (#4818): the node's self-broadcast status,
-                            shown as a short subtitle like the official clients. Inline
-                            style avoids touching the frozen nodes.css. Rendered verbatim
+                            shown as a short subtitle like the official clients. Styled via
+                            a CSS module (not the frozen nodes.css). Rendered verbatim
                             (React escapes untrusted mesh text); title shows the full text. */}
                         {node.nodeStatus && (
-                          <div
-                            className="node-status-line"
-                            title={node.nodeStatus}
-                            style={{
-                              fontStyle: 'italic',
-                              opacity: 0.7,
-                              fontSize: '0.85em',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap',
-                              maxWidth: '100%',
-                            }}
-                          >
+                          <div className={nodeStatusStyles.statusLine} title={node.nodeStatus}>
                             {node.nodeStatus}
                           </div>
                         )}

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -2376,6 +2376,27 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                         {node.user?.role !== undefined && node.user?.role !== null && getRoleName(node.user.role) && (
                           <div className="node-role" title={t('nodes.node_role')}>{getRoleName(node.user.role)}</div>
                         )}
+                        {/* Status Message (#4818): the node's self-broadcast status,
+                            shown as a short subtitle like the official clients. Inline
+                            style avoids touching the frozen nodes.css. Rendered verbatim
+                            (React escapes untrusted mesh text); title shows the full text. */}
+                        {node.nodeStatus && (
+                          <div
+                            className="node-status-line"
+                            title={node.nodeStatus}
+                            style={{
+                              fontStyle: 'italic',
+                              opacity: 0.7,
+                              fontSize: '0.85em',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                              maxWidth: '100%',
+                            }}
+                          >
+                            {node.nodeStatus}
+                          </div>
+                        )}
                       </div>
                     </div>
                     <div className="node-actions">

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -163,6 +163,7 @@ import { migration as addReticulumInterfaceRadioConfigMigration, runMigration145
 import { migration as createReticulumPathsMigration, runMigration146Postgres, runMigration146Mysql } from '../server/migrations/146_create_reticulum_paths.js';
 import { migration as addMeshBeaconOffersMigration, runMigration147Postgres, runMigration147Mysql } from '../server/migrations/147_add_mesh_beacon_offers.js';
 import { migration as fixEnvCurrentUnitMigration, runMigration148Postgres, runMigration148Mysql } from '../server/migrations/148_fix_env_current_unit.js';
+import { migration as addNodeStatusMigration, runMigration149Postgres, runMigration149Mysql } from '../server/migrations/149_add_node_status.js';
 
 // ============================================================================
 // Registry
@@ -2367,4 +2368,19 @@ registry.register({
   sqlite: (db) => fixEnvCurrentUnitMigration.up(db),
   postgres: (client) => runMigration148Postgres(client),
   mysql: (pool) => runMigration148Mysql(pool),
+});
+
+// Migration 149: add `nodeStatus` + `nodeStatusUpdatedAt` to `nodes` — the
+// receive side of the Status Message feature (#4818). Stores each node's
+// self-broadcast status (PortNum.NODE_STATUS_APP) as a per-node attribute.
+// Meshtastic-only, idempotent.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 149,
+  name: 'add_node_status',
+  settingsKey: 'migration_149_add_node_status',
+  sqlite: (db) => addNodeStatusMigration.up(db),
+  postgres: (client) => runMigration149Postgres(client),
+  mysql: (pool) => runMigration149Mysql(pool),
 });

--- a/src/db/repositories/nodes.test.ts
+++ b/src/db/repositories/nodes.test.ts
@@ -71,6 +71,8 @@ const POSTGRES_CREATE = `
     "isTimeOffsetIssue" BOOLEAN DEFAULT FALSE,
     "timeOffsetSeconds" INTEGER,
     "welcomedAt" BIGINT,
+    "nodeStatus" TEXT,
+    "nodeStatusUpdatedAt" BIGINT,
     "positionChannel" INTEGER,
     "positionPrecisionBits" INTEGER,
     "positionGpsAccuracy" REAL,
@@ -147,6 +149,8 @@ const MYSQL_CREATE = `
     isTimeOffsetIssue BOOLEAN DEFAULT FALSE,
     timeOffsetSeconds INTEGER,
     welcomedAt BIGINT,
+    nodeStatus VARCHAR(80),
+    nodeStatusUpdatedAt BIGINT,
     positionChannel INTEGER,
     positionPrecisionBits INTEGER,
     positionGpsAccuracy DOUBLE,
@@ -257,6 +261,40 @@ function runNodesTests(getBackend: () => TestBackend) {
     const updated = await repo.getNode(221);
     expect(Boolean(updated!.isUnmessagable)).toBe(false);
     expect(Boolean(updated!.isLicensed)).toBe(false);
+  });
+
+  // #4818 Status Message: stored as a node attribute; set on insert/update,
+  // cleared to null on an empty broadcast, preserved when a non-status upsert
+  // omits it entirely.
+  it('upsertNode - nodeStatus: insert, clear-on-empty, preserve-on-undefined (#4818)', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    // Insert path carries the status + timestamp.
+    await repo.upsertNode(makeNode(230, { nodeStatus: 'On the trail', nodeStatusUpdatedAt: 1000 }));
+    const inserted = await repo.getNode(230);
+    expect(inserted!.nodeStatus).toBe('On the trail');
+    expect(Number(inserted!.nodeStatusUpdatedAt)).toBe(1000);
+
+    // A non-status upsert (no nodeStatus key) must PRESERVE the stored status.
+    await repo.upsertNode(makeNode(230, { longName: 'Renamed' }));
+    const preserved = await repo.getNode(230);
+    expect(preserved!.longName).toBe('Renamed');
+    expect(preserved!.nodeStatus).toBe('On the trail');
+
+    // Update path overwrites with a new status.
+    await repo.upsertNode(makeNode(230, { nodeStatus: 'Back at base', nodeStatusUpdatedAt: 2000 }));
+    const updated = await repo.getNode(230);
+    expect(updated!.nodeStatus).toBe('Back at base');
+    expect(Number(updated!.nodeStatusUpdatedAt)).toBe(2000);
+
+    // An empty status is a genuine CLEAR → null (matches the official clients).
+    await repo.upsertNode(makeNode(230, { nodeStatus: '', nodeStatusUpdatedAt: 3000 }));
+    const cleared = await repo.getNode(230);
+    expect(cleared!.nodeStatus == null).toBe(true);
   });
 
   it('upsertNode - does NOT clobber learned name/macaddr/hwModel with blanks (#3505)', async () => {

--- a/src/db/repositories/nodes.ts
+++ b/src/db/repositories/nodes.ts
@@ -490,6 +490,16 @@ export class NodesRepository extends BaseRepository {
           // #3684: User capability flags from NodeInfo (preserve prior value if not present)
           isUnmessagable: nodeData.isUnmessagable ?? existingNode.isUnmessagable,
           isLicensed: nodeData.isLicensed ?? existingNode.isLicensed,
+          // #4818 Status Message: only the NODE_STATUS_APP handler provides
+          // nodeStatus, so `undefined` = "not this packet" (preserve). An empty
+          // string is a genuine clear from the node → store null, matching the
+          // official clients.
+          nodeStatus: nodeData.nodeStatus !== undefined
+            ? (nodeData.nodeStatus === '' ? null : nodeData.nodeStatus)
+            : existingNode.nodeStatus,
+          nodeStatusUpdatedAt: nodeData.nodeStatusUpdatedAt !== undefined
+            ? this.coerceBigintField(nodeData.nodeStatusUpdatedAt)
+            : existingNode.nodeStatusUpdatedAt,
           updatedAt: now,
         })
         .where(and(eq(nodes.nodeNum, nodeData.nodeNum), eq(nodes.sourceId, effectiveSourceId)));
@@ -543,6 +553,10 @@ export class NodesRepository extends BaseRepository {
         notes: nodeData.notes ?? null,
         isUnmessagable: nodeData.isUnmessagable ?? false,
         isLicensed: nodeData.isLicensed ?? false,
+        // #4818 Status Message (first-seen): store the broadcast status; a blank
+        // status persists as null.
+        nodeStatus: nodeData.nodeStatus ? nodeData.nodeStatus : null,
+        nodeStatusUpdatedAt: this.coerceBigintField(nodeData.nodeStatusUpdatedAt),
         createdAt: now,
         updatedAt: now,
       } as any;
@@ -608,6 +622,11 @@ export class NodesRepository extends BaseRepository {
         // packet-driven upsert conflict. It is only written by setNodeNotes.
         isUnmessagable: nodeData.isUnmessagable ?? false,
         isLicensed: nodeData.isLicensed ?? false,
+        // Note: nodeStatus/nodeStatusUpdatedAt are intentionally NOT included
+        // here (#4818) — same reasoning as notes/mobile above. This conflict
+        // path only fires in the first-seen race; leaving them out means a
+        // racing non-status packet can never clobber an existing node's status
+        // to null. Status packets update via the UPDATE branch above.
         updatedAt: now,
       };
 
@@ -1717,6 +1736,13 @@ export class NodesRepository extends BaseRepository {
       if (nodeData.positionPrecisionBits !== undefined) updateSet.positionPrecisionBits = nodeData.positionPrecisionBits;
       if (nodeData.positionLocationSource !== undefined) updateSet.positionLocationSource = nodeData.positionLocationSource;
       if (nodeData.positionTimestamp !== undefined) updateSet.positionTimestamp = nodeData.positionTimestamp;
+      // #4818 Status Message: explicit key present clears on '' (null), matching
+      // the async upsertNode path and the official clients; absent key keeps
+      // the existing value.
+      if ('nodeStatus' in nodeData) {
+        updateSet.nodeStatus = nodeData.nodeStatus ? nodeData.nodeStatus : null;
+      }
+      if (nodeData.nodeStatusUpdatedAt !== undefined) updateSet.nodeStatusUpdatedAt = nodeData.nodeStatusUpdatedAt;
       // Per-source blocklist is authoritative (issue #2601): re-apply the ignore
       // flag on update when the caller signals the node is still blocklisted,
       // overriding any un-ignored status the device just reported. Note the
@@ -1763,6 +1789,8 @@ export class NodesRepository extends BaseRepository {
         duplicateKeyDetected: !!nodeData.duplicateKeyDetected,
         keyMismatchDetected: !!nodeData.keyMismatchDetected,
         keySecurityIssueDetails: nodeData.keySecurityIssueDetails || null,
+        nodeStatus: nodeData.nodeStatus || null,
+        nodeStatusUpdatedAt: nodeData.nodeStatusUpdatedAt || null,
         positionChannel: nodeData.positionChannel !== undefined ? nodeData.positionChannel : null,
         positionPrecisionBits: nodeData.positionPrecisionBits !== undefined ? nodeData.positionPrecisionBits : null,
         positionLocationSource: nodeData.positionLocationSource !== undefined ? nodeData.positionLocationSource : null,

--- a/src/db/schema/nodes.ts
+++ b/src/db/schema/nodes.ts
@@ -65,6 +65,11 @@ export const nodesSqlite = sqliteTable('nodes', {
   isTimeOffsetIssue: integer('isTimeOffsetIssue', { mode: 'boolean' }).default(false),
   timeOffsetSeconds: integer('timeOffsetSeconds'),
   welcomedAt: integer('welcomedAt'),
+  // Status Message (#4818): the node's self-broadcast status from
+  // PortNum.NODE_STATUS_APP (36), max 80 chars. One current value, cleared
+  // (null) when the node broadcasts an empty status. Meshtastic-only.
+  nodeStatus: text('nodeStatus'),
+  nodeStatusUpdatedAt: integer('nodeStatusUpdatedAt'),
   // Position precision tracking
   positionChannel: integer('positionChannel'),
   positionPrecisionBits: integer('positionPrecisionBits'),
@@ -159,6 +164,10 @@ export const nodesPostgres = pgTable('nodes', {
   isTimeOffsetIssue: pgBoolean('isTimeOffsetIssue').default(false),
   timeOffsetSeconds: pgInteger('timeOffsetSeconds'),
   welcomedAt: pgBigint('welcomedAt', { mode: 'number' }),
+  // Status Message (#4818): self-broadcast status from NODE_STATUS_APP (36),
+  // max 80 chars; null when the node broadcasts an empty status.
+  nodeStatus: pgText('nodeStatus'),
+  nodeStatusUpdatedAt: pgBigint('nodeStatusUpdatedAt', { mode: 'number' }),
   // Position precision tracking
   positionChannel: pgInteger('positionChannel'),
   positionPrecisionBits: pgInteger('positionPrecisionBits'),
@@ -252,6 +261,10 @@ export const nodesMysql = mysqlTable('nodes', {
   isTimeOffsetIssue: myBoolean('isTimeOffsetIssue').default(false),
   timeOffsetSeconds: myInt('timeOffsetSeconds'),
   welcomedAt: myBigint('welcomedAt', { mode: 'number' }),
+  // Status Message (#4818): self-broadcast status from NODE_STATUS_APP (36),
+  // max 80 chars; null when the node broadcasts an empty status.
+  nodeStatus: myVarchar('nodeStatus', { length: 80 }),
+  nodeStatusUpdatedAt: myBigint('nodeStatusUpdatedAt', { mode: 'number' }),
   // Position precision tracking
   positionChannel: myInt('positionChannel'),
   positionPrecisionBits: myInt('positionPrecisionBits'),

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -77,6 +77,9 @@ export interface DbNode {
   lastMeshReceivedKey?: string | null;
   keySecurityIssueDetails?: string | null;
   welcomedAt?: number | null;
+  /** #4818 Status Message: node's self-broadcast status (NODE_STATUS_APP), max 80 chars; null when cleared. */
+  nodeStatus?: string | null;
+  nodeStatusUpdatedAt?: number | null;
   positionChannel?: number | null;
   positionPrecisionBits?: number | null;
   positionGpsAccuracy?: number | null;

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -79,6 +79,7 @@ export interface DbNode {
   welcomedAt?: number | null;
   /** #4818 Status Message: node's self-broadcast status (NODE_STATUS_APP), max 80 chars; null when cleared. */
   nodeStatus?: string | null;
+  /** Epoch milliseconds (Date.now) — NOT seconds like lastHeard. */
   nodeStatusUpdatedAt?: number | null;
   positionChannel?: number | null;
   positionPrecisionBits?: number | null;

--- a/src/server/meshtasticManager.nodeStatus.test.ts
+++ b/src/server/meshtasticManager.nodeStatus.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Status Message receive-side ingest (#4818).
+ *
+ * The firmware StatusMessageModule broadcasts each node's self-set status on
+ * PortNum.NODE_STATUS_APP (36) as `meshtastic.StatusMessage { string status }`.
+ * `processNodeStatusMessageProtobuf` stores it as a per-node attribute via
+ * `upsertNodeAsync` — never as a message/DM. These tests pin the handler's
+ * upsert payload: the status is set, clamped to 80 chars, an empty status is
+ * carried through as '' (the repo maps that to a null "clear"), and a packet
+ * with no `from` is ignored.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockUpsertNodeAsync = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    upsertNodeAsync: mockUpsertNodeAsync,
+    nodes: { getAllNodes: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+/** The nodeData object passed to the most recent upsertNodeAsync call. */
+function lastUpsert(): any {
+  const call = mockUpsertNodeAsync.mock.calls.at(-1);
+  return call?.[0];
+}
+
+describe('MeshtasticManager - Status Message ingest (#4818)', () => {
+  let manager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module = await import('./meshtasticManager.js');
+    manager = module.fallbackManager;
+    // trackPKIEncryption hits other state/DB; not under test here.
+    vi.spyOn(manager, 'trackPKIEncryption').mockResolvedValue(undefined);
+  });
+
+  const meshPacket = { from: 0x11111111, id: 42, rxSnr: 5, rxRssi: -80 };
+
+  it('upserts the node status as a per-node attribute (not a message)', async () => {
+    await manager.processNodeStatusMessageProtobuf(meshPacket, { status: 'On the ridge 🏔' });
+
+    expect(mockUpsertNodeAsync).toHaveBeenCalledTimes(1);
+    const data = lastUpsert();
+    expect(data.nodeNum).toBe(0x11111111);
+    expect(data.nodeId).toBe('!11111111');
+    expect(data.nodeStatus).toBe('On the ridge 🏔');
+    expect(typeof data.nodeStatusUpdatedAt).toBe('number');
+  });
+
+  it('clamps the status to 80 characters', async () => {
+    const long = 'x'.repeat(200);
+    await manager.processNodeStatusMessageProtobuf(meshPacket, { status: long });
+    expect(lastUpsert().nodeStatus).toHaveLength(80);
+  });
+
+  it('carries an empty status through as "" (the repo turns that into a clear)', async () => {
+    await manager.processNodeStatusMessageProtobuf(meshPacket, { status: '' });
+    expect(mockUpsertNodeAsync).toHaveBeenCalledTimes(1);
+    expect(lastUpsert().nodeStatus).toBe('');
+  });
+
+  it('treats a missing status field as an empty clear', async () => {
+    await manager.processNodeStatusMessageProtobuf(meshPacket, {});
+    expect(lastUpsert().nodeStatus).toBe('');
+  });
+
+  it('ignores a packet with no sender (from = 0)', async () => {
+    await manager.processNodeStatusMessageProtobuf({ from: 0 }, { status: 'ignored' });
+    expect(mockUpsertNodeAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7740,7 +7740,7 @@ class MeshtasticManager implements ISourceManager {
         nodeNum: fromNum,
         nodeId,
         nodeStatus: status, // '' clears the stored value in the repo merge
-        nodeStatusUpdatedAt: Date.now(),
+        nodeStatusUpdatedAt: Date.now(), // epoch ms (NOT seconds like lastHeard)
         // Replay guard: omit lastHeard for replayed/retained frames so a stale
         // status can't resurrect an offline node (#4192/#4445).
         lastHeard: this.lastHeardFor(meshPacket),

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6145,6 +6145,13 @@ class MeshtasticManager implements ISourceManager {
             }, this.sourceId);
             break;
           }
+          case PortNum.NODE_STATUS_APP: {
+            // StatusMessage (fw 2.7.20+/2.8, #4818): the node's self-broadcast
+            // status. Stored as a per-node attribute (cleared on empty),
+            // mirroring the official clients — never a message/DM.
+            await this.processNodeStatusMessageProtobuf(meshPacket, processedPayload as { status?: unknown });
+            break;
+          }
           default:
             logger.debug(`🤷 Unhandled portnum: ${normalizedPortNum} (${meshtasticProtobufService.getPortNumName(portnum)})`);
         }
@@ -7706,6 +7713,47 @@ class MeshtasticManager implements ISourceManager {
    * Process paxcounter message
    * Paxcounter counts nearby WiFi and BLE devices
    */
+  /**
+   * Status Message receive (#4818). The firmware StatusMessageModule broadcasts
+   * each node's self-set status on PortNum.NODE_STATUS_APP (36) as
+   * `meshtastic.StatusMessage { string status }`. Store it as a per-node
+   * attribute; an empty status CLEARS the stored value (the repo merge maps ''
+   * to null), matching the official Android/Apple clients. Never persisted as a
+   * message or DM — it is a node property like long/short name.
+   */
+  private async processNodeStatusMessageProtobuf(
+    meshPacket: { from?: unknown; rxSnr?: number | null; rxRssi?: number | null; rxTime?: unknown },
+    statusMessage: { status?: unknown },
+  ): Promise<void> {
+    try {
+      const fromNum = Number(meshPacket.from);
+      if (!fromNum) return;
+      const nodeId = `!${fromNum.toString(16).padStart(8, '0')}`;
+      // Max 80 chars per the protobuf; clamp defensively. '' is a valid "clear".
+      const raw = typeof statusMessage?.status === 'string' ? statusMessage.status : '';
+      const status = raw.slice(0, 80);
+      logger.debug(`📝 Node status from ${nodeId}: "${status}"`);
+
+      await this.trackPKIEncryption(meshPacket, fromNum);
+
+      const nodeData: Parameters<typeof databaseService.upsertNodeAsync>[0] = {
+        nodeNum: fromNum,
+        nodeId,
+        nodeStatus: status, // '' clears the stored value in the repo merge
+        nodeStatusUpdatedAt: Date.now(),
+        // Replay guard: omit lastHeard for replayed/retained frames so a stale
+        // status can't resurrect an offline node (#4192/#4445).
+        lastHeard: this.lastHeardFor(meshPacket),
+      };
+      if (meshPacket.rxSnr != null && meshPacket.rxSnr !== -128) nodeData.snr = meshPacket.rxSnr;
+      if (meshPacket.rxRssi != null) nodeData.rssi = meshPacket.rxRssi;
+
+      await databaseService.upsertNodeAsync(nodeData, this.sourceId);
+    } catch (error) {
+      logger.error('Failed to process node status message:', error);
+    }
+  }
+
   private async processPaxcounterMessageProtobuf(meshPacket: any, paxcount: any): Promise<void> {
     try {
       logger.debug('📊 Processing paxcounter message');

--- a/src/server/meshtasticProtobufService.test.ts
+++ b/src/server/meshtasticProtobufService.test.ts
@@ -465,6 +465,27 @@ describe('MeshtasticProtobufService', () => {
     });
   });
 
+  describe('processPayload NODE_STATUS_APP (#4818)', () => {
+    function encodeStatus(status: string): Uint8Array {
+      const root = getProtobufRoot()!;
+      const StatusMessage = root.lookupType('meshtastic.StatusMessage');
+      return StatusMessage.encode(StatusMessage.create({ status })).finish();
+    }
+
+    it('decodes a StatusMessage payload to { status }', () => {
+      if (!requireProtobufs()) return;
+      const decoded: any = service.processPayload(36, encodeStatus('Roaming the ridge 🏔'));
+      expect(decoded?.status).toBe('Roaming the ridge 🏔');
+    });
+
+    it('decodes an empty status (the node clearing its status)', () => {
+      if (!requireProtobufs()) return;
+      const decoded: any = service.processPayload(36, encodeStatus(''));
+      // protobufjs omits an empty proto3 string; normalize to '' for the check.
+      expect(decoded?.status ?? '').toBe('');
+    });
+  });
+
   describe('decodeServiceEnvelope', () => {
     it('decodes a valid ServiceEnvelope with packet', () => {
       if (!protobufInitialized) return;

--- a/src/server/meshtasticProtobufService.ts
+++ b/src/server/meshtasticProtobufService.ts
@@ -919,6 +919,13 @@ export class MeshtasticProtobufService {
           return MeshBeacon.decode(payload);
         }
 
+        case PortNum.NODE_STATUS_APP: {
+          // StatusMessage (firmware 2.7.20+/2.8, #4818): the node's self-set
+          // status string (max 80 chars), broadcast on change and ~every 12h.
+          const StatusMessage = root.lookupType('meshtastic.StatusMessage');
+          return StatusMessage.decode(payload);
+        }
+
         case PortNum.ATAK_PLUGIN: {
           // TAKPacket (ATAK plugin, portnum 72): oneof PLI/GeoChat/detail payload_variant.
           const TAKPacket = root.lookupType('meshtastic.TAKPacket');

--- a/src/server/migrations/149_add_node_status.test.ts
+++ b/src/server/migrations/149_add_node_status.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for migration 149 — `nodeStatus` + `nodeStatusUpdatedAt` columns on
+ * `nodes` (Status Message receive side, #4818).
+ */
+import Database from 'better-sqlite3';
+import { describe, expect, it, vi } from 'vitest';
+import { migration, runMigration149Postgres, runMigration149Mysql } from './149_add_node_status.js';
+
+/** A minimal `nodes` table without the status columns. */
+function createParentTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS nodes (
+      nodeNum INTEGER NOT NULL,
+      nodeId TEXT NOT NULL,
+      longName TEXT,
+      shortName TEXT,
+      sourceId TEXT NOT NULL DEFAULT 'default',
+      createdAt INTEGER NOT NULL DEFAULT 0,
+      updatedAt INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (nodeNum, sourceId)
+    )
+  `);
+}
+
+function columnNames(db: Database.Database, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((c) => c.name);
+}
+
+describe('Migration 149 — nodes status columns', () => {
+  describe('SQLite', () => {
+    it('adds nodeStatus + nodeStatusUpdatedAt and is idempotent (second up() does not throw)', () => {
+      const db = new Database(':memory:');
+      createParentTable(db);
+
+      migration.up(db);
+      expect(() => migration.up(db)).not.toThrow();
+
+      const cols = columnNames(db, 'nodes');
+      expect(cols).toContain('nodeStatus');
+      expect(cols).toContain('nodeStatusUpdatedAt');
+
+      db.close();
+    });
+
+    it('existing rows read null for the new columns, and a status write round-trips', () => {
+      const db = new Database(':memory:');
+      createParentTable(db);
+      db.prepare(`INSERT INTO nodes (nodeNum, nodeId, sourceId) VALUES (?, ?, ?)`)
+        .run(0x11111111, '!11111111', 'default');
+
+      migration.up(db);
+
+      const before = db.prepare(`SELECT * FROM nodes WHERE nodeNum = ?`).get(0x11111111) as any;
+      expect(before.nodeStatus).toBeNull();
+      expect(before.nodeStatusUpdatedAt).toBeNull();
+
+      db.prepare(`UPDATE nodes SET nodeStatus = ?, nodeStatusUpdatedAt = ? WHERE nodeNum = ?`)
+        .run('On the ridge', 1234, 0x11111111);
+      const after = db.prepare(`SELECT * FROM nodes WHERE nodeNum = ?`).get(0x11111111) as any;
+      expect(after.nodeStatus).toBe('On the ridge');
+      expect(after.nodeStatusUpdatedAt).toBe(1234);
+
+      db.close();
+    });
+  });
+
+  describe('PostgreSQL', () => {
+    it('adds both columns via ADD COLUMN IF NOT EXISTS with quoted camelCase', async () => {
+      const calls: string[] = [];
+      const client = { query: vi.fn(async (sql: string) => { calls.push(sql); return { rows: [] }; }) } as any;
+
+      await runMigration149Postgres(client);
+
+      const joined = calls.join('\n');
+      expect(joined).toMatch(/ADD COLUMN IF NOT EXISTS "nodeStatus" TEXT/);
+      expect(joined).toMatch(/ADD COLUMN IF NOT EXISTS "nodeStatusUpdatedAt" BIGINT/);
+    });
+  });
+
+  describe('MySQL', () => {
+    it('pre-checks information_schema then adds each missing column', async () => {
+      // Report every column as absent so the helper proceeds to ADD COLUMN.
+      const conn = {
+        query: vi.fn().mockImplementation((sql: string) => {
+          if (sql.includes('information_schema.COLUMNS')) return Promise.resolve([[]]);
+          return Promise.resolve([[]]);
+        }),
+        release: vi.fn(),
+      };
+      const pool = { getConnection: vi.fn().mockResolvedValue(conn) } as any;
+
+      await runMigration149Mysql(pool);
+
+      const ddl = conn.query.mock.calls.map((c: any[]) => String(c[0])).join('\n');
+      expect(ddl).toContain('ALTER TABLE nodes ADD COLUMN nodeStatus VARCHAR(80)');
+      expect(ddl).toContain('ALTER TABLE nodes ADD COLUMN nodeStatusUpdatedAt BIGINT');
+      expect(conn.release).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/migrations/149_add_node_status.ts
+++ b/src/server/migrations/149_add_node_status.ts
@@ -1,0 +1,57 @@
+/**
+ * Migration 149: add `nodeStatus` + `nodeStatusUpdatedAt` columns to `nodes`
+ * (Status Message receive side, #4818).
+ *
+ * The firmware `StatusMessageModule` (fw 2.7.20+/2.8.0) broadcasts each node's
+ * self-set status on `PortNum.NODE_STATUS_APP` (36) as
+ * `meshtastic.StatusMessage { string status }` (max 80 chars) — on change, and
+ * otherwise ~every 12h. MeshMonitor now decodes and stores it as a per-node
+ * attribute (one current value, cleared to NULL on an empty broadcast),
+ * mirroring the official Android/Apple clients. Meshtastic-only.
+ *
+ * Both columns are nullable. Idempotent across SQLite / PostgreSQL / MySQL via
+ * the shared helpers.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+import {
+  addColumnIfMissing,
+  addColumnIfMissingPostgres,
+  addColumnIfMissingMysql,
+} from './helpers.js';
+
+const LABEL = 'Migration 149';
+const TABLE = 'nodes';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding node-status columns to ${TABLE}...`);
+    addColumnIfMissing(db, TABLE, 'nodeStatus', 'nodeStatus TEXT');
+    addColumnIfMissing(db, TABLE, 'nodeStatusUpdatedAt', 'nodeStatusUpdatedAt INTEGER');
+    logger.info(`${LABEL} complete (SQLite)`);
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration149Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding node-status columns to ${TABLE}...`);
+  await addColumnIfMissingPostgres(client, TABLE, 'nodeStatus', '"nodeStatus" TEXT');
+  await addColumnIfMissingPostgres(client, TABLE, 'nodeStatusUpdatedAt', '"nodeStatusUpdatedAt" BIGINT');
+  logger.info(`${LABEL} complete (PostgreSQL)`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration149Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding node-status columns to ${TABLE}...`);
+  await addColumnIfMissingMysql(pool, TABLE, 'nodeStatus', 'nodeStatus VARCHAR(80)');
+  await addColumnIfMissingMysql(pool, TABLE, 'nodeStatusUpdatedAt', 'nodeStatusUpdatedAt BIGINT');
+  logger.info(`${LABEL} complete (MySQL)`);
+}

--- a/src/server/services/nodeDbMaintenanceService.ts
+++ b/src/server/services/nodeDbMaintenanceService.ts
@@ -76,6 +76,14 @@ export function mapDbNodeToDeviceInfo(node: any, uptimeSeconds?: number, noiseFl
     deviceInfo.hopsAway = node.hopsAway;
   }
 
+  // Status Message (#4818): the node's self-broadcast status (NODE_STATUS_APP).
+  // null when the node cleared it — omit rather than send null so the client's
+  // "has a status?" check is a simple truthiness test.
+  if (node.nodeStatus) {
+    deviceInfo.nodeStatus = node.nodeStatus;
+    deviceInfo.nodeStatusUpdatedAt = node.nodeStatusUpdatedAt ?? undefined;
+  }
+
   // Add lastMessageHops if it exists (for "All messages" hop calculation mode)
   if (node.lastMessageHops !== null && node.lastMessageHops !== undefined) {
     deviceInfo.lastMessageHops = node.lastMessageHops;

--- a/src/types/device.ts
+++ b/src/types/device.ts
@@ -37,6 +37,10 @@ export interface DeviceInfo {
    */
   uptimeSeconds?: number;
   hopsAway?: number;
+  /** #4818 Status Message: the node's self-broadcast status (NODE_STATUS_APP), max 80 chars. Absent when unset. */
+  nodeStatus?: string;
+  /** Epoch ms when nodeStatus was last received. */
+  nodeStatusUpdatedAt?: number;
   lastMessageHops?: number; // Hops from most recent packet (hopStart - hopLimit)
   viaMqtt?: boolean;
   /**

--- a/src/types/device.ts
+++ b/src/types/device.ts
@@ -39,7 +39,11 @@ export interface DeviceInfo {
   hopsAway?: number;
   /** #4818 Status Message: the node's self-broadcast status (NODE_STATUS_APP), max 80 chars. Absent when unset. */
   nodeStatus?: string;
-  /** Epoch ms when nodeStatus was last received. */
+  /**
+   * Epoch **milliseconds** when nodeStatus was last received (server clock).
+   * NOTE: this is ms, unlike `lastHeard` which is Unix **seconds** — a
+   * "status updated X ago" display must not mix the two units.
+   */
   nodeStatusUpdatedAt?: number;
   lastMessageHops?: number; // Hops from most recent packet (hopStart - hopLimit)
   viaMqtt?: boolean;


### PR DESCRIPTION
Closes #4818.

## What

The firmware `StatusMessageModule` (fw 2.7.20+/2.8) broadcasts each node's self-set status on `PortNum.NODE_STATUS_APP` (36) as `meshtastic.StatusMessage { string status }` (max 80 chars), on change and ~every 12h. MeshMonitor already knew the port number and let you **set** your own status (`StatusMessageConfigSection`, #1925), but silently **dropped** incoming ones. This adds the receive side and surfaces it — exactly the two placements the reporter asked for.

## The model (verified against both official clients)

Researched Android + Apple source before building. A received status is a **per-node attribute** — one current value, overwritten on update, **cleared to null on an empty broadcast** — shown in **Node Details** and the **Node List**, and **never** posted into a channel feed or a DM thread. This PR mirrors that exactly.

## Changes

**Backend**
- `nodes` schema: `nodeStatus` (≤80) + `nodeStatusUpdatedAt` on all three backends; migration **149** (idempotent, registered); `DbNode` type + hand-written PG/MySQL DDL in `nodes.test.ts`.
- Decode: `NODE_STATUS_APP` → `meshtastic.StatusMessage`.
- Ingest: `processNodeStatusMessageProtobuf` upserts it as an attribute. **Clear-on-empty, preserve-on-undefined**, and deliberately **excluded from the conflict-overwrite `upsertSet`** (same reasoning as `notes`, #3921) so a racing non-status packet can never clobber a good status to null.

**Frontend**
- `DeviceInfo.nodeStatus` + the `mapDbNodeToDeviceInfo` mapping.
- **Node Details**: a "Status" card (rendered verbatim — untrusted mesh text — and wraps).
- **Nodes list**: a short italic subtitle under the role.

## Mesh impact

None. This is a **passive receive** of a broadcast the firmware already sends on its own schedule — we only decode and store data that's already arriving. No packets sent, no timers, no caps needed.

## Testing

- Protobuf decode (2), manager ingest (5), repo set/clear/preserve (multi-backend), migration 149 SQLite/PG/MySQL (4).
- **Full suite: 16,108 passed / 0 failed / 0 suites failed with PostgreSQL + MySQL containers up** (multi-backend suites ran, not skipped). `tsc` + `lint:ci` clean.

## Scope notes

- Meshtastic-only — MeshCore has no equivalent concept.
- The map popup (`DashboardNodePopup`, also used on the 3D map) could show the status too; kept out of this PR to match the issue's explicit asks (Node Details + Node list). Easy fast-follow if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G