### PR TITLE
feat(meshcore): autopoll neighbours — per-node retrieval scheduler (#4618)

### DIFF
--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -9,6 +9,7 @@ import { meshcoreRoleIconName, meshcoreRoleLabelKey, meshcoreRoleLabel } from '.
 import { MeshCoreMessageStream } from './MeshCoreMessageStream';
 import { MeshCoreContactDetailPanel } from './MeshCoreContactDetailPanel';
 import { MeshCoreNodeTelemetryConfig } from './MeshCoreNodeTelemetryConfig';
+import { MeshCoreNodeNeighboursConfig } from './MeshCoreNodeNeighboursConfig';
 import TelemetryGraphs from '../TelemetryGraphs';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSettings } from '../../contexts/SettingsContext';
@@ -579,6 +580,12 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
               {!!sourceId && typeof baseUrl === 'string' && isRealNodeKey(selected) && (
                 <>
                   <MeshCoreNodeTelemetryConfig
+                    baseUrl={baseUrl}
+                    sourceId={sourceId}
+                    publicKey={selected}
+                    receiveOnly={receiveOnly}
+                  />
+                  <MeshCoreNodeNeighboursConfig
                     baseUrl={baseUrl}
                     sourceId={sourceId}
                     publicKey={selected}

--- a/src/components/MeshCore/MeshCoreNodeNeighboursConfig.test.tsx
+++ b/src/components/MeshCore/MeshCoreNodeNeighboursConfig.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the per-node MeshCore neighbours-retrieval config panel (#4618):
+ * the manual "Poll Neighbours" button, the enable toggle, and the
+ * receive-only gating (mirrors MeshCoreNodeTelemetryConfig).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MeshCoreNodeNeighboursConfig } from './MeshCoreNodeNeighboursConfig';
+
+const { csrfFetchMock, hasPermissionMock, showToastMock } = vi.hoisted(() => ({
+  csrfFetchMock: vi.fn(),
+  hasPermissionMock: vi.fn(),
+  showToastMock: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string | Record<string, unknown>) =>
+      typeof fallback === 'string' ? fallback : _key,
+  }),
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: hasPermissionMock }),
+}));
+
+vi.mock('../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => csrfFetchMock,
+}));
+
+vi.mock('../ToastContainer', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
+const PK = 'a'.repeat(64);
+
+const okResponse = (body: unknown) => ({ ok: true, json: async () => body });
+
+const renderPanel = (receiveOnly = false) =>
+  render(<MeshCoreNodeNeighboursConfig baseUrl="" sourceId="test-source" publicKey={PK} receiveOnly={receiveOnly} />);
+
+describe('MeshCoreNodeNeighboursConfig — poll + config', () => {
+  beforeEach(() => {
+    hasPermissionMock.mockReset().mockReturnValue(true);
+    showToastMock.mockReset();
+    csrfFetchMock.mockReset().mockImplementation((_url: string, opts?: { method?: string; body?: string }) => {
+      if (opts?.method === 'POST') {
+        return Promise.resolve(okResponse({ success: true, data: { total: 3, written: 2 } }));
+      }
+      if (opts?.method === 'PATCH') {
+        const patch = JSON.parse(opts.body ?? '{}');
+        return Promise.resolve(okResponse({
+          success: true,
+          data: { enabled: patch.enabled ?? false, intervalMinutes: patch.intervalMinutes ?? 60, lastRequestAt: null },
+        }));
+      }
+      // Initial neighbours-config GET on mount.
+      return Promise.resolve(
+        okResponse({ success: true, data: { enabled: false, intervalMinutes: 60, lastRequestAt: null } }),
+      );
+    });
+  });
+
+  it('renders the poll button once loaded', async () => {
+    renderPanel();
+    expect(await screen.findByText('Poll Neighbours')).toBeInTheDocument();
+  });
+
+  it('POSTs to the neighbours/poll endpoint and shows the stored count', async () => {
+    renderPanel();
+    fireEvent.click(await screen.findByText('Poll Neighbours'));
+    await waitFor(() =>
+      expect(csrfFetchMock).toHaveBeenCalledWith(
+        '/api/sources/test-source/meshcore/nodes/' + PK + '/neighbours/poll',
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+    await waitFor(() => expect(screen.getByText(/Stored 2 neighbour/)).toBeInTheDocument());
+  });
+
+  it('PATCHes neighbours-config when the enable checkbox is toggled', async () => {
+    renderPanel();
+    await screen.findByText('Poll Neighbours');
+    fireEvent.click(screen.getByRole('checkbox'));
+    await waitFor(() =>
+      expect(csrfFetchMock).toHaveBeenCalledWith(
+        '/api/sources/test-source/meshcore/nodes/' + PK + '/neighbours-config',
+        expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ enabled: true }) }),
+      ),
+    );
+  });
+
+  it('disables the poll button without nodes:read permission', async () => {
+    hasPermissionMock.mockImplementation((resource: string) => resource !== 'nodes');
+    renderPanel();
+    const btn = await screen.findByText('Poll Neighbours');
+    expect(btn.closest('button')).toBeDisabled();
+  });
+
+  it('disables the poll button in receive-only mode; the enable checkbox stays enabled', async () => {
+    renderPanel(true);
+    const btn = (await screen.findByText('Poll Neighbours')).closest('button');
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('title', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.');
+    expect(screen.getByRole('checkbox')).not.toBeDisabled();
+  });
+
+  it('detects a 409 TX_DISABLED response and toasts instead of the inline error', async () => {
+    csrfFetchMock.mockImplementation((_url: string, opts?: { method?: string }) => {
+      if (opts?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          json: async () => ({ success: false, code: 'TX_DISABLED', error: 'Transmit is disabled' }),
+        });
+      }
+      return Promise.resolve(
+        okResponse({ success: true, data: { enabled: false, intervalMinutes: 60, lastRequestAt: null } }),
+      );
+    });
+    renderPanel(false);
+    fireEvent.click(await screen.findByText('Poll Neighbours'));
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(
+      'Receive-only mode is on for this MeshCore source — nothing was sent.', 'warning',
+    ));
+    expect(screen.queryByText('Transmit is disabled')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/MeshCore/MeshCoreNodeNeighboursConfig.tsx
+++ b/src/components/MeshCore/MeshCoreNodeNeighboursConfig.tsx
@@ -253,6 +253,7 @@ export const MeshCoreNodeNeighboursConfig: React.FC<MeshCoreNodeNeighboursConfig
                 onChange={(e) => setIntervalDraft(e.target.value)}
                 onBlur={handleIntervalCommit}
                 disabled={!canWriteConfig || saving}
+                aria-label={t('meshcore.neighbours_config.interval_label', 'Interval (minutes)')}
                 style={{ width: '6rem' }}
               />
             </div>

--- a/src/components/MeshCore/MeshCoreNodeNeighboursConfig.tsx
+++ b/src/components/MeshCore/MeshCoreNodeNeighboursConfig.tsx
@@ -1,0 +1,323 @@
+/**
+ * Per-node neighbours-retrieval config panel for the MeshCore per-node detail
+ * view (issue #4618).
+ *
+ * A sibling of `MeshCoreNodeTelemetryConfig`: mounts in the DM/contact detail
+ * pane of `MeshCoreDirectMessagesView` for a peer with a real 64-hex pubkey,
+ * reads/writes `(enabled, intervalMinutes)` for the (sourceId, publicKey) pair
+ * from `/api/sources/:id/meshcore/nodes/:publicKey/neighbours-config`, and
+ * offers a manual "Poll Now" that hits `/neighbours/poll`. The scheduler fills
+ * the node's neighbour table into Node Details on the chosen cadence. Gated by
+ * `configuration:write` for edits, `nodes:read` for the manual poll.
+ */
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../contexts/AuthContext';
+import { useCsrfFetch } from '../../hooks/useCsrfFetch';
+import { useToast } from '../ToastContainer';
+import { isTxDisabledBody } from '../../utils/txDisabled';
+import { MeshCoreReceiveOnlyNote } from './MeshCoreReceiveOnlyNote';
+
+interface MeshCoreNodeNeighboursConfigProps {
+  /** Frontend basename (e.g. '' or '/meshmonitor'). */
+  baseUrl: string;
+  /** Owning source id (UUID). */
+  sourceId: string;
+  /** 64-char hex pubkey of the remote MeshCore node. */
+  publicKey: string;
+  /** True when this MeshCore source is in strict receive-only mode (#4547). */
+  receiveOnly?: boolean;
+}
+
+interface NeighboursConfigState {
+  enabled: boolean;
+  intervalMinutes: number;
+  lastRequestAt: number | null;
+}
+
+const DEFAULT_CFG: NeighboursConfigState = {
+  enabled: false,
+  intervalMinutes: 60,
+  lastRequestAt: null,
+};
+
+const MIN_INTERVAL = 1;
+const MAX_INTERVAL = 24 * 60;
+
+export const MeshCoreNodeNeighboursConfig: React.FC<MeshCoreNodeNeighboursConfigProps> = ({
+  baseUrl,
+  sourceId,
+  publicKey,
+  receiveOnly = false,
+}) => {
+  const { t } = useTranslation();
+  const csrfFetch = useCsrfFetch();
+  const { showToast } = useToast();
+  const { hasPermission } = useAuth();
+  const canWriteConfig = hasPermission('configuration', 'write');
+  // A manual poll is a user-initiated read that happens to transmit, gated on
+  // nodes:read to match the backend route.
+  const canPoll = hasPermission('nodes', 'read');
+
+  const [cfg, setCfg] = useState<NeighboursConfigState>(DEFAULT_CFG);
+  const [intervalDraft, setIntervalDraft] = useState<string>('60');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [polling, setPolling] = useState(false);
+  const [pollMsg, setPollMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+
+  const endpoint = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/nodes/${encodeURIComponent(publicKey)}/neighbours-config`;
+  const pollEndpoint = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/nodes/${encodeURIComponent(publicKey)}/neighbours/poll`;
+
+  // Refetch whenever the selected node or source changes.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setSaved(false);
+    setPollMsg(null);
+    void (async () => {
+      try {
+        const response = await csrfFetch(endpoint);
+        const data = await response.json();
+        if (cancelled) return;
+        if (data.success && data.data) {
+          const next: NeighboursConfigState = {
+            enabled: Boolean(data.data.enabled),
+            intervalMinutes: typeof data.data.intervalMinutes === 'number' ? data.data.intervalMinutes : 60,
+            lastRequestAt: data.data.lastRequestAt ?? null,
+          };
+          setCfg(next);
+          setIntervalDraft(String(next.intervalMinutes));
+        } else {
+          setError(data.error || t('meshcore.neighbours_config.load_error', 'Failed to load config'));
+        }
+      } catch (_err) {
+        if (!cancelled) {
+          setError(t('meshcore.neighbours_config.load_error', 'Failed to load config'));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [endpoint, csrfFetch, t]);
+
+  const save = async (patch: { enabled?: boolean; intervalMinutes?: number }) => {
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    try {
+      const response = await csrfFetch(endpoint, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+      const data = await response.json();
+      if (data.success && data.data) {
+        setCfg({
+          enabled: Boolean(data.data.enabled),
+          intervalMinutes: typeof data.data.intervalMinutes === 'number' ? data.data.intervalMinutes : 60,
+          lastRequestAt: data.data.lastRequestAt ?? null,
+        });
+        setSaved(true);
+        window.setTimeout(() => setSaved(false), 1800);
+      } else {
+        setError(data.error || t('meshcore.neighbours_config.save_error', 'Failed to save'));
+      }
+    } catch (_err) {
+      setError(t('meshcore.neighbours_config.save_error', 'Failed to save'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggle = (next: boolean) => {
+    setCfg((prev) => ({ ...prev, enabled: next }));
+    void save({ enabled: next });
+  };
+
+  const handleIntervalCommit = () => {
+    const n = parseInt(intervalDraft, 10);
+    if (!Number.isFinite(n) || n < MIN_INTERVAL || n > MAX_INTERVAL) {
+      setIntervalDraft(String(cfg.intervalMinutes));
+      setError(t('meshcore.neighbours_config.interval_range', `Interval must be between ${MIN_INTERVAL} and ${MAX_INTERVAL} minutes`));
+      return;
+    }
+    if (n === cfg.intervalMinutes) return;
+    void save({ intervalMinutes: n });
+  };
+
+  const poll = async () => {
+    setPolling(true);
+    setPollMsg(null);
+    try {
+      const response = await csrfFetch(pollEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      const data = await response.json();
+      if (response.ok && data.success) {
+        const written: number = typeof data.data?.written === 'number' ? data.data.written : 0;
+        setPollMsg({
+          kind: 'ok',
+          text:
+            written > 0
+              ? t('meshcore.neighbours_config.poll_wrote', `Stored ${written} neighbour(s).`)
+              : t('meshcore.neighbours_config.poll_empty', 'Request sent — no neighbours returned.'),
+        });
+      } else if (isTxDisabledBody(response.status, data)) {
+        showToast(t('meshcore.receive_only.blocked_toast', 'Receive-only mode is on for this MeshCore source — nothing was sent.'), 'warning');
+      } else {
+        setPollMsg({
+          kind: 'err',
+          text: data.error || t('meshcore.neighbours_config.poll_error', 'Poll failed'),
+        });
+      }
+    } catch (_err) {
+      setPollMsg({ kind: 'err', text: t('meshcore.neighbours_config.poll_error', 'Poll failed') });
+    } finally {
+      setPolling(false);
+    }
+  };
+
+  return (
+    <div className="node-details-block">
+      <div className="node-details-header">
+        <h3 className="node-details-title">
+          {t('meshcore.neighbours_config.title', 'Neighbours Retrieval')}
+        </h3>
+      </div>
+
+      <p className="hint" style={{ marginBottom: '0.75rem' }}>
+        {t(
+          'meshcore.neighbours_config.hint',
+          "Periodically request this node's neighbour table over RF and fill it into Node Details. A 60-second minimum spacing is enforced across all scheduled mesh ops on this source, tracked separately from Telemetry Retrieval.",
+        )}
+      </p>
+
+      {!canWriteConfig && (
+        <div
+          className="meshcore-empty-state"
+          style={{ marginBottom: '0.75rem', color: 'var(--color-warning)' }}
+          role="status"
+        >
+          {t(
+            'meshcore.config.permission_denied',
+            "You don't have permission to change configuration for this source.",
+          )}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="meshcore-empty-state">{t('meshcore.neighbours_config.loading', 'Loading…')}</div>
+      ) : (
+        <div className="node-details-grid">
+          <div className="node-detail-card">
+            <div className="node-detail-label">
+              {t('meshcore.neighbours_config.enabled_label', 'Retrieval')}
+            </div>
+            <div className="node-detail-value">
+              <label style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem' }}>
+                <input
+                  type="checkbox"
+                  checked={cfg.enabled}
+                  onChange={(e) => handleToggle(e.target.checked)}
+                  disabled={!canWriteConfig || saving}
+                  aria-label={t('meshcore.neighbours_config.enabled_label', 'Retrieval')}
+                />
+                <span>
+                  {cfg.enabled
+                    ? t('meshcore.neighbours_config.on', 'On')
+                    : t('meshcore.neighbours_config.off', 'Off')}
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <div className="node-detail-card">
+            <div className="node-detail-label">
+              {t('meshcore.neighbours_config.interval_label', 'Interval (minutes)')}
+            </div>
+            <div className="node-detail-value">
+              <input
+                type="number"
+                min={MIN_INTERVAL}
+                max={MAX_INTERVAL}
+                value={intervalDraft}
+                onChange={(e) => setIntervalDraft(e.target.value)}
+                onBlur={handleIntervalCommit}
+                disabled={!canWriteConfig || saving}
+                style={{ width: '6rem' }}
+              />
+            </div>
+          </div>
+
+          {cfg.lastRequestAt && (
+            <div className="node-detail-card node-detail-card-2col">
+              <div className="node-detail-label">
+                {t('meshcore.neighbours_config.last_request', 'Last request')}
+              </div>
+              <div className="node-detail-value">
+                {new Date(cfg.lastRequestAt).toLocaleString()}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div style={{ marginTop: '1rem', borderTop: '1px solid var(--color-surface)', paddingTop: '0.75rem' }}>
+        <div className="node-details-header">
+          <h4 className="node-details-title" style={{ fontSize: '0.95rem' }}>
+            {t('meshcore.neighbours_config.poll_title', 'Poll Now')}
+          </h4>
+        </div>
+        <p className="hint" style={{ marginBottom: '0.5rem' }}>
+          {t(
+            'meshcore.neighbours_config.poll_hint',
+            'Request neighbours immediately, outside the scheduled interval. Subject to the same 60-second mesh-TX spacing.',
+          )}
+        </p>
+        <MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={() => void poll()}
+            disabled={!canPoll || polling || receiveOnly}
+            title={receiveOnly ? t('meshcore.receive_only.control_tooltip', 'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.') : undefined}
+          >
+            {polling
+              ? t('meshcore.neighbours_config.polling', 'Polling…')
+              : t('meshcore.neighbours_config.poll_button', 'Poll Neighbours')}
+          </button>
+        </div>
+        {pollMsg && (
+          <div
+            className="meshcore-empty-state"
+            style={{ marginTop: '0.5rem', color: pollMsg.kind === 'ok' ? 'var(--color-success)' : 'var(--color-error)' }}
+            role={pollMsg.kind === 'ok' ? 'status' : 'alert'}
+          >
+            {pollMsg.text}
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="meshcore-empty-state" style={{ marginTop: '0.5rem', color: 'var(--color-error)' }} role="alert">
+          {error}
+        </div>
+      )}
+      {saved && (
+        <div className="meshcore-empty-state" style={{ marginTop: '0.5rem', color: 'var(--color-success)' }} role="status">
+          {t('meshcore.neighbours_config.saved', 'Saved.')}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/map/BaseMap.css
+++ b/src/components/map/BaseMap.css
@@ -1,0 +1,19 @@
+/*
+ * Satellite imagery tone adjustment (#4860).
+ *
+ * ESRI's World_Imagery raster (our "Satellite" and "Satellite + Labels"
+ * tilesets) renders water bodies as a flat, over-saturated synthetic blue where
+ * high-resolution imagery is unavailable — it reads like an unnatural blue
+ * overlay on rivers and lakes. We can't restyle individual features of a raster
+ * tile, so we damp the whole base layer's saturation a touch: the blue is the
+ * most-saturated element, so it calms the most, while the already-muted terrain
+ * imagery is barely affected. Applied to the BASE tiles only (the hybrid label
+ * overlay is a separate layer and stays crisp).
+ *
+ * Scoped by the `mm-satellite-base-tile` class BaseMap adds to the provided
+ * satellite tilesets. `saturate()` is per-pixel, so it introduces no tile seams.
+ * The value is intentionally conservative and easy to tune.
+ */
+.leaflet-tile.mm-satellite-base-tile {
+  filter: saturate(0.8);
+}

--- a/src/components/map/BaseMap.test.tsx
+++ b/src/components/map/BaseMap.test.tsx
@@ -23,13 +23,14 @@ vi.mock('react-leaflet', () => ({
       {children}
     </div>
   ),
-  TileLayer: (props: { url?: string; maxZoom?: number; zIndex?: number; attribution?: string }) => (
+  TileLayer: (props: { url?: string; maxZoom?: number; zIndex?: number; attribution?: string; className?: string }) => (
     <div
       data-testid="raster-tile"
       data-url={props.url}
       data-maxzoom={String(props.maxZoom)}
       data-zindex={props.zIndex === undefined ? '' : String(props.zIndex)}
       data-attribution={props.attribution}
+      data-classname={props.className ?? ''}
     />
   ),
   useMap: () => ({ invalidateSize: vi.fn() }),
@@ -129,6 +130,20 @@ describe('BaseMap', () => {
     const tiles = screen.getAllByTestId('raster-tile');
     expect(tiles).toHaveLength(1);
     expect(tiles[0].getAttribute('data-url')).toContain('World_Imagery');
+    // #4860: the provided satellite base gets the saturation-damping class.
+    expect(tiles[0].getAttribute('data-classname')).toBe('mm-satellite-base-tile');
+  });
+
+  it('damps only the base imagery on esriHybrid, not the label overlay (#4860)', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} tilesetId="esriHybrid" />);
+    const [base, overlay] = screen.getAllByTestId('raster-tile');
+    expect(base.getAttribute('data-classname')).toBe('mm-satellite-base-tile');
+    expect(overlay.getAttribute('data-classname')).toBe(''); // labels stay crisp
+  });
+
+  it('does not damp non-satellite raster tilesets (#4860)', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} tilesetId="osm" />);
+    expect(screen.getByTestId('raster-tile').getAttribute('data-classname')).toBe('');
   });
 
   // 3b. Raster tile-layer keying (tile-loading regression fix): the raster

--- a/src/components/map/BaseMap.tsx
+++ b/src/components/map/BaseMap.tsx
@@ -6,6 +6,7 @@ import { VectorTileLayer } from '../VectorTileLayer';
 import { TilesetSelector } from '../TilesetSelector';
 import MapResizeHandler from '../MapResizeHandler';
 import './leafletDefaultIcon';
+import './BaseMap.css';
 
 export interface BaseMapProps {
   /** Initial center. Like react-leaflet, this is applied once at mount and is
@@ -154,6 +155,14 @@ export function BaseMap({
                 url={tileset.url}
                 attribution={tileset.attribution}
                 maxZoom={tileset.maxZoom}
+                // Damp ESRI World_Imagery's over-saturated synthetic water blue
+                // on our provided satellite tilesets (#4860). Base tiles only —
+                // the hybrid label overlay below is left untouched.
+                className={
+                  tileset.id === 'esriSatellite' || tileset.id === 'esriHybrid'
+                    ? 'mm-satellite-base-tile'
+                    : undefined
+                }
               />
               {/* Optional transparent label/road overlay drawn on top of the
                   base raster (e.g. the satellite+labels hybrid). Keyed like the

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -167,6 +167,7 @@ import { migration as addNodeStatusMigration, runMigration149Postgres, runMigrat
 import { migration as addRoutingErrorCodeMigration, runMigration150Postgres, runMigration150Mysql } from '../server/migrations/150_add_routing_error_code.js';
 import { migration as createMessageEventsMigration, runMigration151Postgres, runMigration151Mysql } from '../server/migrations/151_create_message_events.js';
 import { migration as createMeshtasticHeardRepeatersMigration, runMigration152Postgres, runMigration152Mysql } from '../server/migrations/152_create_meshtastic_heard_repeaters.js';
+import { migration as meshcoreNodeNeighborsConfigMigration, runMigration153Postgres, runMigration153Mysql } from '../server/migrations/153_meshcore_node_neighbors_config.js';
 
 // ============================================================================
 // Registry
@@ -2434,4 +2435,21 @@ registry.register({
   sqlite: (db) => createMeshtasticHeardRepeatersMigration.up(db),
   postgres: (client) => runMigration152Postgres(client),
   mysql: (pool) => runMigration152Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 153: Per-node neighbours-retrieval config columns on meshcore_nodes
+// (neighborsEnabled, neighborsIntervalMinutes, lastNeighborsRequestAt). Read by
+// the MeshCoreNeighboursScheduler each tick (#4618). A separate column set from
+// the migration-060 telemetry trio so the two schedulers keep independent
+// cadences. Idempotent across SQLite / PostgreSQL / MySQL.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 153,
+  name: 'meshcore_node_neighbors_config',
+  settingsKey: 'migration_153_meshcore_node_neighbors_config',
+  sqlite: (db) => meshcoreNodeNeighborsConfigMigration.up(db),
+  postgres: (client) => runMigration153Postgres(client),
+  mysql: (pool) => runMigration153Mysql(pool),
 });

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -227,6 +227,9 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         telemetryEnabled INTEGER DEFAULT 0,
         telemetryIntervalMinutes INTEGER DEFAULT 60,
         lastTelemetryRequestAt INTEGER,
+        neighborsEnabled INTEGER DEFAULT 0,
+        neighborsIntervalMinutes INTEGER DEFAULT 60,
+        lastNeighborsRequestAt INTEGER,
         out_path TEXT,
         path_len INTEGER,
         adminCredential TEXT,
@@ -474,6 +477,9 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         telemetryEnabled INTEGER DEFAULT 0,
         telemetryIntervalMinutes INTEGER DEFAULT 60,
         lastTelemetryRequestAt INTEGER,
+        neighborsEnabled INTEGER DEFAULT 0,
+        neighborsIntervalMinutes INTEGER DEFAULT 60,
+        lastNeighborsRequestAt INTEGER,
         out_path TEXT,
         path_len INTEGER,
         adminCredential TEXT,
@@ -564,6 +570,56 @@ describe('MeshCoreRepository — sourceId stamping', () => {
     ).rejects.toThrow(/requires a sourceId/);
   });
 
+  // ============ Neighbours-retrieval config (#4618) ============
+
+  it('getNeighborsEnabledNodes only returns rows with neighborsEnabled=true and matching sourceId', async () => {
+    await repo.upsertNode({ publicKey: 'pk-1' }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk-2' }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk-3' }, 'src-b');
+    await repo.setNodeNeighborsConfig('src-a', 'pk-1', { enabled: true });
+    await repo.setNodeNeighborsConfig('src-a', 'pk-2', { enabled: false });
+    await repo.setNodeNeighborsConfig('src-b', 'pk-3', { enabled: true });
+
+    const aResult = await repo.getNeighborsEnabledNodes('src-a');
+    expect(aResult.map((n) => n.publicKey)).toEqual(['pk-1']);
+
+    const bResult = await repo.getNeighborsEnabledNodes('src-b');
+    expect(bResult.map((n) => n.publicKey)).toEqual(['pk-3']);
+  });
+
+  it('markNeighborsRequested stamps lastNeighborsRequestAt WITHOUT touching lastTelemetryRequestAt', async () => {
+    await repo.upsertNode({ publicKey: 'pk-1' }, 'src-a');
+    await repo.setNodeNeighborsConfig('src-a', 'pk-1', { enabled: true });
+    await repo.markTelemetryRequested('src-a', 'pk-1', 111_111);
+    await repo.markNeighborsRequested('src-a', 'pk-1', 999_999);
+
+    const row = db
+      .prepare(`SELECT lastNeighborsRequestAt, lastTelemetryRequestAt FROM meshcore_nodes WHERE publicKey = 'pk-1'`)
+      .get() as { lastNeighborsRequestAt: number; lastTelemetryRequestAt: number };
+    // The two cadences must stay independent — a neighbours poll must never
+    // reset the telemetry timer (#4618).
+    expect(row.lastNeighborsRequestAt).toBe(999_999);
+    expect(row.lastTelemetryRequestAt).toBe(111_111);
+  });
+
+  it('setNodeNeighborsConfig is scoped by sourceId — same publicKey on two sources is independent', async () => {
+    await repo.upsertNode({ publicKey: 'pk-1' }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk-1' }, 'src-b');
+    await repo.setNodeNeighborsConfig('src-a', 'pk-1', { enabled: true, intervalMinutes: 10 });
+    await repo.setNodeNeighborsConfig('src-b', 'pk-1', { enabled: false, intervalMinutes: 90 });
+
+    const a = await repo.getNeighborsEnabledNodes('src-a');
+    expect(a.map((n) => n.publicKey)).toEqual(['pk-1']);
+    const b = await repo.getNeighborsEnabledNodes('src-b');
+    expect(b).toHaveLength(0);
+  });
+
+  it('setNodeNeighborsConfig throws without a sourceId', async () => {
+    await expect(
+      repo.setNodeNeighborsConfig('', 'pk-1', { enabled: true }),
+    ).rejects.toThrow(/requires a sourceId/);
+  });
+
   // ============ Composite-PK regression (issue: UNIQUE constraint failed) ============
 
   it('setNodeTelemetryConfig succeeds for the same publicKey under two sources on the composite-PK schema', async () => {
@@ -600,6 +656,9 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         telemetryEnabled INTEGER DEFAULT 0,
         telemetryIntervalMinutes INTEGER DEFAULT 60,
         lastTelemetryRequestAt INTEGER,
+        neighborsEnabled INTEGER DEFAULT 0,
+        neighborsIntervalMinutes INTEGER DEFAULT 60,
+        lastNeighborsRequestAt INTEGER,
         out_path TEXT,
         path_len INTEGER,
         adminCredential TEXT,
@@ -670,6 +729,9 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         telemetryEnabled INTEGER DEFAULT 0,
         telemetryIntervalMinutes INTEGER DEFAULT 60,
         lastTelemetryRequestAt INTEGER,
+        neighborsEnabled INTEGER DEFAULT 0,
+        neighborsIntervalMinutes INTEGER DEFAULT 60,
+        lastNeighborsRequestAt INTEGER,
         out_path TEXT,
         path_len INTEGER,
         adminCredential TEXT,

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -68,6 +68,16 @@ export interface DbMeshCoreNode {
   telemetryIntervalMinutes?: number | null;
   lastTelemetryRequestAt?: number | null;
   /**
+   * Per-node neighbours-retrieval config (migration 153, #4618). Controls
+   * whether the MeshCoreNeighboursScheduler periodically requests this
+   * node's neighbour table and at what cadence — independent of the
+   * telemetry-retrieval trio above so the two schedulers never reset each
+   * other's timers.
+   */
+  neighborsEnabled?: boolean | null;
+  neighborsIntervalMinutes?: number | null;
+  lastNeighborsRequestAt?: number | null;
+  /**
    * MeshCore per-contact forwarding route (migration 068). `outPath` is a
    * comma-separated hex chain of hop hashes ("a3,7f,02"); `pathLen` is the
    * hop count. Both null means the firmware's OUT_PATH_UNKNOWN (0xFF)
@@ -438,6 +448,48 @@ export class MeshCoreRepository extends BaseRepository {
   }
 
   /**
+   * Persist the per-node neighbours-retrieval config (migration 153, #4618).
+   * Direct mirror of `setNodeTelemetryConfig` — inserts a stub row when the
+   * node has only been seen in-memory, idempotent on (publicKey, sourceId).
+   * Passing `undefined` for either field leaves the existing value intact
+   * (on update) or applies the column default (on insert). Caller validates
+   * `intervalMinutes`.
+   */
+  async setNodeNeighborsConfig(
+    sourceId: string,
+    publicKey: string,
+    cfg: { enabled?: boolean; intervalMinutes?: number },
+  ): Promise<void> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.setNodeNeighborsConfig requires a sourceId');
+    }
+    const now = this.now();
+    const { meshcoreNodes } = this.tables;
+    const existing = await this.getNodeByPublicKeyAndSource(publicKey, sourceId);
+
+    if (existing) {
+      const patch: Record<string, unknown> = { updatedAt: now };
+      if (cfg.enabled !== undefined) patch.neighborsEnabled = cfg.enabled;
+      if (cfg.intervalMinutes !== undefined) patch.neighborsIntervalMinutes = cfg.intervalMinutes;
+      await this.db
+        .update(meshcoreNodes)
+        .set(patch)
+        .where(and(eq(meshcoreNodes.publicKey, publicKey), eq(meshcoreNodes.sourceId, sourceId)));
+      return;
+    }
+
+    const seed: Record<string, unknown> = {
+      publicKey,
+      sourceId,
+      createdAt: now,
+      updatedAt: now,
+    };
+    if (cfg.enabled !== undefined) seed.neighborsEnabled = cfg.enabled;
+    if (cfg.intervalMinutes !== undefined) seed.neighborsIntervalMinutes = cfg.intervalMinutes;
+    await this.db.insert(meshcoreNodes).values(seed);
+  }
+
+  /**
    * Set the local favorite flag for a (sourceId, publicKey) node
    * (migration 094). This repository method only writes local state; syncing
    * the firmware favourite bit to the device (#4838) is handled separately by
@@ -494,6 +546,28 @@ export class MeshCoreRepository extends BaseRepository {
     await this.db
       .update(meshcoreNodes)
       .set({ lastTelemetryRequestAt: when, updatedAt: when })
+      .where(and(eq(meshcoreNodes.publicKey, publicKey), eq(meshcoreNodes.sourceId, sourceId)));
+  }
+
+  /**
+   * Mark a node as having just had a neighbours request sent. Stamps
+   * `lastNeighborsRequestAt` so the scheduler waits at least
+   * `neighborsIntervalMinutes` before picking it again. Separate from
+   * `markTelemetryRequested` so a neighbours poll never resets the
+   * telemetry cadence (#4618).
+   */
+  async markNeighborsRequested(
+    sourceId: string,
+    publicKey: string,
+    when: number = this.now(),
+  ): Promise<void> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.markNeighborsRequested requires a sourceId');
+    }
+    const { meshcoreNodes } = this.tables;
+    await this.db
+      .update(meshcoreNodes)
+      .set({ lastNeighborsRequestAt: when, updatedAt: when })
       .where(and(eq(meshcoreNodes.publicKey, publicKey), eq(meshcoreNodes.sourceId, sourceId)));
   }
 
@@ -700,6 +774,21 @@ export class MeshCoreRepository extends BaseRepository {
       .select()
       .from(meshcoreNodes)
       .where(and(eq(meshcoreNodes.sourceId, sourceId), eq(meshcoreNodes.telemetryEnabled, true)));
+    return this.normalizeBigInts(result) as unknown as DbMeshCoreNode[];
+  }
+
+  /**
+   * Return every node in a source that currently has neighbours retrieval
+   * enabled. Like `getTelemetryEnabledNodes`, per-node eligibility (interval
+   * vs `lastNeighborsRequestAt`) is decided in memory by the scheduler so
+   * the query stays engine-portable (#4618).
+   */
+  async getNeighborsEnabledNodes(sourceId: string): Promise<DbMeshCoreNode[]> {
+    const { meshcoreNodes } = this.tables;
+    const result = await this.db
+      .select()
+      .from(meshcoreNodes)
+      .where(and(eq(meshcoreNodes.sourceId, sourceId), eq(meshcoreNodes.neighborsEnabled, true)));
     return this.normalizeBigInts(result) as unknown as DbMeshCoreNode[];
   }
 

--- a/src/db/schema/meshcoreNodes.ts
+++ b/src/db/schema/meshcoreNodes.ts
@@ -82,6 +82,13 @@ export const meshcoreNodesSqlite = sqliteTable('meshcore_nodes', {
   telemetryIntervalMinutes: integer('telemetryIntervalMinutes').default(60),
   lastTelemetryRequestAt: integer('lastTelemetryRequestAt'),
 
+  // Per-node neighbours-retrieval config (migration 153, #4618). Read by the
+  // MeshCoreNeighboursScheduler; a separate column set from the telemetry trio
+  // above so the two schedulers keep independent per-node cadences.
+  neighborsEnabled: integer('neighborsEnabled', { mode: 'boolean' }).default(false),
+  neighborsIntervalMinutes: integer('neighborsIntervalMinutes').default(60),
+  lastNeighborsRequestAt: integer('lastNeighborsRequestAt'),
+
   // Per-room-server sync config (migration 072).
   roomSyncEnabled: integer('roomSyncEnabled', { mode: 'boolean' }).default(false),
   roomSyncIntervalMinutes: integer('roomSyncIntervalMinutes').default(60),

--- a/src/db/schema/meshcoreNodes.ts
+++ b/src/db/schema/meshcoreNodes.ts
@@ -151,6 +151,10 @@ export const meshcoreNodesPostgres = pgTable('meshcore_nodes', {
   telemetryIntervalMinutes: pgInteger('telemetryIntervalMinutes').default(60),
   lastTelemetryRequestAt: pgBigint('lastTelemetryRequestAt', { mode: 'number' }),
 
+  neighborsEnabled: pgBoolean('neighborsEnabled').default(false),
+  neighborsIntervalMinutes: pgInteger('neighborsIntervalMinutes').default(60),
+  lastNeighborsRequestAt: pgBigint('lastNeighborsRequestAt', { mode: 'number' }),
+
   roomSyncEnabled: pgBoolean('roomSyncEnabled').default(false),
   roomSyncIntervalMinutes: pgInteger('roomSyncIntervalMinutes').default(60),
   lastRoomSyncAt: pgBigint('lastRoomSyncAt', { mode: 'number' }),
@@ -206,6 +210,10 @@ export const meshcoreNodesMysql = mysqlTable('meshcore_nodes', {
   telemetryEnabled: myBoolean('telemetryEnabled').default(false),
   telemetryIntervalMinutes: myInt('telemetryIntervalMinutes').default(60),
   lastTelemetryRequestAt: myBigint('lastTelemetryRequestAt', { mode: 'number' }),
+
+  neighborsEnabled: myBoolean('neighborsEnabled').default(false),
+  neighborsIntervalMinutes: myInt('neighborsIntervalMinutes').default(60),
+  lastNeighborsRequestAt: myBigint('lastNeighborsRequestAt', { mode: 'number' }),
 
   roomSyncEnabled: myBoolean('roomSyncEnabled').default(false),
   roomSyncIntervalMinutes: myInt('roomSyncIntervalMinutes').default(60),

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -5016,6 +5016,39 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   }
 
   /**
+   * Query a node's neighbour table over RF and persist the result, resolving
+   * each returned prefix to a full contact pubkey the same way
+   * `startAutoPathfinding` does. Shared by the MeshCoreNeighboursScheduler
+   * (#4618) and the manual per-node neighbours-poll route so both paths use
+   * identical request → resolve → store logic.
+   *
+   * Returns `{ total, written }` (`written` = neighbours we could resolve and
+   * store), or `null` when the query failed (disconnected, not a Companion,
+   * firmware too old, or the bridge returned an error). Does NOT own the
+   * per-source 60s TX gate or the `lastNeighborsRequestAt` stamp — callers
+   * enforce those, mirroring the telemetry scheduler's division of labour.
+   */
+  async pollNeighborsAndStore(publicKey: string): Promise<{ total: number; written: number } | null> {
+    const result = await this.getNeighbours(publicKey);
+    if (!result) return null;
+
+    const toStore = result.neighbours
+      .map((n) => {
+        const contact = this.resolveContactByPrefix(n.publicKeyPrefix);
+        return contact?.publicKey
+          ? { neighborPublicKey: contact.publicKey, snr: n.snr, lastHeardSecs: n.heardSecondsAgo }
+          : null;
+      })
+      .filter((n): n is NonNullable<typeof n> => n !== null);
+
+    // Always call insertNeighborsBatch — even with zero resolved neighbours it
+    // clears the previous (now stale) set for this reporter, matching the
+    // route/auto-pathfinding semantics.
+    await databaseService.meshcore.insertNeighborsBatch(this.sourceId, publicKey, toStore);
+    return { total: result.total, written: toStore.length };
+  }
+
+  /**
    * Reboot the locally connected device. Companion only. This is a
    * destructive operation — the device will disconnect and restart.
    */

--- a/src/server/migrations/153_meshcore_node_neighbors_config.pgmysql.test.ts
+++ b/src/server/migrations/153_meshcore_node_neighbors_config.pgmysql.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Migration 153 — PostgreSQL / MySQL container behaviour (#4618).
+ *
+ * `describe.skipIf(!postgresAvailable/!mysqlAvailable)` — seeds a minimal
+ * `meshcore_nodes` table against the live test containers (localhost:5433 /
+ * :3307), runs the ADD-COLUMN migration, asserts the three neighbours columns
+ * exist with their defaults, and asserts idempotency (running twice is a
+ * no-op). A silent skip here still reports `success: true` at the suite level
+ * — confirm via `numPendingTests` in the JSON reporter, not just the pass/fail
+ * summary (see CLAUDE.md Multi-Database section).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import mysql from 'mysql2/promise';
+import { runMigration153Postgres, runMigration153Mysql } from './153_meshcore_node_neighbors_config.js';
+import { postgresAvailable, mysqlAvailable } from '../../db/repositories/test-utils.js';
+
+const { Pool: PgPool } = pg;
+
+describe.skipIf(!postgresAvailable)('migration 153 — PostgreSQL (container)', () => {
+  let pool: InstanceType<typeof PgPool>;
+
+  beforeAll(async () => {
+    pool = new PgPool({
+      host: 'localhost',
+      port: 5433,
+      user: 'test',
+      password: 'test',
+      database: 'meshmonitor_test',
+    });
+    await pool.query('DROP TABLE IF EXISTS meshcore_nodes CASCADE');
+    await pool.query(`
+      CREATE TABLE meshcore_nodes (
+        "publicKey" TEXT NOT NULL,
+        name TEXT,
+        "sourceId" TEXT NOT NULL,
+        "createdAt" BIGINT NOT NULL,
+        "updatedAt" BIGINT NOT NULL,
+        PRIMARY KEY ("sourceId", "publicKey")
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query('DROP TABLE IF EXISTS meshcore_nodes CASCADE');
+      await pool.end();
+    }
+  });
+
+  it('adds the neighbours columns with defaults and is idempotent', async () => {
+    const client = await pool.connect();
+    try {
+      await runMigration153Postgres(client);
+      await expect(runMigration153Postgres(client)).resolves.toBeUndefined();
+    } finally {
+      client.release();
+    }
+
+    const now = Date.now();
+    await pool.query(
+      `INSERT INTO meshcore_nodes ("publicKey", name, "sourceId", "createdAt", "updatedAt")
+       VALUES ($1, $2, $3, $4, $4)`,
+      ['pk-1', 'node-1', 'src-a', now],
+    );
+
+    const { rows } = await pool.query(
+      `SELECT "neighborsEnabled", "neighborsIntervalMinutes", "lastNeighborsRequestAt"
+       FROM meshcore_nodes WHERE "publicKey" = 'pk-1'`,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].neighborsEnabled).toBe(false);
+    expect(rows[0].neighborsIntervalMinutes).toBe(60);
+    expect(rows[0].lastNeighborsRequestAt).toBeNull();
+  });
+});
+
+describe.skipIf(!mysqlAvailable)('migration 153 — MySQL (container)', () => {
+  let pool: mysql.Pool;
+
+  beforeAll(async () => {
+    pool = mysql.createPool({
+      host: 'localhost',
+      port: 3307,
+      user: 'test',
+      password: 'test',
+      database: 'meshmonitor_test',
+      connectionLimit: 5,
+    });
+    await pool.query('DROP TABLE IF EXISTS meshcore_nodes');
+    await pool.query(`
+      CREATE TABLE meshcore_nodes (
+        publicKey VARCHAR(64) NOT NULL,
+        name VARCHAR(255),
+        sourceId VARCHAR(64) NOT NULL,
+        createdAt BIGINT NOT NULL,
+        updatedAt BIGINT NOT NULL,
+        PRIMARY KEY (sourceId, publicKey)
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query('DROP TABLE IF EXISTS meshcore_nodes');
+      await pool.end();
+    }
+  });
+
+  it('adds the neighbours columns with defaults and is idempotent', async () => {
+    await runMigration153Mysql(pool);
+    await expect(runMigration153Mysql(pool)).resolves.toBeUndefined();
+
+    const now = Date.now();
+    await pool.query(
+      `INSERT INTO meshcore_nodes (publicKey, name, sourceId, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, ?)`,
+      ['pk-1', 'node-1', 'src-a', now, now],
+    );
+
+    const [rows] = await pool.query(
+      `SELECT neighborsEnabled, neighborsIntervalMinutes, lastNeighborsRequestAt
+       FROM meshcore_nodes WHERE publicKey = 'pk-1'`,
+    );
+    const result = rows as any[];
+    expect(result).toHaveLength(1);
+    expect(result[0].neighborsEnabled).toBe(0);
+    expect(result[0].neighborsIntervalMinutes).toBe(60);
+    expect(result[0].lastNeighborsRequestAt).toBeNull();
+  });
+});

--- a/src/server/migrations/153_meshcore_node_neighbors_config.test.ts
+++ b/src/server/migrations/153_meshcore_node_neighbors_config.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Migration 153 — Per-node neighbours-retrieval columns on `meshcore_nodes`
+ * (#4618). SQLite-only test; the PostgreSQL / MySQL paths share the same
+ * shape and are exercised by the integration suite.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './153_meshcore_node_neighbors_config.js';
+
+function createSchema(db: Database.Database) {
+  // Post-migration-057 shape: meshcore_nodes already has sourceId.
+  db.exec(`
+    CREATE TABLE meshcore_nodes (
+      publicKey TEXT PRIMARY KEY,
+      name TEXT,
+      sourceId TEXT,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL
+    );
+  `);
+}
+
+describe('Migration 153 — meshcore_nodes neighbours-retrieval columns', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createSchema(db);
+  });
+
+  it('adds neighborsEnabled, neighborsIntervalMinutes, lastNeighborsRequestAt', () => {
+    migration.up(db);
+    const cols = db.prepare(`PRAGMA table_info(meshcore_nodes)`).all() as Array<{
+      name: string;
+      type: string;
+      dflt_value: unknown;
+    }>;
+    const colNames = cols.map((c) => c.name);
+    expect(colNames).toContain('neighborsEnabled');
+    expect(colNames).toContain('neighborsIntervalMinutes');
+    expect(colNames).toContain('lastNeighborsRequestAt');
+  });
+
+  it('applies safe defaults — disabled, 60-minute interval, null lastRequest', () => {
+    migration.up(db);
+    const ts = Date.now();
+    db.prepare(
+      `INSERT INTO meshcore_nodes (publicKey, name, sourceId, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)`,
+    ).run('pk-1', 'node-1', 'src-a', ts, ts);
+
+    const row = db
+      .prepare(
+        `SELECT neighborsEnabled, neighborsIntervalMinutes, lastNeighborsRequestAt
+         FROM meshcore_nodes WHERE publicKey = 'pk-1'`,
+      )
+      .get() as {
+      neighborsEnabled: number;
+      neighborsIntervalMinutes: number;
+      lastNeighborsRequestAt: number | null;
+    };
+    expect(row.neighborsEnabled).toBe(0);
+    expect(row.neighborsIntervalMinutes).toBe(60);
+    expect(row.lastNeighborsRequestAt).toBeNull();
+  });
+
+  it('is idempotent — running twice does not fail or duplicate columns', () => {
+    migration.up(db);
+    expect(() => migration.up(db)).not.toThrow();
+    const cols = db.prepare(`PRAGMA table_info(meshcore_nodes)`).all() as Array<{ name: string }>;
+    const neighborCols = cols.filter(
+      (c) => c.name.startsWith('neighbors') || c.name.startsWith('lastNeighbors'),
+    );
+    expect(neighborCols).toHaveLength(3);
+  });
+
+  it('does not touch the telemetry columns — cadences stay independent', () => {
+    // Seed the migration-060 telemetry trio first, then run 153: the two sets
+    // must coexist so a neighbours poll never resets the telemetry timer.
+    db.exec(`ALTER TABLE meshcore_nodes ADD COLUMN telemetryEnabled INTEGER DEFAULT 0`);
+    db.exec(`ALTER TABLE meshcore_nodes ADD COLUMN lastTelemetryRequestAt INTEGER`);
+    migration.up(db);
+    const colNames = (db.prepare(`PRAGMA table_info(meshcore_nodes)`).all() as Array<{ name: string }>)
+      .map((c) => c.name);
+    expect(colNames).toContain('telemetryEnabled');
+    expect(colNames).toContain('lastTelemetryRequestAt');
+    expect(colNames).toContain('neighborsEnabled');
+    expect(colNames).toContain('lastNeighborsRequestAt');
+  });
+});

--- a/src/server/migrations/153_meshcore_node_neighbors_config.ts
+++ b/src/server/migrations/153_meshcore_node_neighbors_config.ts
@@ -1,0 +1,116 @@
+/**
+ * Migration 153: Per-node neighbours-retrieval config on `meshcore_nodes`.
+ *
+ * Adds three nullable columns the new MeshCore neighbours scheduler
+ * (`MeshCoreNeighboursScheduler`, issue #4618) reads on each tick — a
+ * direct mirror of the migration-060 telemetry-retrieval trio, kept as a
+ * SEPARATE set of columns so a neighbours poll never resets the telemetry
+ * cadence (and vice versa):
+ *
+ *   neighborsEnabled          BOOLEAN  (false by default)
+ *   neighborsIntervalMinutes  INTEGER  (60 default; 0 disables this row)
+ *   lastNeighborsRequestAt    BIGINT   (ms; null until first attempt)
+ *
+ * Backfill is unnecessary — the absence of `neighborsEnabled=true` means
+ * the scheduler will never pick the row. Existing rows therefore keep
+ * their current behaviour without explicit migration work.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 153';
+
+interface ColumnSpec {
+  name: string;
+  sqliteType: string;
+  postgresType: string;
+  mysqlType: string;
+}
+
+const COLUMNS: ColumnSpec[] = [
+  {
+    name: 'neighborsEnabled',
+    sqliteType: 'INTEGER DEFAULT 0',
+    postgresType: 'BOOLEAN DEFAULT FALSE',
+    mysqlType: 'TINYINT(1) DEFAULT 0',
+  },
+  {
+    name: 'neighborsIntervalMinutes',
+    sqliteType: 'INTEGER DEFAULT 60',
+    postgresType: 'INTEGER DEFAULT 60',
+    mysqlType: 'INT DEFAULT 60',
+  },
+  {
+    name: 'lastNeighborsRequestAt',
+    sqliteType: 'INTEGER',
+    postgresType: 'BIGINT',
+    mysqlType: 'BIGINT',
+  },
+];
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding per-node neighbours-retrieval columns to meshcore_nodes...`);
+
+    for (const col of COLUMNS) {
+      try {
+        db.exec(`ALTER TABLE meshcore_nodes ADD COLUMN ${col.name} ${col.sqliteType}`);
+        logger.debug(`${LABEL} (SQLite): added meshcore_nodes.${col.name}`);
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        if (message.includes('duplicate column')) {
+          logger.debug(`${LABEL} (SQLite): meshcore_nodes.${col.name} already exists, skipping`);
+        } else {
+          logger.error(`${LABEL} (SQLite): could not add meshcore_nodes.${col.name}:`, message);
+          throw e;
+        }
+      }
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration153Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding per-node neighbours-retrieval columns...`);
+
+  for (const col of COLUMNS) {
+    await client.query(
+      `ALTER TABLE meshcore_nodes ADD COLUMN IF NOT EXISTS "${col.name}" ${col.postgresType}`,
+    );
+    logger.debug(`${LABEL} (PostgreSQL): ensured meshcore_nodes.${col.name}`);
+  }
+}
+
+// ============ MySQL ============
+
+export async function runMigration153Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding per-node neighbours-retrieval columns...`);
+
+  const conn = await pool.getConnection();
+  try {
+    for (const col of COLUMNS) {
+      const [rows] = await conn.query(
+        `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'meshcore_nodes' AND COLUMN_NAME = ?`,
+        [col.name],
+      );
+      if (!Array.isArray(rows) || rows.length === 0) {
+        await conn.query(`ALTER TABLE meshcore_nodes ADD COLUMN ${col.name} ${col.mysqlType}`);
+        logger.debug(`${LABEL} (MySQL): added meshcore_nodes.${col.name}`);
+      } else {
+        logger.debug(`${LABEL} (MySQL): meshcore_nodes.${col.name} already exists, skipping`);
+      }
+    }
+  } finally {
+    conn.release();
+  }
+}

--- a/src/server/routes/meshcoreContactsRoutes.ts
+++ b/src/server/routes/meshcoreContactsRoutes.ts
@@ -971,6 +971,204 @@ router.patch(
 );
 
 /**
+ * GET /api/sources/:id/meshcore/nodes/:publicKey/neighbours-config
+ *
+ * Read the per-node neighbours-retrieval config (issue #4618). Returns the
+ * persisted (neighborsEnabled, neighborsIntervalMinutes,
+ * lastNeighborsRequestAt) triple, or defaults (`enabled: false,
+ * intervalMinutes: 60, lastRequestAt: null`) if the node has never been
+ * written. Mirror of the telemetry-config GET.
+ */
+router.get(
+  '/nodes/:publicKey/neighbours-config',
+  optionalAuth(),
+  requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id: string }).id;
+      const { publicKey } = req.params;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
+      }
+      const node = await databaseService.meshcore.getNodeByPublicKeyAndSource(publicKey, sourceId);
+      res.json({
+        success: true,
+        data: {
+          publicKey,
+          sourceId,
+          enabled: Boolean(node?.neighborsEnabled),
+          intervalMinutes: node?.neighborsIntervalMinutes ?? 60,
+          lastRequestAt: node?.lastNeighborsRequestAt ?? null,
+        },
+      });
+    } catch (error) {
+      logger.error('[API] Error getting per-node neighbours-config:', error);
+      res.status(500).json({ success: false, error: 'Failed to read neighbours-config' });
+    }
+  },
+);
+
+/**
+ * POST /api/sources/:id/meshcore/nodes/:publicKey/neighbours/poll
+ *
+ * Manually request this node's neighbour table immediately, outside the
+ * scheduler's cadence (#4618). Honours the same per-source 60s mesh-TX gate
+ * as the scheduler and the telemetry poll, so the button can't be spammed
+ * onto the air. Gated by `nodes:read` (a manual poll is a user-initiated
+ * read that happens to transmit) and rate-limited by `meshcoreDeviceLimiter`.
+ */
+router.post(
+  '/nodes/:publicKey/neighbours/poll',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }),
+  requireMeshcoreTx(),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id: string }).id;
+      const { publicKey } = req.params;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
+      }
+
+      const manager = managerFor(req, res);
+      if (!manager.isConnected()) {
+        return res.status(409).json({ success: false, error: 'MeshCore source is not connected' });
+      }
+
+      // Per-source 60s mesh-TX gate — the same primitive the scheduler uses,
+      // so a manual poll can't flood the air or collide with a scheduled
+      // request already in flight on this source.
+      const lastTx = manager.getLastMeshTxAt();
+      const sinceLastTx = Date.now() - lastTx;
+      if (lastTx > 0 && sinceLastTx < MIN_INTERVAL_BETWEEN_REQUESTS_MS) {
+        const retryAfterSecs = Math.ceil((MIN_INTERVAL_BETWEEN_REQUESTS_MS - sinceLastTx) / 1000);
+        res.set('Retry-After', String(retryAfterSecs));
+        return res.status(429).json({
+          success: false,
+          error: `Too soon since last mesh transmission; retry in ${retryAfterSecs}s`,
+          retryAfterSecs,
+        });
+      }
+
+      // Stamp before issuing so the gate applies regardless of result and the
+      // scheduler's fair-rotation clock advances too.
+      const now = Date.now();
+      manager.recordMeshTx(now);
+      await databaseService.meshcore.markNeighborsRequested(sourceId, publicKey, now);
+
+      const result = await manager.pollNeighborsAndStore(publicKey);
+      if (!result) {
+        return res.json({
+          success: true,
+          data: { total: 0, written: 0, notSupported: true },
+        });
+      }
+
+      res.json({
+        success: true,
+        data: { total: result.total, written: result.written },
+      });
+    } catch (error) {
+      if (failIfTxDisabled(res, error)) return;
+      logger.error('[API] Error polling node neighbours:', error);
+      res.status(500).json({ success: false, error: 'Neighbours poll failed' });
+    }
+  },
+);
+
+/**
+ * PATCH /api/sources/:id/meshcore/nodes/:publicKey/neighbours-config
+ *
+ * Update the per-node neighbours-retrieval config. Body:
+ *   { enabled?: boolean, intervalMinutes?: number }
+ *
+ * Gated by `configuration:write`, mirroring the telemetry-config PATCH.
+ */
+router.patch(
+  '/nodes/:publicKey/neighbours-config',
+  requireAuth(),
+  requirePermission('configuration', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id: string }).id;
+      const { publicKey } = req.params;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
+      }
+
+      const { enabled, intervalMinutes } = req.body ?? {};
+
+      const patch: { enabled?: boolean; intervalMinutes?: number } = {};
+      if (enabled !== undefined) {
+        if (typeof enabled !== 'boolean') {
+          return res.status(400).json({ success: false, error: 'enabled must be a boolean' });
+        }
+        patch.enabled = enabled;
+      }
+      if (intervalMinutes !== undefined) {
+        const n = Number(intervalMinutes);
+        if (!Number.isInteger(n) || n < 1 || n > MAX_INTERVAL_MINUTES) {
+          return res.status(400).json({
+            success: false,
+            error: `intervalMinutes must be an integer between 1 and ${MAX_INTERVAL_MINUTES}`,
+          });
+        }
+        patch.intervalMinutes = n;
+      }
+      if (patch.enabled === undefined && patch.intervalMinutes === undefined) {
+        return res.status(400).json({ success: false, error: 'No fields to update' });
+      }
+
+      // Backfill advType/advName/position from the in-memory contact before
+      // seeding the stub row, mirroring the telemetry-config PATCH so the
+      // node is classified correctly and Node Details has a name to show.
+      const manager = managerFor(req, res);
+      const contact = manager.getContact(publicKey);
+      if (contact) {
+        try {
+          await databaseService.meshcore.upsertNode(
+            {
+              publicKey,
+              name: contact.advName ?? contact.name ?? null,
+              advType: contact.advType ?? null,
+              latitude: contact.latitude ?? null,
+              longitude: contact.longitude ?? null,
+              positionSource: (typeof contact.latitude === 'number'
+                && typeof contact.longitude === 'number'
+                && !isBogusPosition(contact.latitude, contact.longitude))
+                ? 'contact'
+                : undefined,
+              lastHeard: contact.lastSeen ?? null,
+            },
+            sourceId,
+          );
+        } catch (err) {
+          logger.warn(
+            `[API] neighbours-config: contact backfill for ${publicKey.substring(0, 16)}… failed: ${(err as Error).message}`,
+          );
+        }
+      }
+      await databaseService.meshcore.setNodeNeighborsConfig(sourceId, publicKey, patch);
+      const node = await databaseService.meshcore.getNodeByPublicKeyAndSource(publicKey, sourceId);
+      res.json({
+        success: true,
+        data: {
+          publicKey,
+          sourceId,
+          enabled: Boolean(node?.neighborsEnabled),
+          intervalMinutes: node?.neighborsIntervalMinutes ?? 60,
+          lastRequestAt: node?.lastNeighborsRequestAt ?? null,
+        },
+      });
+    } catch (error) {
+      logger.error('[API] Error setting per-node neighbours-config:', error);
+      res.status(500).json({ success: false, error: 'Failed to update neighbours-config' });
+    }
+  },
+);
+
+/**
  * POST /api/sources/:id/meshcore/nodes/:publicKey/favorite
  *
  * Toggle the server-side favorite flag for a MeshCore node (any role:

--- a/src/server/routes/meshcoreContactsRoutes.ts
+++ b/src/server/routes/meshcoreContactsRoutes.ts
@@ -15,6 +15,12 @@ import {
   MIN_INTERVAL_BETWEEN_REQUESTS_MS,
   getMeshCoreRemoteTelemetryScheduler,
 } from '../services/meshcoreRemoteTelemetryScheduler.js';
+// The neighbours routes gate against the neighbours scheduler's own limits so
+// they stay correct if the two schedulers' constants ever diverge (#4618).
+import {
+  MAX_INTERVAL_MINUTES as NEIGHBOURS_MAX_INTERVAL_MINUTES,
+  MIN_INTERVAL_BETWEEN_REQUESTS_MS as NEIGHBOURS_MIN_INTERVAL_BETWEEN_REQUESTS_MS,
+} from '../services/meshcoreNeighboursScheduler.js';
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
@@ -1041,8 +1047,8 @@ router.post(
       // request already in flight on this source.
       const lastTx = manager.getLastMeshTxAt();
       const sinceLastTx = Date.now() - lastTx;
-      if (lastTx > 0 && sinceLastTx < MIN_INTERVAL_BETWEEN_REQUESTS_MS) {
-        const retryAfterSecs = Math.ceil((MIN_INTERVAL_BETWEEN_REQUESTS_MS - sinceLastTx) / 1000);
+      if (lastTx > 0 && sinceLastTx < NEIGHBOURS_MIN_INTERVAL_BETWEEN_REQUESTS_MS) {
+        const retryAfterSecs = Math.ceil((NEIGHBOURS_MIN_INTERVAL_BETWEEN_REQUESTS_MS - sinceLastTx) / 1000);
         res.set('Retry-After', String(retryAfterSecs));
         return res.status(429).json({
           success: false,
@@ -1108,10 +1114,10 @@ router.patch(
       }
       if (intervalMinutes !== undefined) {
         const n = Number(intervalMinutes);
-        if (!Number.isInteger(n) || n < 1 || n > MAX_INTERVAL_MINUTES) {
+        if (!Number.isInteger(n) || n < 1 || n > NEIGHBOURS_MAX_INTERVAL_MINUTES) {
           return res.status(400).json({
             success: false,
-            error: `intervalMinutes must be an integer between 1 and ${MAX_INTERVAL_MINUTES}`,
+            error: `intervalMinutes must be an integer between 1 and ${NEIGHBOURS_MAX_INTERVAL_MINUTES}`,
           });
         }
         patch.intervalMinutes = n;

--- a/src/server/routes/meshcoreRoutes.receiveOnly.test.ts
+++ b/src/server/routes/meshcoreRoutes.receiveOnly.test.ts
@@ -175,6 +175,7 @@ describe('MeshCore receive-only — 409 TX_DISABLED mapping (#4547)', () => {
     { name: 'POST /contacts/:publicKey/share', method: 'post', path: `/contacts/${VALID_PK}/share` },
     { name: 'GET /contacts/:publicKey/neighbours', method: 'get', path: `/contacts/${VALID_PK}/neighbours` },
     { name: 'POST /nodes/:publicKey/telemetry/poll', method: 'post', path: `/nodes/${VALID_PK}/telemetry/poll`, body: { type: 'status' } },
+    { name: 'POST /nodes/:publicKey/neighbours/poll', method: 'post', path: `/nodes/${VALID_PK}/neighbours/poll` },
     { name: 'POST /admin/login', method: 'post', path: '/admin/login', body: { publicKey: VALID_PK, password: '' } },
     { name: 'POST /admin/cli', method: 'post', path: '/admin/cli', body: { publicKey: VALID_PK, command: 'ver' } },
     { name: 'POST /admin/login-with-saved', method: 'post', path: '/admin/login-with-saved', body: { publicKey: VALID_PK } },
@@ -184,8 +185,8 @@ describe('MeshCore receive-only — 409 TX_DISABLED mapping (#4547)', () => {
     { name: 'POST /automation/timers/:triggerId/run', method: 'post', path: '/automation/timers/t1/run' },
   ];
 
-  it('sanity: exactly 20 unconditional routes are under test (spec §2.5.2)', () => {
-    expect(unconditionalRoutes).toHaveLength(20);
+  it('sanity: exactly 21 unconditional routes are under test (spec §2.5.2)', () => {
+    expect(unconditionalRoutes).toHaveLength(21);
   });
 
   describe.each(unconditionalRoutes)('$name', ({ method, path }) => {

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -79,6 +79,8 @@ const meshcoreManager = {
   // Mesh-TX throttle primitives read by the manual telemetry-poll route.
   getLastMeshTxAt: vi.fn().mockReturnValue(0),
   recordMeshTx: vi.fn(),
+  // Shared request→resolve→store used by the manual neighbours-poll route (#4618).
+  pollNeighborsAndStore: vi.fn().mockResolvedValue({ total: 2, written: 2 }),
   // Fire-and-forget scope-cache refresh invoked by the saved-regions routes (#3829).
   notifySavedRegionsChanged: vi.fn(),
   // Receive-only TX guard (#4547) — requireMeshcoreTx() calls this unconditionally
@@ -1751,6 +1753,148 @@ describe('MeshCore Routes', () => {
       expect(res.body.retryAfterSecs).toBeGreaterThan(0);
       expect(res.headers['retry-after']).toBeDefined();
       expect(requestTelemetryForNode).not.toHaveBeenCalled();
+      expect(meshcoreManager.recordMeshTx).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PATCH /api/sources/test-source/meshcore/nodes/:publicKey/neighbours-config', () => {
+    const NB_PUBKEY = 'e'.repeat(64);
+    const upsertNode = vi.fn().mockResolvedValue(undefined);
+    const setNodeNeighborsConfig = vi.fn().mockResolvedValue(undefined);
+    const getNodeByPublicKeyAndSource = vi.fn().mockResolvedValue({
+      publicKey: NB_PUBKEY,
+      neighborsEnabled: true,
+      neighborsIntervalMinutes: 60,
+      lastNeighborsRequestAt: null,
+    });
+
+    beforeEach(() => {
+      (DatabaseService as any).meshcore = {
+        upsertNode,
+        setNodeNeighborsConfig,
+        getNodeByPublicKeyAndSource,
+      };
+      upsertNode.mockClear();
+      setNodeNeighborsConfig.mockClear();
+      getNodeByPublicKeyAndSource.mockClear();
+      meshcoreManager.getContact.mockReset();
+    });
+
+    it('requires authentication', async () => {
+      const res = await request(app)
+        .patch(`/api/sources/test-source/meshcore/nodes/${NB_PUBKEY}/neighbours-config`)
+        .send({ enabled: true });
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects a non-integer interval', async () => {
+      const res = await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${NB_PUBKEY}/neighbours-config`)
+        .send({ intervalMinutes: 3.5 });
+      expect(res.status).toBe(400);
+      expect(setNodeNeighborsConfig).not.toHaveBeenCalled();
+    });
+
+    it('persists enabled + interval and echoes the stored config', async () => {
+      meshcoreManager.getContact.mockReturnValueOnce(undefined);
+      const res = await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${NB_PUBKEY}/neighbours-config`)
+        .send({ enabled: true, intervalMinutes: 120 });
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(setNodeNeighborsConfig).toHaveBeenCalledWith(
+        'test-source',
+        NB_PUBKEY,
+        { enabled: true, intervalMinutes: 120 },
+      );
+      expect(res.body.data).toMatchObject({ enabled: true, intervalMinutes: 60 });
+    });
+
+    it('backfills advType/advName from the in-memory contact before seeding the row', async () => {
+      meshcoreManager.getContact.mockReturnValueOnce({
+        publicKey: NB_PUBKEY,
+        advName: 'MyRepeater',
+        advType: 2,
+        lastSeen: 1_700_000_000_000,
+      });
+      await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${NB_PUBKEY}/neighbours-config`)
+        .send({ enabled: true });
+      expect(upsertNode).toHaveBeenCalledWith(
+        expect.objectContaining({ publicKey: NB_PUBKEY, name: 'MyRepeater', advType: 2 }),
+        'test-source',
+      );
+      const upsertOrder = upsertNode.mock.invocationCallOrder[0];
+      const setCfgOrder = setNodeNeighborsConfig.mock.invocationCallOrder[0];
+      expect(upsertOrder).toBeLessThan(setCfgOrder);
+    });
+  });
+
+  describe('POST /api/sources/test-source/meshcore/nodes/:publicKey/neighbours/poll', () => {
+    const POLL_PUBKEY = 'a'.repeat(64);
+    const MALFORMED = 'abcd1234';
+    const markNeighborsRequested = vi.fn();
+
+    beforeEach(() => {
+      (DatabaseService as any).meshcore = { markNeighborsRequested };
+      markNeighborsRequested.mockReset().mockResolvedValue(undefined);
+      meshcoreManager.isConnected.mockReturnValue(true);
+      meshcoreManager.getLastMeshTxAt.mockReturnValue(0);
+      meshcoreManager.recordMeshTx.mockReset();
+      meshcoreManager.pollNeighborsAndStore.mockReset().mockResolvedValue({ total: 3, written: 2 });
+    });
+
+    afterEach(() => {
+      meshcoreManager.isConnected.mockReturnValue(false);
+      meshcoreManager.getLastMeshTxAt.mockReturnValue(0);
+    });
+
+    it('requires authentication', async () => {
+      const res = await request(app)
+        .post(`/api/sources/test-source/meshcore/nodes/${POLL_PUBKEY}/neighbours/poll`);
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects a malformed public key', async () => {
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${MALFORMED}/neighbours/poll`);
+      expect(res.status).toBe(400);
+    });
+
+    it('polls: stamps the gate and returns total + written', async () => {
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${POLL_PUBKEY}/neighbours/poll`);
+      expect(res.status).toBe(200);
+      expect(res.body.data).toMatchObject({ total: 3, written: 2 });
+      expect(meshcoreManager.pollNeighborsAndStore).toHaveBeenCalledWith(POLL_PUBKEY);
+      expect(meshcoreManager.recordMeshTx).toHaveBeenCalledTimes(1);
+      expect(markNeighborsRequested).toHaveBeenCalledWith('test-source', POLL_PUBKEY, expect.any(Number));
+    });
+
+    it('reports notSupported when the query returns null', async () => {
+      meshcoreManager.pollNeighborsAndStore.mockResolvedValueOnce(null);
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${POLL_PUBKEY}/neighbours/poll`);
+      expect(res.status).toBe(200);
+      expect(res.body.data).toMatchObject({ total: 0, written: 0, notSupported: true });
+    });
+
+    it('returns 409 when the source is not connected', async () => {
+      meshcoreManager.isConnected.mockReturnValue(false);
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${POLL_PUBKEY}/neighbours/poll`);
+      expect(res.status).toBe(409);
+      expect(meshcoreManager.pollNeighborsAndStore).not.toHaveBeenCalled();
+    });
+
+    it('enforces the shared 60s mesh-TX gate with 429 + Retry-After', async () => {
+      meshcoreManager.getLastMeshTxAt.mockReturnValue(Date.now() - 5_000);
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${POLL_PUBKEY}/neighbours/poll`);
+      expect(res.status).toBe(429);
+      expect(res.body.retryAfterSecs).toBeGreaterThan(0);
+      expect(res.headers['retry-after']).toBeDefined();
+      expect(meshcoreManager.pollNeighborsAndStore).not.toHaveBeenCalled();
       expect(meshcoreManager.recordMeshTx).not.toHaveBeenCalled();
     });
   });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -555,6 +555,26 @@ setTimeout(async () => {
   }
 }, 10000); // After telemetry scheduler.
 
+// MeshCore Neighbours Scheduler (#4618) — periodically requests each opt-in
+// node's neighbour table over RF and fills it into Node Details. Like the
+// remote-telemetry scheduler it transmits, so it honours the same per-source
+// 60s minimum via the shared `MeshCoreManager.lastMeshTxAt` primitive; its
+// per-node cadence lives in a SEPARATE column set (`lastNeighborsRequestAt`)
+// so telemetry and neighbours polls never reset each other's timers.
+export const meshcoreNeighboursScheduler = new MeshCoreNeighboursScheduler({
+  registry: sourceManagerRegistry,
+  database: databaseService,
+});
+setMeshCoreNeighboursScheduler(meshcoreNeighboursScheduler);
+setTimeout(async () => {
+  try {
+    await databaseService.waitForReady();
+    meshcoreNeighboursScheduler.start();
+  } catch (error) {
+    logger.error('Failed to start MeshCore neighbours scheduler:', error);
+  }
+}, 9000); // After telemetry scheduler, before room-sync.
+
 // ==========================================
 // Version Check (detection / notification only)
 // ==========================================
@@ -613,6 +633,10 @@ import {
   MeshCoreRoomSyncScheduler,
   setMeshCoreRoomSyncScheduler,
 } from './services/meshcoreRoomSyncScheduler.js';
+import {
+  MeshCoreNeighboursScheduler,
+  setMeshCoreNeighboursScheduler,
+} from './services/meshcoreNeighboursScheduler.js';
 import { getMeshCoreCredentialStore } from './services/meshcoreCredentialStore.js';
 import embedProfileRoutes from './routes/embedProfileRoutes.js';
 import embedPublicRoutes from './routes/embedPublicRoutes.js';

--- a/src/server/services/meshcoreNeighboursScheduler.test.ts
+++ b/src/server/services/meshcoreNeighboursScheduler.test.ts
@@ -1,0 +1,204 @@
+/**
+ * MeshCoreNeighboursScheduler tests (#4618).
+ *
+ * Covers the pure helpers (`isNodeEligible`, `pickMostOverdue`) and
+ * `tickOneManager`: the receive-only (#4547) skip, the SHARED per-source 60s
+ * mesh-TX floor (the guarantee that a neighbours poll never collides with a
+ * telemetry poll — both read `getLastMeshTxAt`), and the pre-stamp ordering
+ * (`markNeighborsRequested` + `recordMeshTx` BEFORE the RF query).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  MeshCoreNeighboursScheduler,
+  isNodeEligible,
+  pickMostOverdue,
+  type NeighboursSchedulerDatabase,
+} from './meshcoreNeighboursScheduler.js';
+import type { DbMeshCoreNode } from '../../db/repositories/meshcore.js';
+import type { MeshCoreManager } from '../meshcoreManager.js';
+import type { SourceManagerRegistry } from '../sourceManagerRegistry.js';
+
+function node(over: Partial<DbMeshCoreNode>): DbMeshCoreNode {
+  return {
+    publicKey: 'pk-x',
+    neighborsEnabled: true,
+    neighborsIntervalMinutes: 60,
+    lastNeighborsRequestAt: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...over,
+  } as unknown as DbMeshCoreNode;
+}
+
+describe('isNodeEligible', () => {
+  it('rejects disabled nodes', () => {
+    expect(isNodeEligible(node({ neighborsEnabled: false }), 0)).toBe(false);
+  });
+
+  it('rejects a non-positive interval', () => {
+    expect(isNodeEligible(node({ neighborsIntervalMinutes: 0 }), 1_000_000)).toBe(false);
+  });
+
+  it('accepts a node never polled before', () => {
+    expect(isNodeEligible(node({ lastNeighborsRequestAt: null }), 100_000_000)).toBe(true);
+  });
+
+  it('rejects a node still inside its interval', () => {
+    const now = 100_000_000;
+    expect(isNodeEligible(node({ neighborsIntervalMinutes: 60, lastNeighborsRequestAt: now - 30 * 60_000 }), now)).toBe(false);
+  });
+
+  it('accepts a node past its interval', () => {
+    const now = 100_000_000;
+    expect(isNodeEligible(node({ neighborsIntervalMinutes: 60, lastNeighborsRequestAt: now - 61 * 60_000 }), now)).toBe(true);
+  });
+});
+
+describe('pickMostOverdue', () => {
+  it('returns undefined when nothing is eligible', () => {
+    expect(pickMostOverdue([node({ neighborsEnabled: false })], 1_000_000)).toBeUndefined();
+  });
+
+  it('picks the most overdue eligible node, publicKey as tiebreaker', () => {
+    const now = 100_000_000;
+    const a = node({ publicKey: 'aaa', lastNeighborsRequestAt: now - 70 * 60_000 });
+    const b = node({ publicKey: 'bbb', lastNeighborsRequestAt: now - 120 * 60_000 });
+    expect(pickMostOverdue([a, b], now)?.publicKey).toBe('bbb');
+  });
+});
+
+// ============ tickOneManager ============
+
+interface FakeState {
+  sourceId: string;
+  connected: boolean;
+  receiveOnly: boolean;
+  lastMeshTxAt: number;
+  polledFor: string[];
+  pollResult: { total: number; written: number } | null;
+}
+
+function makeFakeManager(init: Partial<FakeState>): MeshCoreManager & { _state: FakeState } {
+  const state: FakeState = {
+    sourceId: 'src-a',
+    connected: true,
+    receiveOnly: false,
+    lastMeshTxAt: 0,
+    polledFor: [],
+    pollResult: { total: 2, written: 2 },
+    ...init,
+  };
+  const m: any = {
+    sourceId: state.sourceId,
+    sourceType: 'meshcore',
+    isConnected: () => state.connected,
+    isReceiveOnly: () => state.receiveOnly,
+    getLastMeshTxAt: () => state.lastMeshTxAt,
+    recordMeshTx: (when: number = Date.now()) => { state.lastMeshTxAt = when; },
+    pollNeighborsAndStore: async (publicKey: string) => {
+      state.polledFor.push(publicKey);
+      return state.pollResult;
+    },
+    _state: state,
+  };
+  return m as MeshCoreManager & { _state: FakeState };
+}
+
+function makeRegistry(managers: MeshCoreManager[]): SourceManagerRegistry {
+  return { getAllManagers: () => managers } as unknown as SourceManagerRegistry;
+}
+
+function makeDb(nodes: DbMeshCoreNode[]): {
+  db: NeighboursSchedulerDatabase;
+  getEnabled: ReturnType<typeof vi.fn>;
+  mark: ReturnType<typeof vi.fn>;
+} {
+  const getEnabled = vi.fn().mockResolvedValue(nodes);
+  const mark = vi.fn().mockResolvedValue(undefined);
+  return {
+    db: { meshcore: { getNeighborsEnabledNodes: getEnabled, markNeighborsRequested: mark } },
+    getEnabled,
+    mark,
+  };
+}
+
+describe('MeshCoreNeighboursScheduler.tickOneManager', () => {
+  it('skips a receive-only manager before the enabled-nodes DB read', async () => {
+    const manager = makeFakeManager({ receiveOnly: true });
+    const { db, getEnabled } = makeDb([node({ publicKey: 'pk-a' })]);
+    const scheduler = new MeshCoreNeighboursScheduler({
+      registry: makeRegistry([manager]),
+      database: db,
+      now: () => 10_000_000,
+    });
+
+    await (scheduler as any).tickOneManager(manager);
+
+    expect(getEnabled).not.toHaveBeenCalled();
+    expect(manager._state.polledFor).toEqual([]);
+  });
+
+  it('polls the most-overdue node and pre-stamps mark + recordMeshTx', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({ lastMeshTxAt: 0 });
+    const { db, mark } = makeDb([node({ publicKey: 'pk-a', lastNeighborsRequestAt: null })]);
+    const scheduler = new MeshCoreNeighboursScheduler({
+      registry: makeRegistry([manager]),
+      database: db,
+      now: () => now,
+    });
+
+    await (scheduler as any).tickOneManager(manager);
+
+    expect(mark).toHaveBeenCalledWith('src-a', 'pk-a', now);
+    expect(manager._state.lastMeshTxAt).toBe(now); // recordMeshTx pre-stamp
+    expect(manager._state.polledFor).toEqual(['pk-a']);
+  });
+
+  it('honours the shared 60s floor — a recent telemetry TX blocks a neighbours poll', async () => {
+    const now = 10_000_000;
+    // lastMeshTxAt was set 30s ago (e.g. by the telemetry scheduler on the
+    // same source). The neighbours scheduler must back off, so the two never
+    // transmit within 60s of each other.
+    const manager = makeFakeManager({ lastMeshTxAt: now - 30_000 });
+    const { db, getEnabled } = makeDb([node({ publicKey: 'pk-a' })]);
+    const scheduler = new MeshCoreNeighboursScheduler({
+      registry: makeRegistry([manager]),
+      database: db,
+      now: () => now,
+    });
+
+    await (scheduler as any).tickOneManager(manager);
+
+    expect(getEnabled).not.toHaveBeenCalled();
+    expect(manager._state.polledFor).toEqual([]);
+  });
+
+  it('allows a poll once 60s has elapsed since the last mesh TX', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({ lastMeshTxAt: now - 61_000 });
+    const { db } = makeDb([node({ publicKey: 'pk-a' })]);
+    const scheduler = new MeshCoreNeighboursScheduler({
+      registry: makeRegistry([manager]),
+      database: db,
+      now: () => now,
+    });
+
+    await (scheduler as any).tickOneManager(manager);
+
+    expect(manager._state.polledFor).toEqual(['pk-a']);
+  });
+
+  it('does nothing when no node is enabled', async () => {
+    const manager = makeFakeManager({});
+    const { db } = makeDb([]);
+    const scheduler = new MeshCoreNeighboursScheduler({
+      registry: makeRegistry([manager]),
+      database: db,
+      now: () => 10_000_000,
+    });
+
+    await (scheduler as any).tickOneManager(manager);
+    expect(manager._state.polledFor).toEqual([]);
+  });
+});

--- a/src/server/services/meshcoreNeighboursScheduler.ts
+++ b/src/server/services/meshcoreNeighboursScheduler.ts
@@ -1,0 +1,226 @@
+/**
+ * MeshCore Neighbours Scheduler — periodic `get_neighbours` for each opt-in
+ * node across every connected source (issue #4618).
+ *
+ * Models the MeshCoreRemoteTelemetryScheduler exactly, but drives the
+ * neighbour-table query instead of telemetry. Like that scheduler it PUTS
+ * PACKETS ON THE AIR, so throttling is non-negotiable:
+ *
+ *   - Per-node cadence: `neighborsIntervalMinutes` from `meshcore_nodes`.
+ *   - Per-source minimum: `MIN_INTERVAL_BETWEEN_REQUESTS_MS` (60s) between
+ *     any two scheduled mesh ops on the same manager — enforced via the
+ *     SHARED `MeshCoreManager.lastMeshTxAt` primitive. Because telemetry,
+ *     room-sync, and neighbours schedulers all coordinate against that one
+ *     field, a neighbours request and a telemetry request are never emitted
+ *     within 60s of each other on the same source — they interleave rather
+ *     than collide.
+ *   - Per-tick budget: at most one request per manager per tick.
+ *
+ * The per-node cadence and last-request stamp are held in a SEPARATE column
+ * set (`lastNeighborsRequestAt`) from the telemetry trio, so a neighbours
+ * poll never resets the telemetry timer or vice versa — the "separate 60s
+ * spacing" the issue asks for.
+ *
+ * Tick cadence defaults to 30s. Configurable via `MESHCORE_NEIGHBORS_TICK_MS`.
+ */
+import { logger } from '../../utils/logger.js';
+import type { DbMeshCoreNode } from '../../db/repositories/meshcore.js';
+import type { MeshCoreManager } from '../meshcoreManager.js';
+import type { SourceManagerRegistry } from '../sourceManagerRegistry.js';
+import { isMeshCoreManager } from '../sourceManagerTypes.js';
+
+/** Database surface the scheduler depends on (kept thin for testability). */
+export interface NeighboursSchedulerDatabase {
+  meshcore: {
+    getNeighborsEnabledNodes: (sourceId: string) => Promise<DbMeshCoreNode[]>;
+    markNeighborsRequested: (sourceId: string, publicKey: string, when?: number) => Promise<void>;
+  };
+}
+
+/** Minimum spacing between scheduled mesh requests on the same source (ms). */
+export const MIN_INTERVAL_BETWEEN_REQUESTS_MS = 60_000;
+
+/** Default scheduler tick (ms); always >= 1s, clamped on parse. */
+export const DEFAULT_TICK_MS = 30_000;
+const MIN_TICK_MS = 1_000;
+
+/** Sanity ceiling on the per-node interval the UI can set, in minutes. */
+export const MAX_INTERVAL_MINUTES = 24 * 60;
+
+export interface MeshCoreNeighboursSchedulerOptions {
+  registry: SourceManagerRegistry;
+  database: NeighboursSchedulerDatabase;
+  /** Override the env-derived tick (tests). */
+  tickMs?: number;
+  /** Override the inter-request minimum (tests). */
+  minIntervalMs?: number;
+  /** Inject a clock for tests. */
+  now?: () => number;
+}
+
+export function resolveTickMs(envValue: string | undefined): number {
+  if (!envValue) return DEFAULT_TICK_MS;
+  const parsed = parseInt(envValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TICK_MS;
+  return Math.max(parsed, MIN_TICK_MS);
+}
+
+/**
+ * Decide whether a node is currently eligible for a fresh neighbours request.
+ * Pure function, exported for the unit test.
+ */
+export function isNodeEligible(node: DbMeshCoreNode, now: number): boolean {
+  if (!node.neighborsEnabled) return false;
+  const interval = node.neighborsIntervalMinutes;
+  if (interval === null || interval === undefined || interval <= 0) return false;
+  const last = node.lastNeighborsRequestAt ?? 0;
+  return (now - last) >= interval * 60_000;
+}
+
+/**
+ * Pick the most overdue eligible node, or undefined if none. Stable
+ * tiebreaker on publicKey so two nodes that came due in the same tick don't
+ * ping-pong on every cycle.
+ */
+export function pickMostOverdue(nodes: DbMeshCoreNode[], now: number): DbMeshCoreNode | undefined {
+  const eligible = nodes.filter((n) => isNodeEligible(n, now));
+  if (eligible.length === 0) return undefined;
+  eligible.sort((a, b) => {
+    const aOver = now - (a.lastNeighborsRequestAt ?? 0);
+    const bOver = now - (b.lastNeighborsRequestAt ?? 0);
+    if (aOver !== bOver) return bOver - aOver;
+    return a.publicKey.localeCompare(b.publicKey);
+  });
+  return eligible[0];
+}
+
+export class MeshCoreNeighboursScheduler {
+  private readonly registry: SourceManagerRegistry;
+  private readonly database: NeighboursSchedulerDatabase;
+  private readonly tickMs: number;
+  private readonly minIntervalMs: number;
+  private readonly nowFn: () => number;
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+
+  constructor(opts: MeshCoreNeighboursSchedulerOptions) {
+    this.registry = opts.registry;
+    this.database = opts.database;
+    this.tickMs = opts.tickMs ?? resolveTickMs(process.env.MESHCORE_NEIGHBORS_TICK_MS);
+    this.minIntervalMs = opts.minIntervalMs ?? MIN_INTERVAL_BETWEEN_REQUESTS_MS;
+    this.nowFn = opts.now ?? Date.now;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    logger.info(
+      `[MeshCoreNeighbours] Scheduler starting (tick=${Math.round(this.tickMs / 1000)}s, ` +
+        `min-interval=${Math.round(this.minIntervalMs / 1000)}s)`,
+    );
+    this.timer = setInterval(() => {
+      this.tick().catch((err) => logger.error('[MeshCoreNeighbours] Unhandled tick error:', err));
+    }, this.tickMs);
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * One tick. Visible for tests. Walks every registered manager and issues
+   * at most one neighbours request per source, gated by both the in-DB
+   * per-node cadence and the per-manager 60s minimum.
+   */
+  async tick(): Promise<void> {
+    if (this.running) {
+      logger.debug('[MeshCoreNeighbours] Previous tick still running, skipping');
+      return;
+    }
+    this.running = true;
+    try {
+      const managers = this.registry.getAllManagers().filter(isMeshCoreManager);
+      for (const manager of managers) {
+        try {
+          await this.tickOneManager(manager);
+        } catch (err) {
+          logger.warn(`[MeshCoreNeighbours:${manager.sourceId}] Tick failed:`, err);
+        }
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /** Process a single manager. Visible for tests. */
+  async tickOneManager(manager: MeshCoreManager): Promise<void> {
+    if (!manager.isConnected()) return;
+    // Receive-only (#4547): skip before any guarded send primitive —
+    // pollNeighborsAndStore → getNeighbours → requireTransmit would otherwise
+    // throw and rely on tick()'s per-manager catch.
+    if (manager.isReceiveOnly()) {
+      logger.debug(`[MeshCoreNeighbours:${manager.sourceId}] Skipping - receive-only mode`);
+      return;
+    }
+
+    const now = this.nowFn();
+    const sinceLastTx = now - manager.getLastMeshTxAt();
+    if (manager.getLastMeshTxAt() > 0 && sinceLastTx < this.minIntervalMs) {
+      logger.debug(
+        `[MeshCoreNeighbours:${manager.sourceId}] Throttled — last mesh tx was ${Math.round(sinceLastTx / 1000)}s ago`,
+      );
+      return;
+    }
+
+    const nodes = await this.database.meshcore.getNeighborsEnabledNodes(manager.sourceId);
+    if (nodes.length === 0) return;
+
+    const target = pickMostOverdue(nodes, now);
+    if (!target) return;
+
+    const keyShort = target.publicKey.substring(0, 16);
+    logger.debug(`[MeshCoreNeighbours:${manager.sourceId}] Requesting neighbours from ${keyShort}…`);
+
+    // Stamp BEFORE issuing — preserves fair rotation when several nodes share
+    // the same overdue-by, and applies the per-source 60s gate regardless of
+    // how long the query takes. Mirrors the telemetry scheduler.
+    await this.database.meshcore.markNeighborsRequested(manager.sourceId, target.publicKey, now);
+    manager.recordMeshTx(now);
+
+    try {
+      const result = await manager.pollNeighborsAndStore(target.publicKey);
+      if (result) {
+        logger.debug(
+          `[MeshCoreNeighbours:${manager.sourceId}] ${keyShort}… → ${result.total} reported, ${result.written} stored`,
+        );
+      } else {
+        logger.debug(
+          `[MeshCoreNeighbours:${manager.sourceId}] ${keyShort}… → no neighbours (failed/timeout/not a Companion source)`,
+        );
+      }
+    } catch (err) {
+      logger.warn(
+        `[MeshCoreNeighbours:${manager.sourceId}] pollNeighborsAndStore(${keyShort}…) threw:`,
+        err,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level singleton — mirrors the telemetry/room-sync schedulers so the
+// manual-poll route can reach the same instance.
+// ---------------------------------------------------------------------------
+
+let _scheduler: MeshCoreNeighboursScheduler | null = null;
+
+export function setMeshCoreNeighboursScheduler(scheduler: MeshCoreNeighboursScheduler | null): void {
+  _scheduler = scheduler;
+}
+
+export function getMeshCoreNeighboursScheduler(): MeshCoreNeighboursScheduler | null {
+  return _scheduler;
+}


### PR DESCRIPTION
Closes #4618.

## What

A MeshCore **Neighbours Retrieval** feature modeled on the existing per-node **Telemetry Retrieval**. Enable it per node in Node Details, pick an interval, and a scheduler periodically requests that node's neighbour table over RF and fills it into Node Details. A manual **Poll Neighbours** button covers on-demand refresh.

## Design decisions (per issue #4618 + interview)

- **Per-node, mirrors Telemetry Retrieval** — new opt-in trio on `meshcore_nodes` (`neighborsEnabled` / `neighborsIntervalMinutes` / `lastNeighborsRequestAt`, migration 153), a dedicated scheduler, and a Node-Details panel next to the telemetry one.
- **Separate timers, shared floor** — the neighbours cadence is a *separate* column set from the telemetry trio, so a neighbours poll never resets the telemetry timer (and vice versa). Both schedulers still coordinate against the same per-source `MeshCoreManager.lastMeshTxAt`, so a telemetry request and a neighbours request are **never transmitted within 60s of each other** on one source — they interleave rather than collide (exactly what the issue asks for).
- **Default cadence 60 min** (neighbour tables change slowly).

## Mesh impact checklist

- **Airtime:** one `get_neighbours` request per enabled node per interval (default 60 min). Opt-in per node, so it does not scale with mesh size unless the operator enables many nodes.
- **Spam:** no message/notification fan-out; it only writes rows. Per-source 60s minimum + one-request-per-tick budget cap the burst rate.
- **Timer safety:** last-poll timestamp is persisted to `meshcore_nodes.lastNeighborsRequestAt` (not an in-memory field), so a container restart or settings save does not re-arm or reset the cadence. Pre-stamped before the RF request for fair rotation.
- **Receive-only (#4547):** the scheduler and route skip before any TX primitive.

## Surface

- `MeshCoreNeighboursScheduler` (clone of the remote-telemetry scheduler), wired in `server.ts` between the telemetry and room-sync schedulers.
- `MeshCoreManager.pollNeighborsAndStore()` — shared by the scheduler and the manual-poll route (`getNeighbours` → resolve prefixes via `resolveContactByPrefix` → `insertNeighborsBatch`).
- Routes: `GET`/`PATCH /api/sources/:id/meshcore/nodes/:publicKey/neighbours-config` + `POST /nodes/:publicKey/neighbours/poll` (nodes:read, `requireMeshcoreTx`, shared 60s gate).
- `MeshCoreNodeNeighboursConfig` panel in Node Details.

## Tests

- Migration 153: SQLite + **PG/MySQL container** (verified running against live containers, 0 skipped).
- Scheduler unit: eligibility, most-overdue pick, receive-only skip, **shared 60s floor blocks a poll after a recent telemetry TX**, pre-stamp ordering.
- Route: PATCH validation + backfill, poll gate/409/429/notSupported.
- Repository: source isolation + **cadence independence** (`markNeighborsRequested` does not touch `lastTelemetryRequestAt`).
- Component: poll, toggle→PATCH, permission + receive-only gating.

Full `src/server/migrations/` + `src/db/` suites: **2206 passed, 0 failed, 0 skipped** with PG+MySQL containers up. Lint ratchet clean; server typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)