### PR TITLE
fix(meshcore): widen LogRxData correlation window for slow companions

### DIFF
--- a/src/server/meshcoreNativeBackend.otaPacket.test.ts
+++ b/src/server/meshcoreNativeBackend.otaPacket.test.ts
@@ -32,23 +32,39 @@ const BinaryRequestTypes = { GetTelemetryData: 0x03 };
 const AdvType = { None: 0, Chat: 1, Repeater: 2, Room: 3 };
 const TxtTypes = { Plain: 0, CliData: 1, SignedPlain: 2 };
 
-// Mock Packet parser. Wire layout used by these tests:
-//   raw[0] = payload_type
-//   raw[1] = route_type
-//   raw[2] = pathLen (packed: top 2 bits = hashSize-1, bottom 6 = hopCount)
-//   raw[3..] = path bytes
+// Mock Packet parser — real MeshCore OTA wire layout (matches meshcore.js /
+// decodeMeshCorePacket) so LogRxData buffering and extractTxtMsgSenderPrefix
+// see the same bytes production does:
+//   raw[0] = header byte (route in low 2 bits, payload type in bits 2–5)
+//   raw[1] = pathLen (packed: top 2 bits = hashSize-1, bottom 6 = hopCount)
+//   raw[2..] = path bytes (+ payload for TXT_MSG tests)
 const PAYLOAD_NAMES: Record<number, string> = { 0x02: 'TXT_MSG', 0x04: 'ADVERT', 0x05: 'GRP_TXT' };
 const ROUTE_NAMES: Record<number, string> = { 0x01: 'FLOOD', 0x02: 'DIRECT' };
