### PR TITLE
feat(automation): nodePowerChanged trigger — external power lost/restored (#4558) [Phase C]

### DIFF
--- a/src/components/automations/SubstitutionsHelp.tsx
+++ b/src/components/automations/SubstitutionsHelp.tsx
@@ -51,6 +51,7 @@ export const TRIGGER_TOKENS: Record<string, Array<[string, string]>> = {
   'trigger.nodeStale': [['nodeNum', 'Node number (Meshtastic)'], ['publicKey', 'Public key (MeshCore)'], ['ageMinutes', 'Minutes since last heard'], ['staleAfterMinutes', 'Configured silence threshold (min)'], ['lastHeard', 'Last-heard time (epoch ms)']],
   'trigger.nodeOnline': [['nodeNum', 'Node number (Meshtastic)'], ['publicKey', 'Public key (MeshCore)'], ['offlineDurationMinutes', 'Minutes the node was offline'], ['staleAfterMinutes', 'Configured silence threshold (min)']],
   'trigger.nodeRebooted': [['nodeNum', 'Node number'], ['previousUptimeSeconds', 'Uptime before the reset (s)'], ['uptimeSeconds', 'Uptime after the reset (s)']],
+  'trigger.nodePowerChanged': [['nodeNum', 'Node number'], ['direction', 'lost (now on battery) / restored (now powered)'], ['powered', 'true if now on external/USB power'], ['previousPowered', 'true if previously on external/USB power'], ['batteryLevel', 'Battery level (%, >100 = powered)']],
   'trigger.schedule': [],
 };
 
@@ -62,6 +63,7 @@ const TRIGGER_LABEL: Record<string, string> = {
   'trigger.meshBeacon': 'MeshBeacon',
   'trigger.nodeStale': 'Node silent', 'trigger.nodeOnline': 'Node recovered',
   'trigger.nodeRebooted': 'Node rebooted',
+  'trigger.nodePowerChanged': 'Node power changed',
 };
 
 /** Drawer listing every available substitution token (current trigger first). */

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -276,11 +276,29 @@ export const TRIGGERS: BlockDef[] = [
       COOLDOWN_SCOPE,
     ],
   },
+  {
+    type: 'trigger.nodePowerChanged',
+    label: 'A node switches power source (mains ↔ battery)',
+    description: 'Fires when a node crosses between external/USB power and battery power. Detected from the battery-level telemetry a node already reports (the firmware reports a value above 100% when powered), by comparing each new reading against the last stored one; there is no extra polling and no packet is sent. Meshtastic only for now. It never fires on the first battery reading for a node (no prior to compare). Note: a reading above 100 conflates “on USB / no battery” with “charging”, so this is a powered-state signal, not a clean “on wall power” flag.',
+    fields: [
+      {
+        name: 'direction', label: 'Direction', kind: 'select',
+        help: 'Which transition to fire on. “Either” covers both losing and regaining external power.',
+        options: [
+          { value: 'either', label: 'Either direction' },
+          { value: 'lost', label: 'Lost external power (now on battery)' },
+          { value: 'restored', label: 'Regained external power' },
+        ],
+      },
+      COOLDOWN,
+      COOLDOWN_SCOPE,
+    ],
+  },
 ];
 
 // ─── Comparison field registry (event / node / latest-telemetry) ─────────────
 
