### PR TITLE
feat(notifications): show service, channel, and instance in notifications (#4845)

### DIFF
--- a/src/server/services/messagePushNotifier.test.ts
+++ b/src/server/services/messagePushNotifier.test.ts
@@ -23,7 +23,7 @@ vi.mock('../../services/database.js', () => ({
     nodes: { getNode: vi.fn(async () => ({ nodeNum: 0x0a0b0c0d, nodeId: '!0a0b0c0d', longName: 'Far Node', shortName: 'FAR' })) },
     channels: { getChannelById: vi.fn(async () => null) },
     channelDatabase: { getByIdAsync: vi.fn(async () => ({ id: 3, name: 'LongFast' })) },
-    sources: { getSource: vi.fn(async () => ({ id: 'bridge-1', name: 'Public Bridge' })) },
+    sources: { getSource: vi.fn(async () => ({ id: 'bridge-1', name: 'Public Bridge', type: 'meshtastic_tcp' })) },
   },
 }));
 
@@ -66,8 +66,10 @@ describe('sendMessagePushNotification', () => {
 
     expect(broadcast).toHaveBeenCalledTimes(1);
     const [payload, filterCtx] = (broadcast as any).mock.calls[0];
-    expect(payload.title).toContain('Far Node');
-    expect(payload.body).toBe('hello mesh');
+    // #4845: title carries the service; body carries channel • source then sender.
+    expect(payload.title).toBe('New Meshtastic Message');
+    expect(payload.body).toContain('Public Bridge');
+    expect(payload.body).toContain('Far Node: hello mesh');
     expect(payload.sourceId).toBe('bridge-1');
     expect(payload.sourceName).toBe('Public Bridge');
     expect(payload.data).toMatchObject({ type: 'channel', sourceId: 'bridge-1', channelId: 0 });
@@ -82,7 +84,11 @@ describe('sendMessagePushNotification', () => {
       sourceId: 'bridge-1',
     });
 
-    expect((broadcast as any).mock.calls[0][0].title).toBe('Far Node in LongFast');
+    const p = (broadcast as any).mock.calls[0][0];
+    expect(p.title).toBe('New Meshtastic Message');
+    // Virtual (channel_database) channel named, not its offset id (#4845 body line 1).
+    expect(p.body).toContain('LongFast • Public Bridge');
+    expect(p.body).toContain('Far Node: hi');
   });
 
   it('titles a DM and carries the sender node id for deep linking', async () => {
@@ -94,7 +100,11 @@ describe('sendMessagePushNotification', () => {
     });
 
     const payload = (broadcast as any).mock.calls[0][0];
-    expect(payload.title).toBe('Direct Message from Far Node');
+    // #4845: DM title carries the service; body drops the channel line (source only).
+    expect(payload.title).toBe('New Meshtastic Direct Message');
+    expect(payload.body).toContain('Public Bridge');
+    expect(payload.body).toContain('Far Node: psst');
+    expect(payload.body).not.toContain('•');
     expect(payload.data).toMatchObject({ type: 'dm', senderNodeId: '!0a0b0c0d' });
   });
 

--- a/src/server/services/messagePushNotifier.ts
+++ b/src/server/services/messagePushNotifier.ts
@@ -49,6 +49,22 @@ export interface MessagePushInput {
 }
 
 /** Resolve a display name for the message's channel, including virtual (channel_database) ids. */
