### PR TITLE
fix(#4860): damp ESRI satellite's synthetic water-blue

### DIFF
--- a/src/components/map/BaseMap.css
+++ b/src/components/map/BaseMap.css
@@ -1,0 +1,19 @@
+/*
+ * Satellite imagery tone adjustment (#4860).
+ *
+ * ESRI's World_Imagery raster (our "Satellite" and "Satellite + Labels"
+ * tilesets) renders water bodies as a flat, over-saturated synthetic blue where
+ * high-resolution imagery is unavailable — it reads like an unnatural blue
+ * overlay on rivers and lakes. We can't restyle individual features of a raster
+ * tile, so we damp the whole base layer's saturation a touch: the blue is the
+ * most-saturated element, so it calms the most, while the already-muted terrain
+ * imagery is barely affected. Applied to the BASE tiles only (the hybrid label
+ * overlay is a separate layer and stays crisp).
+ *
+ * Scoped by the `mm-satellite-base-tile` class BaseMap adds to the provided
+ * satellite tilesets. `saturate()` is per-pixel, so it introduces no tile seams.
+ * The value is intentionally conservative and easy to tune.
+ */
+.leaflet-tile.mm-satellite-base-tile {
+  filter: saturate(0.8);
+}

--- a/src/components/map/BaseMap.test.tsx
+++ b/src/components/map/BaseMap.test.tsx
@@ -23,13 +23,14 @@ vi.mock('react-leaflet', () => ({
       {children}
     </div>
   ),
-  TileLayer: (props: { url?: string; maxZoom?: number; zIndex?: number; attribution?: string }) => (
+  TileLayer: (props: { url?: string; maxZoom?: number; zIndex?: number; attribution?: string; className?: string }) => (
     <div
       data-testid="raster-tile"
       data-url={props.url}
       data-maxzoom={String(props.maxZoom)}
       data-zindex={props.zIndex === undefined ? '' : String(props.zIndex)}
       data-attribution={props.attribution}
+      data-classname={props.className ?? ''}
     />
   ),
   useMap: () => ({ invalidateSize: vi.fn() }),
@@ -129,6 +130,20 @@ describe('BaseMap', () => {
     const tiles = screen.getAllByTestId('raster-tile');
     expect(tiles).toHaveLength(1);
     expect(tiles[0].getAttribute('data-url')).toContain('World_Imagery');
+    // #4860: the provided satellite base gets the saturation-damping class.
+    expect(tiles[0].getAttribute('data-classname')).toBe('mm-satellite-base-tile');
+  });
+
+  it('damps only the base imagery on esriHybrid, not the label overlay (#4860)', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} tilesetId="esriHybrid" />);
+    const [base, overlay] = screen.getAllByTestId('raster-tile');
+    expect(base.getAttribute('data-classname')).toBe('mm-satellite-base-tile');
+    expect(overlay.getAttribute('data-classname')).toBe(''); // labels stay crisp
+  });
+
+  it('does not damp non-satellite raster tilesets (#4860)', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} tilesetId="osm" />);
+    expect(screen.getByTestId('raster-tile').getAttribute('data-classname')).toBe('');
   });
 
   // 3b. Raster tile-layer keying (tile-loading regression fix): the raster

--- a/src/components/map/BaseMap.tsx
+++ b/src/components/map/BaseMap.tsx
@@ -6,6 +6,7 @@ import { VectorTileLayer } from '../VectorTileLayer';
 import { TilesetSelector } from '../TilesetSelector';
 import MapResizeHandler from '../MapResizeHandler';
 import './leafletDefaultIcon';
+import './BaseMap.css';
 
 export interface BaseMapProps {
   /** Initial center. Like react-leaflet, this is applied once at mount and is
@@ -154,6 +155,14 @@ export function BaseMap({
                 url={tileset.url}
                 attribution={tileset.attribution}
                 maxZoom={tileset.maxZoom}
+                // Damp ESRI World_Imagery's over-saturated synthetic water blue
+                // on our provided satellite tilesets (#4860). Base tiles only —
+                // the hybrid label overlay below is left untouched.
+                className={
+                  tileset.id === 'esriSatellite' || tileset.id === 'esriHybrid'
+                    ? 'mm-satellite-base-tile'
+                    : undefined
+                }
               />
               {/* Optional transparent label/road overlay drawn on top of the
                   base raster (e.g. the satellite+labels hybrid). Keyed like the


### PR DESCRIPTION
Addresses the **water-tint** half of #4860 (the label half shipped in #4872).

## What's actually happening

The "translucent blue on rivers/lakes" is **not drawn by MeshMonitor**. I verified:
- No MeshMonitor map layer tints water (ATAK overlay is orange; coverage/accuracy-region layers are opt-in and node-scoped; the polar grid is cyan only when enabled).
- The tint shows on **both** pure Satellite (which has **no** overlay) and Hybrid → it's the **shared ESRI `World_Imagery` base**, which flat-fills water bodies with an over-saturated synthetic blue where hi-res imagery is unavailable.

So there's no per-feature style/GeoJSON knob and no overlay of ours to adjust — raster tiles can't be restyled per feature.

## The fix

Damp the satellite **base** layer's saturation a touch (`filter: saturate(0.8)`). The synthetic blue is the most-saturated element, so it calms the most, while the already-muted terrain imagery is barely affected. Scoped precisely:
- Applied via a `mm-satellite-base-tile` class that `BaseMap` adds **only** to `esriSatellite` / `esriHybrid`.
- **Base tiles only** — the hybrid label overlay is a separate `TileLayer` and stays crisp.
- `saturate()` is per-pixel, so no tile seams.

`src/components/map/BaseMap.css` carries the rule (documented); the value is conservative and trivially tunable.

## ⚠️ Needs a human eye

I can't see the satellite tiles, so I couldn't dial in the exact value — `saturate(0.8)` is a sensible starting point. **Please eyeball it on live satellite/hybrid imagery** and tell me if you want it stronger (e.g. `0.7`) or gentler (`0.9`); it's a one-line change. If the dulling of terrain isn't worth it, we can also just drop this and treat the tint as provider-imagery we accept.

## Tests

`BaseMap.test.tsx` asserts the class lands on the satellite base, is absent on the hybrid label overlay, and is absent on non-satellite rasters. Suite (20) green; client `tsc` + `lint:ci` clean.

## Mesh impact

None — client-only CSS on the tile layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)