### PR TITLE
fix(#4851): persist ACK metadata for confirmed DMs in Delivery Details

### DIFF
--- a/src/db/repositories/messages.ackMeta.test.ts
+++ b/src/db/repositories/messages.ackMeta.test.ts
@@ -1,0 +1,125 @@
+/**
+ * MessagesRepository.updateMessageDeliveryState — ack metadata persistence
+ * (#4851: Delivery Details popup showed every field but delivery state as
+ * "Unknown" because the destination ACK's ackFromNode/relayNode/rxSnr/rxRssi
+ * were never written back to the message row).
+ *
+ * Mirrors messages.routingErrorCode.perSource.test.ts: verifies the optional
+ * 4th argument writes the ack metadata, that call sites which omit it leave
+ * the columns untouched (NULL), and that a later omitted call doesn't clobber
+ * previously-written values.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { MessagesRepository } from './messages.js';
+import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
+
+describe('MessagesRepository.updateMessageDeliveryState — ack metadata', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: MessagesRepository;
+
+  const NODE_NUM = 0xaabbccdd;
+  const NODE_ID = '!aabbccdd';
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    const now = Date.now();
+    db.prepare(
+      'INSERT INTO nodes (nodeNum, nodeId, sourceId, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)',
+    ).run(NODE_NUM, NODE_ID, 'src-a', now, now);
+    repo = new MessagesRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => db.close());
+
+  const insert = async (id: string, requestId: number) =>
+    repo.insertMessage(
+      {
+        id,
+        fromNodeNum: NODE_NUM,
+        toNodeNum: NODE_NUM,
+        fromNodeId: NODE_ID,
+        toNodeId: NODE_ID,
+        text: 'hi',
+        channel: -1,
+        portnum: 1,
+        requestId,
+        timestamp: 1000,
+        createdAt: 1000,
+      } as any,
+      'src-a',
+    );
+
+  it('writes ackFromNode/relayNode/rxSnr/rxRssi when the 4th arg is passed on a destination ACK', async () => {
+    await insert('msg-1', 111);
+
+    const updated = await repo.updateMessageDeliveryState(111, 'confirmed', undefined, {
+      ackFromNode: 0x22222222,
+      relayNode: 0x4a,
+      rxSnr: 7.25,
+      rxRssi: -91,
+    });
+    expect(updated).toBe(true);
+
+    const msg = await repo.getMessage('msg-1');
+    expect(msg?.deliveryState).toBe('confirmed');
+    expect(msg?.ackFromNode).toBe(0x22222222);
+    expect(msg?.relayNode).toBe(0x4a);
+    expect(msg?.rxSnr).toBe(7.25);
+    expect(msg?.rxRssi).toBe(-91);
+  });
+
+  it('leaves ack metadata NULL when a call omits the 4th arg', async () => {
+    await insert('msg-2', 222);
+
+    const updated = await repo.updateMessageDeliveryState(222, 'delivered');
+    expect(updated).toBe(true);
+
+    const msg = await repo.getMessage('msg-2');
+    expect(msg?.deliveryState).toBe('delivered');
+    expect(msg?.ackFromNode ?? null).toBeNull();
+    expect(msg?.relayNode ?? null).toBeNull();
+    expect(msg?.rxSnr ?? null).toBeNull();
+    expect(msg?.rxRssi ?? null).toBeNull();
+  });
+
+  it('does not clobber existing ack metadata when a later call omits the 4th arg', async () => {
+    await insert('msg-3', 333);
+
+    await repo.updateMessageDeliveryState(333, 'confirmed', undefined, {
+      ackFromNode: 0x33333333,
+      relayNode: 0x7f,
+      rxSnr: 3.5,
+      rxRssi: -100,
+    });
+
+    // A hypothetical follow-up call (e.g. a duplicate/retried ack) without
+    // the 4th arg must not wipe out what was already recorded.
+    await repo.updateMessageDeliveryState(333, 'confirmed');
+
+    const msg = await repo.getMessage('msg-3');
+    expect(msg?.ackFromNode).toBe(0x33333333);
+    expect(msg?.relayNode).toBe(0x7f);
+    expect(msg?.rxSnr).toBe(3.5);
+    expect(msg?.rxRssi).toBe(-100);
+  });
+
+  it('writes only the ack metadata fields explicitly provided, leaving the rest untouched', async () => {
+    await insert('msg-4', 444);
+
+    await repo.updateMessageDeliveryState(444, 'confirmed', undefined, {
+      ackFromNode: 0x44444444,
+    });
+
+    const msg = await repo.getMessage('msg-4');
+    expect(msg?.ackFromNode).toBe(0x44444444);
+    expect(msg?.relayNode ?? null).toBeNull();
+    expect(msg?.rxSnr ?? null).toBeNull();
+    expect(msg?.rxRssi ?? null).toBeNull();
+  });
+});

--- a/src/db/repositories/messages.ts
+++ b/src/db/repositories/messages.ts
@@ -579,15 +579,28 @@ export class MessagesRepository extends BaseRepository {
    * Update message delivery state.
    *
    * `routingErrorCode` (#4816 Phase 2) is optional and defaults to being
-   * omitted from the update set entirely — the success/ack call sites
-   * (`'delivered'` / `'confirmed'`) never pass it, so the column stays NULL
-   * (or whatever it already was) rather than being clobbered. Only the
-   * failed-routing call site passes a concrete numeric RoutingError reason.
+   * omitted from the update set entirely — the failed-routing call site is
+   * the only one that passes a concrete numeric RoutingError reason, so the
+   * column stays NULL (or whatever it already was) rather than being
+   * clobbered on the other states.
+   *
+   * `ackMeta` (#4851) carries fields read directly off the ACK packet itself
+   * — who sent it, and the signal it was received with — for the Delivery
+   * Details popup's Identity/Signal sections. Only the destination-ACK
+   * ('confirmed') call site has a genuine over-the-air packet to read these
+   * from, so every other call site omits it and the columns stay untouched,
+   * same NULL-preserving contract as `routingErrorCode` above.
    */
   async updateMessageDeliveryState(
     requestId: number,
     deliveryState: 'delivered' | 'confirmed' | 'failed',
     routingErrorCode?: number | null,
+    ackMeta?: {
+      ackFromNode?: number | null;
+      relayNode?: number | null;
+      rxSnr?: number | null;
+      rxRssi?: number | null;
+    },
   ): Promise<boolean> {
     const { messages } = this.tables;
     const existing = await this.db
@@ -597,10 +610,21 @@ export class MessagesRepository extends BaseRepository {
 
     if (existing.length === 0) return false;
 
-    const updateSet: { deliveryState: string; routingErrorCode?: number | null } = { deliveryState };
+    const updateSet: {
+      deliveryState: string;
+      routingErrorCode?: number | null;
+      ackFromNode?: number | null;
+      relayNode?: number | null;
+      rxSnr?: number | null;
+      rxRssi?: number | null;
+    } = { deliveryState };
     if (routingErrorCode !== undefined) {
       updateSet.routingErrorCode = routingErrorCode;
     }
+    if (ackMeta?.ackFromNode !== undefined) updateSet.ackFromNode = ackMeta.ackFromNode;
+    if (ackMeta?.relayNode !== undefined) updateSet.relayNode = ackMeta.relayNode;
+    if (ackMeta?.rxSnr !== undefined) updateSet.rxSnr = ackMeta.rxSnr;
+    if (ackMeta?.rxRssi !== undefined) updateSet.rxRssi = ackMeta.rxRssi;
 
     await this.db
       .update(messages)

--- a/src/server/meshtasticManager.deliveryEvents.test.ts
+++ b/src/server/meshtasticManager.deliveryEvents.test.ts
@@ -352,7 +352,7 @@ describe('MeshtasticManager - delivery-diagnostics event recording (#4816 Phase 
       );
     });
 
-    it('records "confirmed" on the destination DM ack', async () => {
+    it('records "confirmed" on the destination DM ack, persisting who ACKed and its signal (#4851)', async () => {
       mockGetMessageByRequestId.mockResolvedValue({
         id: 'msg-confirmed-1',
         toNodeId: toNodeId(PEER),
@@ -360,10 +360,23 @@ describe('MeshtasticManager - delivery-diagnostics event recording (#4816 Phase 
         channel: -1,
       });
 
-      const packet = { from: PEER, to: LOCAL, rxTime: 0, decoded: { requestId: REQ_ID } };
+      const packet = {
+        from: PEER,
+        to: LOCAL,
+        rxTime: 0,
+        decoded: { requestId: REQ_ID },
+        relayNode: 0x4a,
+        rxSnr: 7.25,
+        rxRssi: -91,
+      };
       await (manager as any).processRoutingErrorMessage(packet, { errorReason: 0 });
 
-      expect(mockUpdateMessageDeliveryState).toHaveBeenCalledWith(REQ_ID, 'confirmed');
+      expect(mockUpdateMessageDeliveryState).toHaveBeenCalledWith(REQ_ID, 'confirmed', undefined, {
+        ackFromNode: PEER,
+        relayNode: 0x4a,
+        rxSnr: 7.25,
+        rxRssi: -91,
+      });
       expect(mockRecordEvent).toHaveBeenCalledTimes(1);
       expect(mockRecordEvent).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -8574,7 +8574,18 @@ class MeshtasticManager implements ISourceManager {
           // ACK from target node - message confirmed received by recipient (only for DMs)
           if (fromNodeId === targetNodeId && isDM) {
             logger.debug(`✅ ACK received from TARGET node ${fromNodeId} for requestId ${requestId} - message confirmed`);
-            const updated = await databaseService.messages.updateMessageDeliveryState(requestId, 'confirmed');
+            // This ACK packet is a genuine over-the-air reception from the
+            // destination itself (unlike the own-radio 'delivered' ack above,
+            // which is a locally-synthesized notification with no real RF
+            // metadata) — persist who sent it and how it was received so the
+            // Delivery Details popup's Identity/Signal sections aren't stuck
+            // on "Unknown" for confirmed DMs (#4851).
+            const updated = await databaseService.messages.updateMessageDeliveryState(requestId, 'confirmed', undefined, {
+              ackFromNode: fromNum,
+              relayNode: meshPacket.relayNode ?? undefined,
+              rxSnr: meshPacket.rxSnr ?? meshPacket.rx_snr,
+              rxRssi: meshPacket.rxRssi ?? meshPacket.rx_rssi,
+            });
             if (updated) {
               logger.debug(`💾 Marked message ${requestId} as confirmed (received by target)`);
               // Emit WebSocket event for real-time delivery status update


### PR DESCRIPTION
## Summary

Fixes #4851, where the Delivery Details popup shows every field as "Unknown" except the top-level delivery status.

- `processRoutingErrorMessage()` (`src/server/meshtasticManager.ts`) processes incoming routing ACKs but only ever wrote `deliveryState` (and, on failure, `routingErrorCode`) back to the message row via `MessagesRepository.updateMessageDeliveryState()`.
- It never persisted `ackFromNode` / `relayNode` / `rxSnr` / `rxRssi` from the ACK packet itself — even for a DM confirmed by its actual destination, where those fields come from a genuine over-the-air reception, not a locally-synthesized notification.
- Since `describeMeshtasticDelivery()` (the Delivery Details data builder) reads those columns straight off the message row, the popup's Identity and Signal sections showed "Unknown" for every message regardless of outcome.

## Fix

- Extended `MessagesRepository.updateMessageDeliveryState()` with an optional 4th `ackMeta` argument (`ackFromNode`, `relayNode`, `rxSnr`, `rxRssi`), following the same NULL-preserving contract as the existing `routingErrorCode` argument — call sites that omit it leave those columns untouched.
- Wired it up only at the destination-ACK ("confirmed") call site, since that's the one branch where the ACK packet reflects a genuine RF reception. The own-radio "delivered" (ack-by-mesh) branch is a locally-synthesized notification with no real per-node/signal data, so it's intentionally left alone — showing "Unknown" there is correct, not a bug.

## Not fixed here — flagged for a maintainer decision

While investigating I found a second, more fundamental reason the Route section (Starting Hop Limit / Hop Limit / Hops Used / Route Type) is *also* always "Unknown": `hopStart`/`hopLimit` are hard-coded to `undefined` at insert time for our own outgoing messages, and `meshtasticProtobufService.createTextMessage()` never sets an explicit `hop_limit` on the outgoing packet at all — unlike every other packet builder in that file (position/nodeinfo/waypoint/admin all set it explicitly). That's a question about actual on-air transmit behavior, not just a display gap, so per this repo's Mesh Impact Checklist it needs a maintainer decision before any change. Left it out of scope here and posted the details on the issue.

## Test plan

- [x] New repository-level tests (`src/db/repositories/messages.ackMeta.test.ts`): writes ack metadata when provided, leaves columns NULL when omitted, doesn't clobber existing values on a later omitted call, and only writes the fields explicitly passed.
- [x] Updated `meshtasticManager.deliveryEvents.test.ts` "confirmed" case to assert the new metadata is read off the ACK packet and passed through.
- [x] `npx tsc --noEmit -p tsconfig.server.json` — clean.
- [x] `npm run lint:ci` — no new baseline violations.
- [x] Full `npx vitest run` — 1097 files / 15627 tests passed, 823 skipped (PostgreSQL/MySQL containers not running locally), 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEd5qinLRZUk3AMjYT39gv


---
_Generated by [Claude Code](https://claude.ai/code/session_01LEd5qinLRZUk3AMjYT39gv)_