### PR TITLE
fix(channels): show the unread bell in the mobile channel dropdown (#4660)

### DIFF
--- a/src/components/ChannelsTab.tsx
+++ b/src/components/ChannelsTab.tsx
@@ -631,11 +631,16 @@ export default function ChannelsTab({
                   const optionTitle = `${encryptionLabel}${locationLabel ? ` · ${locationLabel}` : ''}${
                     channelConfig?.uplinkEnabled ? ` · ${t('channels.mqtt_uplink', 'Uplink')}` : ''
                   }${channelConfig?.downlinkEnabled ? ` · ${t('channels.mqtt_downlink', 'Downlink')}` : ''}`;
+                  // Bell + count for unread channels. A native <option> cannot
+                  // host UiIcon (see the glyphs above), so mirror #4660's
+                  // channel-list bell here with the 🔔 emoji instead.
+                  // eslint-disable-next-line meshmonitor-ui/no-hardcoded-ui-glyph -- #4660 native <option> cannot host UiIcon
+                  const unreadBadge = unread > 0 ? ` 🔔${unread}` : '';
 
                   return (
                     <option key={channelId} value={channelId} title={optionTitle}>
                       {encryptionIcon}{locationIcon ? ` ${locationIcon}` : ''} {displayName} #{channelId} {uplink}
-                      {downlink} {unread > 0 ? `(${unread})` : ''}
+                      {downlink}{unreadBadge}
                     </option>
                   );
                 })}

--- a/src/components/ChannelsTab.unreadDropdownBell.test.tsx
+++ b/src/components/ChannelsTab.unreadDropdownBell.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #4660 follow-up: the channel-list unread bell (#4669) only reached the
+ * desktop expanded list (`.unread-badge` with a <UiIcon>). The mobile channel
+ * picker is a native <select>, which cannot host an SVG icon, so it showed the
+ * unread count as bare "(N)" with no bell. This asserts the dropdown's <option>
+ * now carries a 🔔 emoji + count for unread channels, and nothing for read ones.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ChannelsTab from './ChannelsTab';
+
+vi.mock('../hooks/useServerData', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useNodes: () => ({ nodes: [], isLoading: false, error: null }),
+}));
+
+vi.mock('../contexts/SettingsContext', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useSettings: () => ({ distanceUnit: 'km' }),
+  useNotificationMuteSettings: () => ({
+    isChannelMuted: () => false,
+    muteChannel: async () => {},
+    unmuteChannel: async () => {},
+  }),
+}));
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      (opts && typeof opts === 'object' && 'defaultValue' in opts
+        ? (opts.defaultValue as string)
+        : undefined) ?? key,
+  }),
+}));
+
+beforeAll(() => {
+  if (!('ResizeObserver' in globalThis)) {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+type ChannelsTabProps = React.ComponentProps<typeof ChannelsTab>;
+
+function makeProps(overrides: Partial<ChannelsTabProps> = {}): ChannelsTabProps {
+  const noop = () => {};
+  const asyncNoop = async () => {};
+  return {
+    channels: [
+      { id: 0, name: 'Primary', psk: '', uplinkEnabled: true, downlinkEnabled: true },
+      { id: 2, name: 'gauntlet', psk: '', uplinkEnabled: false, downlinkEnabled: false },
+    ],
+    channelDatabaseEntries: [],
+    channelMessages: {},
+    messages: [],
+    currentNodeId: '!cccccccc',
+    sourceId: 'src1',
+    connectionStatus: 'connected',
+    selectedChannel: 0,
+    setSelectedChannel: noop,
+    selectedChannelRef: { current: 0 },
+    showMqttMessages: true,
+    setShowMqttMessages: noop,
+    newMessage: '',
+    setNewMessage: noop,
+    replyingTo: null,
+    setReplyingTo: noop,
+    unreadCounts: { 2: 3 },
+    setUnreadCounts: noop,
+    markMessagesAsRead: noop,
+    channelInfoModal: null,
+    setChannelInfoModal: noop,
+    showPsk: false,
+    setShowPsk: noop,
+    timeFormat: '24' as const,
+    dateFormat: 'MM/DD/YYYY' as const,
+    hasPermission: () => true,
+    handleSendMessage: asyncNoop,
+    handleResendMessage: asyncNoop,
+    handleDeleteMessage: asyncNoop,
+    handleSendTapback: noop,
+    handlePurgeChannelMessages: asyncNoop,
+    handleSenderClick: noop,
+    onSendBell: asyncNoop,
+    onSendPosition: asyncNoop,
+    shouldShowData: () => true,
+    getNodeName: (id: string) => id,
+    getNodeShortName: (id: string) => id,
+    isMqttBridgeMessage: () => false,
+    setEmojiPickerMessage: noop,
+    channelMessagesContainerRef: { current: null },
+    ...overrides,
+  } as unknown as ChannelsTabProps;
+}
+
+describe('ChannelsTab mobile channel dropdown unread bell (#4660)', () => {
+  it('shows 🔔 + count on an unread channel option and nothing on read ones', () => {
+    render(<ChannelsTab {...makeProps()} />);
+
+    const gauntlet = screen.getByRole('option', { name: /gauntlet/ }) as HTMLOptionElement;
+    const primary = screen.getByRole('option', { name: /Primary/ }) as HTMLOptionElement;
+
+    expect(gauntlet.textContent).toContain('🔔3');
+    expect(primary.textContent).not.toContain('🔔');
+  });
+});


### PR DESCRIPTION
Follow-up to #4669 (issue #4660).

## Problem

#4669 added an unread **bell** to the channel list, but only on the **desktop** expanded list, where the badge is a `<UiIcon>` inside `.unread-badge`. On **mobile**, the channel picker is a native `<select>` — and a native `<option>` cannot render an SVG child — so the bell never showed. The option displayed a bare `(N)` count instead (e.g. `gauntlet #2 (1)`), which is what the reporter saw.

## Fix

Mirror the bell in the dropdown with the 🔔 **emoji**, matching the emoji-glyph pattern this same `<select>` already uses for encryption/location (🔒 🔐 🔓 📍 📌) under the `#4217` `no-hardcoded-ui-glyph` exception — a native `<option>` genuinely can't host `UiIcon`. Unread channels now read `gauntlet #2 🔔3`; read channels are unchanged.

## Test

New `ChannelsTab.unreadDropdownBell.test.tsx`: asserts the unread channel's `<option>` contains `🔔<count>` and a read channel's does not. ChannelsTab suite: 17/17 pass. `lint:ci` clean (the eslint exception matches the existing pattern).

## Mesh impact

None — display only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)