### PR TITLE
fix(3d-map): stop role glyphs collapsing to plain discs on zoom (#4863)

### DIFF
--- a/src/components/map/Base3DMap.test.tsx
+++ b/src/components/map/Base3DMap.test.tsx
@@ -252,6 +252,47 @@ describe('Base3DMap', () => {
     expect(map.addLayer).toHaveBeenCalledWith(expect.objectContaining({ id: 'nodes-label', type: 'symbol' }));
   });
 
+  // #4863: MapLibre stores a single `sdfIcons` flag per tile bucket, so mixing
+  // the SDF disc (standard nodes) and the non-SDF glyph rasters in ONE symbol
+  // layer makes a glyph render as a tinted disc whenever it shares a bucket with
+  // a disc — and which one wins flips with the zoom-dependent tiling. The two
+  // icon families must therefore live in separate, filter-partitioned layers.
+  it('splits SDF disc and non-SDF glyph markers into separate filtered layers (#4863)', () => {
+    render(
+      <Base3DMap center={[40.0, -105.0]} zoom={12} basemap={basemap} terrainTileUrl={terrainTileUrl} nodes={nodes} />,
+    );
+    const map = currentFakeMap();
+    act(() => {
+      map.triggerLoad();
+    });
+
+    const layers = map.addLayer.mock.calls.map((c: unknown[]) => c[0] as any);
+    const discLayer = layers.find((l: any) => l.id === 'nodes-marker');
+    const glyphLayer = layers.find((l: any) => l.id === 'nodes-glyph');
+
+    // Both icon layers exist and read the same data-driven icon-image.
+    expect(discLayer).toBeDefined();
+    expect(glyphLayer).toBeDefined();
+    expect(discLayer.type).toBe('symbol');
+    expect(glyphLayer.type).toBe('symbol');
+    expect(discLayer.layout['icon-image']).toEqual(['get', 'iconImage']);
+    expect(glyphLayer.layout['icon-image']).toEqual(['get', 'iconImage']);
+
+    // The disc layer is SDF-only (standard nodes) and keeps the SDF-only paints.
+    expect(discLayer.filter).toEqual(['==', ['get', 'category'], 'standard']);
+    expect(discLayer.paint['icon-color']).toEqual(['get', 'color']);
+
+    // The glyph layer is non-SDF-only (every non-standard family) and must NOT
+    // set icon-color — tinting an SDF flag onto a full-color raster is exactly
+    // the flatten-to-disc bug. Opacity (which applies to all icons) is kept.
+    expect(glyphLayer.filter).toEqual(['!=', ['get', 'category'], 'standard']);
+    expect(glyphLayer.paint['icon-color']).toBeUndefined();
+    expect(glyphLayer.paint['icon-opacity']).toEqual(['get', 'opacity']);
+
+    // A glyph marker must be clickable via its own layer's handler.
+    expect(map.layerHandlers['click:nodes-glyph']).toBeDefined();
+  });
+
   it('calls onNodeClick with the clicked feature key', () => {
     const onNodeClick = vi.fn();
     render(

--- a/src/components/map/Base3DMap.tsx
+++ b/src/components/map/Base3DMap.tsx
@@ -126,7 +126,20 @@ const TERRAIN_SOURCE_ID = 'terrain-dem';
 const HILLSHADE_LAYER_ID = 'terrain-hillshade';
 const NODES_SOURCE_ID = 'nodes';
 const NODES_MARKER_LAYER_ID = 'nodes-marker';
+// Separate symbol layer for the per-type glyph rasters (#4863). MapLibre stores
+// a SINGLE `sdfIcons` flag per tile bucket (set by the first icon shaped into
+// it) and renders every icon in that bucket in that one mode — mixing SDF and
+// non-SDF icons in one layer only logs "Cannot mix SDF and non-SDF icons in one
+// buffer" and draws them all in whichever mode won the bucket. The SDF disc
+// (standard nodes) and the full-color glyph rasters therefore MUST live in
+// separate layers, or a glyph sharing a tile bucket with a disc renders as a
+// tinted disc — and which one wins flips with the zoom-dependent tiling.
+const NODES_GLYPH_LAYER_ID = 'nodes-glyph';
 const NODES_LABEL_LAYER_ID = 'nodes-label';
+// Both node icon layers are interactive (click / hover), so event handlers bind
+// to each. Order matters for hit-testing only cosmetically here (icons don't
+// overlap within a node), but keep the disc layer first for stable listing.
+const NODE_ICON_LAYER_IDS = [NODES_MARKER_LAYER_ID, NODES_GLYPH_LAYER_ID] as const;
 const LINES_SOURCE_ID = 'lines';
 const LINES_LAYER_PREFIX = 'lines-';
 
@@ -465,15 +478,17 @@ export function Base3DMap({
           })
           .catch(() => pendingGlyphIcons.delete(id));
       });
+      // Standard nodes: the tinted SDF disc. Filtered to `category === 'standard'`
+      // so this layer's buckets are SDF-only (#4863) — `icon-color`/`icon-halo`
+      // apply only to SDF icons, and the sdfIcons bucket flag must stay uniform.
       map.addLayer({
         id: NODES_MARKER_LAYER_ID,
         type: 'symbol',
         source: NODES_SOURCE_ID,
+        filter: ['==', ['get', 'category'], 'standard'],
         layout: {
-          // `standard` → the tinted SDF disc; glyph families → the pre-colored
-          // raster keyed by `iconImage` (see toNodesFeatureCollection).
           'icon-image': ['get', 'iconImage'],
-          // 64px source image scaled down; glyph markers read at this size.
+          // 64px source image scaled down; markers read at this size.
           'icon-size': 0.35,
           // Always draw every dot — dots must never be dropped by symbol
           // collision the way a label legitimately can be.
@@ -490,6 +505,29 @@ export function Base3DMap({
           'icon-halo-color': '#ffffff',
           'icon-halo-width': 1.5,
           // Fade aged nodes exactly as the 2D map does (#4808).
+          'icon-opacity': ['get', 'opacity'],
+        },
+      });
+      // Glyph nodes (repeater/sensor/roomServer/companion): pre-colored, full-
+      // color rasters. A SEPARATE layer keeps this bucket non-SDF-only (#4863),
+      // so a glyph never shares a bucket with an SDF disc and gets flattened
+      // into a tinted disc. No `icon-color`/`icon-halo` — those only tint SDF
+      // icons and the raster already carries the white disc + hop-colored glyph.
+      map.addLayer({
+        id: NODES_GLYPH_LAYER_ID,
+        type: 'symbol',
+        source: NODES_SOURCE_ID,
+        filter: ['!=', ['get', 'category'], 'standard'],
+        layout: {
+          'icon-image': ['get', 'iconImage'],
+          'icon-size': 0.35,
+          'icon-allow-overlap': true,
+          'icon-ignore-placement': true,
+          'icon-rotation-alignment': 'viewport',
+          'icon-pitch-alignment': 'viewport',
+        },
+        paint: {
+          // Non-SDF raster: icon-color/halo are ignored, only opacity applies.
           'icon-opacity': ['get', 'opacity'],
         },
       });
@@ -511,7 +549,11 @@ export function Base3DMap({
         },
       });
 
-      map.on('click', NODES_MARKER_LAYER_ID, (e) => {
+      // Bind the same interaction handlers to both icon layers (#4863): the disc
+      // and glyph markers are two layers sharing one source, but click/hover
+      // behave identically.
+      for (const iconLayerId of NODE_ICON_LAYER_IDS) {
+      map.on('click', iconLayerId, (e) => {
         const feature = e.features?.[0];
         const key = feature?.properties?.key;
         if (typeof key !== 'string') return;
@@ -544,12 +586,13 @@ export function Base3DMap({
           setOpenPopup({ key, container });
         }
       });
-      map.on('mouseenter', NODES_MARKER_LAYER_ID, () => {
+      map.on('mouseenter', iconLayerId, () => {
         map.getCanvas().style.cursor = 'pointer';
       });
-      map.on('mouseleave', NODES_MARKER_LAYER_ID, () => {
+      map.on('mouseleave', iconLayerId, () => {
         map.getCanvas().style.cursor = '';
       });
+      }
 
       // Lines source + one line layer per distinct dash pattern (spec §2.1/§3.1),
       // inserted below the node marker/label layers so markers stay clickable


### PR DESCRIPTION
Fixes #4863.

## Symptom

In the 3D terrain map, a repeater/router node showed its role glyph (white circle + tower glyph) when zoomed **in**, but reverted to a plain tinted **disc** when zoomed **out**. Expected: the glyph stays consistent across zoom, matching the 2D map. Shipped in #4808 (v4.15.0).

## Root cause

The node icons were drawn in a **single** MapLibre symbol layer that mixed two image types:
- standard nodes → an **SDF** disc image (tinted via `icon-color`)
- per-type glyph families → **non-SDF** full-color rasters

MapLibre tracks SDF-ness with **one flag per tile bucket**, set by the first icon shaped into that bucket:

```js
// node_modules/maplibre-gl/.../maplibre-gl-csp-worker-dev.js
if (args.bucket.sdfIcons === undefined) args.bucket.sdfIcons = isSDFIcon;
else if (args.bucket.sdfIcons !== isSDFIcon) warnOnce('Cannot mix SDF and non-SDF icons in one buffer');
```

Mixing only warns and draws **every** icon in the bucket in whichever mode won. When a glyph shared a bucket with a disc that set the flag to SDF first, the glyph was rendered in SDF mode — its alpha treated as a distance field — so the white circle collapsed into a solid disc tinted by `icon-color` and the glyph vanished. Which icon wins the per-bucket flag depends on how the GeoJSON source tiles nodes together, and **that changes with zoom** — hence glyph-in, disc-out.

(Ruled out: `category`/`iconImage` flipping by zoom — it's a pure function of node data, recomputed only on `[nodesWithPosition, effectiveMaxAge]` and pushed via `setData` only on `[nodes, loaded]`; no zoom input.)

## Fix

Split the one node-icon layer into two homogeneous layers over the same source, so no bucket ever mixes modes:
- **`nodes-marker`** (SDF disc): `filter: category == 'standard'`, keeps `icon-color` / `icon-halo`.
- **`nodes-glyph`** (new, non-SDF rasters): `filter: category != 'standard'`, **no** `icon-color` / `icon-halo` (the raster is pre-colored; tinting is what flattened it), keeps `icon-opacity` for age dimming.
- Click / mouseenter / mouseleave bind to both layers so glyph markers stay clickable and open popups; line layers still insert before `nodes-marker`, keeping edges below both icon layers.

## Test

New regression test in `Base3DMap.test.tsx`: asserts both filtered layers exist with the right category filters, that only the disc layer carries `icon-color`, and that the glyph layer is click-wired. Fails before the fix (no `nodes-glyph` layer), passes after.

- `Base3DMap`, `nodeGlyphIcons`, `MapAnalysisCanvas`, `DashboardMap`, `Map3DView` suites: 115/115 pass (`success: true`).

## Mesh impact

None — client-side map rendering only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)