### PR TITLE
feat(automation): expose noise floor as a telemetry alert field (#4558) [Phase D]

### DIFF
--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -161,6 +161,7 @@ export const TRIGGERS: BlockDef[] = [
           { value: 'temperature', label: 'Temperature' },
           { value: 'channelUtilization', label: 'Channel utilization' },
           { value: 'airUtilTx', label: 'Air util TX' },
+          { value: 'noiseFloor', label: 'Noise floor (dBm) — local node only' },
         ],
       },
       COOLDOWN,
@@ -403,6 +404,7 @@ const TELEMETRY_FIELDS: FieldOpt[] = [
   { value: 'telemetry.temperature', label: 'Temperature' }, { value: 'telemetry.relativeHumidity', label: 'Humidity' },
   { value: 'telemetry.barometricPressure', label: 'Pressure' }, { value: 'telemetry.channelUtilization', label: 'Channel utilization' },
   { value: 'telemetry.airUtilTx', label: 'Air util TX' }, { value: 'telemetry.current', label: 'Current' }, { value: 'telemetry.iaq', label: 'IAQ (air quality)' },
+  { value: 'telemetry.noiseFloor', label: 'Noise floor (local node only)' },
 ];
 
 export function numericFields(triggerType: string): FieldGroup[] {


### PR DESCRIPTION
Phase D of Device Health (#4558). Makes **noise floor** selectable so a "noise floor above threshold" alert is expressible via `trigger.telemetry` + `condition.numeric`.

## Change

`noiseFloor` is already a canonical telemetry key (`telemetryKeys.ts`) that gets stored and emitted onto the automation bus, and `telemetry.*` fields resolve generically in the engine (`engineContext.ts:319`). It simply wasn't offered in the builder. This PR adds it to:
- the `trigger.telemetry` **Metric** selector, and
- the subject-node **telemetry.** condition fields.

**No backend change.**

## Caveat (labelled in the UI)

Both options are labelled **"local node only"**: on Meshtastic, `noise_floor` lives in `LocalStats`, which is delivered to the connected client only — so it's available for the *local* node, **not per remote node**. MeshCore parses it but doesn't persist it. The label sets that expectation up front (this was the feasibility limit flagged when the epic was scoped).

## Tests

Declarative catalog exposure of an already-tested telemetry path — covered by the existing automation/catalog suites (1021 pass, 0 fail) plus `catalog.integrity` + `validateAutomationGraph`.

## Scope

Phase D of 6 (A ✅ · B ✅ · C ✅ · **D** · E charging-trend · F template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)