### PR TITLE
fix(#4860): white halo on satellite-map node labels

### DIFF
--- a/src/components/map/markerIcons.test.ts
+++ b/src/components/map/markerIcons.test.ts
@@ -209,6 +209,9 @@ describe('createNodeIcon — variant:"meshtastic" (default) unchanged code paths
     // satellite imagery where the backing circle washes out on bright terrain.
     expect(icon.html).toContain('paint-order="stroke"');
     expect(icon.html).toContain('stroke="#ffffff"');
+    // A non-zero width is what actually makes the halo visible — guard against a
+    // future stroke-width="0" that would keep the attributes but disable it.
+    expect(icon.html).toContain('stroke-width="3"');
   });
 
   it('animate + highlightSelected classes are applied when requested', () => {

--- a/src/components/map/markerIcons.test.ts
+++ b/src/components/map/markerIcons.test.ts
@@ -205,6 +205,10 @@ describe('createNodeIcon — variant:"meshtastic" (default) unchanged code paths
     expect(icon.popupAnchor).toEqual([0, -24]);
     expect(icon.html).toContain('ABCD');
     expect(icon.html).toContain(getHopColor(0)); // #22c55e
+    // #4860: the short name carries a white halo so it stays legible over
+    // satellite imagery where the backing circle washes out on bright terrain.
+    expect(icon.html).toContain('paint-order="stroke"');
+    expect(icon.html).toContain('stroke="#ffffff"');
   });
 
   it('animate + highlightSelected classes are applied when requested', () => {

--- a/src/components/map/markerIcons.ts
+++ b/src/components/map/markerIcons.ts
@@ -172,7 +172,11 @@ export function createNodeIcon(options: CreateNodeIconOptions): L.DivIcon {
     ` : `
       <svg width="${circleSize}" height="${circleSize}" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
         <circle cx="24" cy="24" r="20" fill="white" fill-opacity="0.95" stroke="${color}" stroke-width="${strokeWidth}" />
-        <text x="24" y="28" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#333">${shortName || '?'}</text>
+        <!-- White halo under the glyph so the short name stays legible over
+             satellite imagery even where the backing circle washes out against
+             bright terrain (snow/sand/cloud). paint-order draws the stroke first
+             so the dark fill sits on top of its own outline (#4860). -->
+        <text x="24" y="28" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#333" stroke="#ffffff" stroke-width="3" stroke-linejoin="round" paint-order="stroke">${shortName || '?'}</text>
       </svg>
     `;
 


### PR DESCRIPTION
Addresses the **label-readability** half of #4860. (The water-tint half is not fixable in our code — see below.)

## Labels (fixed)

On satellite/hybrid imagery the node **short name** sits inside a white backing circle, but that circle washes out against bright terrain (snow, sand, cloud), leaving the dark `#333` glyph floating with no contrast — hence "labels are very hard to read on satellite."

Added a **white text halo** (`paint-order="stroke"` + white `stroke`) to the official-style short name (`src/components/map/markerIcons.ts:175`), so the glyph is legible over any imagery regardless of whether the backing circle is visible. It helps on every basemap and is visually a no-op on light street maps.

`markerIcons.test.ts` asserts the halo is present on the official pin style. Full marker suite (42) green; `lint:ci` clean. The strict MeshCore byte-parity tests are untouched (I deliberately kept the change to the Meshtastic official style).

## Water tint (not addressed — and why)

The "translucent blue on rivers/lakes" is **not drawn by MeshMonitor**:

- Our provided **Satellite** (`esriSatellite`) is raster ESRI `World_Imagery` — it renders through Leaflet's `TileLayer` with no water layer, no vector style, and no CSS filter of ours.
- Our `water`/`waterway` style layers (`VectorTileLayer.tsx`, the "GeoJSON style features") only apply to **vector** tilesets — never the raster satellite.
- **Hybrid**'s overlay is ESRI's transparent `World_Reference_Overlay` (place names / roads / boundaries) — it paints **no** water fill. (That's a different layer from ESRI's *Hydro* Reference Overlay, which we don't use.)

So the blue is baked into **ESRI's imagery tiles** (the shared satellite base, which flat-fills water bodies where hi-res imagery is unavailable). There's no style/GeoJSON feature or overlay setting of ours to adjust, and dimming the hybrid overlay would only fade the labels without touching the water. Fixing it is a product decision on the imagery source (e.g. a different satellite provider) — worth splitting into its own issue.

## Mesh impact

None — client-only marker styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)