### PR TITLE
fix(meshcore): keep a contact's identity when the firmware evicts it (#4838)

### DIFF
--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -588,6 +588,30 @@ This is fixed in 4.5 — source create/update/delete/connect/disconnect endpoint
 - Check that the radio frequency and parameters match other nodes in your mesh.
 - Try sending an advert to announce your presence on the network.
 
+### A contact loses its name and shows its public key instead
+
+The companion firmware stores contacts in a fixed-size table (100 entries on
+most companion builds). When it fills up, the firmware evicts the
+least-recently-adverted **non-favorite** contact to make room. A repeater on a
+long advert interval is usually the first to go, which is why this tends to
+show up after days rather than immediately.
+
+MeshMonitor keeps the contact listed with its name and type when this happens
+(it restores the entry from `meshcore_nodes`), but the radio can no longer
+address it: ping and Discover Path report that the contact was evicted, and
+Auto-Pathfinding skips it. The contact becomes fully usable again on the
+node's next advert.
+
+To stop it happening:
+
+- **Favorite the node on the device**, in the official MeshCore app or MeshCore
+  Web. MeshMonitor's own ⭐ is a local display flag and does **not** set the
+  firmware's favorite bit, so it does not protect a contact from eviction.
+- **Prune contacts you don't need** from the device, via the contact-management
+  panel, to keep the table below its limit.
+- **Consider turning off Discover Nearby Nodes** if you don't need it —
+  it auto-adds every responder as a device contact, which fills the table faster.
+
 ### Radio parameter changes "revert" on save
 Earlier 4.x versions had a hook-dependency bug where Phase 3 push events overwrote staged radio/location edits before Save fired. Fixed in 4.5.
 

--- a/src/server/meshcoreManager.contactEviction.test.ts
+++ b/src/server/meshcoreManager.contactEviction.test.ts
@@ -24,6 +24,7 @@ vi.mock('../services/database.js', () => ({
     meshcore: {
       getNodesBySource: (...args: unknown[]) => getNodesBySource(...args),
       upsertNode: (...args: unknown[]) => upsertNode(...args),
+      insertMessage: vi.fn().mockResolvedValue(undefined),
     },
   },
 }));
