### PR TITLE
fix(#4849): don't attribute relayed packets' RSSI/SNR to the source node

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -50,6 +50,7 @@ import { isWithinTimeWindow } from './utils/timeWindow.js';
 import { compileUserRegex } from '../utils/safeRegex.js';
 import { shouldGateAutomations, averageStrongestNeighborUtilization, DEFAULT_AIRTIME_CUTOFF_THRESHOLD, DEFAULT_AIRTIME_CUTOFF_SOURCE, NEIGHBOR_UTIL_SAMPLE_COUNT, type AirtimeCutoffSource, type NeighborUtilContributor } from './utils/airtimeCutoff.js';
 import { resolveLastHopName } from './utils/lastHop.js';
+import { isRelayedReception } from './utils/packetHops.js';
 import { resolveLastHeardSec } from './utils/replayGuard.js';
 import { autoAckIsZeroHop, autoAckCellKey, resolveAutoAckReplyRouting } from './utils/autoAckDecision.js';
 import { hopCountEmoji, HOP_COUNT_EMOJIS } from '../utils/hopEmoji.js';
@@ -7535,6 +7536,19 @@ class MeshtasticManager implements ISourceManager {
       // Track if this packet was PKI encrypted (using the helper method)
       await this.trackPKIEncryption(meshPacket, fromNum);
 
+      // A relayed packet's rx_snr/rx_rssi describe the link to the LAST repeater,
+      // not the originating node, so recording them as this node's signal
+      // telemetry makes its chart swing to the repeater's signal (#4849). Skip
+      // the time-series inserts for known-relayed receptions; the current-value
+      // badge (nodeData.snr/rssi) is left as-is, and packet_log still records the
+      // real per-reception value with hop info. Unknown hop counts are treated as
+      // direct so we don't drop legitimate readings from transports that omit
+      // hop_start.
+      const relayedReception = isRelayedReception(
+        meshPacket.hopStart ?? meshPacket.hop_start,
+        meshPacket.hopLimit ?? meshPacket.hop_limit,
+      );
+
       // Only include SNR/RSSI if they have valid values.
       // Use the firmware-sentinel check (-128 = "no SNR") rather than a truthiness
       // guard, so a legitimate 0 dB SNR from a directly-heard node is not dropped (#3590).
@@ -7545,9 +7559,9 @@ class MeshtasticManager implements ISourceManager {
         // This ensures we have historical data for stable links
         const latestSnrTelemetry = await databaseService.getLatestTelemetryForTypeAsync(nodeId, 'snr_local');
         const tenMinutesMs = 10 * 60 * 1000;
-        const shouldSaveSnr = !latestSnrTelemetry ||
+        const shouldSaveSnr = !relayedReception && (!latestSnrTelemetry ||
                               latestSnrTelemetry.value !== meshPacket.rxSnr ||
-                              (timestamp - latestSnrTelemetry.timestamp) >= tenMinutesMs;
+                              (timestamp - latestSnrTelemetry.timestamp) >= tenMinutesMs);
 
         if (shouldSaveSnr) {
           await databaseService.telemetry.insertTelemetry({
@@ -7572,9 +7586,9 @@ class MeshtasticManager implements ISourceManager {
         // This ensures we have historical data for stable links
         const latestRssiTelemetry = await databaseService.getLatestTelemetryForTypeAsync(nodeId, 'rssi');
         const tenMinutesMs = 10 * 60 * 1000;
-        const shouldSaveRssi = !latestRssiTelemetry ||
+        const shouldSaveRssi = !relayedReception && (!latestRssiTelemetry ||
                                latestRssiTelemetry.value !== meshPacket.rxRssi ||
-                               (timestamp - latestRssiTelemetry.timestamp) >= tenMinutesMs;
+                               (timestamp - latestRssiTelemetry.timestamp) >= tenMinutesMs);
 
         if (shouldSaveRssi) {
           await databaseService.telemetry.insertTelemetry({

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7548,6 +7548,7 @@ class MeshtasticManager implements ISourceManager {
         meshPacket.hopStart ?? meshPacket.hop_start,
         meshPacket.hopLimit ?? meshPacket.hop_limit,
       );
+      const tenMinutesMs = 10 * 60 * 1000;
 
       // Only include SNR/RSSI if they have valid values.
       // Use the firmware-sentinel check (-128 = "no SNR") rather than a truthiness
@@ -7558,7 +7559,6 @@ class MeshtasticManager implements ISourceManager {
         // Save SNR as telemetry if it has changed OR if 10+ minutes have passed
         // This ensures we have historical data for stable links
         const latestSnrTelemetry = await databaseService.getLatestTelemetryForTypeAsync(nodeId, 'snr_local');
-        const tenMinutesMs = 10 * 60 * 1000;
         const shouldSaveSnr = !relayedReception && (!latestSnrTelemetry ||
                               latestSnrTelemetry.value !== meshPacket.rxSnr ||
                               (timestamp - latestSnrTelemetry.timestamp) >= tenMinutesMs);
@@ -7585,7 +7585,6 @@ class MeshtasticManager implements ISourceManager {
         // Save RSSI as telemetry if it has changed OR if 10+ minutes have passed
         // This ensures we have historical data for stable links
         const latestRssiTelemetry = await databaseService.getLatestTelemetryForTypeAsync(nodeId, 'rssi');
-        const tenMinutesMs = 10 * 60 * 1000;
         const shouldSaveRssi = !relayedReception && (!latestRssiTelemetry ||
                                latestRssiTelemetry.value !== meshPacket.rxRssi ||
                                (timestamp - latestRssiTelemetry.timestamp) >= tenMinutesMs);

--- a/src/server/utils/packetHops.test.ts
+++ b/src/server/utils/packetHops.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { meshtasticPacketHopsAway, isRelayedReception } from './packetHops.js';
+
+describe('meshtasticPacketHopsAway (#4849)', () => {
+  it('returns 0 for a direct reception (hop_start == hop_limit)', () => {
+    expect(meshtasticPacketHopsAway(3, 3)).toBe(0);
+    expect(meshtasticPacketHopsAway(7, 7)).toBe(0);
+  });
+
+  it('returns the hop count for a relayed reception', () => {
+    expect(meshtasticPacketHopsAway(3, 1)).toBe(2);
+    expect(meshtasticPacketHopsAway(3, 0)).toBe(3);
+  });
+
+  it('returns null when hop_start is 0/absent (unknown, not "0 hops")', () => {
+    expect(meshtasticPacketHopsAway(0, 0)).toBeNull();
+    expect(meshtasticPacketHopsAway(undefined, 3)).toBeNull();
+    expect(meshtasticPacketHopsAway(null, 3)).toBeNull();
+  });
+
+  it('returns null when hop_limit is absent', () => {
+    expect(meshtasticPacketHopsAway(3, undefined)).toBeNull();
+    expect(meshtasticPacketHopsAway(3, null)).toBeNull();
+  });
+
+  it('returns null for the impossible hop_start < hop_limit case', () => {
+    expect(meshtasticPacketHopsAway(3, 5)).toBeNull();
+  });
+});
+
+describe('isRelayedReception (#4849)', () => {
+  it('is false for a direct reception', () => {
+    expect(isRelayedReception(3, 3)).toBe(false);
+  });
+
+  it('is true only when hops are known to be > 0', () => {
+    expect(isRelayedReception(3, 1)).toBe(true);
+    expect(isRelayedReception(2, 1)).toBe(true);
+  });
+
+  it('is false when the hop count cannot be determined (do not over-drop)', () => {
+    expect(isRelayedReception(0, 0)).toBe(false);
+    expect(isRelayedReception(undefined, undefined)).toBe(false);
+    expect(isRelayedReception(null, 2)).toBe(false);
+    expect(isRelayedReception(3, undefined)).toBe(false);
+  });
+});

--- a/src/server/utils/packetHops.ts
+++ b/src/server/utils/packetHops.ts
@@ -1,0 +1,43 @@
+/**
+ * Hop-count helpers for received Meshtastic packets (#4849).
+ *
+ * A packet's `rx_rssi` / `rx_snr` describe the RF link of the LAST transmitter
+ * we heard — the originating node for a direct reception, but the nearest
+ * repeater for a relayed one. Attributing a relayed packet's signal to the
+ * source node makes its telemetry chart swing wildly (a distant node briefly
+ * shows its neighbour's strong signal). These helpers let callers detect a
+ * relayed reception so they can skip recording the misleading value.
+ */
+
+/**
+ * Hops a received packet travelled, or `null` when it can't be determined.
+ *
+ * `hop_start` is a proto3 `uint32` scalar (an unset field decodes as `0`), so a
+ * `0`/absent `hop_start` is "unknown", NOT "0 hops" — some firmware, MQTT-bridged
+ * paths, and transports that strip the LoRa header bits never populate it. We
+ * only trust a count when `hop_start > 0` and `hop_start >= hop_limit`, mirroring
+ * the existing message-hops guard in the RX path.
+ */
+export function meshtasticPacketHopsAway(
+  hopStart: number | null | undefined,
+  hopLimit: number | null | undefined,
+): number | null {
+  if (hopStart == null || hopLimit == null) return null;
+  if (hopStart <= 0) return null;
+  if (hopStart < hopLimit) return null; // impossible over the air → treat as unknown
+  return hopStart - hopLimit;
+}
+
+/**
+ * True only when a packet is KNOWN to have been relayed (hops > 0). Used to skip
+ * attributing a relayed packet's RSSI/SNR to the source node (#4849). An
+ * undetermined hop count returns `false` — we don't over-drop legitimate direct
+ * receptions just because a transport didn't populate `hop_start`.
+ */
+export function isRelayedReception(
+  hopStart: number | null | undefined,
+  hopLimit: number | null | undefined,
+): boolean {
+  const hops = meshtasticPacketHopsAway(hopStart, hopLimit);
+  return hops != null && hops > 0;
+}


### PR DESCRIPTION
Fixes #4849.

## The bug

A Meshtastic packet's `rx_rssi` / `rx_snr` describe the RF link of the **last transmitter we heard** — the originating node for a direct reception, but the **nearest repeater** for a relayed one. MeshMonitor recorded that value as the *source node's* signal telemetry regardless of hops, so a multi-hop node's RSSI/SNR chart swings to its neighbour's signal (the reporter saw RSSI spike to -25 dBm on packets that arrived via a nearby repeater at hop count 1–3, not a real change in the distant node's link).

## The fix

Skip the `rssi` / `snr_local` telemetry time-series inserts in `processNodeInfoMessageProtobuf` for **known-relayed** receptions (hops > 0). Those two inserts are what feed the node's RSSI/SNR chart (`TelemetryChart`) and the signal-trend badge (`signalTrend.ts` reads exactly `rssi` + `snr_local`).

Deliberately **unchanged**:
- **`packet_log`** still records the real per-reception RSSI/SNR with full hop info — the reception record stays intact for diagnostics.
- The node's **current-value badge** (`nodes.snr`/`nodes.rssi`) is left as-is (scope: chart + trend only).
- **Unknown** hop counts (`hop_start` absent — older firmware, some MQTT-bridged paths, transports that strip the LoRa header) are treated as **direct**, so we don't drop legitimate readings just because a transport didn't populate `hop_start`.

### How "relayed" is determined

New pure helpers in `src/server/utils/packetHops.ts`:
- `meshtasticPacketHopsAway(hopStart, hopLimit)` → hop count, or `null` when undeterminable. `hop_start` is a proto3 `uint32` (unset decodes `0`), so it only trusts a count when `hop_start > 0` and `hop_start >= hop_limit` — mirroring the existing message-hops guard already in the RX path.
- `isRelayedReception(...)` → `true` only when hops are **known** to be > 0.

## Scope

- **Meshtastic only.** MeshCore has no LoRa `hop_start`/`hop_limit` model; its per-node RSSI/SNR comes from a remote node's self-reported status stats, not our reception of a forwarded packet, so the misattribution doesn't apply.
- The `snr_remote` telemetry type (the remote node's own self-reported SNR from a NodeDB dump) is untouched — no local reception involved.

## Mesh impact

None — read-only classification of already-received packets. No packets sent, no timers, no notifications.

## Testing

- New `src/server/utils/packetHops.test.ts` — 8 cases: direct (hop_start == hop_limit → 0), relayed (→ N), unknown (`hop_start` 0/absent → null, not "0 hops"), missing `hop_limit`, and the impossible `hop_start < hop_limit` case.
- Full Meshtastic manager suite (842 tests) green; `tsc -p tsconfig.server.json` and `npm run lint:ci` clean.
- Not verified against live multi-hop hardware; behaviour follows the documented `hop_start`/`hop_limit` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)