-const SUBJECT_NODE_TRIGGERS = ['trigger.message', 'trigger.nodeDiscovered', 'trigger.nodeUpdated', 'trigger.telemetry', 'trigger.geofence', 'trigger.becameMobile', 'trigger.leftHome', 'trigger.meshBeacon', 'trigger.nodeStale', 'trigger.nodeOnline', 'trigger.nodeRebooted'];
+const SUBJECT_NODE_TRIGGERS = ['trigger.message', 'trigger.nodeDiscovered', 'trigger.nodeUpdated', 'trigger.telemetry', 'trigger.geofence', 'trigger.becameMobile', 'trigger.leftHome', 'trigger.meshBeacon', 'trigger.nodeStale', 'trigger.nodeOnline', 'trigger.nodeRebooted', 'trigger.nodePowerChanged'];
 const hasSubjectNode = (t: string) => SUBJECT_NODE_TRIGGERS.includes(t);
 
 const EVENT_NUMERIC: Record<string, FieldOpt[]> = {
@@ -326,6 +344,12 @@ const EVENT_NUMERIC: Record<string, FieldOpt[]> = {
     { value: 'nodeNum', label: 'Node #' },
     { value: 'previousUptimeSeconds', label: 'Uptime before reset (s)' },
     { value: 'uptimeSeconds', label: 'Uptime after reset (s)' },
+  ],
+  'trigger.nodePowerChanged': [
+    { value: 'nodeNum', label: 'Node #' },
+    { value: 'batteryLevel', label: 'Battery level (%, >100 = powered)' },
+    { value: 'powered', label: 'Now powered (1 = external, 0 = battery)' },
+    { value: 'previousPowered', label: 'Was powered (1 = external, 0 = battery)' },
   ],
   'trigger.becameMobile': [{ value: 'nodeNum', label: 'Node #' }, { value: 'mobile', label: 'Mobile flag (1)' }, { value: 'previousMobile', label: 'Previous mobile flag' }],
   'trigger.leftHome': [

--- a/src/components/automations/substitutionNodeTokens.ts
+++ b/src/components/automations/substitutionNodeTokens.ts
@@ -38,4 +38,5 @@ export const SUBJECT_NODE_TRIGGER_TYPES = [
   'trigger.nodeStale',
   'trigger.nodeOnline',
   'trigger.nodeRebooted',
+  'trigger.nodePowerChanged',
 ] as const;

--- a/src/components/map/BaseMap.css
+++ b/src/components/map/BaseMap.css
@@ -1,0 +1,19 @@
+/*
+ * Satellite imagery tone adjustment (#4860).
+ *
+ * ESRI's World_Imagery raster (our "Satellite" and "Satellite + Labels"
+ * tilesets) renders water bodies as a flat, over-saturated synthetic blue where
+ * high-resolution imagery is unavailable — it reads like an unnatural blue
+ * overlay on rivers and lakes. We can't restyle individual features of a raster
+ * tile, so we damp the whole base layer's saturation a touch: the blue is the
+ * most-saturated element, so it calms the most, while the already-muted terrain
+ * imagery is barely affected. Applied to the BASE tiles only (the hybrid label
+ * overlay is a separate layer and stays crisp).
+ *
+ * Scoped by the `mm-satellite-base-tile` class BaseMap adds to the provided
+ * satellite tilesets. `saturate()` is per-pixel, so it introduces no tile seams.
+ * The value is intentionally conservative and easy to tune.
+ */
+.leaflet-tile.mm-satellite-base-tile {
+  filter: saturate(0.8);
+}

--- a/src/components/map/BaseMap.test.tsx
+++ b/src/components/map/BaseMap.test.tsx
@@ -23,13 +23,14 @@ vi.mock('react-leaflet', () => ({
       {children}
     </div>
   ),
-  TileLayer: (props: { url?: string; maxZoom?: number; zIndex?: number; attribution?: string }) => (
+  TileLayer: (props: { url?: string; maxZoom?: number; zIndex?: number; attribution?: string; className?: string }) => (
     <div
       data-testid="raster-tile"
       data-url={props.url}
       data-maxzoom={String(props.maxZoom)}
       data-zindex={props.zIndex === undefined ? '' : String(props.zIndex)}
       data-attribution={props.attribution}
+      data-classname={props.className ?? ''}
     />
   ),
   useMap: () => ({ invalidateSize: vi.fn() }),
@@ -129,6 +130,20 @@ describe('BaseMap', () => {
     const tiles = screen.getAllByTestId('raster-tile');
     expect(tiles).toHaveLength(1);
     expect(tiles[0].getAttribute('data-url')).toContain('World_Imagery');
+    // #4860: the provided satellite base gets the saturation-damping class.
+    expect(tiles[0].getAttribute('data-classname')).toBe('mm-satellite-base-tile');
+  });
+
+  it('damps only the base imagery on esriHybrid, not the label overlay (#4860)', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} tilesetId="esriHybrid" />);
+    const [base, overlay] = screen.getAllByTestId('raster-tile');
+    expect(base.getAttribute('data-classname')).toBe('mm-satellite-base-tile');
+    expect(overlay.getAttribute('data-classname')).toBe(''); // labels stay crisp
+  });
+
+  it('does not damp non-satellite raster tilesets (#4860)', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} tilesetId="osm" />);
+    expect(screen.getByTestId('raster-tile').getAttribute('data-classname')).toBe('');
   });
 
   // 3b. Raster tile-layer keying (tile-loading regression fix): the raster

--- a/src/components/map/BaseMap.tsx
+++ b/src/components/map/BaseMap.tsx
@@ -6,6 +6,7 @@ import { VectorTileLayer } from '../VectorTileLayer';
 import { TilesetSelector } from '../TilesetSelector';
 import MapResizeHandler from '../MapResizeHandler';
 import './leafletDefaultIcon';
