### PR TITLE
chore(release): 4.15.2-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [4.15.1] - 2026-08-21
+## [4.15.2-rc2] - 2026-08-22
+
+### Added
+- **Device Health automation triggers + template** (#4558) — five new Automation Engine triggers built on data MeshMonitor already receives, so node-health alerts no longer need a bespoke feature: **node silent** (not heard for N minutes / heartbeat lost), **node online** (recovery), **node rebooted** (uptime reset), **node power changed** (external power lost/restored), and **battery declining** (a "not charging" trend proxy). Noise floor is now a selectable telemetry field too. A new **Device Health** starter template quick-creates the notifications — pick a source/node, toggle any of ten alerts with thresholds, and it builds one automation per alert (each still fully editable). All alerts are passive (zero mesh airtime) and restart-safe. Caveats surfaced in the UI: noise floor is local-node-only on Meshtastic; power/charging are heuristics (no charge-state field in the protocol); MeshCore reboot/power/trend detection is deferred. (#4873, #4874, #4876, #4877, #4878, #4881)
+- **MeshCore neighbour autopoll** — a per-node retrieval scheduler that keeps neighbour data fresh. (#4618)
+- **Reception Heard column shows seconds** — the per-source reception table on the Unified Messages page now displays `HH:MM:SS`, for relay-delay and telemetry-correlation analysis. (#4869)
+- **Unread bell in the mobile channel dropdown** — the channel picker's unread count now carries the 🔔 indicator on mobile, matching the desktop channel list. (#4660)
+
+### Fixed
+- **3D node markers keep their role glyph across zoom** — mixing the SDF disc and non-SDF glyph rasters in one MapLibre layer made glyph markers collapse into plain discs at some zoom levels; they now render in two homogeneous layers. (#4863)
+- **ESRI satellite basemap** — damped the synthetic water-blue tint via a saturation filter, and fixed the white halo on satellite-map node labels. (#4860)
 
 ### Fixed
 - **Site Planner no longer fails with a JSON parse error** — the predictive RF coverage request was sent to `/rf/coverage` instead of `/api/rf/coverage`, so it fell through to the SPA and returned HTML, which the frontend then tried to parse as JSON (`Unexpected token '<'`). The path now includes the `/api` prefix like every other API call. (#4862)

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.15.1",
+  "version": "4.15.2-rc2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.15.1",
+  "version": "4.15.2-rc2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.15.1
-appVersion: "4.15.1"
+version: 4.15.2-rc2
+appVersion: "4.15.2-rc2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.1",
+  "version": "4.15.2-rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.15.1",
+      "version": "4.15.2-rc2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.1",
+  "version": "4.15.2-rc2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
First release candidate since 4.15.1. Bundles the **Device Health** automation epic (#4558) and the map/messages fixes merged since.

**Version → 4.15.2-rc2** across all five files (`package.json`, `package-lock.json`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`, `helm/meshmonitor/Chart.yaml`).

## Highlights (see CHANGELOG for full detail)

- **Device Health triggers + template** (#4558) — 5 new Automation Engine triggers (node silent, online, rebooted, power changed, battery declining) + selectable noise-floor field + a Device Health quick-create template. Passive (zero airtime), restart-safe. Caveats documented (noise-floor local-only; power/charging heuristic; MeshCore reboot/power/trend deferred).
- **MeshCore neighbour autopoll** (#4618)
- **Reception Heard column seconds** (#4869)
- **Mobile channel-dropdown unread bell** (#4660)
- **3D marker glyph fix across zoom** (#4863) and **ESRI satellite tint/label fixes** (#4860)

## Mesh impact

None from this PR (version/changelog only). The Device Health triggers it packages are all passive DB-driven with no packet sends.

## Test plan

- [x] Version consistent across all five files + lockfile regenerated
- [ ] CI + system tests green (system-test label applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)