+/**
+ * Human-readable service label from a Source.type, for notification titles
+ * (#4845). Lets a mobile notification say "New Meshtastic Message" vs
+ * "New MeshCore Message" at a glance across a multi-source install.
+ */
+function serviceLabelFromSourceType(type: string | undefined): string {
+  switch (type) {
+    case 'meshcore': return 'MeshCore';
+    case 'meshtastic_tcp': return 'Meshtastic';
+    case 'mqtt_bridge':
+    case 'mqtt_broker': return 'MQTT';
+    case 'reticulum': return 'Reticulum';
+    default: return 'Mesh';
+  }
+}
+
 async function resolveChannelName(channelId: number, sourceId: string): Promise<string> {
   try {
     const channel = await databaseService.channels.getChannelById(channelId, sourceId);
@@ -105,11 +121,24 @@ export async function sendMessagePushNotification(input: MessagePushInput): Prom
     const fromNode = await databaseService.nodes.getNode(message.fromNodeNum);
     const senderName = fromNode?.longName || fromNode?.shortName || `Node ${message.fromNodeNum}`;
 
-    // Determine notification title and body
-    const body = messageText.length > 100 ? messageText.substring(0, 97) + '...' : messageText;
+    // Resolve the source (name + service type) so the notification can say
+    // which service, channel, and instance the message came from (#4845).
+    const source = await databaseService.sources.getSource(sourceId);
+    const sourceName = source?.name || sourceId;
+    const serviceLabel = serviceLabelFromSourceType(source?.type);
+
+    // Determine notification title and body (#4845):
+    //   Title: "New {Service} Message" / "New {Service} Direct Message"
+    //   Body:  line 1 "{Channel} • {Source}" (DM: just "{Source}")
+    //          line 2 "{Sender}: {text}"
+    const truncatedText = messageText.length > 100 ? messageText.substring(0, 97) + '...' : messageText;
     const title = isDirectMessage
-      ? `Direct Message from ${senderName}`
-      : `${senderName} in ${await resolveChannelName(message.channel, sourceId)}`;
+      ? `New ${serviceLabel} Direct Message`
+      : `New ${serviceLabel} Message`;
+    const locationLine = isDirectMessage
+      ? sourceName
+      : `${await resolveChannelName(message.channel, sourceId)} • ${sourceName}`;
+    const body = `${locationLine}\n${senderName}: ${truncatedText}`;
 
     // Build navigation data for push notification click handling.
     // `sourceId` is required for the cold-launch deep link: the service
@@ -128,10 +157,6 @@ export async function sendMessagePushNotification(input: MessagePushInput): Prom
           channelId: message.channel,
           messageId: message.id,
         };
-
-    // Phase B: resolve source name for prefixing
-    const source = await databaseService.sources.getSource(sourceId);
-    const sourceName = source?.name || sourceId;
 
     // Send notifications (Web Push + Apprise) with filtering to all subscribed users
     const result = await notificationService.broadcast({

--- a/src/server/services/notificationService.test.ts
+++ b/src/server/services/notificationService.test.ts
@@ -170,16 +170,20 @@ describe('notificationService.notifyNewNode', () => {
     await notificationService.notifyNewNode('!abc123', 'Test Node', 'TN', 100, 1, 'src1', 'Source One');
     expect(mockPush.broadcastToPreferenceUsers).toHaveBeenCalledWith(
       'notifyOnNewNode',
-      expect.objectContaining({ title: expect.stringContaining('🆕 New Node Discovered') }),
+      expect.objectContaining({ title: 'New Meshtastic Node Detected' }),
       undefined,
       'src1'
     );
     expect(mockApprise.broadcastToPreferenceUsers).toHaveBeenCalledWith(
       'notifyOnNewNode',
-      expect.objectContaining({ title: expect.stringContaining('🆕 New Node Discovered') }),
+      expect.objectContaining({ title: 'New Meshtastic Node Detected' }),
       undefined,
       'src1'
     );
+    // #4845: body names the node and which instance detected it.
+    const body = mockPush.broadcastToPreferenceUsers.mock.calls[0][1].body;
+    expect(body).toContain('Test Node (TN)');
+    expect(body).toContain('detected by Source One');
   });
 
   it('includes hops away in body when provided', async () => {
@@ -213,6 +217,30 @@ describe('notificationService.notifyNewNode', () => {
     await expect(
       notificationService.notifyNewNode('!abc123', 'Test Node', 'TN', undefined, undefined, 'src1', 'Source One')
     ).resolves.toBeUndefined();
+  });
+});
+
+// ─── notifyNewMeshCoreNode (#4845) ────────────────────────────────────────────
+
+describe('notificationService.notifyNewMeshCoreNode', () => {
+  it('titles the notification for the MeshCore service and names the detecting instance', async () => {
+    await notificationService.notifyNewMeshCoreNode('pubkey123', 'Base Repeater', 'Repeater', 'src2', 'MTDL Base');
+    expect(mockPush.broadcastToPreferenceUsers).toHaveBeenCalledWith(
+      'notifyOnNewNode',
+      expect.objectContaining({ title: 'New MeshCore Device Detected' }),
+      undefined,
+      'src2'
+    );
+    const body = mockPush.broadcastToPreferenceUsers.mock.calls[0][1].body;
+    expect(body).toContain('Base Repeater');
+    expect(body).toContain('detected by MTDL Base');
+    expect(body).toContain('Repeater'); // device type retained
+  });
+
+  it('omits the device-type suffix when none is provided', async () => {
+    await notificationService.notifyNewMeshCoreNode('pubkey123', 'Nameless', undefined, 'src2', 'MTDL Base');
+    const body = mockPush.broadcastToPreferenceUsers.mock.calls[0][1].body;
+    expect(body).toBe('Nameless detected by MTDL Base');
   });
 });
 

--- a/src/server/services/notificationService.ts
+++ b/src/server/services/notificationService.ts
@@ -183,9 +183,10 @@ class NotificationService {
     try {
       const hopsText = hopsAway !== undefined ? ` (${hopsAway} ${hopsAway === 1 ? 'hop' : 'hops'} away)` : '';
       const hwModelText = hwModel !== undefined ? ` - ${getHardwareModelName(hwModel) || 'Unknown'}` : '';
+      // #4845: title carries the service, body says which instance detected it.
       const payload: NotificationPayload = {
-        title: `[${sourceName}] 🆕 New Node Discovered`,
-        body: `[${sourceName}] ${longName} (${shortName})${hwModelText}${hopsText}`,
+        title: `New Meshtastic Node Detected`,
+        body: `${longName} (${shortName}) detected by ${sourceName}${hwModelText}${hopsText}`,
         type: 'info',
         sourceId,
         sourceName
@@ -223,9 +224,10 @@ class NotificationService {
   ): Promise<void> {
     try {
       const typeText = deviceTypeLabel ? ` - ${deviceTypeLabel}` : '';
+      // #4845: title carries the service, body says which instance detected it.
       const payload: NotificationPayload = {
-        title: `[${sourceName}] 🆕 New Node Discovered`,
-        body: `[${sourceName}] ${displayName}${typeText}`,
+        title: `New MeshCore Device Detected`,
+        body: `${displayName} detected by ${sourceName}${typeText}`,
         type: 'info',
         sourceId,
         sourceName


### PR DESCRIPTION
Closes #4845.

On a multi-source install, a mobile notification gave no way to tell which **service**, **channel**, or **MeshMonitor instance** an event came from. This reshapes the notification title/body. **Server-side only** — `sw.ts` just renders `title`/`body`, so there's no client/service-worker change.

### Messages (`messagePushNotifier.ts`)
- **Title:** `New {Service} Message` / `New {Service} Direct Message` — `{Service}` derived from `Source.type` (Meshtastic / MeshCore / MQTT / Reticulum).
- **Body:** `{Channel} • {Source}` then `{Sender}: {text}` (DMs drop the channel line).

### New nodes (`notificationService.ts`)
- Meshtastic `notifyNewNode` → **`New Meshtastic Node Detected`**, body `{name} ({short}) detected by {Source}{hw}{hops}`.
- MeshCore `notifyNewMeshCoreNode` → **`New MeshCore Device Detected`**, body `{name} detected by {Source}{type}`.

### Notes
- Navigation `data` (sourceId/channelId/messageId/…) is untouched — deep-linking still works; keyword filtering still keys off the raw `messageText`.
- Apprise and desktop reuse the same builders, so they get the same new format (this replaces the prior `[source] 🆕 New Node Discovered` wording on those surfaces too).
- No mesh impact — notification text formatting only.

### Testing
Updated message title/body assertions (channel + DM), added "detected by {source}" new-node assertions, and added `notifyNewMeshCoreNode` coverage. 33 tests pass; `tsc` (server) + `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G