### PR TITLE
chore(release): 4.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.15.1] - 2026-08-21
+
+### Fixed
+- **Site Planner no longer fails with a JSON parse error** — the predictive RF coverage request was sent to `/rf/coverage` instead of `/api/rf/coverage`, so it fell through to the SPA and returned HTML, which the frontend then tried to parse as JSON (`Unexpected token '<'`). The path now includes the `/api` prefix like every other API call. (#4862)
+
 ## [4.15.0] - 2026-08-21
 
 ### Added

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.15.0",
+  "version": "4.15.1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.15.0
-appVersion: "4.15.0"
+version: 4.15.1
+appVersion: "4.15.1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.15.0",
+      "version": "4.15.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.0",
+  "version": "4.15.1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Patch release for the **Site Planner** fix merged in #4862.

The predictive RF coverage request was going to `/rf/coverage` instead of `/api/rf/coverage`, so it fell through to the SPA and returned `index.html` — the frontend then failed to parse it as JSON (`Unexpected token '<'`). #4862 corrected the path; this bumps the version and records it in the changelog.

**Version → 4.15.1** across all five files (`package.json`, `package-lock.json`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, `helm/meshmonitor/Chart.yaml`).

## Mesh impact

None — version/changelog only.

## Test plan

- [x] Version consistent across all five files + lockfile regenerated
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)