@@ -165,6 +166,39 @@ describe('MeshCoreManager — firmware contact eviction (#4838)', () => {
     await Promise.resolve();
 
     expect(m.getContact(REPEATER)?.onDevice).toBe(true);
+  });
+
+  it('clears the off-device flag when a DM arrives from the contact', async () => {
+    const m = makeManager([companionContact]);
+    await m.refreshContacts();
+    expect(m.getContact(REPEATER)?.onDevice).toBe(false);
+
+    // The companion can only decrypt a DM it has a contact-table entry for.
+    (m as any).handleBridgeEvent({
+      event_type: 'contact_message',
+      data: { pubkey_prefix: REPEATER.substring(0, 12), text: 'hi', sender_timestamp: 1_700_001_000 },
+    });
+    await Promise.resolve();
+
+    expect(m.getContact(REPEATER)?.onDevice).toBe(true);
+  });
+
+  it('does not flood a discover-path request at an evicted contact', async () => {
+    const m = makeManager([companionContact]);
+    await m.refreshContacts();
+
+    const sent: string[] = [];
+    (m as any).sendBridgeCommand = async (cmd: string) => {
+      sent.push(cmd);
+      return { id: '3', success: true, data: {} };
+    };
+
+    await expect(m.discoverContactPath(REPEATER)).resolves.toBe(false);
+    expect(sent).not.toContain('discover_path');
+
+    // An on-device contact still goes out over the air as before.
+    await expect(m.discoverContactPath(COMPANION)).resolves.toBe(true);
+    expect(sent).toContain('discover_path');
   });
 
   it('does not resurrect a contact the user just removed', async () => {

--- a/src/server/meshcoreManager.contactEviction.test.ts
+++ b/src/server/meshcoreManager.contactEviction.test.ts
@@ -19,13 +19,27 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 const getNodesBySource = vi.fn();
 const upsertNode = vi.fn().mockResolvedValue(undefined);
 
+const PATHFINDING_SETTINGS: Record<string, string> = {
+  meshcoreAutoPathfindingEnabled: 'true',
+  meshcoreAutoPathfindingPathDiscoveryEnabled: 'true',
+  meshcoreAutoPathfindingNeighborsEnabled: 'true',
+  meshcoreAutoPathfindingIntervalMinutes: '3',
+  meshcoreAutoPathfindingRepeatHours: '1',
+};
+
 vi.mock('../services/database.js', () => ({
   default: {
     meshcore: {
       getNodesBySource: (...args: unknown[]) => getNodesBySource(...args),
       upsertNode: (...args: unknown[]) => upsertNode(...args),
       insertMessage: vi.fn().mockResolvedValue(undefined),
+      insertNeighborsBatch: vi.fn().mockResolvedValue(undefined),
     },
+    settings: {
+      getSettingForSource: async (_sourceId: unknown, key: string) =>
+        PATHFINDING_SETTINGS[key] ?? null,
+    },
+    getMeshcorePathfindingFilterSettingsAsync: async () => ({ enabled: false }),
   },
 }));
 
@@ -199,6 +213,38 @@ describe('MeshCoreManager — firmware contact eviction (#4838)', () => {
     // An on-device contact still goes out over the air as before.
     await expect(m.discoverContactPath(COMPANION)).resolves.toBe(true);
     expect(sent).toContain('discover_path');
+  });
+
+  it('Auto-Pathfinding skips evicted contacts, sparing the airtime', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0); // no jitter
+    try {
+      // Both nodes are known; only the companion is still on the device.
+      const m = makeManager([companionContact]);
+      await m.refreshContacts();
+
+      const discovered: string[] = [];
+      const neighboured: string[] = [];
+      (m as any).discoverContactPath = async (k: string) => { discovered.push(k); return true; };
+      (m as any).getNeighbours = async (k: string) => { neighboured.push(k); return null; };
+
+      await m.startAutoPathfinding();
+      // The run walks targets with a configured gap between each (3 min
+      // here), so advance well past it — otherwise only the first target
+      // fires and the assertion below passes for the wrong reason.
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+
+      // The companion is still addressable and gets its probe...
+      expect(discovered).toContain(COMPANION);
+      // ...while the evicted repeater, a get_neighbours target by type, is
+      // skipped rather than costing airtime on a command the device rejects.
+      expect(neighboured).not.toContain(REPEATER);
+
+      m.stopAutoPathfinding();
+    } finally {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
   });
 
   it('does not resurrect a contact the user just removed', async () => {

--- a/src/server/meshcoreManager.contactEviction.test.ts
+++ b/src/server/meshcoreManager.contactEviction.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Regression tests for issue #4838 — a contact evicted from the companion's
+ * own contact table took its identity down with it.
+ *
+ * The MeshCore companion firmware holds contacts in a fixed-size table and
+ * evicts the least-recently-adverted non-favorite entry once it fills. A
+ * rarely-adverting repeater is the natural victim. `refreshContacts()` then
+ * clear-and-replaced its in-memory map from that shorter `get_contacts`
+ * result, so the contact's name and advType vanished — the UI fell back to
+ * a truncated public key, the type defaulted to Companion, and ping/path
+ * discovery failed with "Contact is not known to this source."
+ *
+ * The fix re-seeds those contacts from `meshcore_nodes` after the replace,
+ * flagged `onDevice: false`: identity survives, callers can still tell the
+ * radio cannot address them, and the error text says so.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const getNodesBySource = vi.fn();
+const upsertNode = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      getNodesBySource: (...args: unknown[]) => getNodesBySource(...args),
+      upsertNode: (...args: unknown[]) => upsertNode(...args),
+    },
+  },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: new Proxy({}, { get: () => vi.fn() }),
+}));
+
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+
+const REPEATER = 'a'.repeat(64);
+const COMPANION = 'b'.repeat(64);
+
+/** A `meshcore_nodes` row for the repeater, as it survives an eviction. */
+const REPEATER_ROW = {
+  publicKey: REPEATER,
+  name: 'Hilltop Repeater',
+  advType: MeshCoreDeviceType.REPEATER,
+  rssi: -78,
+  snr: 6,
+  isLocalNode: false,
+  lastHeard: 1_700_000_000_000,
+};
+
+const COMPANION_ROW = {
+  publicKey: COMPANION,
+  name: 'Alice',
+  advType: MeshCoreDeviceType.COMPANION,
+  isLocalNode: false,
+};
+
+/** Device contact-list entry as `get_contacts` reports it. */
+const companionContact = {
+  public_key: COMPANION,
+  adv_name: 'Alice',
+  name: 'Alice',
+  adv_type: MeshCoreDeviceType.COMPANION,
+  last_advert: 1_700_000_500,
+};
+
+const repeaterContact = {
+  public_key: REPEATER,
+  adv_name: 'Hilltop Repeater',
+  name: 'Hilltop Repeater',
+  adv_type: MeshCoreDeviceType.REPEATER,
+  last_advert: 1_700_000_000,
+};
+
+function makeManager(contactsData: unknown[]): MeshCoreManager {
+  const m = new MeshCoreManager('src-a');
+  (m as any).deviceType = MeshCoreDeviceType.COMPANION;
+  (m as any).connected = true;
+  (m as any).sendBridgeCommand = async (cmd: string) => {
+    if (cmd === 'get_contacts') return { id: '1', success: true, data: contactsData };
+    return { id: '1', success: true, data: {} };
+  };
+  return m;
+}
+
+describe('MeshCoreManager — firmware contact eviction (#4838)', () => {
+  beforeEach(() => {
+    getNodesBySource.mockReset();
+    getNodesBySource.mockResolvedValue([REPEATER_ROW, COMPANION_ROW]);
+    upsertNode.mockClear();
+  });
+
+  it('keeps an evicted contact\'s name and advType, restored from the DB', async () => {
+    // The device no longer reports the repeater — only the companion.
+    const m = makeManager([companionContact]);
+
+    await m.refreshContacts();
+
+    const restored = m.getContact(REPEATER);
+    expect(restored).toBeDefined();
+    expect(restored?.advName).toBe('Hilltop Repeater');
+    // Without the fix this defaulted to Companion in the UI.
+    expect(restored?.advType).toBe(MeshCoreDeviceType.REPEATER);
+    expect(restored?.rssi).toBe(-78);
+  });
+
+  it('flags device-reported contacts on-device and restored ones off-device', async () => {
+    const m = makeManager([companionContact]);
+
+    await m.refreshContacts();
+
+    expect(m.getContact(COMPANION)?.onDevice).toBe(true);
+    expect(m.getContact(REPEATER)?.onDevice).toBe(false);
+  });
+
+  it('does not re-persist a restored contact, so the DB row is untouched', async () => {
+    const m = makeManager([companionContact]);
+
+    await m.refreshContacts();
+
+    const persistedKeys = upsertNode.mock.calls.map(([node]) => node.publicKey);
+    expect(persistedKeys).toContain(COMPANION);
+    expect(persistedKeys).not.toContain(REPEATER);
+  });
+
+  it('pings an evicted contact with an actionable error, not "not known to this source"', async () => {
+    const m = makeManager([companionContact]);
+    await m.refreshContacts();
+
+    const result = await m.pingContactZeroHop(REPEATER);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('evicted-contact');
+    expect(result.error).toMatch(/no longer in the device's contact list/);
+    expect(result.error).not.toMatch(/not known to this source/);
+  });
+
+  it('still reports a genuinely unknown key as unknown-contact', async () => {
+    getNodesBySource.mockResolvedValue([COMPANION_ROW]);
+    const m = makeManager([companionContact]);
+    await m.refreshContacts();
+
+    const result = await m.pingContactZeroHop('f'.repeat(64));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('unknown-contact');
+  });
+
+  it('clears the off-device flag when the node adverts again', async () => {
+    const m = makeManager([companionContact]);
+    await m.refreshContacts();
+    expect(m.getContact(REPEATER)?.onDevice).toBe(false);
+
+    // The repeater's next advert puts it back in the companion's table.
+    (m as any).handleBridgeEvent({
+      event_type: 'contact_advertised',
+      data: {
+        public_key: REPEATER,
+        adv_name: 'Hilltop Repeater',
+        adv_type: MeshCoreDeviceType.REPEATER,
+      },
+    });
+    await Promise.resolve();
+
+    expect(m.getContact(REPEATER)?.onDevice).toBe(true);
+  });
+
+  it('does not resurrect a contact the user just removed', async () => {
+    const m = makeManager([companionContact]);
+    // removeContact()/forgetLocalContact() tombstone the key; a DB row can
+    // still be in flight when the next refresh lands.
+    (m as any).tombstoneContact(REPEATER);
+
+    await m.refreshContacts();
+
+    expect(m.getContact(REPEATER)).toBeUndefined();
+  });
+
+  it('leaves the map alone when the device returns an empty list (#3884 guard holds)', async () => {
+    const m = makeManager([companionContact, repeaterContact]);
+    await m.refreshContacts();
+    expect(m.getContacts()).toHaveLength(2);
+
+    (m as any).sendBridgeCommand = async () => ({ id: '2', success: true, data: [] });
+    await m.refreshContacts();
+
+    expect(m.getContacts()).toHaveLength(2);
+    expect(m.getContact(REPEATER)?.onDevice).toBe(true);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -270,7 +270,7 @@ export type ZeroHopPingResult =
     }
   | {
       ok: false;
-      reason: 'not-companion' | 'disconnected' | 'unknown-contact' | 'no-reply';
+      reason: 'not-companion' | 'disconnected' | 'unknown-contact' | 'evicted-contact' | 'no-reply';
       error: string;
     };
 
@@ -515,6 +515,16 @@ export interface MeshCoreContact {
    * route (e.g. "a3,7f,02"). `null` / undefined means OUT_PATH_UNKNOWN.
    */
   outPath?: string | null;
+  /**
+   * `false` when the companion's own contact table no longer carries this
+   * key and the entry was restored from `meshcore_nodes` instead (#4838).
+   * The firmware evicts the least-recently-adverted non-favorite contact
+   * once its fixed-size table fills, which silently stripped the name,
+   * type and every contact-addressed operation until the next advert.
+   * Restoring the row keeps the identity; this flag is what stops us
+   * pretending the radio can still address it.
+   */
+  onDevice?: boolean;
 }
 
 /** Sentinel RSSI (dBm) below which a configured `rssiMin` threshold is a no-op. */
@@ -1859,6 +1869,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
           latitude: data.latitude ?? existing.latitude,
           longitude: data.longitude ?? existing.longitude,
           lastSeen: Date.now(),
+          // An advert puts the contact back in the companion's own table, so
+          // this clears an earlier eviction (#4838). Must be set explicitly:
+          // `...existing` would otherwise carry `onDevice: false` forward.
+          onDevice: true,
         };
         this.contacts.set(publicKey, updated);
         // Mirror to meshcore_nodes so per-source consumers (telemetry
@@ -2014,6 +2028,9 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
           publicKey,
           advType: data.adv_type ?? existing.advType,
           lastSeen: Date.now(),
+          // The native backend registers a discovered node on the device
+          // before this fires, so it is on-device again (#4838).
+          onDevice: true,
         };
         this.contacts.set(publicKey, updated);
         void this.persistContact(updated);
@@ -3113,6 +3130,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
             lastSeen: advertMs ?? nowMs,
             outPath: c.out_path ?? null,
             pathLen: c.path_len ?? null,
+            onDevice: true,
           });
         }
         // Mirror every contact to meshcore_nodes so stale stub rows
