### PR TITLE
feat(automation): nodeRebooted trigger — uptime-reset detection (#4558) [Phase B]

### DIFF
--- a/src/components/automations/SubstitutionsHelp.tsx
+++ b/src/components/automations/SubstitutionsHelp.tsx
@@ -50,6 +50,7 @@ export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
   'trigger.meshBeacon': [['nodeNum', 'Node number'], ['message', 'Beacon text'], ['offerChannelName', 'Offered channel name'], ['offerRegion', 'Offered region code'], ['offerPreset', 'Offered modem preset'], ['hasOffer', 'true if the beacon advertises a network']],
   'trigger.nodeStale': [['nodeNum', 'Node number (Meshtastic)'], ['publicKey', 'Public key (MeshCore)'], ['ageMinutes', 'Minutes since last heard'], ['staleAfterMinutes', 'Configured silence threshold (min)'], ['lastHeard', 'Last-heard time (epoch ms)']],
   'trigger.nodeOnline': [['nodeNum', 'Node number (Meshtastic)'], ['publicKey', 'Public key (MeshCore)'], ['offlineDurationMinutes', 'Minutes the node was offline'], ['staleAfterMinutes', 'Configured silence threshold (min)']],
+  'trigger.nodeRebooted': [['nodeNum', 'Node number'], ['previousUptimeSeconds', 'Uptime before the reset (s)'], ['uptimeSeconds', 'Uptime after the reset (s)']],
   'trigger.schedule': [],
 };
 
@@ -60,6 +61,7 @@ const TRIGGER_LABEL: Record<string, string> = {
   'trigger.becameMobile': 'Became mobile', 'trigger.leftHome': 'Left home', 'trigger.schedule': 'Schedule',
   'trigger.meshBeacon': 'MeshBeacon',
   'trigger.nodeStale': 'Node silent', 'trigger.nodeOnline': 'Node recovered',
+  'trigger.nodeRebooted': 'Node rebooted',
 };
 
 /** Drawer listing every available substitution token (current trigger first). */

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -267,11 +267,20 @@ export const TRIGGERS: BlockDef[] = [
       COOLDOWN_SCOPE,
     ],
   },
+  {
+    type: 'trigger.nodeRebooted',
+    label: 'A node reboots unexpectedly',
+    description: 'Fires when a node’s uptime counter resets — the sign of an unexpected restart. Detected from the uptime telemetry a node already reports, by comparing each new reading against the last stored one; there is no extra polling and no packet is sent. Meshtastic only for now. It never fires on the first uptime reading for a node (no prior to compare).',
+    fields: [
+      COOLDOWN,
+      COOLDOWN_SCOPE,
+    ],
+  },
 ];
 
 // ─── Comparison field registry (event / node / latest-telemetry) ─────────────
 
