### PR TITLE
feat(automation): node lifecycle triggers — heartbeat-lost & recovery (#4558) [Phase A]

### DIFF
--- a/src/components/automations/SubstitutionsHelp.tsx
+++ b/src/components/automations/SubstitutionsHelp.tsx
@@ -48,6 +48,8 @@ export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
   'trigger.becameMobile': [['nodeNum', 'Node number'], ['previousMobile', 'Previous mobile flag (0)'], ['mobile', 'New mobile flag (1)'], ['latitude', 'Node latitude'], ['longitude', 'Node longitude']],
   'trigger.leftHome': [['nodeNum', 'Node number'], ['latitude', 'Node latitude'], ['longitude', 'Node longitude'], ['homeLat', 'Home latitude'], ['homeLon', 'Home longitude'], ['distanceMeters', 'Distance from home (m)'], ['thresholdMeters', 'Configured threshold (m)']],
   'trigger.meshBeacon': [['nodeNum', 'Node number'], ['message', 'Beacon text'], ['offerChannelName', 'Offered channel name'], ['offerRegion', 'Offered region code'], ['offerPreset', 'Offered modem preset'], ['hasOffer', 'true if the beacon advertises a network']],
+  'trigger.nodeStale': [['nodeNum', 'Node number (Meshtastic)'], ['publicKey', 'Public key (MeshCore)'], ['ageMinutes', 'Minutes since last heard'], ['staleAfterMinutes', 'Configured silence threshold (min)'], ['lastHeard', 'Last-heard time (epoch ms)']],
+  'trigger.nodeOnline': [['nodeNum', 'Node number (Meshtastic)'], ['publicKey', 'Public key (MeshCore)'], ['offlineDurationMinutes', 'Minutes the node was offline'], ['staleAfterMinutes', 'Configured silence threshold (min)']],
   'trigger.schedule': [],
 };
 
@@ -57,6 +59,7 @@ const TRIGGER_LABEL: Record<string, string> = {
   'trigger.nodeDiscovered': 'Node discovered', 'trigger.system': 'System event', 'trigger.geofence': 'Geofence',
   'trigger.becameMobile': 'Became mobile', 'trigger.leftHome': 'Left home', 'trigger.schedule': 'Schedule',
   'trigger.meshBeacon': 'MeshBeacon',
+  'trigger.nodeStale': 'Node silent', 'trigger.nodeOnline': 'Node recovered',
 };
 
 /** Drawer listing every available substitution token (current trigger first). */

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -247,11 +247,31 @@ export const TRIGGERS: BlockDef[] = [
       COOLDOWN_SCOPE,
     ],
   },
+  {
+    type: 'trigger.nodeStale',
+    label: 'A node goes silent (heartbeat lost)',
+    description: 'Fires once when a node has not been heard for longer than the threshold — a health/heartbeat alert. There is no packet to react to here, so silence is checked on a periodic tick (about once a minute) against every node on every source; narrow it with a “Source is one of…” condition. Works for Meshtastic and MeshCore. It will not fire again for that node until it is heard and then goes silent once more.',
+    fields: [
+      { name: 'staleAfterMinutes', label: 'Silent for (minutes)', kind: 'number', placeholder: '60', help: 'Fire when the node has not been heard for this many minutes. Silence is polled on a ~1-minute tick, so expect up to a minute of detection lag.' },
+      COOLDOWN,
+      COOLDOWN_SCOPE,
+    ],
+  },
+  {
+    type: 'trigger.nodeOnline',
+    label: 'A silent node is heard again (recovery)',
+    description: 'Fires once when a node that had been silent longer than the threshold is heard again — the recovery counterpart to “A node goes silent”. Works for Meshtastic and MeshCore.',
+    fields: [
+      { name: 'staleAfterMinutes', label: 'Was silent for (minutes)', kind: 'number', placeholder: '60', help: 'How long the node must have been silent to count as recovered when next heard. Match this to the value on your paired “goes silent” rule.' },
+      COOLDOWN,
+      COOLDOWN_SCOPE,
+    ],
+  },
 ];
 
 // ─── Comparison field registry (event / node / latest-telemetry) ─────────────
 
