### PR TITLE
feat(unified-messages): show seconds in the reception Heard column (#4869)

### DIFF
--- a/src/pages/UnifiedMessagesPage.tsx
+++ b/src/pages/UnifiedMessagesPage.tsx
@@ -29,6 +29,7 @@ import { useAuth } from '../contexts/AuthContext';
 import apiService from '../services/api';
 import { renderMessageWithLinks } from '../utils/linkRenderer';
 import { senderLabel, shortSenderLabel } from './unifiedSenderLabels';
+import { formatTime, formatTimeWithSeconds } from './unifiedTimeFormat';
 import { foldUnifiedMessagePages } from '../utils/unifiedMessageAccumulator';
 import LinkPreview from '../components/LinkPreview';
 import '../styles/unified.css';
@@ -113,10 +114,6 @@ function isReactionMessage(msg: UnifiedMessage): boolean {
     if (t.length > 0 && t.length <= 8 && EMOJI_RE.test(t)) return true;
   }
   return false;
-}
-
-function formatTime(timestampMs: number): string {
-  return new Date(timestampMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
 function formatDateDivider(timestampMs: number, t: TFn): string {
@@ -685,7 +682,7 @@ export default function UnifiedMessagesPage() {
                       <td>{hopDisplay(r.hopStart, r.hopLimit, t)}</td>
                       <td>{r.rxSnr != null ? `${r.rxSnr.toFixed(1)} dB` : '—'}</td>
                       <td>{r.rxRssi != null ? `${r.rxRssi} dBm` : '—'}</td>
-                      <td>{formatTime(r.timestamp)}</td>
+                      <td>{formatTimeWithSeconds(r.timestamp)}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/src/pages/unifiedTimeFormat.test.ts
+++ b/src/pages/unifiedTimeFormat.test.ts
@@ -1,0 +1,23 @@
+/**
+ * #4869: the reception-details "Heard" column must show second-level precision,
+ * while the message-card time stays at minute precision.
+ */
+import { describe, it, expect } from 'vitest';
+import { formatTime, formatTimeWithSeconds } from './unifiedTimeFormat';
+
+// 2026-08-21T18:32:09 local — a non-zero seconds value so the distinction shows.
+const ts = new Date(2026, 7, 21, 18, 32, 9).getTime();
+
+describe('unified messages time formatting (#4869)', () => {
+  it('formatTimeWithSeconds includes an HH:MM:SS group', () => {
+    expect(formatTimeWithSeconds(ts)).toMatch(/\d{1,2}:\d{2}:\d{2}/);
+  });
+
+  it('formatTime stays at minute precision (no seconds group)', () => {
+    expect(formatTime(ts)).not.toMatch(/\d{1,2}:\d{2}:\d{2}/);
+  });
+
+  it('the Heard column formatter carries the extra second-level detail', () => {
+    expect(formatTimeWithSeconds(ts).length).toBeGreaterThan(formatTime(ts).length);
+  });
+});

--- a/src/pages/unifiedTimeFormat.ts
+++ b/src/pages/unifiedTimeFormat.ts
@@ -1,0 +1,22 @@
+/**
+ * Time formatters for the Unified Messages view, extracted so they can be
+ * unit-tested without rendering the page (same pattern as unifiedSenderLabels).
+ */
+
+/** Message-card timestamp — minute precision (seconds would be visual noise). */
+export function formatTime(timestampMs: number): string {
+  return new Date(timestampMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+/**
+ * Reception "Heard" column time — second-level precision (#4869). Relay-delay
+ * and telemetry-correlation analysis needs seconds, which `formatTime`
+ * deliberately omits for the message list.
+ */
+export function formatTimeWithSeconds(timestampMs: number): string {
+  return new Date(timestampMs).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}


### PR DESCRIPTION
Fixes #4869.

## Summary

On the Unified Messages page, clicking a message opens a per-source **reception** table. Its **Heard** column showed the timestamp at minute precision (e.g. `18:32`) because it reused the message-card `formatTime` (`hour` + `minute` only). Second-level precision helps measure relay delays across hops and correlate receptions with telemetry.

## Change

- Add `formatTimeWithSeconds` (adds `second: '2-digit'`) and use it for the **Heard** column cell only (`UnifiedMessagesPage.tsx`).
- The message-card time keeps minute precision — seconds there would be visual noise and weren't requested.
- Both formatters move to a sibling `unifiedTimeFormat.ts` so they're unit-testable without rendering the page, matching the existing `unifiedSenderLabels.ts` extraction pattern.

## Test

New `unifiedTimeFormat.test.ts`: asserts `formatTimeWithSeconds` emits an `HH:MM:SS` group, `formatTime` does not, and the seconds variant is longer. 9/9 pass across the touched suites; touched files typecheck clean.

## Mesh impact

None — display formatting only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)