### PR TITLE
fix(site-planner): call /api/rf/coverage, not /rf/coverage

### DIFF
--- a/src/components/MapAnalysis/SitePlannerPanel.test.tsx
+++ b/src/components/MapAnalysis/SitePlannerPanel.test.tsx
@@ -100,7 +100,7 @@ describe('SitePlannerPanel', () => {
 
     await user.click(screen.getByTestId('site-planner-run'));
 
-    await waitFor(() => expect(post).toHaveBeenCalledWith('/rf/coverage', expect.objectContaining({
+    await waitFor(() => expect(post).toHaveBeenCalledWith('/api/rf/coverage', expect.objectContaining({
       origin: { lat: 30, lng: -97 },
       txPowerDbm: 27,
     })));
@@ -150,7 +150,7 @@ describe('SitePlannerPanel', () => {
     await user.type(input, '868');
     await user.click(screen.getByTestId('site-planner-run'));
 
-    await waitFor(() => expect(post).toHaveBeenCalledWith('/rf/coverage',
+    await waitFor(() => expect(post).toHaveBeenCalledWith('/api/rf/coverage',
       expect.objectContaining({ frequencyHz: 868e6 })));
   });
 

--- a/src/components/MapAnalysis/SitePlannerPanel.tsx
+++ b/src/components/MapAnalysis/SitePlannerPanel.tsx
@@ -75,7 +75,7 @@ export default function SitePlannerPanel({
     setError(null);
     try {
       const res = await apiService.post<{ success: boolean; data: PredictedCoverage }>(
-        '/rf/coverage',
+        '/api/rf/coverage',
         {
           origin: { lat: origin.lat, lng: origin.lng },
           txHeightM: params.txHeightM,


### PR DESCRIPTION
## Summary

The Site Planner (predictive RF coverage, shipped in 4.15.0) failed on every run with:

> Unexpected token '<', "<!doctype "... is not valid JSON

**Root cause:** `apiService` builds the request URL as `${baseUrl}${endpoint}` (`src/services/api.ts:332`), so every caller must include the `/api` prefix. `SitePlannerPanel.tsx` passed `'/rf/coverage'`, which resolved to `${baseUrl}/rf/coverage`, missed the mounted route (`/api/rf/coverage`), and fell through to the SPA catch-all — returning `index.html`. The frontend then tried to `JSON.parse` that HTML.

Verified live against the running 4.15.0 container:
- `POST /meshmonitor/api/rf/coverage` → **403 JSON** (route works)
- `POST /meshmonitor/rf/coverage` → **404 HTML** (the bug)

**Fix:** prefix the path with `/api`, matching all 8 other `apiService` callers.

## Why the test didn't catch it

`SitePlannerPanel.test.tsx` mocked `apiService.post` and asserted it was called with the buggy `'/rf/coverage'` — so the test validated the bug and passed. Updated both assertions to `'/api/rf/coverage'` so the test now guards the correct convention.

## Test plan

- [x] `SitePlannerPanel.test.tsx` — 10/10 pass
- [x] Live curl confirms `/api/rf/coverage` reaches the route
- [ ] CI green

## Mesh impact

None — frontend URL fix only. No change to what packets are sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)