-const SUBJECT_NODE_TRIGGERS = ['trigger.message', 'trigger.nodeDiscovered', 'trigger.nodeUpdated', 'trigger.telemetry', 'trigger.geofence', 'trigger.becameMobile', 'trigger.leftHome', 'trigger.meshBeacon', 'trigger.nodeStale', 'trigger.nodeOnline'];
+const SUBJECT_NODE_TRIGGERS = ['trigger.message', 'trigger.nodeDiscovered', 'trigger.nodeUpdated', 'trigger.telemetry', 'trigger.geofence', 'trigger.becameMobile', 'trigger.leftHome', 'trigger.meshBeacon', 'trigger.nodeStale', 'trigger.nodeOnline', 'trigger.nodeRebooted'];
 const hasSubjectNode = (t: string) => SUBJECT_NODE_TRIGGERS.includes(t);
 
 const EVENT_NUMERIC: Record<string, FieldOpt[]> = {
@@ -312,6 +321,11 @@ const EVENT_NUMERIC: Record<string, FieldOpt[]> = {
     { value: 'nodeNum', label: 'Node #' },
     { value: 'offlineDurationMinutes', label: 'Minutes offline' },
     { value: 'staleAfterMinutes', label: 'Silence threshold (min)' },
+  ],
+  'trigger.nodeRebooted': [
+    { value: 'nodeNum', label: 'Node #' },
+    { value: 'previousUptimeSeconds', label: 'Uptime before reset (s)' },
+    { value: 'uptimeSeconds', label: 'Uptime after reset (s)' },
   ],
   'trigger.becameMobile': [{ value: 'nodeNum', label: 'Node #' }, { value: 'mobile', label: 'Mobile flag (1)' }, { value: 'previousMobile', label: 'Previous mobile flag' }],
   'trigger.leftHome': [

--- a/src/components/automations/substitutionNodeTokens.ts
+++ b/src/components/automations/substitutionNodeTokens.ts
@@ -37,4 +37,5 @@ export const SUBJECT_NODE_TRIGGER_TYPES = [
   'trigger.meshBeacon',
   'trigger.nodeStale',
   'trigger.nodeOnline',
+  'trigger.nodeRebooted',
 ] as const;

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -52,6 +52,7 @@ import { shouldGateAutomations, averageStrongestNeighborUtilization, DEFAULT_AIR
 import { resolveLastHopName } from './utils/lastHop.js';
 import { isRelayedReception } from './utils/packetHops.js';
 import { resolveLastHeardSec } from './utils/replayGuard.js';
+import { isUptimeReboot } from './utils/rebootDetection.js';
 import { autoAckIsZeroHop, autoAckCellKey, resolveAutoAckReplyRouting } from './utils/autoAckDecision.js';
 import { hopCountEmoji, HOP_COUNT_EMOJIS } from '../utils/hopEmoji.js';
 import { scriptDependencyEnv } from './utils/scriptRunner.js';
@@ -1383,6 +1384,12 @@ class MeshtasticManager implements ISourceManager {
     const now = Date.now();
     for (const metric of metricsToSave) {
       if (metric.value !== undefined && metric.value !== null && !isNaN(Number(metric.value))) {
+        // Device Health (#4558 Phase B): an uptime reset is a reboot. Read the
+        // PRIOR stored uptime (persistent baseline — restart-safe) BEFORE
+        // inserting this reading and compare. DB read only, no packet sent.
+        if (metric.type === 'uptimeSeconds') {
+          await this.detectRebootFromUptime(nodeId, fromNum, Number(metric.value));
+        }
         await databaseService.telemetry.insertTelemetry({
           nodeId,
           nodeNum: fromNum,
@@ -1395,6 +1402,31 @@ class MeshtasticManager implements ISourceManager {
           packetId
         }, this.sourceId);
       }
+    }
+  }
+
+  /**
+   * Detect an unexpected reboot from an incoming `uptimeSeconds` reading
+   * (Device Health #4558 Phase B). Compares the new value against the node's
+   * latest stored uptime — read from the DB, so a MeshMonitor restart can never
+   * spuriously fire (the baseline is the durable row, not in-memory state). The
+   * first-ever reading has no prior and never fires. On a genuine reset (a real
+   * decrease beyond {@link REBOOT_UPTIME_SLACK_SECONDS}), emit `node:rebooted`
+   * for the automation engine. Must run BEFORE the new row is inserted so the
+   * "latest" it reads is genuinely the prior reading.
+   */
+  private async detectRebootFromUptime(nodeId: string, nodeNum: number, newUptimeSeconds: number): Promise<void> {
+    try {
+      const prior = await databaseService.telemetry.getLatestTelemetryForType(nodeId, 'uptimeSeconds', this.sourceId);
+      const priorUptime = prior ? Number(prior.value) : null;
+      if (!isUptimeReboot(priorUptime, newUptimeSeconds)) return;
+      logger.info(`🔁 Node ${nodeNum} reboot detected: uptime ${priorUptime}s → ${newUptimeSeconds}s (source ${this.sourceId})`);
+      dataEventEmitter.emitNodeRebooted(
+        { nodeNum, previousUptimeSeconds: priorUptime as number, uptimeSeconds: newUptimeSeconds },
+        this.sourceId,
+      );
+    } catch (e) {
+      logger.warn(`Reboot detection failed for node ${nodeNum}: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -40,6 +40,7 @@ import {
   buildLeftHomeContext,
   buildNodeStaleContext,
   buildNodeOnlineContext,
+  buildNodeRebootedContext,
   buildScheduleContext,
   messageMatchesFilter,
   meshCoreMessageMatchesFilter,
@@ -895,6 +896,28 @@ export class AutomationEngineService {
         return `telemetry "${telemetryType}" ≠ rule metric "${want}"`;
       },
     );
+  }
+
+  /**
+   * A node's uptime counter reset — an unexpected reboot (`trigger.nodeRebooted`,
+   * Device Health #4558 Phase B). Detection (reading the prior uptime from the
+   * DB and comparing) already happened at the telemetry-save seam, so this is a
+   * pure event entry point: build the context and fire.
+   *
+   * No self-origin guard (#3914) here — unlike {@link onTelemetry}. This is a
+   * health signal in the same family as {@link runStaleCheck}'s nodeStale/
+   * nodeOnline, which also don't drop our own node: knowing your OWN gateway
+   * rebooted is useful, and a reboot is not something an automation action can
+   * cause, so there is no self-trigger loop to guard against.
+   */
+  async onNodeRebooted(
+    nodeNum: number,
+    previousUptimeSeconds: number,
+    uptimeSeconds: number,
+    sourceId: string | null,
+  ): Promise<number> {
+    const ctx = buildNodeRebootedContext(nodeNum, previousUptimeSeconds, uptimeSeconds, sourceId, this.now());
+    return this.runTrigger(ctx);
   }
 
   /**

--- a/src/server/services/automation/automationEngineSingleton.ts
+++ b/src/server/services/automation/automationEngineSingleton.ts
@@ -139,6 +139,15 @@ async function handleEvent(event: DataEvent): Promise<void> {
       break;
     }
 
+    case 'node:rebooted': {
+      // Device Health (#4558 Phase B): the telemetry-save seam detected a node's
+      // uptime reset. Fire trigger.nodeRebooted. Detection state lives in the DB
+      // (the prior uptime row), not here, so this is a pure event forward.
+      const data = event.data as { nodeNum: number; previousUptimeSeconds: number; uptimeSeconds: number };
+      await e.onNodeRebooted(data.nodeNum, data.previousUptimeSeconds, data.uptimeSeconds, sourceId);
+      break;
+    }
+
     case 'node:mobility': {
       const data = event.data as {
         nodeNum: number;

--- a/src/server/services/automation/nodeRebooted.test.ts
+++ b/src/server/services/automation/nodeRebooted.test.ts
@@ -1,0 +1,214 @@
+/**
+ * trigger.nodeRebooted — Device Health Phase B (#4558).
+ *
+ * A reboot is an uptime RESET: the new `uptimeSeconds` reading is lower than the
+ * node's prior stored reading. Detection lives at the telemetry-save seam, which
+ * reads the prior value from the DB (persistent, so restart-safe) and compares
+ * via the pure {@link isUptimeReboot} helper; the engine's {@link onNodeRebooted}
+ * is a plain event entry point that fires the automation.
+ *
+ * These tests cover both halves:
+ *  - the detection decision (fires on a real drop; not on a rise; not on the
+ *    first reading; ignores jitter within slack; restart-safe; per-source),
+ *    driven through the REAL telemetry repository + DB read the seam uses;
+ *  - the engine firing + token surface + graph validation.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { AutomationsRepository } from '../../../db/repositories/automations.js';
+import { AutomationVariablesRepository } from '../../../db/repositories/automationVariables.js';
+import { TelemetryRepository } from '../../../db/repositories/telemetry.js';
+import { VariableResolver } from './variableResolver.js';
+import { AutomationEngineService } from './automationEngineService.js';
+import type { ActionDeps } from './actionExecutor.js';
+import type { NodeDataProvider } from './engineContext.js';
+import type { AutomationGraph } from '../../../types/automation.js';
+import { validateAutomationGraph } from '../../../types/automation.js';
+import { isUptimeReboot, REBOOT_UPTIME_SLACK_SECONDS } from '../../utils/rebootDetection.js';
+import * as schema from '../../../db/schema/index.js';
+import { createTestDb } from '../../test-helpers/testDb.js';
+import { automationTraceBus } from './automationTraceBus.js';
+
+function recorder() {
+  const calls: Array<{ fn: string; args: any }> = [];
+  const deps: ActionDeps = {
+    sendMessage: async (a) => { calls.push({ fn: 'sendMessage', args: a }); return 1; },
+    sendTapback: async (a) => { calls.push({ fn: 'sendTapback', args: a }); return 2; },
+    manageNode: async (a) => { calls.push({ fn: 'manageNode', args: a }); return 3; },
+    notify: async (a) => { calls.push({ fn: 'notify', args: a }); return 4; },
+    requestData: async (a) => { calls.push({ fn: 'requestData', args: a }); return 5; },
+    rebootDevice: async (a) => { calls.push({ fn: 'rebootDevice', args: a }); return 6; },
+    runScript: async (a) => { calls.push({ fn: 'runScript', args: a }); return { success: true, stdout: '' }; },
+  };
+  return { calls, deps };
+}
+
+/** nodeRebooted rule that notifies, tokenised so we can read the context back. */
+function rebootGraph(): AutomationGraph {
+  return {
+    version: 1,
+    nodes: [
+      { id: 't', type: 'trigger.nodeRebooted', params: {} },
+      { id: 'n', type: 'action.notify', params: { title: 'reboot', body: 'node={{ trigger.nodeNum }} prev={{ trigger.previousUptimeSeconds }} now={{ trigger.uptimeSeconds }} src={{ trigger.sourceId }}' } },
+    ],
+    edges: [{ from: 't', to: 'n' }],
+  };
+}
+
+// ─── detection decision (pure helper) ───────────────────────────────────────
+
+describe('isUptimeReboot (#4558 Phase B)', () => {
+  it('fires when uptime drops well below the prior reading', () => {
+    expect(isUptimeReboot(86_400, 30)).toBe(true);       // a day of uptime → 30 s
+    expect(isUptimeReboot(3_600, 5)).toBe(true);
+  });
+
+  it('does NOT fire when uptime increases normally', () => {
+    expect(isUptimeReboot(3_600, 3_660)).toBe(false);    // +60 s, a normal interval
+    expect(isUptimeReboot(3_600, 3_600)).toBe(false);    // unchanged
+  });
+
+  it('does NOT fire on the first-ever reading (no prior)', () => {
+    expect(isUptimeReboot(null, 3_600)).toBe(false);
+    expect(isUptimeReboot(undefined, 42)).toBe(false);
+  });
+
+  it('ignores a tiny decrease within the jitter slack', () => {
+    // Prior 1000, new 995 — a 5 s dip (rounding / slight reorder), < slack.
+    expect(isUptimeReboot(1_000, 1_000 - (REBOOT_UPTIME_SLACK_SECONDS - 1))).toBe(false);
+    // A decrease exactly at the slack boundary is not yet a reboot (strict <).
+    expect(isUptimeReboot(1_000, 1_000 - REBOOT_UPTIME_SLACK_SECONDS)).toBe(false);
+    // One second past the slack IS a reboot.
+    expect(isUptimeReboot(1_000, 1_000 - REBOOT_UPTIME_SLACK_SECONDS - 1)).toBe(true);
+  });
+
+  it('ignores non-finite readings', () => {
+    expect(isUptimeReboot(1_000, NaN)).toBe(false);
+    expect(isUptimeReboot(NaN, 10)).toBe(false);
+  });
+});
+
+// ─── detection through the real DB read the seam uses ────────────────────────
+
+describe('reboot detection via getLatestTelemetryForType (#4558 Phase B)', () => {
+  let db: ReturnType<typeof createTestDb>['sqlite'];
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let telem: TelemetryRepository;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    telem = new TelemetryRepository(drizzleDb, 'sqlite');
+  });
+  afterEach(() => { db.close(); });
+
+  const insertUptime = (nodeId: string, nodeNum: number, value: number, ts: number, sourceId: string) =>
+    telem.insertTelemetry(
+      { nodeId, nodeNum, telemetryType: 'uptimeSeconds', timestamp: ts, value, unit: 's', createdAt: ts },
+      sourceId,
+    );
+
+  /** Replays the seam's decision: read prior for the source, compare, no insert. */
+  const wouldReboot = async (nodeId: string, newValue: number, sourceId: string) => {
+    const prior = await telem.getLatestTelemetryForType(nodeId, 'uptimeSeconds', sourceId);
+    return isUptimeReboot(prior ? Number(prior.value) : null, newValue);
+  };
+
+  it('first reading has no prior, so nothing fires', async () => {
+    expect(await wouldReboot('!node', 3_600, 'default')).toBe(false);
+  });
+
+  it('a rising reading after a stored one does not fire; a reset does', async () => {
+    await insertUptime('!node', 111, 3_600, 1_000, 'default');
+    expect(await wouldReboot('!node', 7_200, 'default')).toBe(false); // still climbing
+    expect(await wouldReboot('!node', 12, 'default')).toBe(true);     // reset
+  });
+
+  it('is restart-safe: the prior comes from the DB, not memory', async () => {
+    // Simulate a MeshMonitor restart by using a brand-new repository instance
+    // (no carried-over in-memory baseline) against the same DB.
+    await insertUptime('!node', 111, 10_000, 1_000, 'default');
+    const freshTelem = new TelemetryRepository(drizzleDb, 'sqlite');
+    const priorFromDb = await freshTelem.getLatestTelemetryForType('!node', 'uptimeSeconds', 'default');
+    // A continuing-to-climb reading after the "restart" does NOT spuriously fire…
+    expect(isUptimeReboot(Number(priorFromDb!.value), 10_060)).toBe(false);
+    // …and a genuine reset still fires — the durable row is the only baseline.
+    expect(isUptimeReboot(Number(priorFromDb!.value), 5)).toBe(true);
+  });
+
+  it('scopes the prior per source: a reboot on A ignores B’s uptime', async () => {
+    // Same nodeId on two sources; A is up 1 h, B is up 10 h.
+    await insertUptime('!node', 111, 3_600, 1_000, 'A');
+    await insertUptime('!node', 111, 36_000, 1_000, 'B');
+    // A new reading of 30 s on A is a reboot vs A's own 3 600 s prior…
+    expect(await wouldReboot('!node', 30, 'A')).toBe(true);
+    // …and the SAME 30 s on B is also a reboot vs B's own 36 000 s prior —
+    // each source reads its own baseline, never the other's.
+    expect(await wouldReboot('!node', 30, 'B')).toBe(true);
+    // A reading of 3 610 s (a normal climb for A) must NOT read B's 36 000 s and
+    // look like a reboot: scoped to A, it is a rise.
+    expect(await wouldReboot('!node', 3_610, 'A')).toBe(false);
+  });
+});
+
+// ─── engine firing + tokens + validation ─────────────────────────────────────
+
+describe('trigger.nodeRebooted engine (#4558 Phase B)', () => {
+  let db: ReturnType<typeof createTestDb>['sqlite'];
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let autos: AutomationsRepository;
+  let resolver: VariableResolver;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    autos = new AutomationsRepository(drizzleDb, 'sqlite');
+    resolver = new VariableResolver(new AutomationVariablesRepository(drizzleDb, 'sqlite'));
+  });
+  afterEach(() => { db.close(); automationTraceBus.reset(); automationTraceBus.setSink(null); });
+
+  const data: NodeDataProvider = {
+    getNode: async () => null,
+    getTelemetry: async () => null,
+  };
+  const engineWith = (deps: ActionDeps) =>
+    new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data, now: () => 1_000 });
+
+  const createEnabled = (name: string, graph: AutomationGraph) =>
+    autos.createAutomation({ name, enabled: true, config: JSON.stringify(graph) });
+
+  it('validateAutomationGraph accepts a nodeRebooted rule (no required params)', () => {
+    expect(validateAutomationGraph(rebootGraph()).valid).toBe(true);
+  });
+
+  it('fires once on a reboot event, exposing the uptime tokens', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('reboot', rebootGraph());
+    const engine = engineWith(deps);
+    await engine.load();
+
+    expect(await engine.onNodeRebooted(111, 86_400, 12, 'default')).toBe(1);
+    expect(calls.map((c) => c.fn)).toEqual(['notify']);
+    expect(calls[0].args.body).toBe('node=111 prev=86400 now=12 src=default');
+  });
+
+  it('does not fire when no nodeRebooted automation is loaded', async () => {
+    const { calls, deps } = recorder();
+    const engine = engineWith(deps);
+    await engine.load();
+    expect(await engine.onNodeRebooted(111, 86_400, 12, 'default')).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('carries the event source id into the context', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('reboot', rebootGraph());
+    const engine = engineWith(deps);
+    await engine.load();
+
+    await engine.onNodeRebooted(222, 5_000, 3, 'sourceZ');
+    expect(calls[0].args.body).toBe('node=222 prev=5000 now=3 src=sourceZ');
+  });
+});

--- a/src/server/services/automation/triggerContext.ts
+++ b/src/server/services/automation/triggerContext.ts
@@ -433,6 +433,36 @@ export function buildNodeOnlineContext(
   };
 }
 
+/**
+ * Build the trigger context when a node's uptime counter resets, i.e. an
+ * unexpected reboot (`trigger.nodeRebooted` — Device Health #4558 Phase B).
+ * Subject node = the node that rebooted, so `{{ node.* }}` hydration and
+ * node-scoped cooldown work. Detection (reading the prior uptime from the DB and
+ * comparing) happens at the telemetry-save seam; this builder only shapes what
+ * the conditions / interpolation read.
+ */
+export function buildNodeRebootedContext(
+  nodeNum: number,
+  previousUptimeSeconds: number,
+  uptimeSeconds: number,
+  sourceId: string | null,
+  timestamp: number,
+): TriggerContext {
+  return {
+    triggerType: 'trigger.nodeRebooted',
+    sourceId,
+    subjectNodeNum: Number(nodeNum),
+    timestamp,
+    fields: {
+      nodeNum: Number(nodeNum),
+      previousUptimeSeconds,
+      uptimeSeconds,
+      sourceId,
+      timestamp,
+    },
+  };
+}
+
 /** Build the trigger context for a single telemetry reading (engine fans the batch out). */
 export function buildTelemetryContext(
   nodeNum: number,

--- a/src/server/services/dataEventEmitter.ts
+++ b/src/server/services/dataEventEmitter.ts
@@ -20,6 +20,7 @@ import { logger } from '../../utils/logger.js';
 export type DataEventType =
   | 'node:updated'
   | 'node:mobility'
+  | 'node:rebooted'
   | 'message:new'
   | 'channel:updated'
   | 'telemetry:batch'
@@ -76,6 +77,18 @@ export interface MeshBeaconReceivedData {
   offerRegion?: number;
   /** Preset 0 (LONG_FAST) is a real value — `offer_preset` has explicit presence. */
   offerPreset?: number;
+}
+
+/**
+ * A detected node reboot (Device Health #4558 Phase B) — the node's uptime
+ * counter reset. Carries the prior and new uptime so `trigger.nodeRebooted`
+ * automations can report the drop. Not stored anywhere; this event is the only
+ * way a rule sees the reboot.
+ */
+export interface NodeRebootedData {
+  nodeNum: number;
+  previousUptimeSeconds: number;
+  uptimeSeconds: number;
 }
 
 export interface ConnectionStatusData {
@@ -163,6 +176,21 @@ class DataEventEmitter extends EventEmitter {
     };
     this.emit('data', event);
     logger.debug(`[DataEventEmitter] Node mobility: ${nodeNum} ${previous}→${current}`);
+  }
+
+  /**
+   * Emit a node reboot event (used by trigger.nodeRebooted, #4558 Phase B).
+   * Raised by the telemetry-save seam when a node's uptime counter resets.
+   */
+  emitNodeRebooted(data: NodeRebootedData, sourceId?: string): void {
+    const event: DataEvent = {
+      type: 'node:rebooted',
+      data,
+      timestamp: Date.now(),
+      sourceId,
+    };
+    this.emit('data', event);
+    logger.debug(`[DataEventEmitter] Node rebooted: ${data.nodeNum} (uptime ${data.previousUptimeSeconds}s → ${data.uptimeSeconds}s)`);
   }
 
   /**

--- a/src/server/utils/rebootDetection.ts
+++ b/src/server/utils/rebootDetection.ts
@@ -1,0 +1,41 @@
+/**
+ * Reboot detection for Device Health (#4558 Phase B).
+ *
+ * A node's uptime counter is MONOTONIC during normal operation — every fresh
+ * reading is larger than the last by roughly the telemetry reporting interval.
+ * The only way it can DECREASE is a restart, which resets it to near zero, so a
+ * reboot is simply "the new uptime reading is lower than the prior stored one".
+ *
+ * The prior value is read from the telemetry table (persistent), NOT an
+ * in-memory baseline — that is the restart-safety mechanism (CLAUDE.md mesh
+ * -impact checklist §3): a MeshMonitor process restart cannot spuriously fire a
+ * reboot, because the baseline is the durable DB row rather than lost state.
+ * Detection reads the DB only; it sends no packets, so it costs zero airtime.
+ */
+
+/**
+ * Jitter slack (seconds). Uptime should only ever grow, so ANY decrease is
+ * anomalous; this slack only absorbs trivial rounding or a slightly
+ * out-of-order reading (a few seconds). A genuine reboot drops uptime by
+ * minutes to days, so a small 10s slack cleanly separates a real reset from
+ * noise without needing a per-node baseline. Deliberately small (CLAUDE.md
+ * asks for a documented slack): making it larger would risk masking a reboot of
+ * a node that had only been up a short while.
+ */
+export const REBOOT_UPTIME_SLACK_SECONDS = 10;
+
+/**
+ * True when `newUptimeSeconds` represents a reboot relative to the prior stored
+ * uptime — i.e. a real decrease beyond the jitter slack. A missing / non-finite
+ * prior (first-ever reading for a node) never counts as a reboot: with no
+ * baseline there is no transition to detect.
+ */
+export function isUptimeReboot(
+  priorUptimeSeconds: number | null | undefined,
+  newUptimeSeconds: number,
+  slackSeconds: number = REBOOT_UPTIME_SLACK_SECONDS,
+): boolean {
+  if (priorUptimeSeconds == null || !Number.isFinite(priorUptimeSeconds)) return false;
+  if (!Number.isFinite(newUptimeSeconds)) return false;
+  return newUptimeSeconds + slackSeconds < priorUptimeSeconds;
+}

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -26,7 +26,8 @@ export type TriggerType =
   | 'trigger.leftHome'
   | 'trigger.meshBeacon'
   | 'trigger.nodeStale'
-  | 'trigger.nodeOnline';
+  | 'trigger.nodeOnline'
+  | 'trigger.nodeRebooted';
 
 export type ConditionType =
   | 'condition.always'
@@ -75,6 +76,7 @@ export const TRIGGER_TYPES: readonly TriggerType[] = [
   'trigger.meshBeacon',
   'trigger.nodeStale',
   'trigger.nodeOnline',
+  'trigger.nodeRebooted',
 ];
 
 export const CONDITION_TYPES: readonly ConditionType[] = [


### PR DESCRIPTION
Phase B of Device Health (#4558). Adds `trigger.nodeRebooted`, which fires when a node's uptime resets (unexpected reboot) — one of the issue's requested alert types — as a generic Automation Engine trigger.

## Detection

Uptime is already ingested and stored as a `telemetryType='uptimeSeconds'` row. The trigger hooks the Meshtastic telemetry-save seam (`saveTelemetryMetrics`): when an uptime reading arrives, the node's **prior** latest `uptimeSeconds` is read from the DB (per-source scoped) *before* the new row is inserted, and compared via a pure `isUptimeReboot()` helper.

**Reboot = `new + 10s slack < prior`.** Uptime is monotonic during normal operation, so any genuine decrease is anomalous; a reboot resets it by minutes-to-days. The 10s slack absorbs rounding / a slightly out-of-order reading without needing a per-node in-memory baseline.

**Restart-safe (mesh-impact §3):** the prior value is the durable DB row, not memory — a process restart can't spuriously fire, and the first-ever reading (no prior) never fires.

Flow: `node:rebooted` bus event → `engine.onNodeRebooted` → `trigger.nodeRebooted`.

## Mesh impact

Zero airtime — one DB read at an already-running ingest seam, no packets, no new timer. Existing cooldown/rateLimit apply.

## Tokens

`node.*`, `previousUptimeSeconds`, `uptimeSeconds`, `sourceId`, `timestamp`.

## MeshCore: deferred

Scoped to Meshtastic. MeshCore uptime arrives via polled paths (`meshcoreTelemetryPoller`, `meshcoreRemoteTelemetryScheduler`) and a node column with no single passive write seam — different code paths and type names; wiring it correctly is higher-risk than this phase warrants. Flagged as a follow-up.

## Tests

New `nodeRebooted.test.ts`: pure-helper (drop / rise / first-reading / jitter / non-finite), real-DB detection (first reading, normal rise vs reset, restart-safe, per-source scoping), and engine (validation, fires-once-with-tokens, no-op unloaded, sourceId carry-through). Full vitest: **0 failed** (15,667 pass); `catalog.integrity` + `validateAutomationGraph` accept it; server tsc clean; `lint:ci` clean.

## Scope

Phase B of 6 (A ✅ merged · **B** · C powered-state · D noise-floor field · E charging-trend · F Device Health template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)