### PR TITLE
docs: add Portainer Stack to Deployment Methods (#4844)

### DIFF
--- a/docs/configurator.md
+++ b/docs/configurator.md
@@ -57,7 +57,7 @@ After deploying with the generated configuration:
 The configurator can hand you the same deployment in two shapes:
 
 - **docker-compose** (default): a `docker-compose.yml` plus a separate `.env` file holding secrets and credentials. Use this when you run `docker compose up` yourself.
-- **Portainer Stack**: a single YAML to paste into Portainer's stack web editor. Portainer has no `.env` file to read, so this format drops `env_file: .env` and instead lists the variables you must set in Portainer's own **Environment variables** form — `SESSION_SECRET`, your database credentials, and the BLE address, depending on what you picked above.
+- **Portainer Stack**: a single YAML to paste into Portainer's stack web editor. Portainer has no `.env` file to read, so this format drops `env_file: .env` and instead lists the variables you must set in Portainer's own **Environment variables** form — `SESSION_SECRET`, your database credentials, and the BLE address, depending on what you picked above. See [Deploy with Portainer](/getting-started#deploy-with-portainer) for the step-by-step.
 
 The services, ports, and volumes are identical between the two. Only how the secrets reach the container changes.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,6 +15,7 @@ MeshMonitor supports multiple deployment options to fit your infrastructure.
 | Method | Platform | Updating | Complexity | Support |
 |--------|----------|--------------|------------|---------|
 | 🐳 [Docker Compose](#quick-start-with-docker-compose) | Any | `docker compose pull && up -d`, or [Watchtower](/configuration/updating#unattended-updates-with-watchtower) | Low | Official |
+| 🚢 [Portainer Stack](#deploy-with-portainer) | Any | Re-pull image + redeploy the stack | Low | Official |
 | 🖥️ [Desktop App](/configuration/desktop) | Windows / macOS | ❌ Manual | Very Low | Official |
 | ☸️ [Kubernetes / Helm](/deployment/DEPLOYMENT_GUIDE) | Any | ✅ Yes (image pull) | High | Official |
 | 📦 [Proxmox LXC](/deployment/PROXMOX_LXC_GUIDE) | Proxmox VE | `meshmonitor-update` | Low | Community |
@@ -24,6 +25,7 @@ MeshMonitor supports multiple deployment options to fit your infrastructure.
 ### Which Should I Choose?
 
 - **You want the smoothest update experience** → **Docker Compose**. `docker compose pull && docker compose up -d` when you see the update banner, or add [Watchtower](/configuration/updating#unattended-updates-with-watchtower) for unattended updates.
+- **You manage your containers through Portainer** → **[Portainer Stack](#deploy-with-portainer)**. Paste a single generated stack YAML into Portainer's web editor — no `.env` file, secrets go in Portainer's own Environment variables form.
 - **You're on a single Windows or macOS machine and don't want to think about servers** → **Desktop App**. Updates are manual (download a new installer), but setup is the simplest.
 - **You're running on a Kubernetes cluster** → **Helm chart**. Upgrades are an `image:` tag bump and a `helm upgrade`.
 - **You're a Proxmox VE user** → **Proxmox LXC** for a lightweight, native-feeling install. Updates are a single `meshmonitor-update` command.
@@ -54,6 +56,10 @@ and an unattended-updates recipe using Watchtower.
   - Available in our [GitHub repository](https://github.com/yeraze/meshmonitor)
   - See [Deployment Guide](/deployment/DEPLOYMENT_GUIDE) for details
 
+- **🚢 Portainer Stack** - Docker Compose deployed through Portainer's web UI
+  - Generate the stack YAML from the [Configurator](/configurator) (Export format → Portainer Stack)
+  - See [Deploy with Portainer](#deploy-with-portainer) below
+
 ### Community Supported
 
 The following deployment methods are contributed and supported by the community:
@@ -70,6 +76,28 @@ The following deployment methods are contributed and supported by the community:
 - **🔧 Bare Metal** - Direct installation with Node.js
   - For development or custom setups
   - See [Deployment Guide](/deployment/DEPLOYMENT_GUIDE)
+
+### Deploy with Portainer
+
+If you manage Docker through [Portainer](https://www.portainer.io/), deploy
+MeshMonitor as a **Stack** — no shell access or `.env` file required.
+
+1. Open the **[Docker Compose Configurator](/configurator)**, configure your
+   setup (connection type, reverse proxy, security), and set **Export format →
+   Portainer Stack**. It produces a single stack YAML.
+2. In Portainer, go to **Stacks → Add stack → Web editor** and paste the YAML.
+3. Portainer has no `.env` file, so the Configurator drops `env_file: .env` and
+   instead lists the variables you must add in Portainer's **Environment
+   variables** form — typically `SESSION_SECRET`, your database credentials, and
+   the BLE address, depending on the options you chose.
+4. Deploy the stack. To update later, re-pull the image and redeploy the stack
+   from Portainer (Portainer's "Re-pull image and redeploy").
+
+::: tip
+The Portainer format is just Docker Compose delivered through Portainer's UI, so
+everything in the [Quick Start](#quick-start-with-docker-compose) below applies —
+only the delivery mechanism and the env-var handling differ.
+:::
 
 ## Prerequisites
 


### PR DESCRIPTION
Closes #4844.

The Docker Compose Configurator has exported a **Portainer Stack** format since #4282, but the Getting Started → Deployment Methods page didn't mention Portainer. This adds it:

- **A.** Portainer Stack row in the "At a Glance" table (Platform: Any, Complexity: Low, Support: Official).
- **B.** A "Which Should I Choose?" bullet, an Officially Supported list entry, and a new **Deploy with Portainer** section — generate the stack YAML from the Configurator (Export format → Portainer Stack), paste into Portainer → Stacks → Add stack → Web editor, and set secrets in Portainer's Environment variables form (no `.env`).
- **C.** Cross-link from the Configurator page's Export Format section back to the new deployment section.

Docs-only; content matches the existing Configurator behavior and copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G