-const SUBJECT_NODE_TRIGGERS = ['trigger.message', 'trigger.nodeDiscovered', 'trigger.nodeUpdated', 'trigger.telemetry', 'trigger.geofence', 'trigger.becameMobile', 'trigger.leftHome', 'trigger.meshBeacon'];
+const SUBJECT_NODE_TRIGGERS = ['trigger.message', 'trigger.nodeDiscovered', 'trigger.nodeUpdated', 'trigger.telemetry', 'trigger.geofence', 'trigger.becameMobile', 'trigger.leftHome', 'trigger.meshBeacon', 'trigger.nodeStale', 'trigger.nodeOnline'];
 const hasSubjectNode = (t: string) => SUBJECT_NODE_TRIGGERS.includes(t);
 
 const EVENT_NUMERIC: Record<string, FieldOpt[]> = {
@@ -283,6 +303,16 @@ const EVENT_NUMERIC: Record<string, FieldOpt[]> = {
   ],
   'trigger.nodeUpdated': [{ value: 'nodeNum', label: 'Node #' }],
   'trigger.nodeDiscovered': [{ value: 'nodeNum', label: 'Node #' }],
+  'trigger.nodeStale': [
+    { value: 'nodeNum', label: 'Node #' },
+    { value: 'ageMinutes', label: 'Minutes since last heard' },
+    { value: 'staleAfterMinutes', label: 'Silence threshold (min)' },
+  ],
+  'trigger.nodeOnline': [
+    { value: 'nodeNum', label: 'Node #' },
+    { value: 'offlineDurationMinutes', label: 'Minutes offline' },
+    { value: 'staleAfterMinutes', label: 'Silence threshold (min)' },
+  ],
   'trigger.becameMobile': [{ value: 'nodeNum', label: 'Node #' }, { value: 'mobile', label: 'Mobile flag (1)' }, { value: 'previousMobile', label: 'Previous mobile flag' }],
   'trigger.leftHome': [
     { value: 'nodeNum', label: 'Node #' },

--- a/src/components/automations/substitutionNodeTokens.ts
+++ b/src/components/automations/substitutionNodeTokens.ts
@@ -35,4 +35,6 @@ export const SUBJECT_NODE_TRIGGER_TYPES = [
   'trigger.becameMobile',
   'trigger.leftHome',
   'trigger.meshBeacon',
+  'trigger.nodeStale',
+  'trigger.nodeOnline',
 ] as const;

--- a/src/components/map/markerIcons.test.ts
+++ b/src/components/map/markerIcons.test.ts
@@ -209,6 +209,9 @@ describe('createNodeIcon — variant:"meshtastic" (default) unchanged code paths
     // satellite imagery where the backing circle washes out on bright terrain.
     expect(icon.html).toContain('paint-order="stroke"');
     expect(icon.html).toContain('stroke="#ffffff"');
+    // A non-zero width is what actually makes the halo visible — guard against a
+    // future stroke-width="0" that would keep the attributes but disable it.
+    expect(icon.html).toContain('stroke-width="3"');
   });
 
   it('animate + highlightSelected classes are applied when requested', () => {

--- a/src/components/map/markerIcons.test.ts
+++ b/src/components/map/markerIcons.test.ts
@@ -205,6 +205,10 @@ describe('createNodeIcon — variant:"meshtastic" (default) unchanged code paths
     expect(icon.popupAnchor).toEqual([0, -24]);
     expect(icon.html).toContain('ABCD');
     expect(icon.html).toContain(getHopColor(0)); // #22c55e
+    // #4860: the short name carries a white halo so it stays legible over
+    // satellite imagery where the backing circle washes out on bright terrain.
+    expect(icon.html).toContain('paint-order="stroke"');
+    expect(icon.html).toContain('stroke="#ffffff"');
   });
 
   it('animate + highlightSelected classes are applied when requested', () => {

--- a/src/components/map/markerIcons.ts
+++ b/src/components/map/markerIcons.ts
@@ -172,7 +172,11 @@ export function createNodeIcon(options: CreateNodeIconOptions): L.DivIcon {
     ` : `
       <svg width="${circleSize}" height="${circleSize}" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
         <circle cx="24" cy="24" r="20" fill="white" fill-opacity="0.95" stroke="${color}" stroke-width="${strokeWidth}" />
-        <text x="24" y="28" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#333">${shortName || '?'}</text>
+        <!-- White halo under the glyph so the short name stays legible over
+             satellite imagery even where the backing circle washes out against
+             bright terrain (snow/sand/cloud). paint-order draws the stroke first
+             so the dark fill sits on top of its own outline (#4860). -->
+        <text x="24" y="28" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#333" stroke="#ffffff" stroke-width="3" stroke-linejoin="round" paint-order="stroke">${shortName || '?'}</text>
       </svg>
     `;
 

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -38,6 +38,8 @@ import {
   buildGeofenceContext,
   buildBecameMobileContext,
   buildLeftHomeContext,
+  buildNodeStaleContext,
+  buildNodeOnlineContext,
   buildScheduleContext,
   messageMatchesFilter,
   meshCoreMessageMatchesFilter,
@@ -60,6 +62,7 @@ import { executeAction, type ActionDeps } from './actionExecutor.js';
 import {
   type EngineEvalContext,
   type NodeDataProvider,
+  type StaleCandidate,
   varContextFromTrigger,
   resolveOperand,
   cooldownKeyFor,
@@ -128,6 +131,41 @@ const COOLDOWN_KEYS_TRIM_TO = 2048;
  */
 const GEOFENCE_STATE_MAX = 4096;
 const GEOFENCE_STATE_TRIM_TO = 2048;
+
+/**
+ * How often the staleness ticker evaluates node ages (#4558 Phase A). Staleness
+ * is packet ABSENCE, so it cannot be event-driven — the tick is the only signal.
+ * It sends NO mesh packets (airtime cost is zero); it only does DB reads and may
+ * fire automations whose notification spam is bounded by the same
+ * cooldownSeconds/cooldownScope/rateLimit every trigger already has. 60s matches
+ * inactiveNodeNotificationService's tick and means detection lags a "silent for
+ * N minutes" threshold by at most ~1 minute — negligible at minute granularity.
+ */
+const STALE_TICK_INTERVAL_MS = 60_000;
+
+/**
+ * Per-automation staleness-state bounds (#4558 Phase A). Unlike geofenceState,
+ * evicting a stale entry is behaviour-SAFE: a first sighting only ESTABLISHES a
+ * baseline and never fires, so an evicted node simply re-baselines on the next
+ * tick (a still-stale node re-seeds as stale — no spurious "heartbeat lost"; a
+ * fresh node re-seeds fresh). Bounded anyway because an MQTT-fed mesh churns
+ * nodeNums and would otherwise strand one dead entry per node ever seen. Higher
+ * cap than geofence because this watches EVERY node, not only the ones that move.
+ */
+const STALE_STATE_MAX = 8192;
+const STALE_STATE_TRIM_TO = 4096;
+
+/**
+ * Per-(automation, node) staleness baseline (#4558 Phase A). `stale` is whether
+ * the node is currently past its threshold; `lastHeardMs` is the node's last-heard
+ * epoch-ms captured at the last write, used to compute the recovery
+ * offlineDuration; `ts` is when the entry was last touched (eviction ordering).
+ */
+interface StaleEntry {
+  stale: boolean;
+  lastHeardMs: number | null;
+  ts: number;
+}
 
 /** Compact result of evaluating one automation — persisted run-log shape is unchanged;
  *  this is the subset the live trace ("view logs") streams to the browser. */
@@ -223,6 +261,10 @@ export class AutomationEngineService {
   private leftHomeAlarmed = new Map<string, Map<number, boolean>>();
   /** automationId → live cron job, for `trigger.schedule` automations. */
   private cronJobs = new Map<string, { stop: () => void }>();
+  /** automationId → "sourceId:nodeKey" → staleness baseline (#4558 Phase A). */
+  private staleState = new Map<string, Map<string, StaleEntry>>();
+  /** The periodic staleness ticker, or null when not running (#4558 Phase A). */
+  private staleTimer: NodeJS.Timeout | null = null;
 
   constructor(opts: EngineServiceOptions) {
     this.automationsRepo = opts.automationsRepo;
@@ -303,6 +345,13 @@ export class AutomationEngineService {
     // per-node entries, which is the risky case GEOFENCE_STATE_MAX guards.
     for (const id of this.geofenceState.keys()) if (!liveIds.has(id)) this.geofenceState.delete(id);
     for (const id of this.leftHomeAlarmed.keys()) if (!liveIds.has(id)) this.leftHomeAlarmed.delete(id);
+    // Same prune for staleness baselines (#4558): a deleted/disabled automation's
+    // entries are unreachable (runStaleCheck/checkNodeOnline only iterate
+    // `this.index`), so dropping them is unobservable. A still-present automation
+    // keeps its baseline across a reload — so saving OTHER automations never
+    // re-arms a nodeStale timer, and editing this one (same id) never re-fires
+    // "heartbeat lost" for already-stale nodes.
+    for (const id of this.staleState.keys()) if (!liveIds.has(id)) this.staleState.delete(id);
     this.rescheduleCron();
     logger.info(`[AutomationEngine] loaded ${rows.length} enabled automation(s)`);
   }
@@ -328,10 +377,28 @@ export class AutomationEngineService {
     }
   }
 
-  /** Stop all cron jobs (clean shutdown / test teardown). */
+  /** Stop all cron jobs + the staleness ticker (clean shutdown / test teardown). */
   stop(): void {
     for (const job of this.cronJobs.values()) job.stop();
     this.cronJobs.clear();
+    if (this.staleTimer) {
+      clearInterval(this.staleTimer);
+      this.staleTimer = null;
+    }
+  }
+
+  /**
+   * Start the periodic staleness ticker (#4558 Phase A). Idempotent; {@link stop}
+   * clears it. Not started in the constructor so unit tests drive
+   * {@link runStaleCheck} directly against the injected clock without a real timer.
+   */
+  startStaleTicker(intervalMs = STALE_TICK_INTERVAL_MS): void {
+    if (this.staleTimer) return;
+    this.staleTimer = setInterval(() => {
+      this.runStaleCheck().catch((e) => logger.error(`[AutomationEngine] stale check error: ${e?.message}`));
+    }, intervalMs);
+    // Never hold the process open solely for this background timer.
+    if (typeof this.staleTimer.unref === 'function') this.staleTimer.unref();
   }
 
   /**
@@ -1147,6 +1214,167 @@ export class AutomationEngineService {
     return fired;
   }
 
+  // ─── staleness: trigger.nodeStale / trigger.nodeOnline (#4558 Phase A) ──────
+
+  private getStaleBaseline(a: LoadedAutomation, key: string): StaleEntry | undefined {
+    return this.staleState.get(a.id)?.get(key);
+  }
+
+  private setStaleBaseline(a: LoadedAutomation, key: string, entry: StaleEntry): void {
+    let inner = this.staleState.get(a.id);
+    if (!inner) { inner = new Map(); this.staleState.set(a.id, inner); }
+    inner.set(key, entry);
+    if (inner.size > STALE_STATE_MAX) this.pruneStaleState(a, inner);
+  }
+
+  private pruneStaleState(a: LoadedAutomation, inner: Map<string, StaleEntry>): void {
+    if (inner.size <= STALE_STATE_TRIM_TO) return;
+    // Eviction is behaviour-safe (see STALE_STATE_MAX doc): drop the
+    // least-recently-seen entries — those nodes have most likely dropped out of
+    // the enumeration (deleted / churned), and any live one just re-baselines.
+    const byAge = [...inner.entries()].sort((x, y) => x[1].ts - y[1].ts);
+    const dropCount = byAge.length - STALE_STATE_TRIM_TO;
+    for (let i = 0; i < dropCount; i++) inner.delete(byAge[i][0]);
+    logger.debug(`[AutomationEngine] "${a.name}" stale state trimmed to ${inner.size}`);
+  }
+
+  /**
+   * Cooldown + rate-limit gate + fire + trace, shared by both staleness
+   * transitions. Returns 1 if it dispatched, 0 if a guard suppressed it. The
+   * baseline mark is flipped by the CALLER before this runs, so a cooldown that
+   * eats one fire does not cause a re-fire on the next tick — the transition is
+   * recorded regardless of whether its action was allowed to run.
+   */
+  private async fireStaleTransition(a: LoadedAutomation, ctx: TriggerContext, now: number): Promise<number> {
+    const traced = automationTraceBus.activeCount() > 0 && automationTraceBus.isTracing(a.id, now);
+    const gate = this.cooldownGate(a, ctx, now);
+    if (!gate.ok) {
+      if (traced) this.emitTrace(a, ctx, now, { outcome: 'cooldown', reason: gate.reason });
+      return 0;
+    }
+    const rateGate = this.rateLimitGate(a, now);
+    if (!rateGate.ok) {
+      if (traced) this.emitTrace(a, ctx, now, { outcome: 'ratelimited', reason: rateGate.reason });
+      return 0;
+    }
+    this.markFired(a, gate.key, now);
+    this.markRateLimited(a, now);
+    const fr = await this.fireAutomation(a, ctx, now);
+    if (traced) this.emitTrace(a, ctx, now, { outcome: 'fired', status: fr.status, conditionResults: fr.conditionResults, actions: fr.actions, steps: fr.steps });
+    return 1;
+  }
+
+  /**
+   * Periodic staleness evaluation (#4558 Phase A) — the packet-ABSENCE driver for
+   * `trigger.nodeStale` ("heartbeat lost") and `trigger.nodeOnline` ("recovery").
+   *
+   * For every enabled nodeStale/nodeOnline automation, compares each tracked
+   * node's age (now − lastHeard) against that automation's OWN staleAfterMinutes:
+   *  - a node's FIRST sighting only ESTABLISHES a baseline (no fire). This is what
+   *    makes a process restart NOT re-fire "heartbeat lost" for nodes that were
+   *    already stale before the restart — the real state (lastHeard) lives in the
+   *    DB, and the derived baseline is rebuilt silently on the first tick;
+   *  - online → stale fires `trigger.nodeStale` once and marks the node stale;
+   *  - stale → online fires `trigger.nodeOnline` once and clears the mark (also
+   *    reachable faster on a live update via {@link checkNodeOnline}; whichever
+   *    flips the mark first wins, so recovery never double-fires).
+   *
+   * Both triggers maintain the SAME baseline map so recovery is detectable — a
+   * nodeStale automation still marks/clears silently on the recovery side, and a
+   * nodeOnline automation still marks silently on the going-stale side. Returns
+   * the number of automations that dispatched this tick.
+   */
+  async runStaleCheck(): Promise<number> {
+    const autos = [
+      ...(this.index.get('trigger.nodeStale') ?? []),
+      ...(this.index.get('trigger.nodeOnline') ?? []),
+    ];
+    if (autos.length === 0) return 0;
+    if (!this.data.listNodesForStaleCheck) return 0;
+
+    let candidates: StaleCandidate[];
+    try {
+      candidates = await this.data.listNodesForStaleCheck();
+    } catch (e) {
+      logger.error(`[AutomationEngine] stale check node enumeration failed: ${e instanceof Error ? e.message : String(e)}`);
+      return 0;
+    }
+
+    const now = this.now();
+    let fired = 0;
+
+    for (const a of autos) {
+      const thresholdMinutes = Number((a.triggerNode.params as Record<string, unknown>)?.staleAfterMinutes);
+      if (!Number.isFinite(thresholdMinutes) || thresholdMinutes <= 0) continue;
+      const thresholdMs = thresholdMinutes * 60_000;
+      const isStaleTrigger = a.triggerType === 'trigger.nodeStale';
+
+      for (const c of candidates) {
+        if (c.lastHeardMs == null) continue; // never heard → no transition to detect
+        const key = staleKeyFor(c);
+        const isStale = now - c.lastHeardMs >= thresholdMs;
+        const prev = this.getStaleBaseline(a, key);
+
+        if (prev === undefined) {
+          // First sighting after (re)start: baseline only, never a fire.
+          this.setStaleBaseline(a, key, { stale: isStale, lastHeardMs: c.lastHeardMs, ts: now });
+          continue;
+        }
+
+        if (!prev.stale && isStale) {
+          // online → stale. Record the mark first (so a suppressed fire can't re-fire).
+          this.setStaleBaseline(a, key, { stale: true, lastHeardMs: c.lastHeardMs, ts: now });
+          if (isStaleTrigger) {
+            const ageMinutes = Math.max(0, Math.floor((now - c.lastHeardMs) / 60_000));
+            const ctx = buildNodeStaleContext(c.nodeNum, c.publicKey, ageMinutes, thresholdMinutes, c.lastHeardMs, c.sourceId, now);
+            fired += await this.fireStaleTransition(a, ctx, now);
+          }
+        } else if (prev.stale && !isStale) {
+          // stale → online (the tick observed the recovery; the fallback path).
+          const offlineDurationMinutes = Math.max(0, Math.floor((now - (prev.lastHeardMs ?? c.lastHeardMs)) / 60_000));
+          this.setStaleBaseline(a, key, { stale: false, lastHeardMs: c.lastHeardMs, ts: now });
+          if (!isStaleTrigger) {
+            const ctx = buildNodeOnlineContext(c.nodeNum, c.publicKey, offlineDurationMinutes, thresholdMinutes, c.sourceId, now);
+            fired += await this.fireStaleTransition(a, ctx, now);
+          }
+        } else {
+          // No transition — just refresh the touched-timestamp for eviction ordering.
+          this.setStaleBaseline(a, key, { stale: prev.stale, lastHeardMs: prev.lastHeardMs, ts: now });
+        }
+      }
+    }
+    return fired;
+  }
+
+  /**
+   * Live-update recovery path for `trigger.nodeOnline` (#4558 Phase A). Called
+   * when a Meshtastic node update arrives: if any nodeOnline automation had
+   * marked this node stale, fire the recovery now — faster than waiting for the
+   * next stale tick — and clear the mark. The tick reaches the same transition
+   * as a fallback; whichever flips the mark first wins, so it never double-fires.
+   */
+  async checkNodeOnline(nodeNum: number, sourceId: string | null): Promise<number> {
+    const online = this.index.get('trigger.nodeOnline');
+    if (!online || online.length === 0) return 0;
+    const now = this.now();
+    const key = `${sourceId ?? ''}:${nodeNum}`;
+    let fired = 0;
+    for (const a of online) {
+      const prev = this.getStaleBaseline(a, key);
+      if (!prev || !prev.stale) continue;
+      const thresholdMinutes = Number((a.triggerNode.params as Record<string, unknown>)?.staleAfterMinutes);
+      const offlineDurationMinutes = Math.max(0, Math.floor((now - (prev.lastHeardMs ?? now)) / 60_000));
+      // Clear the mark before firing so the tick's fallback can't also fire it.
+      this.setStaleBaseline(a, key, { stale: false, lastHeardMs: now, ts: now });
+      const ctx = buildNodeOnlineContext(
+        nodeNum, null, offlineDurationMinutes,
+        Number.isFinite(thresholdMinutes) ? thresholdMinutes : 0, sourceId, now,
+      );
+      fired += await this.fireStaleTransition(a, ctx, now);
+    }
+    return fired;
+  }
+
   /**
    * Drop in-memory left-home alarmed flags for one automation (e.g. after a
    * homes reset). Persisted anchors are managed by the caller / repository.
@@ -1154,6 +1382,16 @@ export class AutomationEngineService {
   clearLeftHomeRuntimeState(automationId: string): void {
     this.leftHomeAlarmed.delete(automationId);
   }
+}
+
+/**
+ * Per-(source, node) baseline key for the staleness maps. Meshtastic keys off the
+ * numeric node number, MeshCore off the public key — matching {@link staleKeyFor}'s
+ * counterpart in {@link AutomationEngineService.checkNodeOnline} for Meshtastic.
+ */
+function staleKeyFor(c: StaleCandidate): string {
+  const nodeKey = c.nodeNum != null ? String(c.nodeNum) : (c.publicKey ?? '');
+  return `${c.sourceId ?? ''}:${nodeKey}`;
 }
 
 /** EMA weight for leftHome anchor refinement (new fix vs existing home). */

--- a/src/server/services/automation/automationEngineSingleton.ts
+++ b/src/server/services/automation/automationEngineSingleton.ts
@@ -83,6 +83,8 @@ export async function startAutomationEngine(): Promise<void> {
   });
   await engine.load();
   subscribe();
+  // Staleness is packet ABSENCE, so it needs a timer, not an event (#4558 Phase A).
+  engine.startStaleTicker();
   logger.info('[AutomationEngine] started');
   // Fire the system-start event so `trigger.system` (event: bootup) automations run.
   engine.onSystem('bootup', null, null).catch((e) => logger.error(`[AutomationEngine] bootup trigger error: ${e?.message}`));
@@ -126,6 +128,9 @@ async function handleEvent(event: DataEvent): Promise<void> {
       // Discovered vs updated detection (isNew) is deferred to a later phase; fire
       // as nodeUpdated with the changed field keys.
       await e.onNode('trigger.nodeUpdated', nodeNum, changed, sourceId);
+      // Hearing a node again is the fast recovery signal for trigger.nodeOnline
+      // (#4558 Phase A) — the stale tick catches it as a fallback otherwise.
+      await e.checkNodeOnline(nodeNum, sourceId);
       // Geofence + left-home checks only matter when position changed.
       if (changed.includes('latitude') || changed.includes('longitude')) {
         await e.checkGeofences(nodeNum, sourceId);

--- a/src/server/services/automation/engineContext.ts
+++ b/src/server/services/automation/engineContext.ts
@@ -39,6 +39,23 @@ export interface NodeFacts {
   mobile?: number;
 }
 
+/**
+ * One node's staleness inputs, protocol-agnostic (#4558 Phase A). Emitted by
+ * {@link NodeDataProvider.listNodesForStaleCheck} for the periodic
+ * `trigger.nodeStale` / `trigger.nodeOnline` evaluation. `lastHeardMs` is
+ * normalized to epoch MILLISECONDS regardless of protocol (Meshtastic stores
+ * lastHeard in seconds, MeshCore in ms) so the engine compares one unit.
+ */
+export interface StaleCandidate {
+  sourceId: string | null;
+  /** Meshtastic node number; null for a MeshCore node. */
+  nodeNum: number | null;
+  /** MeshCore public key; null for a Meshtastic node. */
+  publicKey: string | null;
+  /** Epoch ms of last contact, or null if never heard (skipped by the checker). */
+  lastHeardMs: number | null;
+}
+
 /** Hydrates the subject node + latest telemetry during evaluation. Injected for testability. */
 export interface NodeDataProvider {
   getNode(sourceId: string | null, nodeNum: number): Promise<NodeFacts | null>;
@@ -104,6 +121,14 @@ export interface NodeDataProvider {
   /** True when a MeshCore public key belongs to ANY MeshCore source MeshMonitor owns —
    *  cross-source fallback for the self-guard on multi-MC-source / bridge setups (#4577 P2). */
   isOwnPublicKey?(pubkey: string): Promise<boolean>;
+  /**
+   * Enumerate every tracked node with its last-heard time across ALL sources and
+   * BOTH protocols, for the periodic staleness check (`trigger.nodeStale` /
+   * `trigger.nodeOnline`, #4558 Phase A). Staleness is packet ABSENCE — there is
+   * no event to react to — so the engine polls this on a timer instead. Optional;
+   * absent → staleness checks are a no-op (e.g. unit tests that don't wire it).
+   */
+  listNodesForStaleCheck?(): Promise<StaleCandidate[]>;
 }
 
 export interface EngineEvalContext {

--- a/src/server/services/automation/meshNodeData.ts
+++ b/src/server/services/automation/meshNodeData.ts
@@ -5,7 +5,7 @@
  */
 import databaseService from '../../../services/database.js';
 import { ALL_SOURCES } from '../../../db/repositories/index.js';
-import type { NodeDataProvider, NodeFacts } from './engineContext.js';
+import type { NodeDataProvider, NodeFacts, StaleCandidate } from './engineContext.js';
 import { sourceProtocol } from './channelUnify.js';
 import { sourceManagerRegistry } from '../../sourceManagerRegistry.js';
 import { isMeshCoreManager } from '../../sourceManagerTypes.js';
@@ -139,6 +139,45 @@ export function createMeshNodeDataProvider(): NodeDataProvider {
       } catch {
         return false;
       }
+    },
+
+    // #4558 Phase A — enumerate every node across all registered sources with a
+    // last-heard time normalized to epoch ms, for the periodic staleness check.
+    // Best-effort: one source failing must not abort the rest, and an empty list
+    // (or a missing method on an older provider) simply means no staleness fires.
+    async listNodesForStaleCheck() {
+      const out: StaleCandidate[] = [];
+      try {
+        for (const m of sourceManagerRegistry.getAllManagers()) {
+          const sourceId = m.sourceId;
+          try {
+            if (m.sourceType === 'meshcore') {
+              const nodes = await databaseService.meshcore.getNodesBySource(sourceId);
+              for (const n of nodes) {
+                // MeshCore lastHeard is already epoch milliseconds.
+                out.push({ sourceId, nodeNum: null, publicKey: n.publicKey, lastHeardMs: n.lastHeard ?? null });
+              }
+            } else if (m.sourceType !== 'reticulum') {
+              // Meshtastic TCP + MQTT bridge/broker all populate the `nodes` table.
+              const nodes = await databaseService.nodes.getAllNodes(sourceId);
+              for (const n of nodes) {
+                // Meshtastic lastHeard is epoch SECONDS → normalize to ms.
+                out.push({
+                  sourceId,
+                  nodeNum: Number(n.nodeNum),
+                  publicKey: null,
+                  lastHeardMs: n.lastHeard != null ? n.lastHeard * 1000 : null,
+                });
+              }
+            }
+          } catch {
+            // skip this source; keep enumerating the others
+          }
+        }
+      } catch {
+        return out;
+      }
+      return out;
     },
   };
 }

--- a/src/server/services/automation/nodeStale.test.ts
+++ b/src/server/services/automation/nodeStale.test.ts
@@ -1,0 +1,303 @@
+/**
+ * trigger.nodeStale / trigger.nodeOnline — Device Health Phase A (#4558).
+ *
+ * Staleness is packet ABSENCE, so it is driven by a periodic evaluation
+ * (`runStaleCheck`) rather than an event. These tests drive that method directly
+ * against an injected clock and a mutable candidate list, plus the live-update
+ * recovery path (`checkNodeOnline`). They assert the transition semantics that
+ * matter for the mesh-impact checklist: fire exactly once per online→stale
+ * transition, never re-fire while stale, re-arm on recovery, and — crucially —
+ * do NOT re-fire already-stale nodes after a restart.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { AutomationsRepository } from '../../../db/repositories/automations.js';
+import { AutomationVariablesRepository } from '../../../db/repositories/automationVariables.js';
+import { VariableResolver } from './variableResolver.js';
+import { AutomationEngineService } from './automationEngineService.js';
+import type { ActionDeps } from './actionExecutor.js';
+import type { NodeDataProvider, StaleCandidate } from './engineContext.js';
+import type { AutomationGraph } from '../../../types/automation.js';
+import { validateAutomationGraph } from '../../../types/automation.js';
+import * as schema from '../../../db/schema/index.js';
+import { createTestDb } from '../../test-helpers/testDb.js';
+import { automationTraceBus } from './automationTraceBus.js';
+
+const MIN = 60_000;
+
+function recorder() {
+  const calls: Array<{ fn: string; args: any }> = [];
+  const deps: ActionDeps = {
+    sendMessage: async (a) => { calls.push({ fn: 'sendMessage', args: a }); return 1; },
+    sendTapback: async (a) => { calls.push({ fn: 'sendTapback', args: a }); return 2; },
+    manageNode: async (a) => { calls.push({ fn: 'manageNode', args: a }); return 3; },
+    notify: async (a) => { calls.push({ fn: 'notify', args: a }); return 4; },
+    requestData: async (a) => { calls.push({ fn: 'requestData', args: a }); return 5; },
+    rebootDevice: async (a) => { calls.push({ fn: 'rebootDevice', args: a }); return 6; },
+    runScript: async (a) => { calls.push({ fn: 'runScript', args: a }); return { success: true, stdout: '' }; },
+  };
+  return { calls, deps };
+}
+
+/** nodeStale rule that notifies, tokenised so we can read the context fields back. */
+function staleGraph(staleAfterMinutes: number): AutomationGraph {
+  return {
+    version: 1,
+    nodes: [
+      { id: 't', type: 'trigger.nodeStale', params: { staleAfterMinutes } },
+      { id: 'n', type: 'action.notify', params: { title: 'stale', body: 'node={{ trigger.nodeNum }} age={{ trigger.ageMinutes }} thr={{ trigger.staleAfterMinutes }}' } },
+    ],
+    edges: [{ from: 't', to: 'n' }],
+  };
+}
+
+/** nodeOnline (recovery) rule that notifies with the offline duration. */
+function onlineGraph(staleAfterMinutes: number): AutomationGraph {
+  return {
+    version: 1,
+    nodes: [
+      { id: 't', type: 'trigger.nodeOnline', params: { staleAfterMinutes } },
+      { id: 'n', type: 'action.notify', params: { title: 'online', body: 'node={{ trigger.nodeNum }} pk={{ trigger.publicKey }} off={{ trigger.offlineDurationMinutes }}' } },
+    ],
+    edges: [{ from: 't', to: 'n' }],
+  };
+}
+
+describe('trigger.nodeStale / trigger.nodeOnline (#4558)', () => {
+  let db: ReturnType<typeof createTestDb>['sqlite'];
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let autos: AutomationsRepository;
+  let resolver: VariableResolver;
+  let clock: number;
+  let candidates: StaleCandidate[];
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    autos = new AutomationsRepository(drizzleDb, 'sqlite');
+    resolver = new VariableResolver(new AutomationVariablesRepository(drizzleDb, 'sqlite'));
+    clock = 10 * 60 * MIN; // t0 well past epoch so ages stay positive
+    candidates = [];
+  });
+  afterEach(() => { db.close(); automationTraceBus.reset(); automationTraceBus.setSink(null); });
+
+  const data: NodeDataProvider = {
+    getNode: async () => null,
+    getTelemetry: async () => null,
+    listNodesForStaleCheck: async () => candidates,
+  };
+  const engineWith = (deps: ActionDeps) =>
+    new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data, now: () => clock });
+
+  const createEnabled = (name: string, graph: AutomationGraph) =>
+    autos.createAutomation({ name, enabled: true, config: JSON.stringify(graph) });
+
+  // ── validation ────────────────────────────────────────────────────────────
+
+  it('validateAutomationGraph accepts both triggers with a positive threshold', () => {
+    expect(validateAutomationGraph(staleGraph(60)).valid).toBe(true);
+    expect(validateAutomationGraph(onlineGraph(60)).valid).toBe(true);
+  });
+
+  it('validateAutomationGraph rejects a missing / non-positive staleAfterMinutes', () => {
+    const bad = staleGraph(60);
+    (bad.nodes[0].params as any).staleAfterMinutes = 0;
+    expect(validateAutomationGraph(bad).valid).toBe(false);
+    delete (bad.nodes[0].params as any).staleAfterMinutes;
+    expect(validateAutomationGraph(bad).valid).toBe(false);
+  });
+
+  // ── nodeStale core transition semantics ─────────────────────────────────────
+
+  it('fires nodeStale exactly once on the online→stale transition, then never while stale', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('stale', staleGraph(60));
+    const engine = engineWith(deps);
+    await engine.load();
+
+    // Node heard 10 min ago (fresh, threshold 60). First tick baselines it.
+    candidates = [{ sourceId: 'default', nodeNum: 111, publicKey: null, lastHeardMs: clock - 10 * MIN }];
+    expect(await engine.runStaleCheck()).toBe(0);
+    expect(calls).toHaveLength(0);
+
+    // Time passes so age crosses 60 min → fires once.
+    clock += 55 * MIN; // now heard 65 min ago
+    expect(await engine.runStaleCheck()).toBe(1);
+    expect(calls.map((c) => c.fn)).toEqual(['notify']);
+    expect(calls[0].args.body).toBe('node=111 age=65 thr=60');
+
+    // Still silent on the next ticks → no re-fire.
+    clock += 30 * MIN;
+    expect(await engine.runStaleCheck()).toBe(0);
+    clock += 30 * MIN;
+    expect(await engine.runStaleCheck()).toBe(0);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('re-arms: heard again fires nodeOnline once, then going silent fires nodeStale again', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('stale', staleGraph(60));
+    await createEnabled('online', onlineGraph(60));
+    const engine = engineWith(deps);
+    await engine.load();
+
+    // Baseline fresh.
+    candidates = [{ sourceId: 'default', nodeNum: 111, publicKey: null, lastHeardMs: clock - 5 * MIN }];
+    await engine.runStaleCheck();
+
+    // Go stale → nodeStale fires.
+    clock += 60 * MIN;
+    expect(await engine.runStaleCheck()).toBe(1);
+    expect(calls.filter((c) => c.args.title === 'stale')).toHaveLength(1);
+
+    // Heard again (lastHeard jumps to now) → tick fires nodeOnline once.
+    clock += 5 * MIN;
+    candidates = [{ sourceId: 'default', nodeNum: 111, publicKey: null, lastHeardMs: clock }];
+    expect(await engine.runStaleCheck()).toBe(1);
+    const online = calls.filter((c) => c.args.title === 'online');
+    expect(online).toHaveLength(1);
+    // Offline gap = from the last-heard-before-stale (t0-5m) to recovery (t0+65m) ≈ 70 min.
+    expect(online[0].args.body).toBe('node=111 pk= off=70');
+
+    // Recovery does not re-fire while it stays fresh.
+    clock += 5 * MIN;
+    expect(await engine.runStaleCheck()).toBe(0);
+
+    // Goes silent again → nodeStale fires a SECOND time (re-armed).
+    clock += 60 * MIN;
+    candidates = [{ sourceId: 'default', nodeNum: 111, publicKey: null, lastHeardMs: clock - 65 * MIN }];
+    expect(await engine.runStaleCheck()).toBe(1);
+    expect(calls.filter((c) => c.args.title === 'stale')).toHaveLength(2);
+  });
+
+  it('does NOT re-fire nodeStale for already-stale nodes after a restart (baseline only)', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('stale', staleGraph(60));
+    // Fresh engine == a process restart: staleState starts empty.
+    const engine = engineWith(deps);
+    await engine.load();
+
+    // Node has been silent for 3 hours when the engine starts.
+    candidates = [{ sourceId: 'default', nodeNum: 111, publicKey: null, lastHeardMs: clock - 180 * MIN }];
+    expect(await engine.runStaleCheck()).toBe(0); // first sighting → baseline, no fire
+    clock += 30 * MIN;
+    expect(await engine.runStaleCheck()).toBe(0); // still stale, still no fire
+    expect(calls).toHaveLength(0);
+  });
+
+  // ── independence + scoping ──────────────────────────────────────────────────
+
+  it('honours each automation’s own threshold independently', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('fast', staleGraph(30));
+    await createEnabled('slow', staleGraph(120));
+    const engine = engineWith(deps);
+    await engine.load();
+
+    candidates = [{ sourceId: 'default', nodeNum: 111, publicKey: null, lastHeardMs: clock }];
+    await engine.runStaleCheck(); // baseline both
+
+    // 45 min silent: only the 30-min rule fires.
+    clock += 45 * MIN;
+    candidates = [{ sourceId: 'default', nodeNum: 111, publicKey: null, lastHeardMs: clock - 45 * MIN }];
+    expect(await engine.runStaleCheck()).toBe(1);
+    expect(calls).toHaveLength(1);
+
+    // 130 min silent: now the 120-min rule fires too (the fast one stays quiet).
+    clock += 85 * MIN;
+    candidates = [{ sourceId: 'default', nodeNum: 111, publicKey: null, lastHeardMs: clock - 130 * MIN }];
+    expect(await engine.runStaleCheck()).toBe(1);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('scopes state per (source, node): the same node number on two sources is tracked separately', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('stale', staleGraph(60));
+    const engine = engineWith(deps);
+    await engine.load();
+
+    candidates = [
+      { sourceId: 'A', nodeNum: 111, publicKey: null, lastHeardMs: clock - 5 * MIN },
+      { sourceId: 'B', nodeNum: 111, publicKey: null, lastHeardMs: clock - 5 * MIN },
+    ];
+    await engine.runStaleCheck();
+
+    // Only source A goes silent; B keeps being heard.
+    clock += 60 * MIN;
+    candidates = [
+      { sourceId: 'A', nodeNum: 111, publicKey: null, lastHeardMs: clock - 65 * MIN },
+      { sourceId: 'B', nodeNum: 111, publicKey: null, lastHeardMs: clock },
+    ];
+    expect(await engine.runStaleCheck()).toBe(1);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args.sourceId).toBe('A');
+  });
+
+  // ── MeshCore path (pubkey, no node number) ──────────────────────────────────
+
+  it('fires for a MeshCore node keyed by public key, then recovers via the tick', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('stale', staleGraph(60));
+    await createEnabled('online', onlineGraph(60));
+    const engine = engineWith(deps);
+    await engine.load();
+
+    candidates = [{ sourceId: 'mc', nodeNum: null, publicKey: 'ABCDEF', lastHeardMs: clock - 5 * MIN }];
+    await engine.runStaleCheck();
+
+    clock += 60 * MIN;
+    candidates = [{ sourceId: 'mc', nodeNum: null, publicKey: 'ABCDEF', lastHeardMs: clock - 65 * MIN }];
+    expect(await engine.runStaleCheck()).toBe(1);
+    const staleCalls = calls.filter((c) => c.args.title === 'stale');
+    expect(staleCalls).toHaveLength(1);
+
+    // Heard again → nodeOnline fires via the tick fallback (no node:updated for MeshCore).
+    clock += 5 * MIN;
+    candidates = [{ sourceId: 'mc', nodeNum: null, publicKey: 'ABCDEF', lastHeardMs: clock }];
+    expect(await engine.runStaleCheck()).toBe(1);
+    const onlineCalls = calls.filter((c) => c.args.title === 'online');
+    expect(onlineCalls).toHaveLength(1);
+    expect(onlineCalls[0].args.body).toContain('pk=ABCDEF');
+  });
+
+  // ── live-update recovery path ───────────────────────────────────────────────
+
+  it('checkNodeOnline fires nodeOnline immediately when a marked-stale node is heard, and does not double-fire with the tick', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('online', onlineGraph(60));
+    const engine = engineWith(deps);
+    await engine.load();
+
+    // Baseline, then go stale (the tick marks it; nodeOnline rule fires nothing yet).
+    candidates = [{ sourceId: 'default', nodeNum: 111, publicKey: null, lastHeardMs: clock - 5 * MIN }];
+    await engine.runStaleCheck();
+    clock += 60 * MIN;
+    candidates = [{ sourceId: 'default', nodeNum: 111, publicKey: null, lastHeardMs: clock - 65 * MIN }];
+    expect(await engine.runStaleCheck()).toBe(0); // nodeStale-side stays silent for an online rule
+    expect(calls).toHaveLength(0);
+
+    // Live update: node heard again.
+    clock += 1 * MIN;
+    expect(await engine.checkNodeOnline(111, 'default')).toBe(1);
+    expect(calls.filter((c) => c.args.title === 'online')).toHaveLength(1);
+
+    // The next tick sees the node as fresh AND the mark already cleared → no double-fire.
+    candidates = [{ sourceId: 'default', nodeNum: 111, publicKey: null, lastHeardMs: clock }];
+    expect(await engine.runStaleCheck()).toBe(0);
+    expect(calls.filter((c) => c.args.title === 'online')).toHaveLength(1);
+  });
+
+  it('is a no-op when the provider cannot enumerate nodes', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('stale', staleGraph(60));
+    const engine = new AutomationEngineService({
+      automationsRepo: autos, varResolver: resolver, deps,
+      data: { getNode: async () => null, getTelemetry: async () => null }, // no listNodesForStaleCheck
+      now: () => clock,
+    });
+    await engine.load();
+    expect(await engine.runStaleCheck()).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/src/server/services/automation/triggerContext.ts
+++ b/src/server/services/automation/triggerContext.ts
@@ -366,6 +366,73 @@ export function buildNodeContext(
   };
 }
 
+/**
+ * Build the trigger context when a watched node crosses its staleness threshold
+ * (`trigger.nodeStale` — "heartbeat lost", #4558 Phase A). Subject node = the
+ * node that went quiet, so `{{ node.* }}` hydration and node-scoped cooldown work
+ * for Meshtastic. MeshCore nodes carry no numeric node id, so `subjectNodeNum`
+ * is null and `subjectNodeKey` is set explicitly to the public key (the same
+ * degrade a MeshCore DM uses) — that keys per-node cooldown off the pubkey.
+ */
+export function buildNodeStaleContext(
+  nodeNum: number | null,
+  publicKey: string | null,
+  ageMinutes: number,
+  staleAfterMinutes: number,
+  lastHeardMs: number | null,
+  sourceId: string | null,
+  timestamp: number,
+): TriggerContext {
+  return {
+    triggerType: 'trigger.nodeStale',
+    sourceId,
+    subjectNodeNum: nodeNum == null ? null : Number(nodeNum),
+    // undefined ⇒ derive from subjectNodeNum (Meshtastic); explicit pubkey for MeshCore.
+    subjectNodeKey: nodeNum == null ? (publicKey ?? null) : undefined,
+    timestamp,
+    fields: {
+      nodeNum: nodeNum == null ? null : Number(nodeNum),
+      publicKey: publicKey ?? undefined,
+      ageMinutes,
+      staleAfterMinutes,
+      lastHeard: lastHeardMs ?? undefined,
+      sourceId,
+      timestamp,
+    },
+  };
+}
+
+/**
+ * Build the trigger context when a previously-stale node is heard again
+ * (`trigger.nodeOnline` — "recovery", #4558 Phase A). Mirrors
+ * {@link buildNodeStaleContext}; `offlineDurationMinutes` is the gap between the
+ * last time we heard the node before it went silent and now hearing it again.
+ */
+export function buildNodeOnlineContext(
+  nodeNum: number | null,
+  publicKey: string | null,
+  offlineDurationMinutes: number,
+  staleAfterMinutes: number,
+  sourceId: string | null,
+  timestamp: number,
+): TriggerContext {
+  return {
+    triggerType: 'trigger.nodeOnline',
+    sourceId,
+    subjectNodeNum: nodeNum == null ? null : Number(nodeNum),
+    subjectNodeKey: nodeNum == null ? (publicKey ?? null) : undefined,
+    timestamp,
+    fields: {
+      nodeNum: nodeNum == null ? null : Number(nodeNum),
+      publicKey: publicKey ?? undefined,
+      offlineDurationMinutes,
+      staleAfterMinutes,
+      sourceId,
+      timestamp,
+    },
+  };
+}
+
 /** Build the trigger context for a single telemetry reading (engine fans the batch out). */
 export function buildTelemetryContext(
   nodeNum: number,

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -24,7 +24,9 @@ export type TriggerType =
   | 'trigger.geofence'
   | 'trigger.becameMobile'
   | 'trigger.leftHome'
-  | 'trigger.meshBeacon';
+  | 'trigger.meshBeacon'
+  | 'trigger.nodeStale'
+  | 'trigger.nodeOnline';
 
 export type ConditionType =
   | 'condition.always'
@@ -71,6 +73,8 @@ export const TRIGGER_TYPES: readonly TriggerType[] = [
   'trigger.becameMobile',
   'trigger.leftHome',
   'trigger.meshBeacon',
+  'trigger.nodeStale',
+  'trigger.nodeOnline',
 ];
 
 export const CONDITION_TYPES: readonly ConditionType[] = [
@@ -529,6 +533,19 @@ export function validateAutomationGraph(input: unknown): ValidationResult {
             if (!Number.isFinite(thr) || thr <= 0) {
               errors.push(`trigger.leftHome "${n.id}" requires params.thresholdMeters > 0`);
             }
+          }
+          break;
+        }
+        case 'trigger.nodeStale':
+        case 'trigger.nodeOnline': {
+          // Staleness is packet ABSENCE (#4558 Phase A): the threshold defines
+          // what "silent long enough" means for BOTH the going-silent alert and
+          // its recovery counterpart, so both require a positive minutes value.
+          const thrMin = p.staleAfterMinutes == null || p.staleAfterMinutes === ''
+            ? NaN
+            : Number(p.staleAfterMinutes);
+          if (!Number.isFinite(thrMin) || thrMin <= 0) {
+            errors.push(`${n.type} "${n.id}" requires params.staleAfterMinutes > 0`);
           }
           break;
         }


### PR DESCRIPTION
Phase A of Device Health (#4558). Adds the two triggers that cover the issue's core complaint — a battery/remote node going silent and coming back — as generic Automation Engine triggers (no bespoke feature), so they compose with conditions, cooldowns, and any notify action.

## New triggers

- **`trigger.nodeStale`** ("heartbeat lost") — a node not heard for ≥ `staleAfterMinutes`.
- **`trigger.nodeOnline`** ("recovery") — a previously-stale node heard again.

Both work for **Meshtastic and MeshCore**, are **per-source** scoped, and are `condition.sourceFilter`-compatible.

## Design — staleness is packet *absence*

Detection is a **60s engine tick** (`runStaleCheck`), not an event: it evaluates each enabled nodeStale rule's own `staleAfterMinutes` against every node's `lastHeard` across all sources. Recovery also fires instantly on a live Meshtastic `node:updated`, with the tick as the MeshCore fallback; whichever flips the mark first wins, so no double-fire.

**Restart-safe (mesh-impact checklist §3):** the first tick after boot only *establishes* a per-(automation, source, node) baseline from the DB `lastHeard` — an already-stale node is marked stale **without firing** "heartbeat lost". So a restart, or saving/editing another automation, never replays alerts. `online→stale` and `stale→online` each fire once and re-arm; existing `cooldownSeconds`/`cooldownScope`/`rateLimit` still apply. State map bounded (8192/4096) with re-baseline-safe eviction.

## Mesh impact

**Zero airtime** — the tick sends no packets; it only reads `lastHeard`. Notification volume is bounded by the existing per-trigger cooldown/rate-limit (user-set), so no new limit was introduced.

## Tokens

- nodeStale: `node.*`, `ageMinutes`, `staleAfterMinutes`, `lastHeard`, `sourceId`
- nodeOnline: `node.*`, `offlineDurationMinutes`, `staleAfterMinutes`, `sourceId`

## Tests

New `nodeStale.test.ts` (10 cases): fire-once/no-re-fire, re-arm, **restart-no-refire**, per-automation threshold independence, per-(source,node) scoping, MeshCore pubkey path, live-update recovery + no-double-fire, provider-absent no-op, validation accept/reject. Full vitest suite: **0 failures**; `catalog.integrity` + `validateAutomationGraph` accept the new triggers; server tsc clean; `lint:ci` clean.

## Scope

Phase A of a 6-phase epic (A: lifecycle · B: uptime-reset · C: powered-state · D: noise-floor field · E: charging-trend · F: **Device Health template**). This PR is backend + catalog + tests only — the quick-create template lands in Phase F once all triggers exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)