### PR TITLE
feat(meshcore): sync ⭐ favorite to the firmware favourite bit (#4838)

### DIFF
--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -90,8 +90,9 @@ export interface MeshCoreNode {
   latitude?: number;
   longitude?: number;
   advLocPolicy?: number;
-  /** Server-side favorite flag (issue #3588). Stored locally only — never
-   *  pushed to the device. Favorited nodes pin to the top of the node list. */
+  /** Favorite flag (issue #3588). Pins the node to the top of the list; for a
+   *  connected Companion source it also syncs the firmware favourite bit so the
+   *  contact is protected from contact-table eviction (#4838). */
   isFavorite?: boolean;
   telemetryModeBase?: TelemetryMode;
   telemetryModeLoc?: TelemetryMode;

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -245,10 +245,11 @@ export interface MeshCoreActions {
   /** Remove a contact from the device's contact list. Resolves `true` when
    *  the device ACKed the removal; `false` for any error. */
   removeContact: (publicKey: string) => Promise<boolean>;
-  /** Toggle the server-side favorite flag for a node (issue #3588). MeshCore
-   *  has no native favorite concept, so this persists locally only and never
-   *  touches the device. Favorited nodes pin to the top of the node list.
-   *  Resolves `true` on success. */
+  /** Toggle the favorite flag for a node (issue #3588). Persists the local
+   *  favorite (which pins the node to the top of the list) and, for a
+   *  connected Companion source, also sets the firmware favourite bit so the
+   *  contact is protected from contact-table eviction (#4838). Resolves `true`
+   *  on success. */
   setNodeFavorite: (publicKey: string, isFavorite: boolean) => Promise<boolean>;
   /** Export a contact as a signed advert blob for sharing. Pass 'self' to
    *  export the local node's identity. Returns the raw bytes or null. */

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -437,9 +437,10 @@ export class MeshCoreRepository extends BaseRepository {
   }
 
   /**
-   * Set the server-side favorite flag for a (sourceId, publicKey) node
-   * (migration 094). MeshCore firmware has no native favorite concept, so
-   * this only ever touches local state — there is no device round-trip.
+   * Set the local favorite flag for a (sourceId, publicKey) node
+   * (migration 094). This repository method only writes local state; syncing
+   * the firmware favourite bit to the device (#4838) is handled separately by
+   * `MeshCoreManager.setNodeFavorite`.
    *
    * Inserts a stub row if one doesn't yet exist, because the user may
    * favorite a node that has only been seen in-memory (the same situation

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -51,9 +51,10 @@ export interface DbMeshCoreNode {
   lastAdminCheck?: number | null;
   isLocalNode?: boolean | null;
   /**
-   * Server-side favorite flag (migration 094). MeshCore firmware has no
-   * native favorite concept, so this is stored locally only and never
-   * pushed to the device. Favorited nodes pin to the top of the node list.
+   * Favorite flag (migration 094). This column is the local favourite that
+   * pins the node to the top of the list; for a connected Companion source
+   * `MeshCoreManager.setNodeFavorite` also syncs the firmware favourite bit
+   * (ContactInfo.flags 0x01) so the contact is protected from eviction (#4838).
    */
   isFavorite?: boolean | null;
   /** Owning source id; required on writes since slice 1 (migration 056). */

--- a/src/server/constants/meshcoreTx.test.ts
+++ b/src/server/constants/meshcoreTx.test.ts
@@ -125,8 +125,8 @@ describe('meshcoreTx denylist completeness (#4547)', () => {
 
   it('pins the current classification sizes (deliberate, like PER_SOURCE_KEYS_NOT_POSTABLE.size)', () => {
     expect(RF_BRIDGE_COMMANDS.size).toBe(14);
-    expect(SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(28);
-    expect(RF_BRIDGE_COMMANDS.size + SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(42);
+    expect(SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(29);
+    expect(RF_BRIDGE_COMMANDS.size + SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(43);
   });
 });
 

--- a/src/server/constants/meshcoreTx.test.ts
+++ b/src/server/constants/meshcoreTx.test.ts
@@ -125,8 +125,8 @@ describe('meshcoreTx denylist completeness (#4547)', () => {
 
   it('pins the current classification sizes (deliberate, like PER_SOURCE_KEYS_NOT_POSTABLE.size)', () => {
     expect(RF_BRIDGE_COMMANDS.size).toBe(14);
-    expect(SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(29);
-    expect(RF_BRIDGE_COMMANDS.size + SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(43);
+    expect(SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(30);
+    expect(RF_BRIDGE_COMMANDS.size + SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(44);
   });
 });
 

--- a/src/server/constants/meshcoreTx.ts
+++ b/src/server/constants/meshcoreTx.ts
@@ -32,7 +32,7 @@ export const RF_BRIDGE_COMMANDS: ReadonlySet<string> = new Set([
 /** Local-serial-only commands. Allowed in receive-only mode. */
 export const SERIAL_ONLY_BRIDGE_COMMANDS: ReadonlySet<string> = new Set([
   'get_channels', 'set_channel', 'delete_channel',
-  'get_self_info', 'get_contacts', 'remove_contact',
+  'get_self_info', 'get_contacts', 'remove_contact', 'set_contact_favorite',
   'export_contact', 'import_contact',
   'export_private_key', 'import_private_key',
   'set_name', 'set_radio', 'set_tx_power', 'set_coords',

--- a/src/server/constants/meshcoreTx.ts
+++ b/src/server/constants/meshcoreTx.ts
@@ -32,7 +32,8 @@ export const RF_BRIDGE_COMMANDS: ReadonlySet<string> = new Set([
 /** Local-serial-only commands. Allowed in receive-only mode. */
 export const SERIAL_ONLY_BRIDGE_COMMANDS: ReadonlySet<string> = new Set([
   'get_channels', 'set_channel', 'delete_channel',
-  'get_self_info', 'get_contacts', 'remove_contact', 'set_contact_favorite',
+  'get_self_info', 'get_contacts', 'remove_contact',
+  'set_contact_favorite', 'set_contacts_favorite',
   'export_contact', 'import_contact',
   'export_private_key', 'import_private_key',
   'set_name', 'set_radio', 'set_tx_power', 'set_coords',

--- a/src/server/meshcoreManager.favoriteSync.test.ts
+++ b/src/server/meshcoreManager.favoriteSync.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for MeshCore favourite ↔ device synchronisation (#4838/#4840 follow-up).
+ *
+ * MeshMonitor's ⭐ used to be a local-only `meshcore_nodes.isFavorite` column
+ * that never touched the device, so a favourited contact was NOT protected from
+ * the companion firmware's contact-table eviction (the firmware only skips
+ * contacts whose `ContactInfo.flags` bit 0 is set). These tests cover the sync
+ * that now writes that firmware favourite bit:
+ *
+ * - `setNodeFavorite` persists the local column AND pushes the firmware bit
+ *   (companion + connected only, best-effort).
+ * - `reconcileDeviceFavorites` mirrors device→app (additive) and re-asserts
+ *   app→device (self-healing) so app favourites survive eviction/re-add.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const getNodesBySource = vi.fn();
+const dbSetNodeFavorite = vi.fn();
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      getNodesBySource: (...args: unknown[]) => getNodesBySource(...args),
+      setNodeFavorite: (...args: unknown[]) => dbSetNodeFavorite(...args),
+    },
+  },
+}));
+
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: {
+    emitMeshCoreContactUpdated: vi.fn(),
+    emitMeshCoreMessage: vi.fn(),
+    emitMeshCoreSelfInfoUpdated: vi.fn(),
+    emitMeshCoreStatusUpdated: vi.fn(),
+  },
+}));
+
+import { MeshCoreManager, MeshCoreDeviceType, type MeshCoreContact } from './meshcoreManager.js';
+
+type Private = {
+  deviceType: MeshCoreDeviceType;
+  connected: boolean;
+  contacts: Map<string, MeshCoreContact>;
+  sendBridgeCommand: (cmd: string, params: Record<string, unknown>) => Promise<unknown>;
+  reconcileDeviceFavorites(): Promise<void>;
+};
+
+const asPrivate = (m: MeshCoreManager) => m as unknown as Private;
+
+const makeCompanion = (connected = true) => {
+  const m = new MeshCoreManager('src-a');
+  const p = asPrivate(m);
+  p.deviceType = MeshCoreDeviceType.COMPANION;
+  p.connected = connected;
+  const bridge = vi.fn().mockResolvedValue({ success: true, data: { favorite: true } });
+  p.sendBridgeCommand = bridge as unknown as Private['sendBridgeCommand'];
+  return { m, p, bridge };
+};
+
+const dbNode = (publicKey: string, isFavorite: boolean) => ({
+  publicKey,
+  name: 'N',
+  advType: MeshCoreDeviceType.REPEATER,
+  isLocalNode: false,
+  isFavorite,
+});
+
+const KEY_A = 'a1'.repeat(32);
+const KEY_B = 'b2'.repeat(32);
+
+describe('MeshCoreManager favourite ↔ device sync', () => {
+  beforeEach(() => {
+    getNodesBySource.mockReset();
+    dbSetNodeFavorite.mockReset();
+    dbSetNodeFavorite.mockResolvedValue(undefined);
+    getNodesBySource.mockResolvedValue([]);
+  });
+
+  describe('setNodeFavorite', () => {
+    it('persists the local column and pushes the firmware bit (companion, connected)', async () => {
+      const { m, bridge } = makeCompanion(true);
+      await m.setNodeFavorite(KEY_A, true);
+
+      expect(dbSetNodeFavorite).toHaveBeenCalledWith('src-a', KEY_A, true);
+      expect(bridge).toHaveBeenCalledWith('set_contact_favorite', { public_key: KEY_A, favorite: true });
+    });
+
+    it('un-favourite pushes favorite:false to the device', async () => {
+      const { m, bridge } = makeCompanion(true);
+      await m.setNodeFavorite(KEY_A, false);
+
+      expect(dbSetNodeFavorite).toHaveBeenCalledWith('src-a', KEY_A, false);
+      expect(bridge).toHaveBeenCalledWith('set_contact_favorite', { public_key: KEY_A, favorite: false });
+    });
+
+    it('persists locally but does NOT push when disconnected', async () => {
+      const { m, bridge } = makeCompanion(false);
+      await m.setNodeFavorite(KEY_A, true);
+
+      expect(dbSetNodeFavorite).toHaveBeenCalledWith('src-a', KEY_A, true);
+      expect(bridge).not.toHaveBeenCalled();
+    });
+
+    it('persists locally but does NOT push for a repeater source', async () => {
+      const { m, p, bridge } = makeCompanion(true);
+      p.deviceType = MeshCoreDeviceType.REPEATER;
+      await m.setNodeFavorite(KEY_A, true);
+
+      expect(dbSetNodeFavorite).toHaveBeenCalledWith('src-a', KEY_A, true);
+      expect(bridge).not.toHaveBeenCalled();
+    });
+
+    it('keeps the local star even when the device push fails', async () => {
+      const { m, p } = makeCompanion(true);
+      p.sendBridgeCommand = vi.fn().mockResolvedValue({ success: false, error: 'Favorite target not in device contact list' }) as unknown as Private['sendBridgeCommand'];
+      await expect(m.setNodeFavorite(KEY_A, true)).resolves.toBeUndefined();
+      expect(dbSetNodeFavorite).toHaveBeenCalledWith('src-a', KEY_A, true);
+    });
+  });
+
+  describe('reconcileDeviceFavorites', () => {
+    it('mirrors a device-side favourite into the local column (additive)', async () => {
+      const { p, bridge } = makeCompanion(true);
+      p.contacts.set(KEY_A, { publicKey: KEY_A, deviceFavorite: true });
+      getNodesBySource.mockResolvedValue([dbNode(KEY_A, false)]);
+
+      await p.reconcileDeviceFavorites();
+
+      expect(dbSetNodeFavorite).toHaveBeenCalledWith('src-a', KEY_A, true);
+      // Device already holds the bit — no redundant push.
+      expect(bridge).not.toHaveBeenCalled();
+    });
+
+    it('re-asserts an app favourite the device is missing (self-healing after eviction/re-add)', async () => {
+      const { p, bridge } = makeCompanion(true);
+      p.contacts.set(KEY_A, { publicKey: KEY_A, deviceFavorite: false });
+      getNodesBySource.mockResolvedValue([dbNode(KEY_A, true)]);
+
+      await p.reconcileDeviceFavorites();
+
+      expect(bridge).toHaveBeenCalledWith('set_contact_favorite', { public_key: KEY_A, favorite: true });
+      // App favourite is already persisted — reconcile must not rewrite the column here.
+      expect(dbSetNodeFavorite).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when device and app agree', async () => {
+      const { p, bridge } = makeCompanion(true);
+      p.contacts.set(KEY_A, { publicKey: KEY_A, deviceFavorite: true });
+      p.contacts.set(KEY_B, { publicKey: KEY_B, deviceFavorite: false });
+      getNodesBySource.mockResolvedValue([dbNode(KEY_A, true), dbNode(KEY_B, false)]);
+
+      await p.reconcileDeviceFavorites();
+
+      expect(bridge).not.toHaveBeenCalled();
+      expect(dbSetNodeFavorite).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op for repeater sources', async () => {
+      const { p, bridge } = makeCompanion(true);
+      p.deviceType = MeshCoreDeviceType.REPEATER;
+      p.contacts.set(KEY_A, { publicKey: KEY_A, deviceFavorite: true });
+
+      await p.reconcileDeviceFavorites();
+
+      expect(getNodesBySource).not.toHaveBeenCalled();
+      expect(bridge).not.toHaveBeenCalled();
+      expect(dbSetNodeFavorite).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/meshcoreManager.favoriteSync.test.ts
+++ b/src/server/meshcoreManager.favoriteSync.test.ts
@@ -130,15 +130,23 @@ describe('MeshCoreManager favourite ↔ device sync', () => {
       expect(bridge).not.toHaveBeenCalled();
     });
 
-    it('re-asserts an app favourite the device is missing (self-healing after eviction/re-add)', async () => {
+    it('re-asserts app favourites the device is missing in a single batch (self-healing)', async () => {
       const { p, bridge } = makeCompanion(true);
       p.contacts.set(KEY_A, { publicKey: KEY_A, deviceFavorite: false });
-      getNodesBySource.mockResolvedValue([dbNode(KEY_A, true)]);
+      p.contacts.set(KEY_B, { publicKey: KEY_B, deviceFavorite: false });
+      getNodesBySource.mockResolvedValue([dbNode(KEY_A, true), dbNode(KEY_B, true)]);
 
       await p.reconcileDeviceFavorites();
 
-      expect(bridge).toHaveBeenCalledWith('set_contact_favorite', { public_key: KEY_A, favorite: true });
-      // App favourite is already persisted — reconcile must not rewrite the column here.
+      // One batched device read+write for both, not one round-trip per contact.
+      expect(bridge).toHaveBeenCalledTimes(1);
+      expect(bridge).toHaveBeenCalledWith('set_contacts_favorite', {
+        favorites: [
+          { public_key: KEY_A, favorite: true },
+          { public_key: KEY_B, favorite: true },
+        ],
+      });
+      // App favourites are already persisted — reconcile must not rewrite the column here.
       expect(dbSetNodeFavorite).not.toHaveBeenCalled();
     });
 

--- a/src/server/meshcoreManager.favoriteSync.test.ts
+++ b/src/server/meshcoreManager.favoriteSync.test.ts
@@ -151,6 +151,24 @@ describe('MeshCoreManager favourite ↔ device sync', () => {
       expect(dbSetNodeFavorite).not.toHaveBeenCalled();
     });
 
+    it('does not mark the in-memory mirror for contacts the batch reported missing', async () => {
+      const { p } = makeCompanion(true);
+      p.contacts.set(KEY_A, { publicKey: KEY_A, deviceFavorite: false });
+      p.contacts.set(KEY_B, { publicKey: KEY_B, deviceFavorite: false });
+      getNodesBySource.mockResolvedValue([dbNode(KEY_A, true), dbNode(KEY_B, true)]);
+      // KEY_B was evicted in the race — the device didn't set it.
+      p.sendBridgeCommand = vi.fn().mockResolvedValue({
+        success: true,
+        data: { updated: 1, missing: [KEY_B] },
+      }) as unknown as Private['sendBridgeCommand'];
+
+      await p.reconcileDeviceFavorites();
+
+      expect(p.contacts.get(KEY_A)!.deviceFavorite).toBe(true);
+      // Left false so the next reconcile retries it instead of assuming it synced.
+      expect(p.contacts.get(KEY_B)!.deviceFavorite).toBe(false);
+    });
+
     it('does nothing when device and app agree', async () => {
       const { p, bridge } = makeCompanion(true);
       p.contacts.set(KEY_A, { publicKey: KEY_A, deviceFavorite: true });

--- a/src/server/meshcoreManager.favoriteSync.test.ts
+++ b/src/server/meshcoreManager.favoriteSync.test.ts
@@ -35,6 +35,7 @@ vi.mock('./services/dataEventEmitter.js', () => ({
 }));
 
 import { MeshCoreManager, MeshCoreDeviceType, type MeshCoreContact } from './meshcoreManager.js';
+import { logger } from '../utils/logger.js';
 
 type Private = {
   deviceType: MeshCoreDeviceType;
@@ -160,6 +161,20 @@ describe('MeshCoreManager favourite ↔ device sync', () => {
 
       expect(bridge).not.toHaveBeenCalled();
       expect(dbSetNodeFavorite).not.toHaveBeenCalled();
+    });
+
+    it('warns (and does not push) for a local favourite absent from the device table', async () => {
+      const { p, bridge } = makeCompanion(true);
+      // KEY_A is favourited locally but NOT in this.contacts (evicted, not re-adverted).
+      getNodesBySource.mockResolvedValue([dbNode(KEY_A, true)]);
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+      await p.reconcileDeviceFavorites();
+
+      expect(bridge).not.toHaveBeenCalled();
+      expect(dbSetNodeFavorite).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('not in the device contact table'));
+      warn.mockRestore();
     });
 
     it('is a no-op for repeater sources', async () => {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -6417,12 +6417,15 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
    *
    * Companion-only and best-effort. Called from `refreshContacts` after the
    * device flags are loaded (so on connect it backfills existing favourites).
+   * The app→device re-assertions are sent as a single `set_contacts_favorite`
+   * batch so the device contact list is read once, not once per contact.
    */
   private async reconcileDeviceFavorites(): Promise<void> {
     if (this.deviceType !== MeshCoreDeviceType.COMPANION) return;
     try {
       const dbNodes = await databaseService.meshcore.getNodesBySource(this.sourceId);
       const appFavByKey = new Map(dbNodes.map((n) => [n.publicKey, n.isFavorite === true]));
+      const toReassert: string[] = [];
       for (const contact of this.contacts.values()) {
         const deviceFav = contact.deviceFavorite === true;
         const appFav = appFavByKey.get(contact.publicKey) === true;
@@ -6433,7 +6436,22 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
           await databaseService.meshcore.setNodeFavorite(this.sourceId, contact.publicKey, true);
         } else {
           // App favourite the device is missing → re-assert it on the device.
-          await this.pushFavoriteToDevice(contact.publicKey, true);
+          toReassert.push(contact.publicKey);
+        }
+      }
+      if (toReassert.length > 0 && this.connected) {
+        const response = await this.sendBridgeCommand('set_contacts_favorite', {
+          favorites: toReassert.map((publicKey) => ({ public_key: publicKey, favorite: true })),
+        });
+        if (response.success) {
+          for (const publicKey of toReassert) {
+            const contact = this.contacts.get(publicKey);
+            if (contact) contact.deviceFavorite = true;
+          }
+        } else {
+          logger.warn(
+            `[MeshCore:${this.sourceId}] set_contacts_favorite (${toReassert.length}) failed: ${response.error}`,
+          );
         }
       }
     } catch (err) {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -6431,13 +6431,28 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         const appFav = appFavByKey.get(contact.publicKey) === true;
         if (deviceFav === appFav) continue;
         if (deviceFav && !appFav) {
-          // Phone-side favourite → reflect into MeshMonitor's local column.
+          // Device/phone has it favourited but MeshMonitor doesn't → adopt the
+          // device state locally (additive). The reverse — app un-favourite vs
+          // device still favourited — is NOT reconciled here; un-favouriting is
+          // authoritative only through setNodeFavorite (see the class doc).
           // Write the DB directly (the device already holds the bit; no push).
           await databaseService.meshcore.setNodeFavorite(this.sourceId, contact.publicKey, true);
         } else {
           // App favourite the device is missing → re-assert it on the device.
           toReassert.push(contact.publicKey);
         }
+      }
+      // Locally-favourited nodes that aren't in the device contact table at all
+      // (truly evicted and not yet re-adverted) can't have their firmware bit
+      // set — there's no record to write. They regain protection once they
+      // re-advert and re-enter this.contacts. Surface the gap so it's visible.
+      const evictedFavCount = dbNodes.filter(
+        (n) => n.isFavorite === true && !this.contacts.has(n.publicKey),
+      ).length;
+      if (evictedFavCount > 0) {
+        logger.warn(
+          `[MeshCore:${this.sourceId}] ${evictedFavCount} locally-favourited node(s) not in the device contact table — eviction protection inactive until they re-advert`,
+        );
       }
       if (toReassert.length > 0 && this.connected) {
         const response = await this.sendBridgeCommand('set_contacts_favorite', {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -516,6 +516,20 @@ export interface MeshCoreContact {
    * route (e.g. "a3,7f,02"). `null` / undefined means OUT_PATH_UNKNOWN.
    */
   outPath?: string | null;
+  /**
+   * Raw firmware `ContactInfo.flags` byte as last read from the device
+   * (bit 0 = favourite, bits 1..7 = telemetry-permission bits). Undefined for
+   * DB-seeded contacts we haven't yet read live.
+   */
+  flags?: number;
+  /**
+   * Whether the firmware's favourite bit (flags & 0x01) is currently set on the
+   * device for this contact. This is what actually protects the contact from
+   * contact-table eviction (#4838), separate from MeshMonitor's local
+   * `meshcore_nodes.isFavorite` column. `reconcileDeviceFavorites` keeps the two
+   * in sync.
+   */
+  deviceFavorite?: boolean;
 }
 
 /** Sentinel RSSI (dBm) below which a configured `rssiMin` threshold is a no-op. */
@@ -3161,6 +3175,8 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
             lastSeen: advertMs ?? nowMs,
             outPath: c.out_path ?? null,
             pathLen: c.path_len ?? null,
+            flags: typeof c.flags === 'number' ? c.flags : undefined,
+            deviceFavorite: c.favorite === true,
           });
         }
         // Mirror every contact to meshcore_nodes so stale stub rows
@@ -3172,6 +3188,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
           Array.from(this.contacts.values()).map((c) => this.persistContact(c)),
         );
         logger.debug(`[MeshCore] Refreshed ${this.contacts.size} contacts`);
+        // Sync the firmware favourite bit with MeshMonitor's local favourites
+        // now that we have fresh device flags. Runs on connect (backfilling
+        // existing favourites onto the device) and on every subsequent refresh.
+        await this.reconcileDeviceFavorites();
       }
     } catch (error) {
       logger.error('[MeshCore] Failed to refresh contacts:', error);
@@ -6331,13 +6351,96 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   }
 
   /**
-   * Toggle the server-side favorite flag for a node (issue #3588). MeshCore
-   * firmware has no native favorite concept, so this persists locally only
-   * and never pushes anything to the device. Favorited nodes pin to the top
-   * of the node list.
+   * Toggle the favorite flag for a node (issue #3588). Persists the local
+   * `meshcore_nodes.isFavorite` column (which pins the node to the top of the
+   * list) AND pushes the firmware favourite bit to the device, so a favourited
+   * contact is protected from the companion's contact-table eviction (#4838).
+   *
+   * The device push is best-effort and companion-only: the local star still
+   * works if the write fails (disconnected, repeater source, or the contact
+   * isn't in the device table because it was never synced or was evicted).
+   * MeshMonitor is the source of truth for favourites — `reconcileDeviceFavorites`
+   * re-asserts local favourites onto the device and mirrors device-side
+   * favourites back into the DB.
    */
   async setNodeFavorite(publicKey: string, isFavorite: boolean): Promise<void> {
     await databaseService.meshcore.setNodeFavorite(this.sourceId, publicKey, isFavorite);
+    await this.pushFavoriteToDevice(publicKey, isFavorite);
+  }
+
+  /**
+   * Set/clear the firmware favourite bit (ContactInfo.flags bit 0) for a
+   * contact via the `set_contact_favorite` bridge command. Companion-only and
+   * best-effort — logs and returns false on any failure rather than throwing,
+   * so callers persist the local favourite regardless. It is a local serial
+   * write (no radio energy), so receive-only mode does not block it.
+   */
+  private async pushFavoriteToDevice(publicKey: string, isFavorite: boolean): Promise<boolean> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) return false;
+    if (!this.connected) return false;
+    try {
+      const response = await this.sendBridgeCommand('set_contact_favorite', {
+        public_key: publicKey,
+        favorite: isFavorite,
+      });
+      if (!response.success) {
+        logger.warn(
+          `[MeshCore:${this.sourceId}] set_contact_favorite failed for ${publicKey.substring(0, 16)}…: ${response.error}`,
+        );
+        return false;
+      }
+      // Keep the in-memory device-favourite mirror in step so the next
+      // reconcile doesn't re-push a change we just made.
+      const contact = this.contacts.get(publicKey);
+      if (contact) contact.deviceFavorite = isFavorite;
+      return true;
+    } catch (err) {
+      logger.warn(
+        `[MeshCore:${this.sourceId}] set_contact_favorite threw for ${publicKey.substring(0, 16)}…: ${(err as Error).message}`,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Reconcile the firmware favourite bit with MeshMonitor's local favourites,
+   * using `this.contacts` (freshly read device flags) and the persisted
+   * `isFavorite` column. Two directions, both preserving the protective intent
+   * of a favourite:
+   *
+   * - **Device → app (additive):** a contact favourited on the device/phone
+   *   that MeshMonitor doesn't know about gets `isFavorite` set locally.
+   * - **App → device (self-healing):** a local favourite the device is missing
+   *   (e.g. a fresh advert re-added an evicted contact with `flags=0`) is
+   *   re-pushed so eviction protection is restored. MeshMonitor favourites are
+   *   authoritative; to remove one, un-favourite it in MeshMonitor.
+   *
+   * Companion-only and best-effort. Called from `refreshContacts` after the
+   * device flags are loaded (so on connect it backfills existing favourites).
+   */
+  private async reconcileDeviceFavorites(): Promise<void> {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) return;
+    try {
+      const dbNodes = await databaseService.meshcore.getNodesBySource(this.sourceId);
+      const appFavByKey = new Map(dbNodes.map((n) => [n.publicKey, n.isFavorite === true]));
+      for (const contact of this.contacts.values()) {
+        const deviceFav = contact.deviceFavorite === true;
+        const appFav = appFavByKey.get(contact.publicKey) === true;
+        if (deviceFav === appFav) continue;
+        if (deviceFav && !appFav) {
+          // Phone-side favourite → reflect into MeshMonitor's local column.
+          // Write the DB directly (the device already holds the bit; no push).
+          await databaseService.meshcore.setNodeFavorite(this.sourceId, contact.publicKey, true);
+        } else {
+          // App favourite the device is missing → re-assert it on the device.
+          await this.pushFavoriteToDevice(contact.publicKey, true);
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        `[MeshCore:${this.sourceId}] reconcileDeviceFavorites failed: ${(err as Error).message}`,
+      );
+    }
   }
 
   getRecentMessages(limit: number = 50): MeshCoreMessage[] {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -6459,7 +6459,17 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
           favorites: toReassert.map((publicKey) => ({ public_key: publicKey, favorite: true })),
         });
         if (response.success) {
+          // Only mark the mirror for contacts the device actually held. A
+          // `missing` entry (evicted in the race between our get_contacts and
+          // the batch) was NOT set, so leaving deviceFavorite=false lets the
+          // next reconcile retry it rather than silently treating it as synced.
+          const missing = new Set(
+            (Array.isArray(response.data?.missing) ? response.data.missing : []).map((k: string) =>
+              k.toLowerCase(),
+            ),
+          );
           for (const publicKey of toReassert) {
+            if (missing.has(publicKey.toLowerCase())) continue;
             const contact = this.contacts.get(publicKey);
             if (contact) contact.deviceFavorite = true;
           }

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -429,6 +429,116 @@ describe('MeshCoreNativeBackend', () => {
     ]);
   });
 
+  it('get_contacts surfaces the firmware favourite bit and raw flags', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    conn.contactsResponse = [
+      // flags 0xA1 = favourite (bit 0) + telemetry-permission bits in the top.
+      { publicKey: Uint8Array.from([0xab, 0xcd, 0xef, ...new Array(29).fill(0)]), type: AdvType.Chat, advName: 'Fav', flags: 0xa1 },
+      // flags 0xA0 = same telemetry perms, favourite bit clear.
+      { publicKey: Uint8Array.from([0x11, 0x22, 0x33, ...new Array(29).fill(0)]), type: AdvType.Chat, advName: 'Plain', flags: 0xa0 },
+    ];
+
+    const resp = await backend.sendCommand('get_contacts', {});
+    expect(resp.success).toBe(true);
+    expect(resp.data[0]).toEqual(expect.objectContaining({ flags: 0xa1, favorite: true }));
+    expect(resp.data[1]).toEqual(expect.objectContaining({ flags: 0xa0, favorite: false }));
+  });
+
+  it('set_contact_favorite sets flags bit 0 while preserving the upper bits', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    const key = Uint8Array.from([0xab, 0xcd, 0xef, ...new Array(29).fill(0)]);
+    // flags 0xA0 = telemetry-permission bits set, favourite bit clear.
+    conn.contactsResponse = [
+      { publicKey: key, type: AdvType.Repeater, flags: 0xa0, outPathLen: 0xff, outPath: new Uint8Array(64), advName: 'Rptr', lastAdvert: 42, advLat: 1, advLon: 2 },
+    ];
+
+    const resp = await backend.sendCommand('set_contact_favorite', {
+      public_key: 'abcdef' + '00'.repeat(29),
+      favorite: true,
+    });
+    expect(resp.success).toBe(true);
+    expect(resp.data).toEqual(expect.objectContaining({ favorite: true, flags: 0xa1 }));
+    // Read-modify-write: only the favourite LSB flipped; every other field
+    // re-sent unchanged so the device record isn't clobbered.
+    expect(conn.addOrUpdateContactCalls).toHaveLength(1);
+    const [pk, type, flags, outPathLen, , advName, lastAdvert, advLat, advLon] = conn.addOrUpdateContactCalls[0];
+    expect(Buffer.from(pk as Uint8Array).toString('hex')).toBe('abcdef' + '00'.repeat(29));
+    expect(type).toBe(AdvType.Repeater);
+    expect(flags).toBe(0xa1);
+    expect(outPathLen).toBe(0xff);
+    expect(advName).toBe('Rptr');
+    expect(lastAdvert).toBe(42);
+    expect(advLat).toBe(1);
+    expect(advLon).toBe(2);
+  });
+
+  it('set_contact_favorite clears flags bit 0 while preserving the upper bits', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    const key = Uint8Array.from([0xab, 0xcd, 0xef, ...new Array(29).fill(0)]);
+    conn.contactsResponse = [
+      { publicKey: key, type: AdvType.Chat, flags: 0xa1, outPathLen: 0, outPath: new Uint8Array(64), advName: 'X', lastAdvert: 1, advLat: 0, advLon: 0 },
+    ];
+
+    const resp = await backend.sendCommand('set_contact_favorite', {
+      public_key: 'abcdef' + '00'.repeat(29),
+      favorite: false,
+    });
+    expect(resp.success).toBe(true);
+    expect(resp.data).toEqual(expect.objectContaining({ favorite: false, flags: 0xa0 }));
+    expect(conn.addOrUpdateContactCalls[0][2]).toBe(0xa0);
+  });
+
+  it('set_contact_favorite is a no-op write when the bit is already in the desired state', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    conn.contactsResponse = [
+      { publicKey: Uint8Array.from([0xab, 0xcd, 0xef, ...new Array(29).fill(0)]), type: AdvType.Chat, flags: 0x01, outPathLen: 0, outPath: new Uint8Array(64), advName: 'Y', lastAdvert: 1, advLat: 0, advLon: 0 },
+    ];
+
+    const resp = await backend.sendCommand('set_contact_favorite', {
+      public_key: 'abcdef' + '00'.repeat(29),
+      favorite: true,
+    });
+    expect(resp.success).toBe(true);
+    expect(conn.addOrUpdateContactCalls).toHaveLength(0);
+  });
+
+  it('set_contact_favorite fails when the contact is not in the device table', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    conn.contactsResponse = [];
+
+    const resp = await backend.sendCommand('set_contact_favorite', {
+      public_key: 'abcdef' + '00'.repeat(29),
+      favorite: true,
+    });
+    expect(resp.success).toBe(false);
+    expect(resp.error).toMatch(/not in device contact list/i);
+  });
+
   it('routes broadcast send_message to channel 0', async () => {
     const backend = new MeshCoreNativeBackend('src-1', {
       connectionType: 'serial',

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -522,6 +522,39 @@ describe('MeshCoreNativeBackend', () => {
     expect(conn.addOrUpdateContactCalls).toHaveLength(0);
   });
 
+  it('set_contacts_favorite applies many favourites with a single getContacts read', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    const keyA = Uint8Array.from([0xab, 0xcd, 0xef, ...new Array(29).fill(0)]);
+    const keyB = Uint8Array.from([0x11, 0x22, 0x33, ...new Array(29).fill(0)]);
+    conn.contactsResponse = [
+      { publicKey: keyA, type: AdvType.Chat, flags: 0xa0, outPathLen: 0, outPath: new Uint8Array(64), advName: 'A', lastAdvert: 1, advLat: 0, advLon: 0 },
+      { publicKey: keyB, type: AdvType.Chat, flags: 0x01, outPathLen: 0, outPath: new Uint8Array(64), advName: 'B', lastAdvert: 1, advLat: 0, advLon: 0 },
+    ];
+    // Count getContacts round-trips.
+    let getContactsCalls = 0;
+    const origGet = conn.getContacts.bind(conn);
+    conn.getContacts = async () => { getContactsCalls++; return origGet(); };
+
+    const resp = await backend.sendCommand('set_contacts_favorite', {
+      favorites: [
+        { public_key: 'abcdef' + '00'.repeat(29), favorite: true },   // 0xa0 -> 0xa1 (changed)
+        { public_key: '112233' + '00'.repeat(29), favorite: true },   // 0x01 -> 0x01 (no-op)
+        { public_key: 'ff'.repeat(32), favorite: true },              // not in table -> missing
+      ],
+    });
+    expect(resp.success).toBe(true);
+    expect(resp.data).toEqual(expect.objectContaining({ updated: 1, missing: ['ff'.repeat(32)] }));
+    // Only the changed contact was re-sent, and the device list was read once.
+    expect(conn.addOrUpdateContactCalls).toHaveLength(1);
+    expect(conn.addOrUpdateContactCalls[0][2]).toBe(0xa1);
+    expect(getContactsCalls).toBe(1);
+  });
+
   it('set_contact_favorite fails when the contact is not in the device table', async () => {
     const backend = new MeshCoreNativeBackend('src-1', {
       connectionType: 'serial',

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -1092,6 +1092,11 @@ export class MeshCoreNativeBackend extends EventEmitter {
             outPathByteCount = (rawLen & 0x3F) * hopHashBytes;
           }
           const { outPathHex, pathLen } = formatOutPath(ct.outPath, outPathByteCount, hopHashBytes);
+          // ContactInfo.flags bit 0 (mask 0x01) is the firmware "favourite"
+          // bit; the upper bits are per-contact telemetry permissions. Surface
+          // both so the manager can mirror the device favourite into
+          // meshcore_nodes.isFavorite and preserve the upper bits on write.
+          const flags = typeof ct.flags === 'number' ? ct.flags : 0;
           return {
             public_key: bytesToHex(ct.publicKey),
             adv_name: ct.advName,
@@ -1102,6 +1107,8 @@ export class MeshCoreNativeBackend extends EventEmitter {
             last_advert: ct.lastAdvert,
             out_path: outPathHex,
             path_len: pathLen,
+            flags,
+            favorite: (flags & 0x01) === 0x01,
           };
         });
       }
@@ -1531,6 +1538,61 @@ export class MeshCoreNativeBackend extends EventEmitter {
           );
         }
         return { ok: true };
+      }
+
+      case 'set_contact_favorite': {
+        // Set/clear the firmware "favourite" bit (ContactInfo.flags bit 0,
+        // mask 0x01) on an existing device contact via CMD_ADD_UPDATE_CONTACT
+        // (opcode 9). The firmware's contact-table eviction skips favourited
+        // contacts (BaseChatMesh.cpp), so this is what actually protects a
+        // node from being dropped when the table fills — MeshMonitor's local
+        // meshcore_nodes.isFavorite column alone never did (#4838).
+        //
+        // Read-modify-write: bit 0 is the favourite flag, bits 1..7 are the
+        // per-contact telemetry-permission bits (firmware reads them as
+        // `flags >> 1`), so we preserve the existing flags byte and only
+        // toggle the LSB. addOrUpdateContact overwrites ALL contact fields, so
+        // we re-send the record's current type/path/name/advert/coords
+        // unchanged (same pattern as set_out_path). Local serial write — it
+        // updates the saved contact table and puts nothing on the radio.
+        const publicKey = await this.resolvePublicKey(params.public_key as string);
+        if (!publicKey) throw new Error('Set-favorite target not found');
+        const favorite = params.favorite === true;
+        const contacts = (await c.getContacts()) as Array<{
+          publicKey: Uint8Array;
+          type: number;
+          flags?: number;
+          outPathLen: number;
+          outPath: Uint8Array;
+          advName: string;
+          lastAdvert: number;
+          advLat: number;
+          advLon: number;
+        }>;
+        const contact = contacts.find((ct) => bytesToHex(ct.publicKey) === bytesToHex(publicKey));
+        if (!contact) {
+          // Not in the device table (never synced, or already evicted). We
+          // can't set a flag on a record that doesn't exist — surface it so
+          // the caller keeps the local star but knows the device isn't
+          // protecting the contact yet.
+          throw new Error('Favorite target not in device contact list');
+        }
+        const currentFlags = typeof contact.flags === 'number' ? contact.flags : 0;
+        const newFlags = (favorite ? (currentFlags | 0x01) : (currentFlags & ~0x01)) & 0xff;
+        if (newFlags !== currentFlags) {
+          await c.addOrUpdateContact(
+            contact.publicKey,
+            contact.type,
+            newFlags,
+            contact.outPathLen,
+            contact.outPath,
+            contact.advName,
+            contact.lastAdvert,
+            contact.advLat,
+            contact.advLon,
+          );
+        }
+        return { ok: true, favorite, flags: newFlags };
       }
 
       case 'send_message': {

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -45,6 +45,21 @@ interface TraceDataResponse {
   lastSnr: number;
 }
 
+/** A raw meshcore.js contact record as returned by `connection.getContacts()`.
+ * These are the wire-format fields (fixed-point coords, packed out_path_len,
+ * 64-byte out_path buffer) needed to re-send a contact via AddUpdateContact. */
+interface RawDeviceContact {
+  publicKey: Uint8Array;
+  type: number;
+  flags?: number;
+  outPathLen: number;
+  outPath: Uint8Array;
+  advName: string;
+  lastAdvert: number;
+  advLat: number;
+  advLon: number;
+}
+
 interface MeshCoreJsModule {
   NodeJSSerialConnection: new (path: string) => AnyConnection;
   TCPConnection: new (host: string, port: number) => AnyConnection;
@@ -1558,18 +1573,9 @@ export class MeshCoreNativeBackend extends EventEmitter {
         const publicKey = await this.resolvePublicKey(params.public_key as string);
         if (!publicKey) throw new Error('Set-favorite target not found');
         const favorite = params.favorite === true;
-        const contacts = (await c.getContacts()) as Array<{
-          publicKey: Uint8Array;
-          type: number;
-          flags?: number;
-          outPathLen: number;
-          outPath: Uint8Array;
-          advName: string;
-          lastAdvert: number;
-          advLat: number;
-          advLon: number;
-        }>;
-        const contact = contacts.find((ct) => bytesToHex(ct.publicKey) === bytesToHex(publicKey));
+        const contacts = (await c.getContacts()) as RawDeviceContact[];
+        const targetHex = bytesToHex(publicKey);
+        const contact = contacts.find((ct) => bytesToHex(ct.publicKey) === targetHex);
         if (!contact) {
           // Not in the device table (never synced, or already evicted). We
           // can't set a flag on a record that doesn't exist — surface it so
@@ -1577,22 +1583,36 @@ export class MeshCoreNativeBackend extends EventEmitter {
           // protecting the contact yet.
           throw new Error('Favorite target not in device contact list');
         }
-        const currentFlags = typeof contact.flags === 'number' ? contact.flags : 0;
-        const newFlags = (favorite ? (currentFlags | 0x01) : (currentFlags & ~0x01)) & 0xff;
-        if (newFlags !== currentFlags) {
-          await c.addOrUpdateContact(
-            contact.publicKey,
-            contact.type,
-            newFlags,
-            contact.outPathLen,
-            contact.outPath,
-            contact.advName,
-            contact.lastAdvert,
-            contact.advLat,
-            contact.advLon,
-          );
+        const { flags } = await this.applyContactFavorite(contact, favorite);
+        return { ok: true, favorite, flags };
+      }
+
+      case 'set_contacts_favorite': {
+        // Batch variant used by reconcileDeviceFavorites: fetch the device
+        // contact list ONCE, then apply many favourite toggles — instead of a
+        // separate getContacts() round-trip per contact when several favourites
+        // need re-asserting at once (e.g. right after a contact-table rebuild).
+        // Same read-modify-write semantics as set_contact_favorite. Contacts
+        // not on the device are reported in `missing` rather than throwing, so
+        // one evicted entry doesn't abort the rest of the batch.
+        const updates = Array.isArray(params.favorites)
+          ? (params.favorites as Array<{ public_key: string; favorite: boolean }>)
+          : [];
+        const contacts = (await c.getContacts()) as RawDeviceContact[];
+        const byHex = new Map(contacts.map((ct) => [bytesToHex(ct.publicKey), ct]));
+        let updated = 0;
+        const missing: string[] = [];
+        for (const u of updates) {
+          const hex = (u.public_key ?? '').toLowerCase();
+          const contact = byHex.get(hex);
+          if (!contact) {
+            missing.push(hex);
+            continue;
+          }
+          const { changed } = await this.applyContactFavorite(contact, u.favorite === true);
+          if (changed) updated++;
         }
-        return { ok: true, favorite, flags: newFlags };
+        return { ok: true, updated, missing };
       }
 
       case 'send_message': {
@@ -2094,6 +2114,35 @@ export class MeshCoreNativeBackend extends EventEmitter {
    * Uint8Array required by meshcore.js DM-shaped APIs. The manager passes
    * around hex strings, but meshcore.js wants raw bytes.
    */
+  /**
+   * Read-modify-write a contact's firmware favourite bit (ContactInfo.flags
+   * bit 0), preserving the upper telemetry-permission bits. Re-sends the full
+   * record via AddUpdateContact only when the bit actually changes. Shared by
+   * the `set_contact_favorite` and `set_contacts_favorite` dispatch cases.
+   */
+  private async applyContactFavorite(
+    contact: RawDeviceContact,
+    favorite: boolean,
+  ): Promise<{ changed: boolean; flags: number }> {
+    const currentFlags = typeof contact.flags === 'number' ? contact.flags : 0;
+    const newFlags = (favorite ? (currentFlags | 0x01) : (currentFlags & ~0x01)) & 0xff;
+    const changed = newFlags !== currentFlags;
+    if (changed && this.connection) {
+      await this.connection.addOrUpdateContact(
+        contact.publicKey,
+        contact.type,
+        newFlags,
+        contact.outPathLen,
+        contact.outPath,
+        contact.advName,
+        contact.lastAdvert,
+        contact.advLat,
+        contact.advLon,
+      );
+    }
+    return { changed, flags: newFlags };
+  }
+
   private async resolvePublicKey(hexKey: string): Promise<Uint8Array | null> {
     if (!hexKey || !this.connection) return null;
     const normalized = hexKey.toLowerCase();

--- a/src/server/routes/meshcoreContactsRoutes.ts
+++ b/src/server/routes/meshcoreContactsRoutes.ts
@@ -976,10 +976,12 @@ router.patch(
  * Toggle the server-side favorite flag for a MeshCore node (any role:
  * Companion, Repeater, Room Server, …). Body: { isFavorite: boolean }.
  *
- * MeshCore firmware has no native favorite concept, so this persists locally
- * only and never pushes anything to the device (unlike Meshtastic, whose
- * favorite toggle round-trips a SetFavoriteNode admin message). Favorited
- * nodes pin to the top of the node list (issue #3588).
+ * Persists the local `meshcore_nodes.isFavorite` column (which pins the node
+ * to the top of the list) AND, for a connected Companion source, pushes the
+ * firmware favourite bit (ContactInfo.flags bit 0) to the device so the
+ * contact is protected from contact-table eviction (#4838). The device push is
+ * best-effort inside `setNodeFavorite`; the local star always sticks (issue
+ * #3588).
  *
  * Gated by `nodes:write` to match the Meshtastic favorite endpoint and the
  * other MeshCore node-mutation routes.


### PR DESCRIPTION
## Summary

MeshMonitor's MeshCore ⭐ was a local-only `meshcore_nodes.isFavorite` column that **never touched the device**. The companion firmware stores contacts in a fixed-size table and evicts the oldest **non-favourite** entry when it fills — protection keyed on `ContactInfo.flags` **bit 0 (`0x01`)**. So starring a node in MeshMonitor did nothing to stop the firmware from dropping it (the root cause behind #4838's evictions).

This PR makes the favourite sync to the hardware, **bidirectionally**.

## Firmware facts (ripplebiz/MeshCore)

- Favourite = `ContactInfo.flags & 0x01` (LSB). Bits 1..7 are per-contact telemetry-permission bits (`flags >> 1`), so writes **read-modify-write** to preserve them.
- Eviction (`BaseChatMesh.cpp`) skips contacts with the bit set; a table of all-favourites evicts nothing.
- Settable over the companion protocol via `AddUpdateContact` (cmd 9) by re-sending the whole contact record with bit 0 toggled. `addOrUpdateContact` overwrites **all** fields, so the record's type/path/name/advert/coords are re-sent unchanged (same pattern as the existing `set_out_path` case).

The old "MeshCore has no native favorite concept" comments were simply wrong and are corrected here.

## What changed

- **`set_contact_favorite`** bridge command (`meshcoreNativeBackend.ts`) — read-modify-writes the flags byte. Added to `SERIAL_ONLY_BRIDGE_COMMANDS` (local write, not RF-gated).
- **`get_contacts`** now surfaces `flags` + `favorite`; `MeshCoreContact` gains `flags`/`deviceFavorite`.
- **`setNodeFavorite`** persists the local column then best-effort pushes the firmware bit (companion + connected). The local star always sticks even if the device write fails.
- **`reconcileDeviceFavorites`** runs inside `refreshContacts` (so **connect = backfill** of existing favourites):
  - device → app: **additive** — a contact favourited on the phone shows up locally.
  - app → device: **self-healing** — a local favourite the device is missing (e.g. a fresh advert re-added an evicted contact with `flags=0`) is re-asserted.
  - MeshMonitor is the source of truth: **un-favourite in MeshMonitor**, not the phone (a phone-side un-favourite is re-asserted). Deliberate, so eviction can never silently un-protect a node.

## Mesh impact

**None.** `set_contact_favorite` is a local serial write to the device's saved contact table and puts nothing on the radio. No new packets, timers, notifications, or rate limits. One extra indexed per-source `getNodesBySource` SELECT per `refreshContacts()` (event-driven, already does a device round-trip + N upserts).

## Testing

- New `src/server/meshcoreManager.favoriteSync.test.ts` (9 cases): DB+device push on toggle, disconnected/repeater no-push, best-effort failure, both reconcile directions, agreement/repeater no-ops.
- `set_contact_favorite` (set/clear/no-op/not-on-device) + `get_contacts` flags cases in `meshcoreNativeBackend.test.ts`.
- `meshcoreTx.test.ts` size pins bumped (28→29 / 42→43).
- Full MeshCore suite (832), MeshCore routes (338) pass. `tsc -p tsconfig.server.json` and `npm run lint:ci` clean.
- **Not verified on live hardware** — no companion with a full contact table to reproduce eviction against; firmware behaviour is sourced from the MeshCore repo.

## Out of scope

No frontend badge for `deviceFavorite`/on-device state; the ⭐ already reflects `isFavorite`, which reconcile keeps in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)