@@ -3123,6 +3141,14 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         await Promise.all(
           Array.from(this.contacts.values()).map((c) => this.persistContact(c)),
         );
+        // The clear above is authoritative for what the *device* holds, not
+        // for what we know. A contact the companion evicted from its own
+        // fixed-size table (least-recently-adverted non-favorite wins) would
+        // otherwise lose its name, its advType and every contact-addressed
+        // operation until its next advert — #4838. Restore those from
+        // meshcore_nodes, flagged `onDevice: false`, so identity survives
+        // while callers can still tell the radio can't address them.
+        await this.seedContactsFromDb();
         logger.debug(`[MeshCore] Refreshed ${this.contacts.size} contacts`);
       }
     } catch (error) {
@@ -3138,6 +3164,11 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
    * `get_contacts` sync degrades. Existing in-memory entries (e.g. a live
    * advert push that raced ahead) are left untouched. Companion-only — repeater
    * sources don't maintain a companion contact list. Non-fatal on DB error.
+   *
+   * Seeded entries carry `onDevice: false`: they are what we remember, not
+   * what the radio can currently address. `refreshContacts()` re-runs this
+   * after its clear-and-replace so a firmware eviction can't strip a
+   * contact's identity (#4838).
    */
   private async seedContactsFromDb(): Promise<void> {
     if (this.deviceType === MeshCoreDeviceType.REPEATER) return;
@@ -3147,6 +3178,9 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       for (const n of dbNodes) {
         if (n.isLocalNode) continue;
         if (this.contacts.has(n.publicKey)) continue;
+        // A contact the user just removed can still have a row in flight;
+        // the tombstone is the same guard refreshContacts applies above.
+        if (this.isContactTombstoned(n.publicKey)) continue;
         this.contacts.set(n.publicKey, {
           publicKey: n.publicKey,
           advName: n.name ?? undefined,
@@ -3159,6 +3193,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
           lastSeen: n.lastHeard ?? undefined,
           outPath: n.outPath ?? null,
           pathLen: n.pathLen ?? null,
+          onDevice: false,
         });
         seeded++;
       }
@@ -4447,6 +4482,15 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         ok: false,
         reason: 'unknown-contact',
         error: 'Contact is not known to this source.',
+      };
+    }
+    if (contact.onDevice === false) {
+      return {
+        ok: false,
+        reason: 'evicted-contact',
+        error: 'This contact is no longer in the device\'s contact list — the companion '
+          + 'evicted it (its table is full, or it was removed). It will return on the '
+          + 'node\'s next advert; favorite it in the MeshCore app to stop it being evicted.',
       };
     }
     this.requireTransmit();