+import './BaseMap.css';
 
 export interface BaseMapProps {
   /** Initial center. Like react-leaflet, this is applied once at mount and is
@@ -154,6 +155,14 @@ export function BaseMap({
                 url={tileset.url}
                 attribution={tileset.attribution}
                 maxZoom={tileset.maxZoom}
+                // Damp ESRI World_Imagery's over-saturated synthetic water blue
+                // on our provided satellite tilesets (#4860). Base tiles only —
+                // the hybrid label overlay below is left untouched.
+                className={
+                  tileset.id === 'esriSatellite' || tileset.id === 'esriHybrid'
+                    ? 'mm-satellite-base-tile'
+                    : undefined
+                }
               />
               {/* Optional transparent label/road overlay drawn on top of the
                   base raster (e.g. the satellite+labels hybrid). Keyed like the

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -53,6 +53,7 @@ import { resolveLastHopName } from './utils/lastHop.js';
 import { isRelayedReception } from './utils/packetHops.js';
 import { resolveLastHeardSec } from './utils/replayGuard.js';
 import { isUptimeReboot } from './utils/rebootDetection.js';
+import { isPowered, detectPowerTransition } from './utils/poweredState.js';
 import { autoAckIsZeroHop, autoAckCellKey, resolveAutoAckReplyRouting } from './utils/autoAckDecision.js';
 import { hopCountEmoji, HOP_COUNT_EMOJIS } from '../utils/hopEmoji.js';
 import { scriptDependencyEnv } from './utils/scriptRunner.js';
@@ -1390,6 +1391,13 @@ class MeshtasticManager implements ISourceManager {
         if (metric.type === 'uptimeSeconds') {
           await this.detectRebootFromUptime(nodeId, fromNum, Number(metric.value));
         }
+        // Device Health (#4558 Phase C): a batteryLevel crossing the firmware's
+        // "powered" threshold (> 100) is an external-power transition. Read the
+        // PRIOR stored batteryLevel (persistent baseline — restart-safe) BEFORE
+        // inserting this reading and compare. DB read only, no packet sent.
+        if (metric.type === 'batteryLevel') {
+          await this.detectPowerChangeFromBattery(nodeId, fromNum, Number(metric.value));
+        }
         await databaseService.telemetry.insertTelemetry({
           nodeId,
           nodeNum: fromNum,
@@ -1427,6 +1435,35 @@ class MeshtasticManager implements ISourceManager {
       );
     } catch (e) {
       logger.warn(`Reboot detection failed for node ${nodeNum}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  /**
+   * Detect an external-power transition from an incoming `batteryLevel` reading
+   * (Device Health #4558 Phase C). Compares the new value against the node's
+   * latest stored batteryLevel — read from the DB, so a MeshMonitor restart can
+   * never spuriously fire (the baseline is the durable row, not in-memory state).
+   * The first-ever reading has no prior and never fires. Powered-state is the
+   * firmware convention `batteryLevel > 100`; when the derived powered-state
+   * flips (via {@link detectPowerTransition}), emit `node:powerChanged` for the
+   * automation engine. Must run BEFORE the new row is inserted so the "latest" it
+   * reads is genuinely the prior reading.
+   */
+  private async detectPowerChangeFromBattery(nodeId: string, nodeNum: number, newBatteryLevel: number): Promise<void> {
+    try {
+      const prior = await databaseService.telemetry.getLatestTelemetryForType(nodeId, 'batteryLevel', this.sourceId);
+      const priorBattery = prior ? Number(prior.value) : null;
+      const direction = detectPowerTransition(priorBattery, newBatteryLevel);
+      if (direction === null) return;
+      const previousPowered = isPowered(priorBattery);
+      const powered = isPowered(newBatteryLevel);
+      logger.info(`🔌 Node ${nodeNum} power ${direction}: battery ${priorBattery} → ${newBatteryLevel} (powered ${previousPowered} → ${powered}, source ${this.sourceId})`);
+      dataEventEmitter.emitNodePowerChanged(
+        { nodeNum, previousPowered, powered, batteryLevel: newBatteryLevel },
+        this.sourceId,
+      );
+    } catch (e) {
+      logger.warn(`Power-change detection failed for node ${nodeNum}: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -41,6 +41,7 @@ import {
   buildNodeStaleContext,
   buildNodeOnlineContext,
   buildNodeRebootedContext,
+  buildNodePowerChangedContext,
   buildScheduleContext,
   messageMatchesFilter,
   meshCoreMessageMatchesFilter,
@@ -918,6 +919,45 @@ export class AutomationEngineService {
   ): Promise<number> {
     const ctx = buildNodeRebootedContext(nodeNum, previousUptimeSeconds, uptimeSeconds, sourceId, this.now());
     return this.runTrigger(ctx);
+  }
+
+  /**
+   * A node's power source flipped between external/USB power and battery
+   * (`trigger.nodePowerChanged`, Device Health #4558 Phase C). Detection (reading
+   * the prior batteryLevel from the DB and comparing against the firmware's > 100
+   * "powered" convention) already happened at the telemetry-save seam, so this is
+   * a pure event entry point: build the context and fire the rules whose
+   * `direction` param matches this transition.
+   *
+   * The `direction` param is 'lost' | 'restored' | 'either' (default 'either'):
+   * a rule fires only when the actual transition matches, so "external power
+   * lost" and its recovery live in one trigger without catalog bloat.
+   *
+   * No self-origin guard (#3914) here — same family as {@link onNodeRebooted}:
+   * a power transition is not something an automation action can cause, so there
+   * is no self-trigger loop to guard against, and knowing your OWN gateway lost
+   * wall power is useful.
+   */
+  async onNodePowerChanged(
+    nodeNum: number,
+    previousPowered: boolean,
+    powered: boolean,
+    batteryLevel: number,
+    sourceId: string | null,
+  ): Promise<number> {
+    const direction = powered ? 'restored' : 'lost';
+    const ctx = buildNodePowerChangedContext(nodeNum, previousPowered, powered, batteryLevel, sourceId, this.now());
+    return this.runTrigger(
+      ctx,
+      (a) => {
+        const want = a.triggerNode.params?.direction;
+        return want == null || want === '' || want === 'either' || want === direction;
+      },
+      (a) => {
+        const want = a.triggerNode.params?.direction ?? 'either';
+        return `power transition "${direction}" ≠ rule direction "${String(want)}"`;
+      },
+    );
   }
 
   /**

--- a/src/server/services/automation/automationEngineSingleton.ts
+++ b/src/server/services/automation/automationEngineSingleton.ts
@@ -148,6 +148,16 @@ async function handleEvent(event: DataEvent): Promise<void> {
       break;
     }
 
+    case 'node:powerChanged': {
+      // Device Health (#4558 Phase C): the telemetry-save seam detected a node's
+      // batteryLevel cross the firmware powered threshold (> 100). Fire
+      // trigger.nodePowerChanged. Detection state lives in the DB (the prior
+      // batteryLevel row), not here, so this is a pure event forward.
+      const data = event.data as { nodeNum: number; previousPowered: boolean; powered: boolean; batteryLevel: number };
+      await e.onNodePowerChanged(data.nodeNum, data.previousPowered, data.powered, data.batteryLevel, sourceId);
+      break;
+    }
+
     case 'node:mobility': {
       const data = event.data as {
         nodeNum: number;

--- a/src/server/services/automation/nodePowerChanged.test.ts
+++ b/src/server/services/automation/nodePowerChanged.test.ts
@@ -1,0 +1,266 @@
+/**
+ * trigger.nodePowerChanged — Device Health Phase C (#4558).
+ *
+ * A power-source change is a batteryLevel crossing the firmware's "powered"
+ * convention: `battery_level > 100` means external/USB power, 0–100 means on
+ * battery at that percent. Detection lives at the telemetry-save seam, which
+ * reads the prior batteryLevel from the DB (persistent, so restart-safe) and
+ * compares via the pure {@link detectPowerTransition} helper; the engine's
+ * {@link AutomationEngineService.onNodePowerChanged} is the event entry point
+ * that fires the automation, honoring the rule's `direction` param.
+ *
+ * These tests cover both halves:
+ *  - the detection decision (powered threshold at 100/101; lost/restored/no
+ *    transition; null handling; first reading; restart-safe; per-source),
+ *    driven through the REAL telemetry repository + DB read the seam uses;
+ *  - the engine firing + direction filter + token surface + graph validation.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { AutomationsRepository } from '../../../db/repositories/automations.js';
+import { AutomationVariablesRepository } from '../../../db/repositories/automationVariables.js';
+import { TelemetryRepository } from '../../../db/repositories/telemetry.js';
+import { VariableResolver } from './variableResolver.js';
+import { AutomationEngineService } from './automationEngineService.js';
+import type { ActionDeps } from './actionExecutor.js';
+import type { NodeDataProvider } from './engineContext.js';
+import type { AutomationGraph } from '../../../types/automation.js';
+import { validateAutomationGraph } from '../../../types/automation.js';
+import { isPowered, detectPowerTransition, POWERED_BATTERY_LEVEL_THRESHOLD } from '../../utils/poweredState.js';
+import * as schema from '../../../db/schema/index.js';
+import { createTestDb } from '../../test-helpers/testDb.js';
+import { automationTraceBus } from './automationTraceBus.js';
+
+function recorder() {
+  const calls: Array<{ fn: string; args: any }> = [];
+  const deps: ActionDeps = {
+    sendMessage: async (a) => { calls.push({ fn: 'sendMessage', args: a }); return 1; },
+    sendTapback: async (a) => { calls.push({ fn: 'sendTapback', args: a }); return 2; },
+    manageNode: async (a) => { calls.push({ fn: 'manageNode', args: a }); return 3; },
+    notify: async (a) => { calls.push({ fn: 'notify', args: a }); return 4; },
+    requestData: async (a) => { calls.push({ fn: 'requestData', args: a }); return 5; },
+    rebootDevice: async (a) => { calls.push({ fn: 'rebootDevice', args: a }); return 6; },
+    runScript: async (a) => { calls.push({ fn: 'runScript', args: a }); return { success: true, stdout: '' }; },
+  };
+  return { calls, deps };
+}
+
+/** nodePowerChanged rule that notifies, tokenised so we can read the context back. */
+function powerGraph(direction?: 'lost' | 'restored' | 'either'): AutomationGraph {
+  return {
+    version: 1,
+    nodes: [
+      { id: 't', type: 'trigger.nodePowerChanged', params: direction ? { direction } : {} },
+      { id: 'n', type: 'action.notify', params: { title: 'power', body: 'node={{ trigger.nodeNum }} dir={{ trigger.direction }} prev={{ trigger.previousPowered }} now={{ trigger.powered }} batt={{ trigger.batteryLevel }} src={{ trigger.sourceId }}' } },
+    ],
+    edges: [{ from: 't', to: 'n' }],
+  };
+}
+
+// ─── detection decision (pure helper) ────────────────────────────────────────
+
+describe('isPowered / detectPowerTransition (#4558 Phase C)', () => {
+  it('treats battery_level > 100 as powered, 0–100 as on battery', () => {
+    expect(POWERED_BATTERY_LEVEL_THRESHOLD).toBe(100);
+    expect(isPowered(101)).toBe(true);        // firmware "powered" sentinel
+    expect(isPowered(150)).toBe(true);
+    expect(isPowered(100)).toBe(false);       // exactly full battery, not powered
+    expect(isPowered(0)).toBe(false);
+    expect(isPowered(50)).toBe(false);
+  });
+
+  it('treats a missing / non-finite reading as not powered', () => {
+    expect(isPowered(null)).toBe(false);
+    expect(isPowered(undefined)).toBe(false);
+    expect(isPowered(NaN)).toBe(false);
+  });
+
+  it('classifies a restored transition (battery → powered)', () => {
+    expect(detectPowerTransition(80, 101)).toBe('restored');
+    expect(detectPowerTransition(100, 101)).toBe('restored'); // boundary: 100 → 101
+  });
+
+  it('classifies a lost transition (powered → battery)', () => {
+    expect(detectPowerTransition(101, 80)).toBe('lost');
+    expect(detectPowerTransition(101, 100)).toBe('lost');     // boundary: 101 → 100
+  });
+
+  it('returns null when the powered-state does not change', () => {
+    expect(detectPowerTransition(80, 90)).toBeNull();     // battery → battery
+    expect(detectPowerTransition(101, 105)).toBeNull();   // powered → powered
+    expect(detectPowerTransition(50, 50)).toBeNull();     // unchanged
+  });
+
+  it('returns null on the first-ever reading (no prior)', () => {
+    expect(detectPowerTransition(null, 101)).toBeNull();
+    expect(detectPowerTransition(undefined, 50)).toBeNull();
+  });
+
+  it('returns null when the new reading is non-finite', () => {
+    expect(detectPowerTransition(101, NaN)).toBeNull();
+    expect(detectPowerTransition(80, null)).toBeNull();
+  });
+});
+
+// ─── detection through the real DB read the seam uses ────────────────────────
+
+describe('power-change detection via getLatestTelemetryForType (#4558 Phase C)', () => {
+  let db: ReturnType<typeof createTestDb>['sqlite'];
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let telem: TelemetryRepository;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    telem = new TelemetryRepository(drizzleDb, 'sqlite');
+  });
+  afterEach(() => { db.close(); });
+
+  const insertBattery = (nodeId: string, nodeNum: number, value: number, ts: number, sourceId: string) =>
+    telem.insertTelemetry(
+      { nodeId, nodeNum, telemetryType: 'batteryLevel', timestamp: ts, value, unit: '%', createdAt: ts },
+      sourceId,
+    );
+
+  /** Replays the seam's decision: read prior for the source, compare, no insert. */
+  const transitionFor = async (nodeId: string, newValue: number, sourceId: string) => {
+    const prior = await telem.getLatestTelemetryForType(nodeId, 'batteryLevel', sourceId);
+    return detectPowerTransition(prior ? Number(prior.value) : null, newValue);
+  };
+
+  it('first reading has no prior, so nothing fires', async () => {
+    expect(await transitionFor('!node', 101, 'default')).toBeNull();
+  });
+
+  it('on-battery → powered is a "restored" transition', async () => {
+    await insertBattery('!node', 111, 80, 1_000, 'default');
+    expect(await transitionFor('!node', 101, 'default')).toBe('restored');
+  });
+
+  it('powered → on-battery is a "lost" transition', async () => {
+    await insertBattery('!node', 111, 101, 1_000, 'default');
+    expect(await transitionFor('!node', 80, 'default')).toBe('lost');
+  });
+
+  it('does not fire when the powered-state is unchanged', async () => {
+    await insertBattery('!node', 111, 80, 1_000, 'default');
+    expect(await transitionFor('!node', 60, 'default')).toBeNull();   // battery → battery
+    await insertBattery('!node', 111, 101, 2_000, 'default');
+    expect(await transitionFor('!node', 105, 'default')).toBeNull();  // powered → powered
+  });
+
+  it('is restart-safe: the prior comes from the DB, not memory', async () => {
+    // Simulate a MeshMonitor restart by using a brand-new repository instance
+    // (no carried-over in-memory baseline) against the same DB.
+    await insertBattery('!node', 111, 101, 1_000, 'default');
+    const freshTelem = new TelemetryRepository(drizzleDb, 'sqlite');
+    const priorFromDb = await freshTelem.getLatestTelemetryForType('!node', 'batteryLevel', 'default');
+    // A still-powered reading after the "restart" does NOT spuriously fire…
+    expect(detectPowerTransition(Number(priorFromDb!.value), 105)).toBeNull();
+    // …and a genuine drop to battery still fires — the durable row is the only baseline.
+    expect(detectPowerTransition(Number(priorFromDb!.value), 80)).toBe('lost');
+  });
+
+  it('scopes the prior per source: a transition on A ignores B’s battery', async () => {
+    // Same nodeId on two sources; on A it is powered, on B it is on battery.
+    await insertBattery('!node', 111, 101, 1_000, 'A');
+    await insertBattery('!node', 111, 80, 1_000, 'B');
+    // A reading of 80 on A is a "lost" vs A's own powered prior…
+    expect(await transitionFor('!node', 80, 'A')).toBe('lost');
+    // …and the SAME 80 on B is unchanged vs B's own on-battery prior — each
+    // source reads its own baseline, never the other's.
+    expect(await transitionFor('!node', 80, 'B')).toBeNull();
+    // A powered reading on B is "restored" scoped to B, not read against A.
+    expect(await transitionFor('!node', 101, 'B')).toBe('restored');
+  });
+});
+
+// ─── engine firing + direction filter + tokens + validation ──────────────────
+
+describe('trigger.nodePowerChanged engine (#4558 Phase C)', () => {
+  let db: ReturnType<typeof createTestDb>['sqlite'];
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let autos: AutomationsRepository;
+  let resolver: VariableResolver;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    autos = new AutomationsRepository(drizzleDb, 'sqlite');
+    resolver = new VariableResolver(new AutomationVariablesRepository(drizzleDb, 'sqlite'));
+  });
+  afterEach(() => { db.close(); automationTraceBus.reset(); automationTraceBus.setSink(null); });
+
+  const data: NodeDataProvider = {
+    getNode: async () => null,
+    getTelemetry: async () => null,
+  };
+  const engineWith = (deps: ActionDeps) =>
+    new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data, now: () => 1_000 });
+
+  const createEnabled = (name: string, graph: AutomationGraph) =>
+    autos.createAutomation({ name, enabled: true, config: JSON.stringify(graph) });
+
+  it('validateAutomationGraph accepts a nodePowerChanged rule (no required params)', () => {
+    expect(validateAutomationGraph(powerGraph()).valid).toBe(true);
+    expect(validateAutomationGraph(powerGraph('lost')).valid).toBe(true);
+    expect(validateAutomationGraph(powerGraph('restored')).valid).toBe(true);
+    expect(validateAutomationGraph(powerGraph('either')).valid).toBe(true);
+  });
+
+  it('rejects an unknown direction value', () => {
+    const bad = powerGraph();
+    (bad.nodes[0].params as any).direction = 'sideways';
+    const result = validateAutomationGraph(bad);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes('direction'))).toBe(true);
+  });
+
+  it('fires on a matching transition, exposing the power tokens', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('power', powerGraph('either'));
+    const engine = engineWith(deps);
+    await engine.load();
+
+    // previousPowered=true, powered=false → "lost"
+    expect(await engine.onNodePowerChanged(111, true, false, 80, 'default')).toBe(1);
+    expect(calls.map((c) => c.fn)).toEqual(['notify']);
+    expect(calls[0].args.body).toBe('node=111 dir=lost prev=true now=false batt=80 src=default');
+  });
+
+  it('direction filter fires only on the matching transition', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('lost-only', powerGraph('lost'));
+    const engine = engineWith(deps);
+    await engine.load();
+
+    // A "restored" transition must NOT fire a lost-only rule…
+    expect(await engine.onNodePowerChanged(111, false, true, 101, 'default')).toBe(0);
+    expect(calls).toHaveLength(0);
+    // …but a "lost" transition does.
+    expect(await engine.onNodePowerChanged(111, true, false, 80, 'default')).toBe(1);
+    expect(calls.map((c) => c.fn)).toEqual(['notify']);
+    expect(calls[0].args.body).toContain('dir=lost');
+  });
+
+  it('does not fire when no nodePowerChanged automation is loaded', async () => {
+    const { calls, deps } = recorder();
+    const engine = engineWith(deps);
+    await engine.load();
+    expect(await engine.onNodePowerChanged(111, true, false, 80, 'default')).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('carries the event source id into the context', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('power', powerGraph('restored'));
+    const engine = engineWith(deps);
+    await engine.load();
+
+    // previousPowered=false, powered=true → "restored"
+    await engine.onNodePowerChanged(222, false, true, 101, 'sourceZ');
+    expect(calls[0].args.body).toBe('node=222 dir=restored prev=false now=true batt=101 src=sourceZ');
+  });
+});

--- a/src/server/services/automation/triggerContext.ts
+++ b/src/server/services/automation/triggerContext.ts
@@ -463,6 +463,41 @@ export function buildNodeRebootedContext(
   };
 }
 
+/**
+ * Build the trigger context when a node's power source flips between external/USB
+ * power and battery (`trigger.nodePowerChanged` — Device Health #4558 Phase C).
+ * Subject node = the node whose power changed, so `{{ node.* }}` hydration and
+ * node-scoped cooldown work. Detection (reading the prior batteryLevel from the
+ * DB and comparing against the firmware's > 100 "powered" convention) happens at
+ * the telemetry-save seam; this builder only shapes what the conditions /
+ * interpolation read. `direction` is 'lost' (was powered, now on battery) or
+ * 'restored' (was on battery, now powered).
+ */
+export function buildNodePowerChangedContext(
+  nodeNum: number,
+  previousPowered: boolean,
+  powered: boolean,
+  batteryLevel: number,
+  sourceId: string | null,
+  timestamp: number,
+): TriggerContext {
+  return {
+    triggerType: 'trigger.nodePowerChanged',
+    sourceId,
+    subjectNodeNum: Number(nodeNum),
+    timestamp,
+    fields: {
+      nodeNum: Number(nodeNum),
+      powered,
+      previousPowered,
+      direction: powered ? 'restored' : 'lost',
+      batteryLevel,
+      sourceId,
+      timestamp,
+    },
+  };
+}
+
 /** Build the trigger context for a single telemetry reading (engine fans the batch out). */
 export function buildTelemetryContext(
   nodeNum: number,

--- a/src/server/services/dataEventEmitter.ts
+++ b/src/server/services/dataEventEmitter.ts
@@ -21,6 +21,7 @@ export type DataEventType =
   | 'node:updated'
   | 'node:mobility'
   | 'node:rebooted'
+  | 'node:powerChanged'
   | 'message:new'
   | 'channel:updated'
   | 'telemetry:batch'
@@ -89,6 +90,21 @@ export interface NodeRebootedData {
   nodeNum: number;
   previousUptimeSeconds: number;
   uptimeSeconds: number;
+}
+
+/**
+ * A detected node power-source transition (Device Health #4558 Phase C) — the
+ * node crossed between external/USB power and battery power, derived from its
+ * `batteryLevel` telemetry (firmware convention: > 100 = powered). Carries the
+ * prior and new powered-states plus the new battery reading so
+ * `trigger.nodePowerChanged` automations can report which way it flipped. Not
+ * stored anywhere; this event is the only way a rule sees the transition.
+ */
+export interface NodePowerChangedData {
+  nodeNum: number;
+  previousPowered: boolean;
+  powered: boolean;
+  batteryLevel: number;
 }
 
 export interface ConnectionStatusData {
@@ -191,6 +207,22 @@ class DataEventEmitter extends EventEmitter {
     };
     this.emit('data', event);
     logger.debug(`[DataEventEmitter] Node rebooted: ${data.nodeNum} (uptime ${data.previousUptimeSeconds}s → ${data.uptimeSeconds}s)`);
+  }
+
+  /**
+   * Emit a node power-source transition event (used by trigger.nodePowerChanged,
+   * #4558 Phase C). Raised by the telemetry-save seam when a node's batteryLevel
+   * reading crosses the firmware's powered threshold (> 100) in either direction.
+   */
+  emitNodePowerChanged(data: NodePowerChangedData, sourceId?: string): void {
+    const event: DataEvent = {
+      type: 'node:powerChanged',
+      data,
+      timestamp: Date.now(),
+      sourceId,
+    };
+    this.emit('data', event);
+    logger.debug(`[DataEventEmitter] Node power changed: ${data.nodeNum} (powered ${data.previousPowered} → ${data.powered}, battery ${data.batteryLevel})`);
   }
 
   /**

--- a/src/server/utils/poweredState.ts
+++ b/src/server/utils/poweredState.ts
@@ -1,0 +1,64 @@
+/**
+ * Powered-state derivation for Device Health (#4558 Phase C).
+ *
+ * Meshtastic's `DeviceMetrics.battery_level` overloads a percentage field to
+ * ALSO signal external power: the firmware convention is that a value ABOVE 100
+ * (in practice 101) means "powered" — running on USB / wall power, or a charging
+ * pack with no distinguishable battery percentage. Values 0–100 are a genuine
+ * battery charge at that percent.
+ *
+ * So a node's power source flips between "on battery" and "powered" purely as a
+ * function of whether its latest battery_level reading crossed the 100 mark. We
+ * detect that transition at the telemetry-save seam by comparing each new
+ * reading against the node's PRIOR stored batteryLevel (read from the DB, so a
+ * MeshMonitor restart can never spuriously fire — the baseline is the durable
+ * row, not in-memory state; CLAUDE.md mesh-impact checklist §3). Detection reads
+ * the DB only and sends no packets, so it costs zero airtime.
+ *
+ * CAVEAT (documented in the trigger help text too): 101 CONFLATES "USB / no
+ * battery" with "charging". It is a powered-state signal, not a clean "on wall
+ * power vs. on battery" flag — a node that is charging its own battery also
+ * reports > 100.
+ */
+
+/** The firmware threshold: battery_level strictly ABOVE this means "powered". */
+export const POWERED_BATTERY_LEVEL_THRESHOLD = 100;
+
+/**
+ * True when `batteryLevel` represents a powered node (external / USB, or charging
+ * with no distinguishable battery) — i.e. a finite value above the firmware's
+ * 100 threshold. A missing / non-finite reading is treated as NOT powered (we
+ * have no evidence of external power), and never as a transition on its own —
+ * transitions are gated by {@link detectPowerTransition}'s null-prior guard.
+ */
+export function isPowered(batteryLevel: number | null | undefined): boolean {
+  if (batteryLevel == null || !Number.isFinite(batteryLevel)) return false;
+  return batteryLevel > POWERED_BATTERY_LEVEL_THRESHOLD;
+}
+
+/**
+ * Classify the power transition between a node's prior and new batteryLevel
+ * readings:
+ *  - `'lost'`     — was powered, now on battery (external power lost);
+ *  - `'restored'` — was on battery, now powered (external power restored);
+ *  - `null`       — no transition (both states equal), OR there is no prior
+ *                   reading to compare against (first-ever reading for a node),
+ *                   OR the new reading is non-finite.
+ *
+ * The null-prior guard is the restart-safety mechanism: with no baseline there
+ * is no transition to detect, so the first reading after a MeshMonitor restart
+ * (or the first reading ever) never fires.
+ */
+export function detectPowerTransition(
+  priorBatteryLevel: number | null | undefined,
+  newBatteryLevel: number | null | undefined,
+): 'lost' | 'restored' | null {
+  // First-ever reading (no durable prior): nothing to transition FROM.
+  if (priorBatteryLevel == null || !Number.isFinite(priorBatteryLevel)) return null;
+  // A non-finite new reading is not a usable state to transition TO.
+  if (newBatteryLevel == null || !Number.isFinite(newBatteryLevel)) return null;
+  const wasPowered = isPowered(priorBatteryLevel);
+  const nowPowered = isPowered(newBatteryLevel);
+  if (wasPowered === nowPowered) return null;
+  return nowPowered ? 'restored' : 'lost';
+}

--- a/src/types/automation.ts
+++ b/src/types/automation.ts
@@ -27,7 +27,8 @@ export type TriggerType =
   | 'trigger.meshBeacon'
   | 'trigger.nodeStale'
   | 'trigger.nodeOnline'
-  | 'trigger.nodeRebooted';
+  | 'trigger.nodeRebooted'
+  | 'trigger.nodePowerChanged';
 
 export type ConditionType =
   | 'condition.always'
@@ -77,6 +78,7 @@ export const TRIGGER_TYPES: readonly TriggerType[] = [
   'trigger.nodeStale',
   'trigger.nodeOnline',
   'trigger.nodeRebooted',
+  'trigger.nodePowerChanged',
 ];
 
 export const CONDITION_TYPES: readonly ConditionType[] = [
@@ -548,6 +550,16 @@ export function validateAutomationGraph(input: unknown): ValidationResult {
             : Number(p.staleAfterMinutes);
           if (!Number.isFinite(thrMin) || thrMin <= 0) {
             errors.push(`${n.type} "${n.id}" requires params.staleAfterMinutes > 0`);
+          }
+          break;
+        }
+        case 'trigger.nodePowerChanged': {
+          // Device Health (#4558 Phase C). Optional direction filter; absent /
+          // blank means 'either', so every pre-existing stored automation and a
+          // freshly-dropped block both validate. Reject only an unknown value.
+          const dir = p.direction == null || p.direction === '' ? 'either' : String(p.direction);
+          if (!['lost', 'restored', 'either'].includes(dir)) {
+            errors.push(`trigger.nodePowerChanged "${n.id}" requires params.direction to be one of: lost, restored, either`);
           }
           break;
         }


### PR DESCRIPTION
Phase C of Device Health (#4558). Adds `trigger.nodePowerChanged` — the issue's "external power lost" alert (and its recovery) — as a generic Automation Engine trigger.

## Powered-state derivation

Meshtastic `DeviceMetrics.battery_level` uses the firmware convention **`> 100` (101) = powered**. So `powered = batteryLevel != null && batteryLevel > 100` (0–100 = on battery at that %).

**Caveat (in help text + helper doc):** 101 conflates "USB / no battery" with "charging" — it's a powered-state signal, not a clean wall-power flag. This is the best passive signal the protocol offers.

## Trigger shape

Single `trigger.nodePowerChanged` with a **`direction`** param = `lost | restored | either` (default `either`); fires only on a matching transition.

## Detection (mirrors Phase B)

At the `saveTelemetryMetrics` seam, on a `batteryLevel` reading, the node's prior `batteryLevel` is read from the durable DB (per-source scoped) *before* the new row inserts; prior vs new powered-state is compared. **Restart-safe** (prior from DB, not memory); first-ever reading never fires; no fire when unchanged. Flow: `node:powerChanged` → `engine.onNodePowerChanged`.

## Mesh impact

Zero airtime — one DB read at an existing ingest seam. No new limit needed.

## Tokens

`node.*`, `powered`, `previousPowered`, `direction`, `batteryLevel`, `sourceId`, `timestamp`.

## MeshCore: deferred

Only raw `batteryMv` (no percentage / 101 convention) — "powered" would be a weak voltage heuristic with no clean passive seam. Follow-up, consistent with Phase B.

## Tests

New `nodePowerChanged.test.ts` (19): pure helper (threshold 100/101, lost/restored/none, null), real-DB detection (first-reading no-fire, restored, lost, unchanged, restart-safe, per-source scoping), engine (validation accept + unknown-direction reject, token surface, direction-filter fires only on match, no-op unloaded, sourceId carry). Full vitest **0 failed**; `catalog.integrity` + `validateAutomationGraph` accept it; server tsc clean; `lint:ci` clean.

## Scope

Phase C of 6 (A ✅ · B ✅ · **C** · D noise-floor field · E charging-trend · F template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)