+
+const wireHeader = (route: number, payload: number) => ((payload & 0x0f) << 2) | (route & 0x03);
+const floodTxt = (pathLen: number, ...rest: number[]) =>
+  Uint8Array.from([wireHeader(0x01, 0x02), pathLen, ...rest]);
+const floodGrp = (pathLen: number, ...rest: number[]) =>
+  Uint8Array.from([wireHeader(0x01, 0x05), pathLen, ...rest]);
+const directTxt = (pathLen: number, ...rest: number[]) =>
+  Uint8Array.from([wireHeader(0x02, 0x02), pathLen, ...rest]);
+const directGrp = (pathLen: number, ...rest: number[]) =>
+  Uint8Array.from([wireHeader(0x02, 0x05), pathLen, ...rest]);
+const directAdvert = (pathLen: number, ...rest: number[]) =>
+  Uint8Array.from([wireHeader(0x02, 0x04), pathLen, ...rest]);
 
 class MockPacket {
   static PAYLOAD_TYPE_TXT_MSG = 0x02;
   static PAYLOAD_TYPE_GRP_TXT = 0x05;
   static fromBytes(raw: Uint8Array | number[]) {
     const arr = raw instanceof Uint8Array ? raw : Uint8Array.from(raw);
-    const payload_type = arr[0];
-    const route_type = arr[1];
-    const pathLen = arr[2];
-    const path = arr.subarray(3);
+    const header = arr[0];
+    const route_type = header & 0x03;
+    const payload_type = (header >> 2) & 0x0f;
+    let offset = 1;
+    if (route_type === 0x00 || route_type === 0x03) offset += 4;
+    const pathLen = arr[offset++];
+    const path = arr.subarray(offset);
     return {
       payload_type,
       payload_type_string: PAYLOAD_NAMES[payload_type] ?? 'OTHER',
@@ -112,7 +128,7 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
   it('emits ota_packet for a TXT_MSG flood packet with decoded path + SNR/RSSI', async () => {
     const { conn, events } = await connectedBackend();
     // TXT_MSG, FLOOD, pathLen=0x02 (1-byte hashes, 2 hops), path=[a3,7f]
-    const raw = Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]);
+    const raw = floodTxt(0x02, 0xa3, 0x7f);
     conn.emit(PushCodes.LogRxData, { lastSnr: 6.25, lastRssi: -42, raw });
 
     const ota = events.find((e) => e.event_type === 'ota_packet');
@@ -125,15 +141,15 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
     expect(ota.data.path_hops).toEqual(['a3', '7f']);
     expect(ota.data.snr).toBe(6.25);
     expect(ota.data.rssi).toBe(-42);
-    expect(ota.data.payload_size).toBe(5);
-    expect(ota.data.raw_hex).toBe('020102a37f');
+    expect(ota.data.payload_size).toBe(4);
+    expect(ota.data.raw_hex).toBe('0902a37f');
     expect(ota.data.path_len_raw).toBe(0x02);
   });
 
   it('emits ota_packet for non-TXT_MSG payloads (e.g. ADVERT, direct route)', async () => {
     const { conn, events } = await connectedBackend();
     // ADVERT, DIRECT, pathLen=0xff (no relay hashes)
-    const raw = Uint8Array.from([0x04, 0x02, 0xff]);
+    const raw = directAdvert(0xff);
     conn.emit(PushCodes.LogRxData, { lastSnr: -1, lastRssi: -90, raw });
 
     const ota = events.find((e) => e.event_type === 'ota_packet');
@@ -147,7 +163,7 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
 
   it('still buffers the TXT_MSG path for the following ContactMsgRecv event', async () => {
     const { conn, events } = await connectedBackend();
-    const raw = Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]);
+    const raw = floodTxt(0x02, 0xa3, 0x7f);
     conn.emit(PushCodes.LogRxData, { lastSnr: 5, lastRssi: -40, raw });
     // Following txt-msg recv on the same packet consumes the buffered path.
     conn.emit(ResponseCodes.ContactMsgRecv, {
@@ -169,7 +185,7 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
   it('carries the buffered LogRxData SNR onto a channel_message event', async () => {
     const { conn, events } = await connectedBackend();
     // Channel messages ride GRP_TXT (0x05) on the wire, not TXT_MSG (0x02).
-    const raw = Uint8Array.from([0x05, 0x01, 0x02, 0xa3, 0x7f]);
+    const raw = floodGrp(0x02, 0xa3, 0x7f);
     conn.emit(PushCodes.LogRxData, { lastSnr: -3.5, lastRssi: -88, raw });
     conn.emit(ResponseCodes.ChannelMsgRecv, {
       channelIdx: 0,
@@ -192,7 +208,7 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
     // miss" users saw was a coincidental stale TXT_MSG buffer being matched.
     const { conn, events } = await connectedBackend();
     // GRP_TXT (0x05), FLOOD, packed pathLen=0x42 (2-byte hashes, 2 hops).
-    const raw = Uint8Array.from([0x05, 0x01, 0x42, 0xde, 0xad, 0xbe, 0xef]);
+    const raw = floodGrp(0x42, 0xde, 0xad, 0xbe, 0xef);
     conn.emit(PushCodes.LogRxData, { lastSnr: 3.25, lastRssi: -55, raw });
     conn.emit(ResponseCodes.ChannelMsgRecv, {
       channelIdx: 0,
@@ -213,7 +229,7 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
     // "(direct)" downstream, matching the DM direct-path behavior.
     const { conn, events } = await connectedBackend();
     // GRP_TXT (0x05), DIRECT, pathLen=0xff (sent direct, no relay hashes).
-    const raw = Uint8Array.from([0x05, 0x02, 0xff]);
+    const raw = directGrp(0xff);
     conn.emit(PushCodes.LogRxData, { lastSnr: 7.0, lastRssi: -38, raw });
     conn.emit(ResponseCodes.ChannelMsgRecv, {
       channelIdx: 0,
@@ -254,7 +270,7 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
   it('does NOT attach a buffered path when the recv pathLen differs (different packet)', async () => {
     const { conn, events } = await connectedBackend();
     // LogRxData buffers a 2-hop path with pathLen=0x02.
-    const raw = Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]);
+    const raw = floodTxt(0x02, 0xa3, 0x7f);
     conn.emit(PushCodes.LogRxData, { lastSnr: 9, lastRssi: -30, raw });
     // The recv that follows is a DIFFERENT packet (direct, pathLen=0xff) whose
     // own LogRxData never arrived. The buffered 0x02 path must NOT be attached.
@@ -279,9 +295,9 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
     // both, matched to their recvs by hop count.
     const { conn, events } = await connectedBackend();
     // Packet A: GRP_TXT FLOOD, 2-byte hashes, 2 hops (packed 0x42).
-    const rawA = Uint8Array.from([0x05, 0x01, 0x42, 0xde, 0xad, 0xbe, 0xef]);
+    const rawA = floodGrp(0x42, 0xde, 0xad, 0xbe, 0xef);
     // Packet B: GRP_TXT FLOOD, 1-byte hash, 1 hop (packed 0x01).
-    const rawB = Uint8Array.from([0x05, 0x01, 0x01, 0xaa]);
+    const rawB = floodGrp(0x01, 0xaa);
     // Both LogRxData pushes land BEFORE either recv (the clobber window).
     conn.emit(PushCodes.LogRxData, { lastSnr: 3.25, lastRssi: -55, raw: rawA });
     conn.emit(PushCodes.LogRxData, { lastSnr: 7.0, lastRssi: -38, raw: rawB });
@@ -294,18 +310,18 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
     // First message keeps packet A's path + SNR + raw bytes (not clobbered).
     expect(msgs[0].data.path_hops).toEqual(['dead', 'beef']);
     expect(msgs[0].data.snr).toBe(3.25);
-    expect(msgs[0].data.raw_hex).toBe('050142deadbeef');
+    expect(msgs[0].data.raw_hex).toBe('1542deadbeef');
     // Second message keeps packet B's.
     expect(msgs[1].data.path_hops).toEqual(['aa']);
     expect(msgs[1].data.snr).toBe(7.0);
-    expect(msgs[1].data.raw_hex).toBe('050101aa');
+    expect(msgs[1].data.raw_hex).toBe('1501aa');
   });
 
   it('does NOT attach a stale buffered path (older than the freshness window)', async () => {
     vi.useFakeTimers();
     try {
       const { conn, events } = await connectedBackend();
-      const raw = Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]);
+      const raw = floodTxt(0x02, 0xa3, 0x7f);
       conn.emit(PushCodes.LogRxData, { lastSnr: 7, lastRssi: -35, raw });
       // Advance well past PENDING_PATH_MAX_AGE_MS (2000ms) before the recv lands.
       vi.advanceTimersByTime(3000);
@@ -326,36 +342,84 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
   });
 
   it('still correlates when LogRxData→recv gap is ~600ms (live companion delay)', async () => {
-    // Production companions can emit ChannelMsgRecv ~500–600ms after LogRxData.
-    // A 500ms freshness window dropped nearly all channel-message scope/route
-    // correlation on a busy mesh; 600ms must still attach.
     vi.useFakeTimers();
     try {
       const { conn, events } = await connectedBackend();
-      // GRP_TXT (0x05), FLOOD, pathLen=0x02 (1-byte hashes, 2 hops) — same layout
-      // as the other channel-message correlation fixtures in this file.
-      const raw = Uint8Array.from([0x05, 0x01, 0x02, 0xa3, 0x7f]);
+      const raw = floodGrp(0x02, 0xa3, 0x7f);
       conn.emit(PushCodes.LogRxData, { lastSnr: 5.5, lastRssi: -80, raw });
       vi.advanceTimersByTime(600);
       conn.emit(ResponseCodes.ChannelMsgRecv, {
         channelIdx: 0,
         text: 'Alice: ping',
         senderTimestamp: 1700,
-        pathLen: 2, // plain hop count (ChannelMsgRecv semantics)
+        pathLen: 2,
       });
       const msg = events.find((e) => e.event_type === 'channel_message');
       expect(msg).toBeDefined();
       expect(msg.data.snr).toBe(5.5);
       expect(msg.data.path_hops).toEqual(['a3', '7f']);
-      expect(msg.data.raw_hex).toBe('050102a37f');
+      expect(msg.data.raw_hex).toBe('1502a37f');
     } finally {
       vi.useRealTimers();
     }
   });
 
+  it('skips a stale orphan and attaches the fresh hop match on busy channels', async () => {
+    vi.useFakeTimers();
+    try {
+      const { conn, events } = await connectedBackend();
+      const orphan = floodGrp(0x02, 0xaa, 0xbb);
+      const fresh = floodGrp(0x02, 0xa3, 0x7f);
+      conn.emit(PushCodes.LogRxData, { lastSnr: 1, lastRssi: -90, raw: orphan });
+      vi.advanceTimersByTime(800);
+      conn.emit(PushCodes.LogRxData, { lastSnr: 5.5, lastRssi: -80, raw: fresh });
+      vi.advanceTimersByTime(100);
+      conn.emit(ResponseCodes.ChannelMsgRecv, {
+        channelIdx: 0,
+        text: 'Bob: ping',
+        senderTimestamp: 1800,
+        pathLen: 2,
+      });
+      const msg = events.find((e) => e.event_type === 'channel_message');
+      expect(msg?.data.snr).toBe(5.5);
+      expect(msg?.data.path_hops).toEqual(['a3', '7f']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('disambiguates same-hop DMs by sender pubkey prefix', async () => {
+    const dest = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+    const senderA = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01];
+    const senderB = [0xca, 0xfe, 0xba, 0xbe, 0x00, 0x02];
+    const rawA = floodTxt(0x02, 0xa3, 0x7f, ...dest, ...senderA, 0x01);
+    const rawB = floodTxt(0x02, 0x11, 0x22, ...dest, ...senderB, 0x02);
+    const { conn, events } = await connectedBackend();
+    conn.emit(PushCodes.LogRxData, { lastSnr: 3, lastRssi: -50, raw: rawA });
+    conn.emit(PushCodes.LogRxData, { lastSnr: 7, lastRssi: -40, raw: rawB });
+    conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from(senderA),
+      text: 'from A',
+      senderTimestamp: 1700,
+      pathLen: 0x02,
+      txtType: TxtTypes.Plain,
+    });
+    conn.emit(ResponseCodes.ContactMsgRecv, {
+      pubKeyPrefix: Uint8Array.from(senderB),
+      text: 'from B',
+      senderTimestamp: 1701,
+      pathLen: 0x02,
+      txtType: TxtTypes.Plain,
+    });
+    const msgs = events.filter((e) => e.event_type === 'contact_message');
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].data.snr).toBe(3);
+    expect(msgs[1].data.snr).toBe(7);
+  });
+
   it('consumes the buffer once — a second recv with no LogRxData gets nothing', async () => {
     const { conn, events } = await connectedBackend();
-    const raw = Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]);
+    const raw = floodTxt(0x02, 0xa3, 0x7f);
     conn.emit(PushCodes.LogRxData, { lastSnr: 4, lastRssi: -50, raw });
     // First recv consumes the buffer.
     conn.emit(ResponseCodes.ContactMsgRecv, {
@@ -384,7 +448,7 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
   it('a room post consumes (and discards) the buffer so it cannot leak onto the next message', async () => {
     const { conn, events } = await connectedBackend();
     // LogRxData for the room post's own packet.
-    const raw = Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]);
+    const raw = floodTxt(0x02, 0xa3, 0x7f);
     conn.emit(PushCodes.LogRxData, { lastSnr: 8, lastRssi: -25, raw });
     // Room post (SignedPlain) — first 4 bytes of text are the author prefix.
     conn.emit(ResponseCodes.ContactMsgRecv, {
@@ -423,7 +487,7 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
     const { conn, events } = await connectedBackend();
     // TXT_MSG, FLOOD, packed pathLen=0x42 (2-byte hashes, 2 hops),
     // path = [adb0, 1234]. extractPathHashCount(0x42) === 2.
-    const raw = Uint8Array.from([0x02, 0x01, 0x42, 0xad, 0xb0, 0x12, 0x34]);
+    const raw = floodTxt(0x42, 0xad, 0xb0, 0x12, 0x34);
     conn.emit(PushCodes.LogRxData, { lastSnr: 5.5, lastRssi: -44, raw });
     // The matching recv reports a PLAIN hop count of 2, NOT the packed 0x42.
     conn.emit(ResponseCodes.ContactMsgRecv, {
@@ -442,7 +506,7 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
   it('attaches the buffered path for a 2-byte-hash flood channel_message (issue #3710)', async () => {
     const { conn, events } = await connectedBackend();
     // GRP_TXT (0x05), FLOOD, packed pathLen=0x42 (2-byte hashes, 2 hops).
-    const raw = Uint8Array.from([0x05, 0x01, 0x42, 0xad, 0xb0, 0x12, 0x34]);
+    const raw = floodGrp(0x42, 0xad, 0xb0, 0x12, 0x34);
     conn.emit(PushCodes.LogRxData, { lastSnr: -2.0, lastRssi: -70, raw });
     conn.emit(ResponseCodes.ChannelMsgRecv, {
       channelIdx: 0,
@@ -459,7 +523,7 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
   it('still rejects a buffered 2-byte-hash path when hop counts differ (issue #3710 guard intact)', async () => {
     const { conn, events } = await connectedBackend();
     // Buffered: 2-byte hashes, 2 hops (packed 0x42).
-    const raw = Uint8Array.from([0x02, 0x01, 0x42, 0xad, 0xb0, 0x12, 0x34]);
+    const raw = floodTxt(0x42, 0xad, 0xb0, 0x12, 0x34);
     conn.emit(PushCodes.LogRxData, { lastSnr: 9, lastRssi: -30, raw });
     // Recv is a different packet: 3 hops. 3 !== decoded(0x42)=2 → reject.
     conn.emit(ResponseCodes.ContactMsgRecv, {
@@ -491,13 +555,13 @@ describe('MeshCoreNativeBackend — RSSI on received messages (#4504)', () => {
   afterEach(() => __setMeshCoreModule(null));
 
   // TXT_MSG, DIRECT, pathLen 0xff → 0 hops.
-  const directTxt = () => Uint8Array.from([0x02, 0x02, 0xff]);
+  const directTxtPkt = () => directTxt(0xff);
   // GRP_TXT, DIRECT, pathLen 0xff → 0 hops.
-  const directGrp = () => Uint8Array.from([0x05, 0x02, 0xff]);
+  const directGrpPkt = () => directGrp(0xff);
 
   it('attaches RSSI (with SNR) to a DM from the preceding LogRxData', async () => {
     const { conn, events } = await connectedBackend();
-    conn.emit(PushCodes.LogRxData, { lastSnr: 6.5, lastRssi: -47, raw: directTxt() });
+    conn.emit(PushCodes.LogRxData, { lastSnr: 6.5, lastRssi: -47, raw: directTxtPkt() });
     conn.emit(ResponseCodes.ContactMsgRecv, {
       pubKeyPrefix: Uint8Array.from([1, 2, 3, 4, 5, 6]),
       pathLen: 0xff, txtType: 0, senderTimestamp: 1700000001, text: 'hi',
@@ -510,7 +574,7 @@ describe('MeshCoreNativeBackend — RSSI on received messages (#4504)', () => {
 
   it('attaches RSSI to a channel message too', async () => {
     const { conn, events } = await connectedBackend();
-    conn.emit(PushCodes.LogRxData, { lastSnr: 4, lastRssi: -61, raw: directGrp() });
+    conn.emit(PushCodes.LogRxData, { lastSnr: 4, lastRssi: -61, raw: directGrpPkt() });
     conn.emit(ResponseCodes.ChannelMsgRecv, {
       channelIdx: 0, pathLen: 0xff, txtType: 0, senderTimestamp: 1700000002, text: 'yo',
     });
@@ -540,7 +604,7 @@ describe('MeshCoreNativeBackend — RSSI on received messages (#4504)', () => {
     const { conn, events } = await connectedBackend();
     conn.emit(PushCodes.LogRxData, {
       lastSnr: 9, lastRssi: -20,
-      raw: Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]), // TXT_MSG, FLOOD, 2 hops
+      raw: floodTxt(0x02, 0xa3, 0x7f), // TXT_MSG, FLOOD, 2 hops
     });
     conn.emit(ResponseCodes.ContactMsgRecv, {
       pubKeyPrefix: Uint8Array.from([1, 2, 3, 4, 5, 6]),
@@ -553,7 +617,7 @@ describe('MeshCoreNativeBackend — RSSI on received messages (#4504)', () => {
 
   it('consumes the buffer once — a second message gets no stale RSSI', async () => {
     const { conn, events } = await connectedBackend();
-    conn.emit(PushCodes.LogRxData, { lastSnr: 3, lastRssi: -70, raw: directTxt() });
+    conn.emit(PushCodes.LogRxData, { lastSnr: 3, lastRssi: -70, raw: directTxtPkt() });
     const recv = (ts: number, text: string) => conn.emit(ResponseCodes.ContactMsgRecv, {
       pubKeyPrefix: Uint8Array.from([1, 2, 3, 4, 5, 6]),
       pathLen: 0xff, txtType: 0, senderTimestamp: ts, text,

--- a/src/server/meshcoreNativeBackend.otaPacket.test.ts
+++ b/src/server/meshcoreNativeBackend.otaPacket.test.ts
@@ -307,8 +307,8 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
       const { conn, events } = await connectedBackend();
       const raw = Uint8Array.from([0x02, 0x01, 0x02, 0xa3, 0x7f]);
       conn.emit(PushCodes.LogRxData, { lastSnr: 7, lastRssi: -35, raw });
-      // Advance well past PENDING_PATH_MAX_AGE_MS (500ms) before the recv lands.
-      vi.advanceTimersByTime(1000);
+      // Advance well past PENDING_PATH_MAX_AGE_MS (2000ms) before the recv lands.
+      vi.advanceTimersByTime(3000);
       conn.emit(ResponseCodes.ContactMsgRecv, {
         pubKeyPrefix: Uint8Array.from([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]),
         text: 'late',
@@ -320,6 +320,34 @@ describe('MeshCoreNativeBackend — ota_packet capture', () => {
       expect(msg).toBeDefined();
       expect(msg.data.snr).toBeUndefined();
       expect(msg.data.path_hops).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('still correlates when LogRxData→recv gap is ~600ms (live companion delay)', async () => {
+    // Production companions can emit ChannelMsgRecv ~500–600ms after LogRxData.
+    // A 500ms freshness window dropped nearly all channel-message scope/route
+    // correlation on a busy mesh; 600ms must still attach.
+    vi.useFakeTimers();
+    try {
+      const { conn, events } = await connectedBackend();
+      // GRP_TXT (0x05), FLOOD, pathLen=0x02 (1-byte hashes, 2 hops) — same layout
+      // as the other channel-message correlation fixtures in this file.
+      const raw = Uint8Array.from([0x05, 0x01, 0x02, 0xa3, 0x7f]);
+      conn.emit(PushCodes.LogRxData, { lastSnr: 5.5, lastRssi: -80, raw });
+      vi.advanceTimersByTime(600);
+      conn.emit(ResponseCodes.ChannelMsgRecv, {
+        channelIdx: 0,
+        text: 'Alice: ping',
+        senderTimestamp: 1700,
+        pathLen: 2, // plain hop count (ChannelMsgRecv semantics)
+      });
+      const msg = events.find((e) => e.event_type === 'channel_message');
+      expect(msg).toBeDefined();
+      expect(msg.data.snr).toBe(5.5);
+      expect(msg.data.path_hops).toEqual(['a3', '7f']);
+      expect(msg.data.raw_hex).toBe('050102a37f');
     } finally {
       vi.useRealTimers();
     }

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -13,6 +13,7 @@
 
 import { EventEmitter } from 'events';
 import { createHash } from 'node:crypto';
+import { decodeMeshCorePacket } from '../utils/meshcorePacketDecode.js';
 import { logger } from '../utils/logger.js';
 import { TxDisabledError } from './errors/txDisabledError.js';
 import { isRfBridgeCommand, MESHCORE_RECEIVE_ONLY_MESSAGE } from './constants/meshcoreTx.js';
@@ -146,6 +147,30 @@ function bytesToHex(bytes: Uint8Array | number[]): string {
   return out;
 }
 
+/** Normalize a MeshCore pubkey prefix to 12 lowercase hex chars (6 bytes). */
+function normalizePubkeyPrefixHex(prefix: string | null | undefined): string | null {
+  if (!prefix) return null;
+  const trimmed = prefix.replace(/[^0-9a-f]/gi, '').toLowerCase();
+  return trimmed.length >= 12 ? trimmed.substring(0, 12) : null;
+}
+
+/**
+ * Extract the 6-byte sender pubkey prefix from a TXT_MSG LogRxData frame.
+ * Plaintext payload layout after the relay path: dest_prefix(6) + src_prefix(6) + ciphertext.
+ */
+export function extractTxtMsgSenderPrefix(rawHex: string | null | undefined): string | null {
+  const decoded = decodeMeshCorePacket(rawHex);
+  if (!decoded || decoded.header.payloadType !== 0x02) return null;
+  const payloadHex = decoded.payload.hex;
+  if (!payloadHex || payloadHex.length < 24) return null;
+  return payloadHex.substring(12, 24).toLowerCase();
+}
+
+interface PendingPathCorrelation {
+  /** ContactMsgRecv pubKeyPrefix — matched against buffered TXT_MSG src prefix. */
+  senderPrefixHex?: string | null;
+}
+
 /**
  * Render a MeshCore contact's `out_path` blob into a comma-separated hex
  * chain like "a3,7f,02" (1-byte hashes) or "a37f,02b0" (2-byte hashes).
@@ -266,10 +291,21 @@ export class MeshCoreNativeBackend extends EventEmitter {
    * the first's buffer before its recv consumed it, so the first message lost
    * its route/SNR and — most visibly — its scope badge (received-message scope
    * intermittently blank on busy meshes, even though the raw bytes were
-   * captured). {@link consumePendingPath} matches by hop count and takes the
-   * oldest unconsumed entry, so concurrent packets no longer evict each other.
+   * captured). {@link consumePendingPath} matches by hop count (and, for DMs,
+   * the sender pubkey prefix extracted from the TXT_MSG payload) and takes the
+   * oldest eligible unconsumed entry, so concurrent packets no longer evict
+   * each other.
    */
-  private pendingTxtMsgPaths: Array<{ hops: string[]; rawPathLen: number; snr?: number; rssi?: number; rawHex?: string; bufferedAt: number }> = [];
+  private pendingTxtMsgPaths: Array<{
+    hops: string[];
+    rawPathLen: number;
+    snr?: number;
+    rssi?: number;
+    rawHex?: string;
+    /** TXT_MSG only — 6-byte sender pubkey prefix from the plaintext payload. */
+    senderPrefixHex?: string;
+    bufferedAt: number;
+  }> = [];
 
   /**
    * Maximum age (ms) of a buffered LogRxData path before we treat it as stale
@@ -285,17 +321,29 @@ export class MeshCoreNativeBackend extends EventEmitter {
    * scope mode always replying unscoped). A buffer older than this window
    * almost certainly belongs to a *different* packet whose recv never
    * arrived, so consuming it would attach the wrong SNR/route/scope.
-   * Hop-count FIFO matching still guards against mis-correlation (#3589);
-   * this window only bounds how long an unmatched buffer may wait.
+   * Hop-count (+ optional pubkey prefix) matching guards against
+   * mis-correlation (#3589); this window only bounds how long an unmatched
+   * buffer may linger in the FIFO before pruning.
    */
   private static readonly PENDING_PATH_MAX_AGE_MS = 2000;
   /**
-   * Cap on buffered LogRxData entries. The FIFO only holds text-packet metadata
-   * for the sub-millisecond gap until the matching recv consumes it (pruned by
-   * age on every push/consume), so this is just a backstop against unbounded
-   * growth if a burst of LogRxData arrives with no following recv events.
+   * When several hop-matching buffers coexist (typical on busy GRP_TXT /
+   * channel traffic), only attach a candidate younger than this age. Covers
+   * the ~500–600ms LogRxData→recv gap on slow USB companions while rejecting
+   * stale orphans whose recv never arrived — the #3589 failure mode a wider
+   * MAX_AGE alone would re-open. Unique-hop and pubkey-prefix matches may
+   * use the full {@link PENDING_PATH_MAX_AGE_MS} window instead.
    */
-  private static readonly PENDING_PATH_MAX_ENTRIES = 8;
+  private static readonly PENDING_PATH_ATTACH_MAX_AGE_MS = 750;
+  /**
+   * Cap on buffered LogRxData entries. With a ~600ms recv gap on busy meshes,
+   * more than the old 8 text packets can sit unconsumed simultaneously; this
+   * backstop prevents unbounded growth when recv events never arrive. Stale
+   * rows are pruned by age in {@link prunePendingTxtMsgPaths} on push and
+   * consume; the length cap only evicts the oldest entry when the FIFO still
+   * overflows after pruning.
+   */
+  private static readonly PENDING_PATH_MAX_ENTRIES = 32;
   /** Constructor reference for the meshcore.js Packet parser, populated when the module loads. */
   private PacketCtor: MeshCoreJsModule['Packet'] | null = null;
   /**
@@ -424,64 +472,88 @@ export class MeshCoreNativeBackend extends EventEmitter {
    * correlating it to the current message-recv event so {SNR}/{ROUTE} only
    * populate from the *matching* packet (issue #3589).
    *
-   * The buffer is ALWAYS cleared (single-slot, consume-once) so a later recv
-   * that got no LogRxData of its own can't reuse a stale buffer. Two guards
-   * decide whether the buffered data is actually attached:
-   *
-   *  1. Freshness — the buffer must be younger than `PENDING_PATH_MAX_AGE_MS`.
-   *     LogRxData fires immediately before its txt-msg recv on the same tick;
-   *     an older buffer belongs to a packet whose recv never arrived.
-   *  2. hop-count correlation — when the recv event carries its own
-   *     `pathLen`, the *hop count* it implies must equal the hop count
-   *     decoded from the buffered packet's packed `rawPathLen`. A mismatch
-   *     proves the buffer is from a *different* packet and must not be
-   *     attached.
-   *
-   *     NOTE: the two values are NOT the same wire byte. ContactMsgRecv /
-   *     ChannelMsgRecv report a PLAIN hop count (0xFF == "sent direct"),
-   *     whereas LogRxData's `rawPathLen` is the PACKED OTA byte (top 2 bits
-   *     = hash-size-1, bottom 6 bits = hop count). Comparing them raw made
-   *     every flood packet using a 2- or 3-byte relay-hash width fail to
-   *     correlate, so {ROUTE} resolved to "—" for any routed message
-   *     (issue #3710). We decode the packed byte to a hop count first.
-   *
-   * Returns `{ hops, snr, rssi }` to attach, or `undefined` when the buffer is
-   * absent, stale, or for a different packet.
+   * Matching rules (prefer miss over wrong attach):
+   *  1. Require a usable recv hop count — no match-all fallback.
+   *  2. Hop count must match the buffered packed `rawPathLen` (#3710).
+   *  3. DMs: optional sender pubkey prefix disambiguates same-hop collisions.
+   *  4. Unique hop match → attach if within `PENDING_PATH_MAX_AGE_MS` (slow
+   *     companions). Several hop matches → attach the oldest candidate still
+   *     within `PENDING_PATH_ATTACH_MAX_AGE_MS`, skipping stale orphans.
    */
-  private consumePendingPath(msgPathLen: unknown): { hops: string[]; snr?: number; rssi?: number; rawHex?: string } | undefined {
-    const now = Date.now();
-    // Drop stale entries first — a buffer whose matching recv never arrived
-    // would mis-correlate route/SNR/scope if attached to a later message
-    // (issue #3589 guard).
+  private prunePendingTxtMsgPaths(now: number = Date.now()): void {
     this.pendingTxtMsgPaths = this.pendingTxtMsgPaths.filter(
       (e) => now - e.bufferedAt <= MeshCoreNativeBackend.PENDING_PATH_MAX_AGE_MS,
     );
+  }
+
+  private bufferedHopCount(rawPathLen: number): number {
+    return rawPathLen === 0xff
+      ? 0
+      : (this.PacketCtor?.extractPathHashCount(rawPathLen) ?? (rawPathLen & 0x3f));
+  }
+
+  private takeBufferedEntry(
+    entry: (typeof this.pendingTxtMsgPaths)[number],
+  ): { hops: string[]; snr?: number; rssi?: number; rawHex?: string } {
+    const idx = this.pendingTxtMsgPaths.indexOf(entry);
+    if (idx === -1) {
+      return { hops: entry.hops, snr: entry.snr, rssi: entry.rssi, rawHex: entry.rawHex };
+    }
+    this.pendingTxtMsgPaths.splice(idx, 1);
+    return { hops: entry.hops, snr: entry.snr, rssi: entry.rssi, rawHex: entry.rawHex };
+  }
+
+  private consumePendingPath(
+    msgPathLen: unknown,
+    correlation?: PendingPathCorrelation,
+    opts?: { discardOnly?: boolean },
+  ): { hops: string[]; snr?: number; rssi?: number; rawHex?: string } | undefined {
+    const now = Date.now();
+    this.prunePendingTxtMsgPaths(now);
     if (this.pendingTxtMsgPaths.length === 0) return undefined;
 
-    // Normalize the recv event's pathLen to a plain hop count (0xFF == sent
-    // direct == 0 hops). The buffered rawPathLen is the packed OTA byte.
     const msgHopCount =
       typeof msgPathLen === 'number' ? (msgPathLen === 0xff ? 0 : msgPathLen & 0x3f) : null;
-    const bufferedHopCount = (rawPathLen: number): number =>
-      rawPathLen === 0xff
-        ? 0
-        : (this.PacketCtor?.extractPathHashCount(rawPathLen) ?? (rawPathLen & 0x3f));
+    if (msgHopCount === null) return undefined;
 
-    // Take the OLDEST unconsumed entry whose hop count matches. LogRxData is
-    // emitted just before its own recv, so across concurrent packets the oldest
-    // hop-matching buffer is this recv's packet. When the recv carries no usable
-    // pathLen, fall back to the oldest entry outright (prior single-slot
-    // behavior generalized to the FIFO).
-    const idx = this.pendingTxtMsgPaths.findIndex(
-      (e) =>
-        msgHopCount === null ||
-        typeof e.rawPathLen !== 'number' ||
-        bufferedHopCount(e.rawPathLen) === msgHopCount,
+    const hopMatching = this.pendingTxtMsgPaths.filter(
+      (e) => typeof e.rawPathLen === 'number' && this.bufferedHopCount(e.rawPathLen) === msgHopCount,
     );
-    if (idx === -1) return undefined;
 
-    const [buffered] = this.pendingTxtMsgPaths.splice(idx, 1); // consume-once
-    return { hops: buffered.hops, snr: buffered.snr, rssi: buffered.rssi, rawHex: buffered.rawHex };
+    if (opts?.discardOnly) {
+      if (hopMatching.length > 0) this.takeBufferedEntry(hopMatching[0]);
+      return undefined;
+    }
+
+    if (hopMatching.length === 0) return undefined;
+
+    const senderPrefix = normalizePubkeyPrefixHex(correlation?.senderPrefixHex);
+    if (senderPrefix) {
+      const prefixMatches = hopMatching.filter((e) => e.senderPrefixHex === senderPrefix);
+      if (prefixMatches.length === 1) {
+        const [match] = prefixMatches;
+        if (now - match.bufferedAt <= MeshCoreNativeBackend.PENDING_PATH_MAX_AGE_MS) {
+          return this.takeBufferedEntry(match);
+        }
+        return undefined;
+      }
+      if (prefixMatches.length > 1) return undefined;
+    }
+
+    if (hopMatching.length === 1) {
+      const [only] = hopMatching;
+      if (now - only.bufferedAt <= MeshCoreNativeBackend.PENDING_PATH_MAX_AGE_MS) {
+        return this.takeBufferedEntry(only);
+      }
+      return undefined;
+    }
+
+    for (const entry of hopMatching) {
+      if (now - entry.bufferedAt <= MeshCoreNativeBackend.PENDING_PATH_ATTACH_MAX_AGE_MS) {
+        return this.takeBufferedEntry(entry);
+      }
+    }
+    return undefined;
   }
 
   private wirePushEvents(): void {
@@ -493,9 +565,9 @@ export class MeshCoreNativeBackend extends EventEmitter {
     // (ContactMsgRecv / ChannelMsgRecv) strip the relay-hash chain, so
     // we parse the raw bytes here, buffer the path for TXT_MSG packets
     // only, and let the next message-recv handler consume it. The
-    // single-buffer design is intentional — under the wire-level
-    // serialization the firmware uses, LogRxData is emitted right
-    // before the corresponding txt-msg event for the same packet.
+        // FIFO design — under wire-level serialization LogRxData is emitted
+        // right before the corresponding txt-msg event for the same packet,
+        // but several packets can be in flight on busy meshes.
     //
     // We also surface EVERY parsed packet as an `ota_packet` bridge event
     // so the MeshCore Packet Monitor can show full OTA metadata (route
@@ -536,7 +608,19 @@ export class MeshCoreNativeBackend extends EventEmitter {
             // each other's route/SNR/scope. Remaining limitation: if LogRxData
             // arrives AFTER its own recv (rare ordering), that packet's buffer is
             // still missed — inherent to the adjacency-buffer design.
-            this.pendingTxtMsgPaths.push({ hops, rawPathLen: pkt.pathLen, snr, rssi, rawHex: bytesToHex(raw), bufferedAt: Date.now() });
+            const rawHex = bytesToHex(raw);
+            const senderPrefixHex =
+              pkt.payload_type === TXT_MSG ? extractTxtMsgSenderPrefix(rawHex) ?? undefined : undefined;
+            this.pendingTxtMsgPaths.push({
+              hops,
+              rawPathLen: pkt.pathLen,
+              snr,
+              rssi,
+              rawHex,
+              senderPrefixHex,
+              bufferedAt: Date.now(),
+            });
+            this.prunePendingTxtMsgPaths();
             // Backstop against unbounded growth (recv-less LogRxData bursts).
             if (this.pendingTxtMsgPaths.length > MeshCoreNativeBackend.PENDING_PATH_MAX_ENTRIES) {
               this.pendingTxtMsgPaths.shift();
@@ -585,7 +669,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
         // the room post's own buffer can't leak onto the NEXT contact/channel
         // message — that leak attached a stale SNR/route to an unrelated
         // message (part of issue #3589). We don't surface SNR on room posts.
-        this.consumePendingPath(msg.pathLen);
+        this.consumePendingPath(msg.pathLen, undefined, { discardOnly: true });
         const rawText: string = msg.text ?? '';
         const authorPrefixHex = Array.from(rawText.substring(0, 4))
           .map((ch: string) => ch.charCodeAt(0).toString(16).padStart(2, '0'))
@@ -605,7 +689,9 @@ export class MeshCoreNativeBackend extends EventEmitter {
       // Consume the path buffered by the preceding LogRxData event, correlated
       // to THIS packet (freshness + pathLen match). Returns undefined when the
       // buffer is absent, stale, or for a different packet (issue #3589).
-      const consumedPath = this.consumePendingPath(msg.pathLen);
+      const consumedPath = this.consumePendingPath(msg.pathLen, {
+        senderPrefixHex: bytesToHex(msg.pubKeyPrefix),
+      });
       const payload = {
         pubkey_prefix: bytesToHex(msg.pubKeyPrefix),
         text: msg.text,

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -273,17 +273,22 @@ export class MeshCoreNativeBackend extends EventEmitter {
 
   /**
    * Maximum age (ms) of a buffered LogRxData path before we treat it as stale
-   * and refuse to attach it to a message-recv event. LogRxData is emitted by
-   * the firmware immediately before the matching txt-msg recv for the SAME
-   * packet, so the correlated recv lands within the same I/O tick (sub-ms). A
-   * buffer older than this window almost certainly belongs to a *different*
-   * packet whose recv event never arrived (e.g. a non-TXT packet, or a
-   * LogRxData with no following recv), so consuming it would attach the wrong
-   * SNR/route to {SNR}/{ROUTE}. 500ms is generous enough to absorb event-loop
-   * scheduling jitter while still rejecting genuinely stale buffers — this is
-   * a core guard against the intermittent mis-correlation in issue #3589.
+   * and refuse to attach it to a message-recv event.
+   *
+   * On paper the firmware emits LogRxData immediately before the matching
+   * txt-msg recv (ContactMsgRecv / ChannelMsgRecv) for the SAME packet, so
+   * the correlated recv should land within the same I/O tick. In practice
+   * some companion firmware / USB stacks introduce a systematic ~500–600ms
+   * gap between the two pushes — observed live on a busy MeshCore mesh
+   * where a 500ms window dropped ~94% of channel-message correlations
+   * (scope badge blank, {SCOPE}/{ROUTE}/{SNR} → "—", auto-ack "trigger"
+   * scope mode always replying unscoped). A buffer older than this window
+   * almost certainly belongs to a *different* packet whose recv never
+   * arrived, so consuming it would attach the wrong SNR/route/scope.
+   * Hop-count FIFO matching still guards against mis-correlation (#3589);
+   * this window only bounds how long an unmatched buffer may wait.
    */
-  private static readonly PENDING_PATH_MAX_AGE_MS = 500;
+  private static readonly PENDING_PATH_MAX_AGE_MS = 2000;
   /**
    * Cap on buffered LogRxData entries. The FIFO only holds text-packet metadata
    * for the sub-millisecond gap until the matching recv consumes it (pruned by


### PR DESCRIPTION
## Summary
Fixes #4883.

- Raise `PENDING_PATH_MAX_AGE_MS` from 500 → 2000 so LogRxData path/SNR/raw bytes still attach when ChannelMsgRecv arrives ~500–600ms later (seen on T-Echo USB; faster companions such as T114 typically stay well under this).
- That correlation is what stamps `scopeCode`/`scopeName`/`routePath` on incoming channel messages; when it misses, auto-ack `{SCOPE}` shows "—" and `scopeMode: trigger` always replies unscoped.
- **Review follow-up (d869f66f):** widening alone would re-open #3589 mis-correlation, so the second commit adds:
  - **DM pubkey-prefix matching** — `extractTxtMsgSenderPrefix()` from TXT_MSG plaintext payload disambiguates same-hop collisions.
  - **750ms attach cap** (`PENDING_PATH_ATTACH_MAX_AGE_MS`) when several hop-matching buffers coexist (channel/GRP_TXT); unique-hop and prefix matches may use the full 2s window.
  - **FIFO cap 8 → 32** with age pruning on push/consume.
  - Tests switched to real OTA wire bytes so prefix extraction is exercised.

## Test plan
- [x] `npx vitest run src/server/meshcoreNativeBackend.otaPacket.test.ts`
- [ ] On a MeshCore companion with measurable LogRxData→ChannelMsgRecv delay (e.g. T-Echo): confirm new channel messages get `routePath` and non-null `scopeCode` (0 = unscoped, named when region known)
- [ ] Auto-ack with `{SCOPE}` and `scopeMode: trigger`: scoped pings resolve region; unscoped show `(unscoped)` rather than `—`
- [ ] Confirm hop-count FIFO still avoids cross-attaching SNR/route under concurrent traffic (#3589)