@@ -6713,8 +6757,12 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       // start) so a config change takes effect on the next tick without
       // requiring a scheduler restart — see PATHFINDING_FILTER_SPEC.md §0/§3.2.
       const filterCfg = await databaseService.getMeshcorePathfindingFilterSettingsAsync(this.sourceId);
-      const filtered = filterPathfindingContacts(contacts, filterCfg);
-      logger.debug(`[MeshCore:${this.sourceId}] Auto-pathfinding: filter ${contacts.length}→${filtered.length} contacts (enabled=${filterCfg.enabled})`);
+      // Contacts restored from the DB after a firmware eviction (#4838) are
+      // names we remember, not addresses the radio can resolve. Probing them
+      // spends airtime on a command the device will reject.
+      const addressable = contacts.filter(c => c.onDevice !== false);
+      const filtered = filterPathfindingContacts(addressable, filterCfg);
+      logger.debug(`[MeshCore:${this.sourceId}] Auto-pathfinding: filter ${contacts.length}→${addressable.length} on-device→${filtered.length} contacts (enabled=${filterCfg.enabled})`);
 
       const companions = pathDiscoveryEnabled
         ? filtered.filter(c => c.advType === MeshCoreDeviceType.COMPANION)

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1760,7 +1760,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       // pushes or the next refreshContacts() poll, so the Contact Details panel
       // can show a stale "1 day ago" moments after a live DM arrives (#4553).
       if (senderContact) {
-        const touchedContact: MeshCoreContact = { ...senderContact, lastSeen: Date.now() };
+        // Decrypting a DM requires the sender's entry in the device's own
+        // contact table, so receiving one is proof it's on-device again —
+        // clears a stale eviction flag (#4838) without waiting for an advert.
+        const touchedContact: MeshCoreContact = { ...senderContact, lastSeen: Date.now(), onDevice: true };
         this.contacts.set(senderContact.publicKey, touchedContact);
         void this.persistContact(touchedContact);
         this.emit('contacts_updated', { sourceId: this.sourceId, contact: touchedContact });
@@ -2003,6 +2006,9 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         outPath: outPathFormatted || null,
         pathLen: outHops,
         lastSeen: Date.now(),
+        // A path response for this contact means the device just addressed
+        // it directly — clears a stale eviction flag (#4838).
+        onDevice: true,
       };
       this.contacts.set(contact.publicKey, updated);
       void this.persistContact(updated);
@@ -3924,6 +3930,14 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       return false;
     }
     if (!this.connected) {
+      return false;
+    }
+    // Discover Path floods a real over-the-air request (see doc comment on
+    // the route). A contact restored from the DB after a firmware eviction
+    // (#4838) isn't addressable — sending anyway just burns airtime the
+    // device will reject.
+    if (this.contacts.get(publicKey)?.onDevice === false) {
+      logger.debug(`[MeshCore] Skipping discover_path for evicted contact ${publicKey.substring(0, 16)}…`);
       return false;
     }
     this.requireTransmit();

--- a/src/server/routes/meshcoreContactsRoutes.ts
+++ b/src/server/routes/meshcoreContactsRoutes.ts
@@ -234,7 +234,16 @@ router.post(
           error: 'Invalid public key — must be 64-char hex',
         });
       }
-      const ok = await managerFor(req, res).discoverContactPath(publicKey);
+      const manager = managerFor(req, res);
+      if (manager.getContact(publicKey)?.onDevice === false) {
+        return res.status(409).json({
+          success: false,
+          error: 'This contact is no longer in the device\'s contact list — the companion '
+            + 'evicted it (its table is full, or it was removed). It will return on the '
+            + 'node\'s next advert; favorite it in the MeshCore app to stop it being evicted.',
+        });
+      }
+      const ok = await manager.discoverContactPath(publicKey);
       if (!ok) {
         return res.status(409).json({
           success: false,

--- a/src/server/routes/meshcoreContactsRoutes.ts
+++ b/src/server/routes/meshcoreContactsRoutes.ts
@@ -377,7 +377,7 @@ router.post(
  * Requires nodes:write like the other transmitting actions.
  *
  * 200 → { success: true, data: { hopHash, rttMs, snrToTarget, snrFromTarget } }
- * 409 → guard failure (not a Companion / disconnected / unknown contact)
+ * 409 → guard failure (not a Companion / disconnected / unknown or evicted contact)
  * 504 → no reply (not in direct range)
  */
 router.post(
@@ -399,6 +399,7 @@ router.post(
           result.reason === 'no-reply' ? 'MESHCORE_PING_NO_REPLY'
           : result.reason === 'not-companion' ? 'MESHCORE_PING_NOT_COMPANION'
           : result.reason === 'disconnected' ? 'MESHCORE_PING_DISCONNECTED'
+          : result.reason === 'evicted-contact' ? 'MESHCORE_PING_EVICTED_CONTACT'
           : 'MESHCORE_PING_UNKNOWN_CONTACT';
         return fail(res, status, code, result.error, { reason: result.reason });
       }


### PR DESCRIPTION
Fixes #4838.

## The bug

The MeshCore companion firmware stores contacts in a fixed-size table (100 entries on most companion builds) and evicts the least-recently-adverted **non-favorite** entry once it fills. A repeater on a long advert interval is the natural victim, which is why the reporter saw this after ~5 days rather than immediately.

`refreshContacts()` then clear-and-replaced its in-memory contact map from that shorter `get_contacts` result:

https://github.com/Yeraze/meshmonitor/blob/ec7ab6e/src/server/meshcoreManager.ts#L3084-L3086

There was already a guard against a *successful-but-empty* response wiping the map (#3884), but nothing against a response that's merely one contact shorter. `seedContactsFromDb()` only ran once, on connect, so it couldn't restore what the clear dropped.

Every reported symptom falls out of that one line:

| Symptom | Cause |
|---|---|
| Name → truncated public key | Detail panel and DM header read the live contact, not the DB row, and fall back to `publicKey.substring(0, 8)…` |
| Node "becomes" a Companion | `advType` came from the contact too; absent, it defaults to `0` = Companion |
| `Contact is not know to this source.` | `pingContactZeroHop` hard-fails on a miss in that same map |
| `path discovery failed - contact may be unknown` | Same map, via the reset-path / discover-path routes |
| A new advert fixes it | The advert re-creates the firmware contact, so the next refresh picks it up |

The `meshcore_nodes` row survived the whole time — `upsertNode` merges rather than clobbers, and nothing prunes MeshCore nodes on a timer. MeshMonitor just stopped joining to it. No user data was lost.

## The fix

`refreshContacts()` re-seeds from `meshcore_nodes` after the clear-and-replace, flagging restored entries `onDevice: false`. Identity survives the eviction, while callers can still tell the radio can't address the contact:

- **Ping** returns a distinct `evicted-contact` reason (`MESHCORE_PING_EVICTED_CONTACT`, 409) explaining what happened and that favoriting the node in the MeshCore app prevents it — instead of the misleading "not known to this source".
- **Discover Path** short-circuits with the same message. It floods a real OTA request, so this is a genuine airtime saving, not just a nicer error.
- **Auto-Pathfinding** skips off-device contacts rather than spending airtime on `discover_path` / `get_neighbours` commands the device will reject.
- The flag clears on any positive evidence the device holds the contact again: an advert, a discovery response, a path-discovery response, or decrypting an inbound DM (which requires an on-device contact-table entry).
- `seedContactsFromDb()` now honours the removal tombstone, so a contact the user explicitly removed can't be resurrected by the new reseed path.

Note that MeshMonitor's ⭐ is a local `meshcore_nodes.isFavorite` column that never touches the device — it does **not** set the firmware's favorite bit and so does not protect a contact from eviction. That confusion is called out in the new troubleshooting docs, along with the real mitigations (favorite on the device, prune the contact table, reconsider Discover Nearby Nodes).

## Mesh impact

Net reduction in airtime. No new packets, timers, or notifications are introduced. Two existing transmit paths are now suppressed when they'd have been rejected by the device anyway: manual Discover Path on an evicted contact, and Auto-Pathfinding's per-contact `discover_path`/`get_neighbours` probes. On a mesh where the contact table is churning, that removes a recurring scheduled send per evicted contact per cycle. No safety timer is reset by this change, and no rate limit needed choosing.

The one added cost is a single indexed per-source `getNodesBySource` SELECT per `refreshContacts()` call. That method is event-driven (connect, a 1.5 s-debounced path-refresh coalescer, and explicit user actions) rather than polled, and already issues a device round-trip plus N upserts per call.

## Testing

- New `src/server/meshcoreManager.contactEviction.test.ts` — 10 cases covering identity restoration, the on/off-device flag transitions, the actionable ping error, unknown-vs-evicted disambiguation, the suppressed discover-path flood, tombstone safety, and the existing empty-response guard.
- Full suite: **15,521 passed, 0 failed** (1,082 files).
- `tsc --noEmit -p tsconfig.server.json` clean; `npm run lint:ci` ratchet passes.
- Not verified against live hardware — I don't have a companion node with a full contact table to reproduce the eviction against. The firmware behaviour is inferred from the reporter's symptoms and MeshCore's documented contact-table handling; I've asked them on the issue to confirm contact count and whether the node also disappears in the official MeshCore app.

## Out of scope

No frontend surface for `onDevice` yet — an evicted contact keeps its name and type in the list, but there's no badge or dimming to flag it proactively. Sending a DM to an evicted contact also still fails with the device-level error rather than the new message. Both are worth a follow-up if we want the proactive UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sni7jk3CptLRY4iqc5HnUs

-- Authored by Roger 🤓

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sni7jk3CptLRY4iqc5HnUs)_