### PR TITLE
feat(automation): MeshCore parity for device-health triggers (#4558)

### DIFF
--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -280,7 +280,7 @@ export const TRIGGERS: BlockDef[] = [
   {
     type: 'trigger.nodePowerChanged',
     label: 'A node switches power source (mains ↔ battery)',
-    description: 'Fires when a node crosses between external/USB power and battery power. Detected from the battery-level telemetry a node already reports (the firmware reports a value above 100% when powered), by comparing each new reading against the last stored one; there is no extra polling and no packet is sent. Meshtastic only for now. It never fires on the first battery reading for a node (no prior to compare). Note: a reading above 100 conflates “on USB / no battery” with “charging”, so this is a powered-state signal, not a clean “on wall power” flag.',
+    description: 'Fires when a node crosses between external/USB power and battery power. Detected from the battery telemetry a node already reports, by comparing each new reading against the last stored one; there is no extra polling and no packet is sent. It never fires on the first battery reading for a node (no prior to compare). On Meshtastic this uses the firmware’s convention (a battery value above 100% means powered); note that above 100 conflates “on USB / no battery” with “charging”, so it is a powered-state signal, not a clean “on wall power” flag. EXPERIMENTAL on MeshCore: the firmware has no powered flag, so this is a heuristic derived from battery voltage (≥ 4.2 V is treated as powered). A full or charging battery reads ~4.2 V and looks identical to wall power, so false “lost”/“restored” alerts are expected on MeshCore.',
     fields: [
       {
         name: 'direction', label: 'Direction', kind: 'select',

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -1430,7 +1430,8 @@ class MeshtasticManager implements ISourceManager {
       if (!isUptimeReboot(priorUptime, newUptimeSeconds)) return;
       logger.info(`🔁 Node ${nodeNum} reboot detected: uptime ${priorUptime}s → ${newUptimeSeconds}s (source ${this.sourceId})`);
       dataEventEmitter.emitNodeRebooted(
-        { nodeNum, previousUptimeSeconds: priorUptime as number, uptimeSeconds: newUptimeSeconds },
+        // Meshtastic reboot: real nodeNum, no pubkey (MeshCore carries the pubkey instead).
+        { nodeNum, publicKey: null, previousUptimeSeconds: priorUptime as number, uptimeSeconds: newUptimeSeconds },
         this.sourceId,
       );
     } catch (e) {

--- a/src/server/services/automation/automationEngineService.ts
+++ b/src/server/services/automation/automationEngineService.ts
@@ -976,14 +976,19 @@ export class AutomationEngineService {
    * nodeOnline, which also don't drop our own node: knowing your OWN gateway
    * rebooted is useful, and a reboot is not something an automation action can
    * cause, so there is no self-trigger loop to guard against.
+   *
+   * Meshtastic reboots pass a real `nodeNum` (`publicKey` null); MeshCore reboots
+   * (#4558 follow-up) pass `nodeNum: null` plus the pubkey, which becomes the
+   * subject identity for `{{ node.* }}`-less pubkey cooldown scoping.
    */
   async onNodeRebooted(
-    nodeNum: number,
+    nodeNum: number | null,
+    publicKey: string | null,
     previousUptimeSeconds: number,
     uptimeSeconds: number,
     sourceId: string | null,
   ): Promise<number> {
-    const ctx = buildNodeRebootedContext(nodeNum, previousUptimeSeconds, uptimeSeconds, sourceId, this.now());
+    const ctx = buildNodeRebootedContext(nodeNum, publicKey, previousUptimeSeconds, uptimeSeconds, sourceId, this.now());
     return this.runTrigger(ctx);
   }
 
@@ -1003,16 +1008,22 @@ export class AutomationEngineService {
    * a power transition is not something an automation action can cause, so there
    * is no self-trigger loop to guard against, and knowing your OWN gateway lost
    * wall power is useful.
+   *
+   * Meshtastic passes a real `nodeNum` (`publicKey` null). MeshCore (#4558
+   * parity) passes `nodeNum: null` plus the pubkey, which becomes the subject
+   * identity — note the MeshCore path is a battery-voltage HEURISTIC and can
+   * misfire (see detectMeshCorePowerChange).
    */
   async onNodePowerChanged(
-    nodeNum: number,
+    nodeNum: number | null,
+    publicKey: string | null,
     previousPowered: boolean,
     powered: boolean,
     batteryLevel: number,
     sourceId: string | null,
   ): Promise<number> {
     const direction = powered ? 'restored' : 'lost';
-    const ctx = buildNodePowerChangedContext(nodeNum, previousPowered, powered, batteryLevel, sourceId, this.now());
+    const ctx = buildNodePowerChangedContext(nodeNum, publicKey, previousPowered, powered, batteryLevel, sourceId, this.now());
     return this.runTrigger(
       ctx,
       (a) => {
@@ -1551,13 +1562,22 @@ export class AutomationEngineService {
    * declining-battery PROXY, not a true "not charging" signal — it can
    * false-positive under heavy transient load and does not model day/night.
    *
-   * MeshCore is excluded (no batteryLevel time-series). Sends NO mesh packets;
-   * returns the number of automations that dispatched this tick.
+   * BOTH protocols are covered (#4558 follow-up). Meshtastic nodes trend on
+   * `batteryLevel` (%): the drop is `startLevel - latestLevel` in percentage
+   * POINTS. MeshCore nodes have no % and no numeric node id, so they trend on
+   * battery VOLTS keyed by pubkey (via {@link NodeDataProvider.getMeshCoreBatteryTrendSamples}),
+   * and the drop is the RELATIVE decline `(startV - latestV) / startV * 100` so
+   * the same `minDropPercent` threshold stays meaningful across both units.
+   * Sends NO mesh packets; returns the number of automations that dispatched
+   * this tick.
    */
   async runBatteryTrendCheck(): Promise<number> {
     const autos = this.index.get('trigger.batteryTrend') ?? [];
     if (autos.length === 0) return 0;
-    if (!this.data.listNodesForStaleCheck || !this.data.getBatteryTrendSamples) return 0;
+    if (!this.data.listNodesForStaleCheck) return 0;
+    // Need at least one battery-sample provider; each protocol's nodes are
+    // skipped individually below when its provider is absent.
+    if (!this.data.getBatteryTrendSamples && !this.data.getMeshCoreBatteryTrendSamples) return 0;
 
     let candidates: StaleCandidate[];
     try {
@@ -1566,8 +1586,6 @@ export class AutomationEngineService {
       logger.error(`[AutomationEngine] battery-trend node enumeration failed: ${e instanceof Error ? e.message : String(e)}`);
       return 0;
     }
-    // Meshtastic only — MeshCore nodes (nodeNum == null) carry no batteryLevel history.
-    const meshtasticNodes = candidates.filter((c) => c.nodeNum != null);
 
     const now = this.now();
     let fired = 0;
@@ -1580,13 +1598,24 @@ export class AutomationEngineService {
       if (!Number.isFinite(minDropPercent) || minDropPercent <= 0) continue;
       const sinceMs = now - windowHours * 3_600_000;
 
-      for (const c of meshtasticNodes) {
-        const nodeNum = Number(c.nodeNum);
-        const key = `${c.sourceId ?? ''}:${nodeNum}`;
+      for (const c of candidates) {
+        const isMeshCore = c.nodeNum == null;
+        const nodeNum = isMeshCore ? null : Number(c.nodeNum);
+        const publicKey = isMeshCore ? (c.publicKey ?? null) : null;
+        // MeshCore candidate with no pubkey is unaddressable; skip it.
+        if (isMeshCore && !publicKey) continue;
+        // Per-(source, node) baseline key: numeric node for Meshtastic, pubkey for MeshCore.
+        const key = staleKeyFor(c);
 
-        let samples: Array<{ timestamp: number; value: number }>;
+        let samples: Array<{ timestamp: number; value: number }> | undefined;
         try {
-          samples = await this.data.getBatteryTrendSamples(c.sourceId, nodeNum, sinceMs);
+          if (isMeshCore) {
+            if (!this.data.getMeshCoreBatteryTrendSamples) continue; // no MeshCore provider → skip
+            samples = await this.data.getMeshCoreBatteryTrendSamples(c.sourceId, publicKey as string, sinceMs);
+          } else {
+            if (!this.data.getBatteryTrendSamples) continue; // no Meshtastic provider → skip
+            samples = await this.data.getBatteryTrendSamples(c.sourceId, nodeNum as number, sinceMs);
+          }
         } catch {
           continue; // a per-node read failure must not abort the rest of the tick
         }
@@ -1601,7 +1630,12 @@ export class AutomationEngineService {
         }
         const startLevel = earliest.value;
         const latestLevel = latest.value;
-        const drop = startLevel - latestLevel;
+        // Meshtastic: battery %, absolute percentage-point drop. MeshCore: volts,
+        // so use the RELATIVE decline against the start voltage — a 0/negative
+        // start can't yield a meaningful percentage, so it never declines.
+        const drop = isMeshCore
+          ? (startLevel > 0 ? ((startLevel - latestLevel) / startLevel) * 100 : 0)
+          : (startLevel - latestLevel);
         const declining = drop >= minDropPercent;
 
         const prev = this.getBatteryTrendBaseline(a, key);
@@ -1615,7 +1649,7 @@ export class AutomationEngineService {
           // calm → declining. Latch alarmed FIRST so a suppressed fire can't re-fire.
           this.setBatteryTrendBaseline(a, key, { alarmed: true, ts: now });
           const ctx = buildBatteryTrendContext(
-            nodeNum, Math.round(drop), windowHours, minDropPercent, startLevel, latestLevel, c.sourceId, now,
+            nodeNum, publicKey, Math.round(drop), windowHours, minDropPercent, startLevel, latestLevel, c.sourceId, now,
           );
           fired += await this.fireStaleTransition(a, ctx, now);
         } else if (prev.alarmed && !declining) {

--- a/src/server/services/automation/automationEngineSingleton.ts
+++ b/src/server/services/automation/automationEngineSingleton.ts
@@ -146,8 +146,8 @@ async function handleEvent(event: DataEvent): Promise<void> {
       // Device Health (#4558 Phase B): the telemetry-save seam detected a node's
       // uptime reset. Fire trigger.nodeRebooted. Detection state lives in the DB
       // (the prior uptime row), not here, so this is a pure event forward.
-      const data = event.data as { nodeNum: number; previousUptimeSeconds: number; uptimeSeconds: number };
-      await e.onNodeRebooted(data.nodeNum, data.previousUptimeSeconds, data.uptimeSeconds, sourceId);
+      const data = event.data as { nodeNum: number | null; publicKey?: string | null; previousUptimeSeconds: number; uptimeSeconds: number };
+      await e.onNodeRebooted(data.nodeNum, data.publicKey ?? null, data.previousUptimeSeconds, data.uptimeSeconds, sourceId);
       break;
     }
 
@@ -156,8 +156,8 @@ async function handleEvent(event: DataEvent): Promise<void> {
       // batteryLevel cross the firmware powered threshold (> 100). Fire
       // trigger.nodePowerChanged. Detection state lives in the DB (the prior
       // batteryLevel row), not here, so this is a pure event forward.
-      const data = event.data as { nodeNum: number; previousPowered: boolean; powered: boolean; batteryLevel: number };
-      await e.onNodePowerChanged(data.nodeNum, data.previousPowered, data.powered, data.batteryLevel, sourceId);
+      const data = event.data as { nodeNum: number | null; publicKey?: string | null; previousPowered: boolean; powered: boolean; batteryLevel: number };
+      await e.onNodePowerChanged(data.nodeNum, data.publicKey ?? null, data.previousPowered, data.powered, data.batteryLevel, sourceId);
       break;
     }
 

--- a/src/server/services/automation/batteryTrend.test.ts
+++ b/src/server/services/automation/batteryTrend.test.ts
@@ -68,6 +68,8 @@ describe('trigger.batteryTrend (#4558 Phase E)', () => {
   let candidates: StaleCandidate[];
   /** `${sourceId}:${nodeNum}` → full battery history (the provider windows it by sinceMs). */
   let history: Map<string, Array<{ timestamp: number; value: number }>>;
+  /** `${sourceId}:${publicKey}` → full battery-VOLTS history for MeshCore nodes. */
+  let mcHistory: Map<string, Array<{ timestamp: number; value: number }>>;
 
   beforeEach(() => {
     const t = createTestDb();
@@ -78,6 +80,7 @@ describe('trigger.batteryTrend (#4558 Phase E)', () => {
     clock = 1000 * HOUR; // well past epoch
     candidates = [];
     history = new Map();
+    mcHistory = new Map();
   });
   afterEach(() => { db.close(); automationTraceBus.reset(); automationTraceBus.setSink(null); });
 
@@ -90,6 +93,11 @@ describe('trigger.batteryTrend (#4558 Phase E)', () => {
       const all = history.get(`${sourceId ?? ''}:${nodeNum}`) ?? [];
       return all.filter((s) => s.timestamp >= sinceMs);
     },
+    // MeshCore volts history, keyed by pubkey (#4558 follow-up).
+    getMeshCoreBatteryTrendSamples: async (sourceId, publicKey, sinceMs) => {
+      const all = mcHistory.get(`${sourceId ?? ''}:${publicKey}`) ?? [];
+      return all.filter((s) => s.timestamp >= sinceMs);
+    },
   };
   const engineWith = (deps: ActionDeps) =>
     new AutomationEngineService({ automationsRepo: autos, varResolver: resolver, deps, data, now: () => clock });
@@ -99,6 +107,25 @@ describe('trigger.batteryTrend (#4558 Phase E)', () => {
 
   const setHistory = (sourceId: string, nodeNum: number, samples: Array<{ timestamp: number; value: number }>) =>
     history.set(`${sourceId}:${nodeNum}`, samples);
+
+  const setMcHistory = (sourceId: string, publicKey: string, samples: Array<{ timestamp: number; value: number }>) =>
+    mcHistory.set(`${sourceId}:${publicKey}`, samples);
+
+  /** batteryTrend rule tokenised to read back the MeshCore pubkey identity. */
+  const mcTrendGraph = (windowHours: number, minDropPercent: number): AutomationGraph => ({
+    version: 1,
+    nodes: [
+      { id: 't', type: 'trigger.batteryTrend', params: { windowHours, minDropPercent } },
+      {
+        id: 'n', type: 'action.notify',
+        params: {
+          title: 'trend',
+          body: 'node={{ trigger.nodeNum }} key={{ trigger.publicKey }} drop={{ trigger.dropPercent }} start={{ trigger.startLevel }} latest={{ trigger.latestLevel }}',
+        },
+      },
+    ],
+    edges: [{ from: 't', to: 'n' }],
+  });
 
   // ── validation ──────────────────────────────────────────────────────────────
 
@@ -297,14 +324,105 @@ describe('trigger.batteryTrend (#4558 Phase E)', () => {
     expect(calls[0].args.sourceId).toBe('A');
   });
 
-  // ── MeshCore exclusion + provider absence ─────────────────────────────────────
+  // ── MeshCore parity (#4558 follow-up) ─────────────────────────────────────────
 
-  it('ignores MeshCore nodes (no batteryLevel history)', async () => {
+  it('fires for a MeshCore node on a relative VOLTS decline ≥ threshold, keyed by pubkey', async () => {
     const { calls, deps } = recorder();
-    await createEnabled('trend', trendGraph(12, 20));
+    await autos.createAutomation({ name: 'mc-trend', enabled: true, config: JSON.stringify(mcTrendGraph(12, 20)) });
     const engine = engineWith(deps);
     await engine.load();
-    // A MeshCore candidate has nodeNum == null; it must never be trended.
+    candidates = [{ sourceId: 'mc', nodeNum: null, publicKey: 'ABCDEF0123', lastHeardMs: clock }];
+
+    // Baseline: volts essentially flat → relative drop ~0.5% < 20% → no fire.
+    setMcHistory('mc', 'ABCDEF0123', [{ timestamp: clock - 2 * HOUR, value: 4.0 }, { timestamp: clock, value: 3.98 }]);
+    expect(await engine.runBatteryTrendCheck()).toBe(0);
+    expect(calls).toHaveLength(0);
+
+    // Volts fall 4.0 → 3.0: relative drop = (1.0 / 4.0) * 100 = 25% ≥ 20% → fires once.
+    setMcHistory('mc', 'ABCDEF0123', [
+      { timestamp: clock - 3 * HOUR, value: 4.0 },
+      { timestamp: clock - 1 * HOUR, value: 3.5 },
+      { timestamp: clock, value: 3.0 },
+    ]);
+    expect(await engine.runBatteryTrendCheck()).toBe(1);
+    expect(calls.map((c) => c.fn)).toEqual(['notify']);
+    // nodeNum interpolates empty (null); the pubkey carries the identity; drop is the relative %.
+    expect(calls[0].args.body).toBe('node= key=ABCDEF0123 drop=25 start=4 latest=3');
+    expect(calls[0].args.sourceId).toBe('mc');
+
+    // Still declining next tick → no re-fire.
+    expect(await engine.runBatteryTrendCheck()).toBe(0);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('does NOT fire for a MeshCore node whose volts are stable or rising', async () => {
+    const { calls, deps } = recorder();
+    await autos.createAutomation({ name: 'mc-trend', enabled: true, config: JSON.stringify(mcTrendGraph(12, 20)) });
+    const engine = engineWith(deps);
+    await engine.load();
+    candidates = [{ sourceId: 'mc', nodeNum: null, publicKey: 'ABCDEF0123', lastHeardMs: clock }];
+
+    // Flat.
+    setMcHistory('mc', 'ABCDEF0123', [{ timestamp: clock - 4 * HOUR, value: 3.8 }, { timestamp: clock, value: 3.8 }]);
+    expect(await engine.runBatteryTrendCheck()).toBe(0);
+    // Rising (charging): latest > start ⇒ negative drop.
+    setMcHistory('mc', 'ABCDEF0123', [{ timestamp: clock - 4 * HOUR, value: 3.2 }, { timestamp: clock, value: 4.1 }]);
+    expect(await engine.runBatteryTrendCheck()).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('is restart-safe for MeshCore: an already-declining node only baselines on first sight', async () => {
+    const { calls, deps } = recorder();
+    await autos.createAutomation({ name: 'mc-trend', enabled: true, config: JSON.stringify(mcTrendGraph(12, 20)) });
+    // Fresh engine == a process restart: batteryTrendState starts empty.
+    const engine = engineWith(deps);
+    await engine.load();
+    candidates = [{ sourceId: 'mc', nodeNum: null, publicKey: 'ABCDEF0123', lastHeardMs: clock }];
+
+    // Node is ALREADY deep into a steep volts decline when the engine starts.
+    setMcHistory('mc', 'ABCDEF0123', [{ timestamp: clock - 5 * HOUR, value: 4.1 }, { timestamp: clock, value: 3.0 }]);
+    expect(await engine.runBatteryTrendCheck()).toBe(0); // first sighting → baseline, no fire
+    expect(await engine.runBatteryTrendCheck()).toBe(0); // still declining, still no fire
+    expect(calls).toHaveLength(0);
+  });
+
+  it('scopes MeshCore state per source: the same pubkey on two sources is tracked separately', async () => {
+    const { calls, deps } = recorder();
+    await autos.createAutomation({ name: 'mc-trend', enabled: true, config: JSON.stringify(mcTrendGraph(12, 20)) });
+    const engine = engineWith(deps);
+    await engine.load();
+    candidates = [
+      { sourceId: 'A', nodeNum: null, publicKey: 'KEY', lastHeardMs: clock },
+      { sourceId: 'B', nodeNum: null, publicKey: 'KEY', lastHeardMs: clock },
+    ];
+
+    // Baseline both calm.
+    setMcHistory('A', 'KEY', [{ timestamp: clock - 2 * HOUR, value: 4.0 }, { timestamp: clock, value: 3.98 }]);
+    setMcHistory('B', 'KEY', [{ timestamp: clock - 2 * HOUR, value: 4.0 }, { timestamp: clock, value: 3.98 }]);
+    await engine.runBatteryTrendCheck();
+
+    // Only source A declines; B stays flat.
+    setMcHistory('A', 'KEY', [{ timestamp: clock - 3 * HOUR, value: 4.0 }, { timestamp: clock, value: 3.0 }]);
+    setMcHistory('B', 'KEY', [{ timestamp: clock - 3 * HOUR, value: 4.0 }, { timestamp: clock, value: 3.98 }]);
+    expect(await engine.runBatteryTrendCheck()).toBe(1);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args.sourceId).toBe('A');
+  });
+
+  it('skips MeshCore nodes when no MeshCore samples provider is wired', async () => {
+    const { calls, deps } = recorder();
+    await createEnabled('trend', trendGraph(12, 20));
+    const engine = new AutomationEngineService({
+      automationsRepo: autos, varResolver: resolver, deps,
+      // has Meshtastic samples + enumeration but NO getMeshCoreBatteryTrendSamples
+      data: {
+        getNode: async () => null, getTelemetry: async () => null,
+        listNodesForStaleCheck: async () => candidates,
+        getBatteryTrendSamples: async () => [],
+      },
+      now: () => clock,
+    });
+    await engine.load();
     candidates = [{ sourceId: 'mc', nodeNum: null, publicKey: 'ABCDEF', lastHeardMs: clock }];
     expect(await engine.runBatteryTrendCheck()).toBe(0);
     expect(await engine.runBatteryTrendCheck()).toBe(0);

--- a/src/server/services/automation/engineContext.ts
+++ b/src/server/services/automation/engineContext.ts
@@ -139,12 +139,30 @@ export interface NodeDataProvider {
    * engine picks the window's oldest and newest by timestamp). Optional; absent
    * → battery-trend checks are a no-op (e.g. unit tests that don't wire it).
    *
-   * MeshCore is out of scope: it stores battery as a single node column, not a
-   * batteryLevel time-series, so there is no history to trend.
+   * For MeshCore nodes use {@link getMeshCoreBatteryTrendSamples} instead — they
+   * have no numeric node id and report battery in volts, not %.
    */
   getBatteryTrendSamples?(
     sourceId: string | null,
     nodeNum: number,
+    sinceMs: number,
+  ): Promise<Array<{ timestamp: number; value: number }>>;
+  /**
+   * Battery-VOLTAGE history for a MeshCore node since a cutoff, for the periodic
+   * declining-battery check (`trigger.batteryTrend`, #4558 follow-up). The
+   * MeshCore analogue of {@link getBatteryTrendSamples}: keyed by the node's
+   * `publicKey` (MeshCore has no numeric node id) and returning VOLTS samples
+   * (MeshCore reports no battery %). Reads the durable MeshCore battery telemetry
+   * series (`mc_battery_volts`, falling back to `mc_status_battery_volts`) so the
+   * trend is recomputed from the DB each tick and a restart never replays an
+   * alert. `sinceMs` is an epoch-MILLISECONDS cutoff. Because the unit is volts,
+   * the engine interprets the drop as a RELATIVE percentage decline against the
+   * window's oldest sample so a single `minDropPercent` threshold still applies.
+   * Optional; absent → MeshCore battery-trend checks are a no-op.
+   */
+  getMeshCoreBatteryTrendSamples?(
+    sourceId: string | null,
+    publicKey: string,
     sinceMs: number,
   ): Promise<Array<{ timestamp: number; value: number }>>;
 }

--- a/src/server/services/automation/meshNodeData.ts
+++ b/src/server/services/automation/meshNodeData.ts
@@ -204,5 +204,35 @@ export function createMeshNodeDataProvider(): NodeDataProvider {
         return [];
       }
     },
+
+    // #4558 follow-up — battery-VOLTAGE history for a MeshCore node over the trend
+    // window. MeshCore reports no battery %, only volts, and is durable ONLY in the
+    // generic telemetry table (never a node column), keyed by nodeId = publicKey.
+    // A local/companion node writes `mc_battery_volts` (the local poller); a remote
+    // repeater/room-server writes `mc_status_battery_volts` (the remote scheduler) —
+    // a given pubkey has one or the other, so we read the poller series first and
+    // fall back to the status series when it's empty. Timestamps are epoch ms,
+    // matching `sinceMs`. Best-effort: a miss returns [] and the node is skipped.
+    async getMeshCoreBatteryTrendSamples(sourceId, publicKey, sinceMs) {
+      const read = async (telemetryType: string) => {
+        const rows = await databaseService.telemetry.getTelemetryByNode(
+          publicKey,
+          2000,
+          sinceMs,
+          undefined,
+          0,
+          telemetryType,
+          sourceId ?? undefined,
+        );
+        return rows.map((r) => ({ timestamp: Number(r.timestamp), value: Number(r.value) }));
+      };
+      try {
+        const volts = await read('mc_battery_volts');
+        if (volts.length > 0) return volts;
+        return await read('mc_status_battery_volts');
+      } catch {
+        return [];
+      }
+    },
   };
 }

--- a/src/server/services/automation/nodePowerChanged.test.ts
+++ b/src/server/services/automation/nodePowerChanged.test.ts
@@ -26,7 +26,10 @@ import type { ActionDeps } from './actionExecutor.js';
 import type { NodeDataProvider } from './engineContext.js';
 import type { AutomationGraph } from '../../../types/automation.js';
 import { validateAutomationGraph } from '../../../types/automation.js';
-import { isPowered, detectPowerTransition, POWERED_BATTERY_LEVEL_THRESHOLD } from '../../utils/poweredState.js';
+import { isPowered, isPoweredMv, detectPowerTransition, POWERED_BATTERY_LEVEL_THRESHOLD, MESHCORE_POWERED_MV_THRESHOLD } from '../../utils/poweredState.js';
+import { buildNodePowerChangedContext } from './triggerContext.js';
+import { detectMeshCorePowerChange } from '../meshcoreDeviceHealth.js';
+import { dataEventEmitter, type DataEvent } from '../dataEventEmitter.js';
 import * as schema from '../../../db/schema/index.js';
 import { createTestDb } from '../../test-helpers/testDb.js';
 import { automationTraceBus } from './automationTraceBus.js';
@@ -99,6 +102,29 @@ describe('isPowered / detectPowerTransition (#4558 Phase C)', () => {
   it('returns null when the new reading is non-finite', () => {
     expect(detectPowerTransition(101, NaN)).toBeNull();
     expect(detectPowerTransition(80, null)).toBeNull();
+  });
+});
+
+// ─── MeshCore powered-voltage heuristic (#4558 MeshCore parity) ───────────────
+
+describe('isPoweredMv (#4558 MeshCore parity)', () => {
+  it('treats >= 4200 mV as powered (the Li-ion full/charging voltage)', () => {
+    expect(MESHCORE_POWERED_MV_THRESHOLD).toBe(4200);
+    expect(isPoweredMv(4200)).toBe(true);   // exactly at the threshold
+    expect(isPoweredMv(4201)).toBe(true);
+    expect(isPoweredMv(4500)).toBe(true);
+  });
+
+  it('treats < 4200 mV as on battery', () => {
+    expect(isPoweredMv(4199)).toBe(false);  // just under the threshold
+    expect(isPoweredMv(3700)).toBe(false);  // nominal Li-ion
+    expect(isPoweredMv(0)).toBe(false);
+  });
+
+  it('treats a missing / non-finite reading as not powered', () => {
+    expect(isPoweredMv(null)).toBe(false);
+    expect(isPoweredMv(undefined)).toBe(false);
+    expect(isPoweredMv(NaN)).toBe(false);
   });
 });
 
@@ -176,6 +202,119 @@ describe('power-change detection via getLatestTelemetryForType (#4558 Phase C)',
   });
 });
 
+// ─── MeshCore seam: detectMeshCorePowerChange → node:powerChanged (parity) ────
+
+describe('detectMeshCorePowerChange seam (#4558 MeshCore parity)', () => {
+  let db: ReturnType<typeof createTestDb>['sqlite'];
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let telem: TelemetryRepository;
+  let events: DataEvent[];
+  let listener: (e: DataEvent) => void;
+
+  // 4300 mV ≥ 4200 threshold ⇒ "powered"; 3700 mV ⇒ on battery.
+  const POWERED_MV = 4300;
+  const BATTERY_MV = 3700;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    telem = new TelemetryRepository(drizzleDb, 'sqlite');
+    events = [];
+    listener = (e) => { if (e.type === 'node:powerChanged') events.push(e); };
+    dataEventEmitter.on('data', listener);
+  });
+  afterEach(() => { dataEventEmitter.off('data', listener); db.close(); });
+
+  const insertBattery = (pk: string, telemetryType: string, value: number, ts: number, unit: string, sourceId: string) =>
+    telem.insertTelemetry(
+      { nodeId: pk, nodeNum: 1, telemetryType, timestamp: ts, value, unit, createdAt: ts },
+      sourceId,
+    );
+
+  // Local-poller path: prior stored as mc_battery_mv (mV → scale 1).
+  const insertMv = (pk: string, value: number, ts: number, sourceId: string) =>
+    insertBattery(pk, 'mc_battery_mv', value, ts, 'mV', sourceId);
+  const detectMv = (pk: string, newMv: number, sourceId: string) =>
+    detectMeshCorePowerChange(telem, pk, 'mc_battery_mv', 1, newMv, sourceId);
+
+  it('emits node:powerChanged (nodeNum null, pubkey) on powered → battery as "lost"', async () => {
+    await insertMv('PUBKEY', POWERED_MV, 1_000, 'mc');
+    await detectMv('PUBKEY', BATTERY_MV, 'mc');
+    expect(events).toHaveLength(1);
+    const data = events[0].data as { nodeNum: number | null; publicKey?: string; previousPowered: boolean; powered: boolean; batteryLevel: number };
+    expect(data.nodeNum).toBeNull();
+    expect(data.publicKey).toBe('PUBKEY');
+    expect(data.previousPowered).toBe(true);
+    expect(data.powered).toBe(false);
+    expect(data.batteryLevel).toBe(BATTERY_MV);
+    expect(events[0].sourceId).toBe('mc');
+  });
+
+  it('emits "restored" on battery → powered', async () => {
+    await insertMv('PUBKEY', BATTERY_MV, 1_000, 'mc');
+    await detectMv('PUBKEY', POWERED_MV, 'mc');
+    expect(events).toHaveLength(1);
+    const data = events[0].data as { previousPowered: boolean; powered: boolean };
+    expect(data.previousPowered).toBe(false);
+    expect(data.powered).toBe(true);
+  });
+
+  it('does not emit when the powered-state is unchanged', async () => {
+    // battery → battery
+    await insertMv('A', BATTERY_MV, 1_000, 'mc');
+    await detectMv('A', 3_600, 'mc');
+    // powered → powered
+    await insertMv('B', POWERED_MV, 1_000, 'mc');
+    await detectMv('B', 4_400, 'mc');
+    expect(events).toHaveLength(0);
+  });
+
+  it('does not emit on the first-ever reading (no prior)', async () => {
+    await detectMv('PUBKEY', POWERED_MV, 'mc');
+    expect(events).toHaveLength(0);
+  });
+
+  it('is restart-safe: the prior comes from the DB, not memory', async () => {
+    await insertMv('PUBKEY', POWERED_MV, 1_000, 'mc');
+    // A brand-new repository instance stands in for a MeshMonitor restart — the
+    // durable row is the only baseline.
+    const freshTelem = new TelemetryRepository(drizzleDb, 'sqlite');
+    await detectMeshCorePowerChange(freshTelem, 'PUBKEY', 'mc_battery_mv', 1, BATTERY_MV, 'mc');
+    expect(events).toHaveLength(1);
+    expect((events[0].data as { powered: boolean }).powered).toBe(false);
+  });
+
+  it('reads the prior per source: a fresh source baselines rather than firing', async () => {
+    await insertMv('PUBKEY', POWERED_MV, 1_000, 'A');
+    // Source B has no prior of its own → first reading, does not fire.
+    await detectMv('PUBKEY', BATTERY_MV, 'B');
+    expect(events).toHaveLength(0);
+    // Source A's own powered prior → a battery reading is a "lost" transition.
+    await detectMv('PUBKEY', BATTERY_MV, 'A');
+    expect(events).toHaveLength(1);
+    expect(events[0].sourceId).toBe('A');
+  });
+
+  it('works on the remote-scheduler volts series (mc_status_battery_volts, scale 1000)', async () => {
+    // The scheduler stores battery in VOLTS; the helper scales the prior ×1000.
+    await insertBattery('PUBKEY', 'mc_status_battery_volts', 4.3, 1_000, 'V', 'mc');
+    await detectMeshCorePowerChange(telem, 'PUBKEY', 'mc_status_battery_volts', 1000, BATTERY_MV, 'mc');
+    expect(events).toHaveLength(1);
+    const data = events[0].data as { publicKey?: string; previousPowered: boolean; powered: boolean };
+    expect(data.publicKey).toBe('PUBKEY');
+    expect(data.previousPowered).toBe(true);
+    expect(data.powered).toBe(false);
+  });
+
+  it('does not emit when newBatteryMv is null / non-finite', async () => {
+    await insertMv('PUBKEY', POWERED_MV, 1_000, 'mc');
+    await detectMeshCorePowerChange(telem, 'PUBKEY', 'mc_battery_mv', 1, null, 'mc');
+    await detectMeshCorePowerChange(telem, 'PUBKEY', 'mc_battery_mv', 1, NaN, 'mc');
+    expect(events).toHaveLength(0);
+  });
+});
+
 // ─── engine firing + direction filter + tokens + validation ──────────────────
 
 describe('trigger.nodePowerChanged engine (#4558 Phase C)', () => {
@@ -225,7 +364,7 @@ describe('trigger.nodePowerChanged engine (#4558 Phase C)', () => {
     await engine.load();
 
     // previousPowered=true, powered=false → "lost"
-    expect(await engine.onNodePowerChanged(111, true, false, 80, 'default')).toBe(1);
+    expect(await engine.onNodePowerChanged(111, null, true, false, 80, 'default')).toBe(1);
     expect(calls.map((c) => c.fn)).toEqual(['notify']);
     expect(calls[0].args.body).toBe('node=111 dir=lost prev=true now=false batt=80 src=default');
   });
@@ -237,10 +376,10 @@ describe('trigger.nodePowerChanged engine (#4558 Phase C)', () => {
     await engine.load();
 
     // A "restored" transition must NOT fire a lost-only rule…
-    expect(await engine.onNodePowerChanged(111, false, true, 101, 'default')).toBe(0);
+    expect(await engine.onNodePowerChanged(111, null, false, true, 101, 'default')).toBe(0);
     expect(calls).toHaveLength(0);
     // …but a "lost" transition does.
-    expect(await engine.onNodePowerChanged(111, true, false, 80, 'default')).toBe(1);
+    expect(await engine.onNodePowerChanged(111, null, true, false, 80, 'default')).toBe(1);
     expect(calls.map((c) => c.fn)).toEqual(['notify']);
     expect(calls[0].args.body).toContain('dir=lost');
   });
@@ -249,7 +388,7 @@ describe('trigger.nodePowerChanged engine (#4558 Phase C)', () => {
     const { calls, deps } = recorder();
     const engine = engineWith(deps);
     await engine.load();
-    expect(await engine.onNodePowerChanged(111, true, false, 80, 'default')).toBe(0);
+    expect(await engine.onNodePowerChanged(111, null, true, false, 80, 'default')).toBe(0);
     expect(calls).toHaveLength(0);
   });
 
@@ -260,7 +399,54 @@ describe('trigger.nodePowerChanged engine (#4558 Phase C)', () => {
     await engine.load();
 
     // previousPowered=false, powered=true → "restored"
-    await engine.onNodePowerChanged(222, false, true, 101, 'sourceZ');
+    await engine.onNodePowerChanged(222, null, false, true, 101, 'sourceZ');
     expect(calls[0].args.body).toBe('node=222 dir=restored prev=false now=true batt=101 src=sourceZ');
+  });
+
+  // ── MeshCore parity (#4558) ──────────────────────────────────────────────────
+
+  it('fires for a MeshCore node identified by pubkey (nodeNum null)', async () => {
+    const { calls, deps } = recorder();
+    // A rule that reads the MeshCore identity: nodeNum is null, publicKey is set.
+    await autos.createAutomation({
+      name: 'mc-power', enabled: true,
+      config: JSON.stringify({
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.nodePowerChanged', params: {} },
+          { id: 'n', type: 'action.notify', params: { title: 'p', body: 'node={{ trigger.nodeNum }} key={{ trigger.publicKey }} dir={{ trigger.direction }} batt={{ trigger.batteryLevel }}' } },
+        ],
+        edges: [{ from: 't', to: 'n' }],
+      }),
+    });
+    const engine = engineWith(deps);
+    await engine.load();
+
+    // previousPowered=true, powered=false → "lost"; batteryLevel is mV on MeshCore.
+    expect(await engine.onNodePowerChanged(null, 'ABCDEF0123', true, false, 3700, 'mc')).toBe(1);
+    // nodeNum interpolates empty (null); the pubkey carries the identity.
+    expect(calls[0].args.body).toBe('node= key=ABCDEF0123 dir=lost batt=3700');
+  });
+});
+
+// ─── context identity: pubkey vs nodeNum ─────────────────────────────────────
+
+describe('buildNodePowerChangedContext identity (#4558 MeshCore parity)', () => {
+  it('Meshtastic subject binds subjectNodeNum and leaves subjectNodeKey to derive', () => {
+    const ctx = buildNodePowerChangedContext(111, null, true, false, 80, 'default', 1_000);
+    expect(ctx.subjectNodeNum).toBe(111);
+    // undefined ⇒ derive from subjectNodeNum (a Meshtastic node), not an explicit key.
+    expect(ctx.subjectNodeKey).toBeUndefined();
+    expect(ctx.fields.nodeNum).toBe(111);
+    expect(ctx.fields.publicKey).toBeUndefined();
+  });
+
+  it('MeshCore subject binds subjectNodeKey to the pubkey with a null node number', () => {
+    const ctx = buildNodePowerChangedContext(null, 'ABCDEF0123', true, false, 3700, 'mc', 1_000);
+    expect(ctx.subjectNodeNum).toBeNull();
+    expect(ctx.subjectNodeKey).toBe('ABCDEF0123');
+    expect(ctx.fields.nodeNum).toBeNull();
+    expect(ctx.fields.publicKey).toBe('ABCDEF0123');
+    expect(ctx.fields.direction).toBe('lost');
   });
 });

--- a/src/server/services/automation/nodeRebooted.test.ts
+++ b/src/server/services/automation/nodeRebooted.test.ts
@@ -25,6 +25,9 @@ import type { NodeDataProvider } from './engineContext.js';
 import type { AutomationGraph } from '../../../types/automation.js';
 import { validateAutomationGraph } from '../../../types/automation.js';
 import { isUptimeReboot, REBOOT_UPTIME_SLACK_SECONDS } from '../../utils/rebootDetection.js';
+import { buildNodeRebootedContext } from './triggerContext.js';
+import { detectMeshCoreReboot } from '../meshcoreDeviceHealth.js';
+import { dataEventEmitter, type DataEvent } from '../dataEventEmitter.js';
 import * as schema from '../../../db/schema/index.js';
 import { createTestDb } from '../../test-helpers/testDb.js';
 import { automationTraceBus } from './automationTraceBus.js';
@@ -152,6 +155,74 @@ describe('reboot detection via getLatestTelemetryForType (#4558 Phase B)', () =>
   });
 });
 
+// ─── MeshCore seam: detectMeshCoreReboot → node:rebooted (#4558 follow-up) ────
+
+describe('detectMeshCoreReboot seam (#4558 follow-up)', () => {
+  let db: ReturnType<typeof createTestDb>['sqlite'];
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let telem: TelemetryRepository;
+  let events: DataEvent[];
+  let listener: (e: DataEvent) => void;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    telem = new TelemetryRepository(drizzleDb, 'sqlite');
+    events = [];
+    listener = (e) => { if (e.type === 'node:rebooted') events.push(e); };
+    dataEventEmitter.on('data', listener);
+  });
+  afterEach(() => { dataEventEmitter.off('data', listener); db.close(); });
+
+  const insertUptime = (pk: string, telemetryType: string, value: number, ts: number, sourceId: string) =>
+    telem.insertTelemetry(
+      { nodeId: pk, nodeNum: 1, telemetryType, timestamp: ts, value, unit: 's', createdAt: ts },
+      sourceId,
+    );
+
+  it('emits node:rebooted carrying the pubkey (nodeNum null) on a genuine uptime reset', async () => {
+    await insertUptime('PUBKEY', 'mc_uptime_secs', 86_400, 1_000, 'mc');
+    await detectMeshCoreReboot(telem, 'PUBKEY', 'mc_uptime_secs', 12, 'mc');
+    expect(events).toHaveLength(1);
+    const data = events[0].data as { nodeNum: number | null; publicKey?: string; previousUptimeSeconds: number; uptimeSeconds: number };
+    expect(data.nodeNum).toBeNull();
+    expect(data.publicKey).toBe('PUBKEY');
+    expect(data.previousUptimeSeconds).toBe(86_400);
+    expect(data.uptimeSeconds).toBe(12);
+    expect(events[0].sourceId).toBe('mc');
+  });
+
+  it('does not emit on the first-ever reading (no prior)', async () => {
+    await detectMeshCoreReboot(telem, 'PUBKEY', 'mc_uptime_secs', 3_600, 'mc');
+    expect(events).toHaveLength(0);
+  });
+
+  it('does not emit on a normal uptime rise', async () => {
+    await insertUptime('PUBKEY', 'mc_uptime_secs', 3_600, 1_000, 'mc');
+    await detectMeshCoreReboot(telem, 'PUBKEY', 'mc_uptime_secs', 7_200, 'mc');
+    expect(events).toHaveLength(0);
+  });
+
+  it('works on the remote-scheduler status uptime series too', async () => {
+    await insertUptime('PUBKEY', 'mc_status_uptime_secs', 50_000, 1_000, 'mc');
+    await detectMeshCoreReboot(telem, 'PUBKEY', 'mc_status_uptime_secs', 5, 'mc');
+    expect(events).toHaveLength(1);
+    expect((events[0].data as { publicKey?: string }).publicKey).toBe('PUBKEY');
+  });
+
+  it('reads the prior per source: a fresh source baselines rather than firing', async () => {
+    await insertUptime('PUBKEY', 'mc_uptime_secs', 3_600, 1_000, 'A');
+    // Source B has no prior of its own → first reading, does not fire.
+    await detectMeshCoreReboot(telem, 'PUBKEY', 'mc_uptime_secs', 30, 'B');
+    expect(events).toHaveLength(0);
+    // Source A's own 3600s prior → a 30s reading is a reset.
+    await detectMeshCoreReboot(telem, 'PUBKEY', 'mc_uptime_secs', 30, 'A');
+    expect(events).toHaveLength(1);
+    expect(events[0].sourceId).toBe('A');
+  });
+});
+
 // ─── engine firing + tokens + validation ─────────────────────────────────────
 
 describe('trigger.nodeRebooted engine (#4558 Phase B)', () => {
@@ -189,7 +260,7 @@ describe('trigger.nodeRebooted engine (#4558 Phase B)', () => {
     const engine = engineWith(deps);
     await engine.load();
 
-    expect(await engine.onNodeRebooted(111, 86_400, 12, 'default')).toBe(1);
+    expect(await engine.onNodeRebooted(111, null, 86_400, 12, 'default')).toBe(1);
     expect(calls.map((c) => c.fn)).toEqual(['notify']);
     expect(calls[0].args.body).toBe('node=111 prev=86400 now=12 src=default');
   });
@@ -198,7 +269,7 @@ describe('trigger.nodeRebooted engine (#4558 Phase B)', () => {
     const { calls, deps } = recorder();
     const engine = engineWith(deps);
     await engine.load();
-    expect(await engine.onNodeRebooted(111, 86_400, 12, 'default')).toBe(0);
+    expect(await engine.onNodeRebooted(111, null, 86_400, 12, 'default')).toBe(0);
     expect(calls).toHaveLength(0);
   });
 
@@ -208,7 +279,52 @@ describe('trigger.nodeRebooted engine (#4558 Phase B)', () => {
     const engine = engineWith(deps);
     await engine.load();
 
-    await engine.onNodeRebooted(222, 5_000, 3, 'sourceZ');
+    await engine.onNodeRebooted(222, null, 5_000, 3, 'sourceZ');
     expect(calls[0].args.body).toBe('node=222 prev=5000 now=3 src=sourceZ');
+  });
+
+  // ── MeshCore parity (#4558 follow-up) ─────────────────────────────────────────
+
+  it('fires for a MeshCore node identified by pubkey (nodeNum null)', async () => {
+    const { calls, deps } = recorder();
+    // A rule that reads the MeshCore identity: nodeNum is null, publicKey is set.
+    await autos.createAutomation({
+      name: 'mc-reboot', enabled: true,
+      config: JSON.stringify({
+        version: 1,
+        nodes: [
+          { id: 't', type: 'trigger.nodeRebooted', params: {} },
+          { id: 'n', type: 'action.notify', params: { title: 'r', body: 'node={{ trigger.nodeNum }} key={{ trigger.publicKey }} prev={{ trigger.previousUptimeSeconds }} now={{ trigger.uptimeSeconds }}' } },
+        ],
+        edges: [{ from: 't', to: 'n' }],
+      }),
+    });
+    const engine = engineWith(deps);
+    await engine.load();
+
+    expect(await engine.onNodeRebooted(null, 'ABCDEF0123', 86_400, 7, 'mc')).toBe(1);
+    // nodeNum interpolates empty (null); the pubkey carries the identity.
+    expect(calls[0].args.body).toBe('node= key=ABCDEF0123 prev=86400 now=7');
+  });
+});
+
+// ─── context identity: pubkey vs nodeNum ─────────────────────────────────────
+
+describe('buildNodeRebootedContext identity (#4558 follow-up)', () => {
+  it('Meshtastic subject binds subjectNodeNum and leaves subjectNodeKey to derive', () => {
+    const ctx = buildNodeRebootedContext(111, null, 86_400, 12, 'default', 1_000);
+    expect(ctx.subjectNodeNum).toBe(111);
+    // undefined ⇒ derive from subjectNodeNum (a Meshtastic node), not an explicit key.
+    expect(ctx.subjectNodeKey).toBeUndefined();
+    expect(ctx.fields.nodeNum).toBe(111);
+    expect(ctx.fields.publicKey).toBeUndefined();
+  });
+
+  it('MeshCore subject binds subjectNodeKey to the pubkey with a null node number', () => {
+    const ctx = buildNodeRebootedContext(null, 'ABCDEF0123', 86_400, 7, 'mc', 1_000);
+    expect(ctx.subjectNodeNum).toBeNull();
+    expect(ctx.subjectNodeKey).toBe('ABCDEF0123');
+    expect(ctx.fields.nodeNum).toBeNull();
+    expect(ctx.fields.publicKey).toBe('ABCDEF0123');
   });
 });

--- a/src/server/services/automation/triggerContext.ts
+++ b/src/server/services/automation/triggerContext.ts
@@ -440,9 +440,16 @@ export function buildNodeOnlineContext(
  * node-scoped cooldown work. Detection (reading the prior uptime from the DB and
  * comparing) happens at the telemetry-save seam; this builder only shapes what
  * the conditions / interpolation read.
+ *
+ * Meshtastic reboots pass a real `nodeNum` (`publicKey` null). MeshCore reboots
+ * (#4558 follow-up) have no Meshtastic node number, so they pass `nodeNum: null`
+ * plus the pubkey — `subjectNodeKey` is then set explicitly to the pubkey (the
+ * same degrade {@link buildNodeStaleContext} uses), which keys per-node cooldown
+ * off the pubkey.
  */
 export function buildNodeRebootedContext(
-  nodeNum: number,
+  nodeNum: number | null,
+  publicKey: string | null,
   previousUptimeSeconds: number,
   uptimeSeconds: number,
   sourceId: string | null,
@@ -451,10 +458,13 @@ export function buildNodeRebootedContext(
   return {
     triggerType: 'trigger.nodeRebooted',
     sourceId,
-    subjectNodeNum: Number(nodeNum),
+    subjectNodeNum: nodeNum == null ? null : Number(nodeNum),
+    // undefined ⇒ derive from subjectNodeNum (Meshtastic); explicit pubkey for MeshCore.
+    subjectNodeKey: nodeNum == null ? (publicKey ?? null) : undefined,
     timestamp,
     fields: {
-      nodeNum: Number(nodeNum),
+      nodeNum: nodeNum == null ? null : Number(nodeNum),
+      publicKey: publicKey ?? undefined,
       previousUptimeSeconds,
       uptimeSeconds,
       sourceId,
@@ -472,9 +482,17 @@ export function buildNodeRebootedContext(
  * the telemetry-save seam; this builder only shapes what the conditions /
  * interpolation read. `direction` is 'lost' (was powered, now on battery) or
  * 'restored' (was on battery, now powered).
+ *
+ * Meshtastic passes a real `nodeNum` (`publicKey` null). MeshCore (#4558 parity)
+ * has no Meshtastic node number, so it passes `nodeNum: null` plus the pubkey —
+ * `subjectNodeKey` is then set explicitly to the pubkey (the same degrade
+ * {@link buildNodeRebootedContext} uses), keying per-node cooldown off the
+ * pubkey. The MeshCore path derives powered-state from battery voltage and is a
+ * HEURISTIC (see detectMeshCorePowerChange).
  */
 export function buildNodePowerChangedContext(
-  nodeNum: number,
+  nodeNum: number | null,
+  publicKey: string | null,
   previousPowered: boolean,
   powered: boolean,
   batteryLevel: number,
@@ -484,10 +502,13 @@ export function buildNodePowerChangedContext(
   return {
     triggerType: 'trigger.nodePowerChanged',
     sourceId,
-    subjectNodeNum: Number(nodeNum),
+    subjectNodeNum: nodeNum == null ? null : Number(nodeNum),
+    // undefined ⇒ derive from subjectNodeNum (Meshtastic); explicit pubkey for MeshCore.
+    subjectNodeKey: nodeNum == null ? (publicKey ?? null) : undefined,
     timestamp,
     fields: {
-      nodeNum: Number(nodeNum),
+      nodeNum: nodeNum == null ? null : Number(nodeNum),
+      publicKey: publicKey ?? undefined,
       powered,
       previousPowered,
       direction: powered ? 'restored' : 'lost',
@@ -506,19 +527,26 @@ export function buildNodePowerChangedContext(
  * tick (see runBatteryTrendCheck); this builder only shapes what the conditions /
  * interpolation read.
  *
- * `startLevel`/`latestLevel` are the battery-level (%) at the window's oldest and
- * newest samples; `dropPercent` is `startLevel - latestLevel` (percentage POINTS,
- * since the metric is batteryLevel %). Meshtastic only — MeshCore stores battery
- * as a single node column, not a batteryLevel time-series — so `subjectNodeNum`
- * is always a real node number here.
+ * `startLevel`/`latestLevel` are the window's oldest and newest battery readings;
+ * `dropPercent` is the decline the automation's `minDropPercent` is compared to.
  *
- * HEURISTIC CAVEAT: the Meshtastic protocol carries no charge-state field, so a
- * falling battery level is only a PROXY for "not charging" (the solar-node alert
- * this phase exists for). It can false-positive under heavy transient load and is
- * blind to day/night — it deliberately does not model solar hours.
+ * The two protocols carry battery in different units, so the meaning of these
+ * fields differs by subject (#4558 follow-up):
+ *  - Meshtastic (`nodeNum` set, `publicKey` null): readings are battery-level
+ *    (%), and `dropPercent = startLevel - latestLevel` in percentage POINTS.
+ *  - MeshCore (`nodeNum` null, `publicKey` set): readings are VOLTS (MeshCore
+ *    reports no %), and `dropPercent` is the RELATIVE decline
+ *    `(startLevel - latestLevel) / startLevel * 100` so a single `minDropPercent`
+ *    threshold stays meaningful across both units. See `runBatteryTrendCheck`.
+ *
+ * HEURISTIC CAVEAT: neither protocol carries a charge-state field, so a falling
+ * battery is only a PROXY for "not charging" (the solar-node alert this exists
+ * for). It can false-positive under heavy transient load and is blind to
+ * day/night — it deliberately does not model solar hours.
  */
 export function buildBatteryTrendContext(
-  nodeNum: number,
+  nodeNum: number | null,
+  publicKey: string | null,
   dropPercent: number,
   windowHours: number,
   minDropPercent: number,
@@ -530,10 +558,13 @@ export function buildBatteryTrendContext(
   return {
     triggerType: 'trigger.batteryTrend',
     sourceId,
-    subjectNodeNum: Number(nodeNum),
+    subjectNodeNum: nodeNum == null ? null : Number(nodeNum),
+    // undefined ⇒ derive from subjectNodeNum (Meshtastic); explicit pubkey for MeshCore.
+    subjectNodeKey: nodeNum == null ? (publicKey ?? null) : undefined,
     timestamp,
     fields: {
-      nodeNum: Number(nodeNum),
+      nodeNum: nodeNum == null ? null : Number(nodeNum),
+      publicKey: publicKey ?? undefined,
       dropPercent,
       windowHours,
       minDropPercent,

--- a/src/server/services/dataEventEmitter.ts
+++ b/src/server/services/dataEventEmitter.ts
@@ -85,9 +85,15 @@ export interface MeshBeaconReceivedData {
  * counter reset. Carries the prior and new uptime so `trigger.nodeRebooted`
  * automations can report the drop. Not stored anywhere; this event is the only
  * way a rule sees the reboot.
+ *
+ * Meshtastic reboots carry a real `nodeNum` (`publicKey` null/undefined).
+ * MeshCore reboots (#4558 follow-up) have NO real Meshtastic node number — only
+ * a synthetic one derived from the pubkey — so they set `nodeNum: null` and
+ * carry the MeshCore `publicKey` as the subject identity instead.
  */
 export interface NodeRebootedData {
-  nodeNum: number;
+  nodeNum: number | null;
+  publicKey?: string | null;
   previousUptimeSeconds: number;
   uptimeSeconds: number;
 }
@@ -101,9 +107,15 @@ export interface NodeRebootedData {
  * stored anywhere; this event is the only way a rule sees the transition.
  */
 export interface NodePowerChangedData {
-  nodeNum: number;
+  /** Meshtastic node number, or `null` for a MeshCore node (identified by
+   *  `publicKey` instead — #4558 MeshCore parity). */
+  nodeNum: number | null;
+  /** MeshCore public key when `nodeNum` is null; absent/null for Meshtastic. */
+  publicKey?: string | null;
   previousPowered: boolean;
   powered: boolean;
+  /** The new battery reading: percent for Meshtastic, millivolts for MeshCore
+   *  (the MeshCore path is a voltage heuristic — see poweredState.ts). */
   batteryLevel: number;
 }
 
@@ -206,7 +218,7 @@ class DataEventEmitter extends EventEmitter {
       sourceId,
     };
     this.emit('data', event);
-    logger.debug(`[DataEventEmitter] Node rebooted: ${data.nodeNum} (uptime ${data.previousUptimeSeconds}s → ${data.uptimeSeconds}s)`);
+    logger.debug(`[DataEventEmitter] Node rebooted: ${data.nodeNum ?? data.publicKey ?? '?'} (uptime ${data.previousUptimeSeconds}s → ${data.uptimeSeconds}s)`);
   }
 
   /**
@@ -222,7 +234,7 @@ class DataEventEmitter extends EventEmitter {
       sourceId,
     };
     this.emit('data', event);
-    logger.debug(`[DataEventEmitter] Node power changed: ${data.nodeNum} (powered ${data.previousPowered} → ${data.powered}, battery ${data.batteryLevel})`);
+    logger.debug(`[DataEventEmitter] Node power changed: ${data.nodeNum ?? data.publicKey ?? '?'} (powered ${data.previousPowered} → ${data.powered}, battery ${data.batteryLevel})`);
   }
 
   /**

--- a/src/server/services/meshcoreDeviceHealth.ts
+++ b/src/server/services/meshcoreDeviceHealth.ts
@@ -1,0 +1,164 @@
+/**
+ * MeshCore device-health detection seam (#4558 follow-up).
+ *
+ * The Meshtastic device-health triggers detect a reboot at the telemetry-save
+ * seam in `meshtasticManager.detectRebootFromUptime`. MeshCore has no single
+ * telemetry-save method — uptime is written from TWO services (the local-node
+ * poller and the remote-telemetry scheduler) — so this shared helper is called
+ * from both. It mirrors the Meshtastic logic exactly: read the PRIOR stored
+ * uptime for the node from the DB (a durable baseline, so a MeshMonitor restart
+ * can never spuriously fire), compare via the same {@link isUptimeReboot} helper,
+ * and on a genuine reset emit `node:rebooted` for the automation engine.
+ *
+ * MeshCore identity is a public key, not a Meshtastic node number, so the emit
+ * carries `nodeNum: null` + the pubkey. Detection reads the DB only; it sends no
+ * packets, so it costs zero airtime. Must run BEFORE the new uptime row is
+ * inserted, so the "latest" it reads is genuinely the prior reading.
+ */
+import { dataEventEmitter } from './dataEventEmitter.js';
+import { isUptimeReboot } from '../utils/rebootDetection.js';
+import {
+  isPoweredMv,
+  detectPowerTransition,
+  POWERED_BATTERY_LEVEL_THRESHOLD,
+} from '../utils/poweredState.js';
+import { logger } from '../../utils/logger.js';
+
+/** The one telemetry-repo method this helper needs. Optional so test/mock
+ *  databases that don't wire it simply never fire a reboot (prior stays null).
+ *  A minimal structural return type (just `value`) so both `DbTelemetry` type
+ *  flavours in the tree — services/database vs db/types, which differ only in
+ *  `unit`'s nullability — satisfy it. */
+export interface RebootDetectionTelemetry {
+  getLatestTelemetryForType?: (
+    nodeId: string,
+    telemetryType: string,
+    sourceId?: string,
+  ) => Promise<{ value: number } | null>;
+}
+
+/**
+ * Detect a MeshCore node reboot from an incoming uptime reading and emit
+ * `node:rebooted` when it is a genuine reset.
+ *
+ * @param telemetry  telemetry repository (uses `getLatestTelemetryForType`)
+ * @param publicKey  the node's MeshCore public key (its `nodeId` in telemetry)
+ * @param uptimeTelemetryType  the uptime metric name — `mc_uptime_secs` (local
+ *   poller) or `mc_status_uptime_secs` (remote scheduler)
+ * @param newUptimeSeconds  the uptime value about to be inserted
+ * @param sourceId  the MeshCore source id (scopes the prior-uptime read)
+ */
+export async function detectMeshCoreReboot(
+  telemetry: RebootDetectionTelemetry,
+  publicKey: string,
+  uptimeTelemetryType: string,
+  newUptimeSeconds: number,
+  sourceId: string,
+): Promise<void> {
+  try {
+    if (!telemetry.getLatestTelemetryForType) return;
+    if (!Number.isFinite(newUptimeSeconds)) return;
+    const prior = await telemetry.getLatestTelemetryForType(publicKey, uptimeTelemetryType, sourceId);
+    const priorUptime = prior ? Number(prior.value) : null;
+    if (!isUptimeReboot(priorUptime, newUptimeSeconds)) return;
+    logger.info(
+      `🔁 MeshCore node ${publicKey.substring(0, 12)}… reboot detected: ` +
+        `uptime ${priorUptime}s → ${newUptimeSeconds}s (source ${sourceId})`,
+    );
+    dataEventEmitter.emitNodeRebooted(
+      { nodeNum: null, publicKey, previousUptimeSeconds: priorUptime as number, uptimeSeconds: newUptimeSeconds },
+      sourceId,
+    );
+  } catch (e) {
+    logger.warn(
+      `MeshCore reboot detection failed for ${publicKey.substring(0, 12)}…: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}
+
+/** The one telemetry-repo method the power-change helper needs. Same structural
+ *  shape as {@link RebootDetectionTelemetry} (a minimal `{ value }` return so
+ *  both `DbTelemetry` type flavours satisfy it), kept as a distinct name so the
+ *  battery seam reads clearly. Optional so mock DBs that don't wire it simply
+ *  never fire (prior stays null). */
+export interface PowerChangeDetectionTelemetry {
+  getLatestTelemetryForType?: (
+    nodeId: string,
+    telemetryType: string,
+    sourceId?: string,
+  ) => Promise<{ value: number } | null>;
+}
+
+/**
+ * Detect a MeshCore node external-power transition from an incoming battery
+ * voltage reading and emit `node:powerChanged` when the powered-state flips.
+ *
+ * EXPERIMENTAL / HEURISTIC. Unlike Meshtastic (where the firmware overloads
+ * `battery_level > 100` as an explicit "powered" flag), MeshCore reports only
+ * raw battery voltage. A full or charging Li-ion cell reads ~4.2 V, which is
+ * indistinguishable from wall/USB power, so this can misfire — a battery topping
+ * up to full looks like "power restored", a battery falling off float looks like
+ * "power lost". See {@link MESHCORE_POWERED_MV_THRESHOLD} for the full caveat.
+ *
+ * Mirrors {@link detectMeshCoreReboot}: reads the node's PRIOR battery voltage
+ * from the DB (a durable baseline, so a MeshMonitor restart can never spuriously
+ * fire), derives prior/next powered-states via {@link isPoweredMv}, and emits on
+ * a genuine transition with `nodeNum: null` + the pubkey. DB read only — no
+ * packet, zero airtime. Must run BEFORE the new battery row is inserted so the
+ * "latest" it reads is genuinely the prior reading.
+ *
+ * The prior is read from `batteryTelemetryType`, whose value is multiplied by
+ * `priorValueToMvScale` to normalise to millivolts, because the two callers
+ * store battery under different metrics/units: the local poller writes
+ * `mc_battery_mv` (mV, scale 1); the remote scheduler writes
+ * `mc_status_battery_volts` (V, scale 1000).
+ *
+ * @param telemetry  telemetry repository (uses `getLatestTelemetryForType`)
+ * @param publicKey  the node's MeshCore public key (its `nodeId` in telemetry)
+ * @param batteryTelemetryType  the battery metric name to read the prior from
+ * @param priorValueToMvScale  factor to convert the stored prior value to mV
+ *   (1 for `mc_battery_mv`, 1000 for `mc_status_battery_volts`)
+ * @param newBatteryMv  the incoming battery voltage, in millivolts
+ * @param sourceId  the MeshCore source id (scopes the prior-battery read)
+ */
+export async function detectMeshCorePowerChange(
+  telemetry: PowerChangeDetectionTelemetry,
+  publicKey: string,
+  batteryTelemetryType: string,
+  priorValueToMvScale: number,
+  newBatteryMv: number | null,
+  sourceId: string,
+): Promise<void> {
+  try {
+    if (!telemetry.getLatestTelemetryForType) return;
+    if (newBatteryMv == null || !Number.isFinite(newBatteryMv)) return;
+    const prior = await telemetry.getLatestTelemetryForType(publicKey, batteryTelemetryType, sourceId);
+    const priorBatteryMv = prior ? Number(prior.value) * priorValueToMvScale : null;
+
+    // Reuse detectPowerTransition — its null-prior guard IS the restart-safety
+    // mechanism (no baseline ⇒ no transition). It classifies via the Meshtastic
+    // isPowered(>100) rule, so map each MeshCore powered-state (from isPoweredMv)
+    // to a sentinel level that rule agrees with: powered → above the threshold,
+    // on-battery → 0.
+    const poweredLevel = (p: boolean) => (p ? POWERED_BATTERY_LEVEL_THRESHOLD + 1 : 0);
+    const priorLevel = priorBatteryMv == null ? null : poweredLevel(isPoweredMv(priorBatteryMv));
+    const direction = detectPowerTransition(priorLevel, poweredLevel(isPoweredMv(newBatteryMv)));
+    if (direction === null) return;
+
+    const previousPowered = isPoweredMv(priorBatteryMv);
+    const powered = isPoweredMv(newBatteryMv);
+    logger.info(
+      `🔌 MeshCore node ${publicKey.substring(0, 12)}… power ${direction} (HEURISTIC): ` +
+        `battery ${priorBatteryMv}mV → ${newBatteryMv}mV ` +
+        `(powered ${previousPowered} → ${powered}, source ${sourceId})`,
+    );
+    dataEventEmitter.emitNodePowerChanged(
+      { nodeNum: null, publicKey, previousPowered, powered, batteryLevel: newBatteryMv },
+      sourceId,
+    );
+  } catch (e) {
+    logger.warn(
+      `MeshCore power-change detection failed for ${publicKey.substring(0, 12)}…: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.ts
@@ -32,6 +32,7 @@ import type { SourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { isMeshCoreManager } from '../sourceManagerTypes.js';
 import { MC_TELEMETRY_PREFIX, nodeNumFromPubkey } from './meshcoreTelemetryPoller.js';
 import { isBogusPosition } from '../../utils/nullIsland.js';
+import { detectMeshCoreReboot, detectMeshCorePowerChange } from './meshcoreDeviceHealth.js';
 
 /**
  * `adv_type` values for MeshCore contacts. Matches the `MeshCoreDeviceType`
@@ -56,6 +57,13 @@ export interface RemoteTelemetrySchedulerDatabase {
   };
   telemetry: {
     insertTelemetryBatch: (rows: DbTelemetry[], sourceId?: string) => Promise<number>;
+    // Optional: used for reboot detection (#4558 follow-up). Absent → no reboot
+    // fires. Minimal return shape so both DbTelemetry flavours satisfy it.
+    getLatestTelemetryForType?: (
+      nodeId: string,
+      telemetryType: string,
+      sourceId?: string,
+    ) => Promise<{ value: number } | null>;
   };
 }
 
@@ -436,6 +444,34 @@ export class MeshCoreRemoteTelemetryScheduler {
       try {
         const status = await manager.requestNodeStatus(target.publicKey);
         if (status) {
+          // Device Health (#4558 follow-up): detect a reboot from the uptime
+          // reading BEFORE the batch insert below, so the "prior" it reads is the
+          // last tick's value. DB read only, no packet sent.
+          if (typeof status.uptimeSecs === 'number') {
+            await detectMeshCoreReboot(
+              this.database.telemetry,
+              target.publicKey,
+              `${MC_TELEMETRY_PREFIX}status_uptime_secs`,
+              status.uptimeSecs,
+              manager.sourceId,
+            );
+          }
+          // Device Health (#4558 MeshCore parity): detect an external-power
+          // transition from the battery voltage BEFORE the batch insert below,
+          // so the prior it reads is the last tick's value. The scheduler stores
+          // battery as mc_status_battery_volts (VOLTS → scale 1000 to mV);
+          // status.batteryMv is already mV. HEURISTIC — a full/charging battery
+          // is indistinguishable from wall power.
+          if (typeof status.batteryMv === 'number') {
+            await detectMeshCorePowerChange(
+              this.database.telemetry,
+              target.publicKey,
+              `${MC_TELEMETRY_PREFIX}status_battery_volts`,
+              1000,
+              status.batteryMv,
+              manager.sourceId,
+            );
+          }
           const statusRows = statusToTelemetryRows(status, target.publicKey, nodeNum, ts);
           if (statusRows.length > 0) {
             rows.push(...statusRows);

--- a/src/server/services/meshcoreTelemetryPoller.ts
+++ b/src/server/services/meshcoreTelemetryPoller.ts
@@ -23,6 +23,7 @@ import type { DbMeshCoreNode } from '../../db/repositories/meshcore.js';
 import type { MeshCoreManager, MeshCoreDeviceInfo } from '../meshcoreManager.js';
 import type { SourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { isMeshCoreManager } from '../sourceManagerTypes.js';
+import { detectMeshCoreReboot, detectMeshCorePowerChange } from './meshcoreDeviceHealth.js';
 
 /**
  * Minimal slice of DatabaseService the poller depends on. Lets us unit-test
@@ -31,6 +32,13 @@ import { isMeshCoreManager } from '../sourceManagerTypes.js';
 export interface PollerDatabase {
   telemetry: {
     insertTelemetryBatch: (rows: DbTelemetry[], sourceId?: string) => Promise<number>;
+    // Optional: used for reboot detection (#4558 follow-up). Absent → no reboot
+    // fires. Minimal return shape so both DbTelemetry flavours satisfy it.
+    getLatestTelemetryForType?: (
+      nodeId: string,
+      telemetryType: string,
+      sourceId?: string,
+    ) => Promise<{ value: number } | null>;
   };
   meshcore: {
     upsertNode: (node: Partial<DbMeshCoreNode> & { publicKey: string }, sourceId: string) => Promise<void>;
@@ -439,6 +447,34 @@ export class MeshCoreTelemetryPoller {
         `[MeshCorePoller:${manager.sourceId}] No metrics produced for ${nodeId.substring(0, 16)}`,
       );
       return;
+    }
+
+    // Device Health (#4558 follow-up): detect a reboot from the uptime reading
+    // BEFORE inserting the new rows, so the "prior" it reads is genuinely the
+    // last poll's value. DB read only, no packet sent.
+    if (core?.uptimeSecs !== undefined) {
+      await detectMeshCoreReboot(
+        this.database.telemetry,
+        nodeId,
+        `${MC_TELEMETRY_PREFIX}uptime_secs`,
+        core.uptimeSecs,
+        manager.sourceId,
+      );
+    }
+
+    // Device Health (#4558 MeshCore parity): detect an external-power transition
+    // from the battery voltage BEFORE inserting the new rows, so the prior it
+    // reads (mc_battery_mv, already in mV → scale 1) is the last poll's value.
+    // HEURISTIC — a full/charging battery is indistinguishable from wall power.
+    if (core?.batteryMv !== undefined) {
+      await detectMeshCorePowerChange(
+        this.database.telemetry,
+        nodeId,
+        `${MC_TELEMETRY_PREFIX}battery_mv`,
+        1,
+        core.batteryMv,
+        manager.sourceId,
+      );
     }
 
     try {

--- a/src/server/utils/poweredState.ts
+++ b/src/server/utils/poweredState.ts
@@ -62,3 +62,33 @@ export function detectPowerTransition(
   if (wasPowered === nowPowered) return null;
   return nowPowered ? 'restored' : 'lost';
 }
+
+/**
+ * MeshCore powered-voltage threshold, in millivolts (#4558 MeshCore parity).
+ *
+ * HEURISTIC — READ THIS BEFORE RELYING ON IT. MeshCore firmware exposes NO
+ * "on external power" flag the way Meshtastic overloads `battery_level > 100`.
+ * All we have is the raw battery voltage. A single-cell Li-ion battery that is
+ * full OR actively charging sits at ~4.2 V, which is INDISTINGUISHABLE from a
+ * node wired to wall/USB power. So we treat ">= 4200 mV" as "powered" and infer
+ * lost/restored transitions from voltage crossing that line.
+ *
+ * The consequence: false transitions are EXPECTED. A battery that charges up to
+ * full looks like "external power restored"; one that drops off the charger's
+ * float looks like "external power lost". This is why the trigger help text and
+ * the catalog label this MeshCore path experimental.
+ */
+export const MESHCORE_POWERED_MV_THRESHOLD = 4200;
+
+/**
+ * True when a MeshCore battery voltage reading (millivolts) is at/above the
+ * powered threshold — see {@link MESHCORE_POWERED_MV_THRESHOLD} for the heavy
+ * caveat that this cannot actually distinguish wall power from a full/charging
+ * battery. A missing / non-finite reading is treated as NOT powered (no evidence
+ * of external power), and never as a transition on its own — transitions are
+ * gated by {@link detectPowerTransition}'s null-prior guard.
+ */
+export function isPoweredMv(batteryMv: number | null | undefined): boolean {
+  if (batteryMv == null || !Number.isFinite(batteryMv)) return false;
+  return batteryMv >= MESHCORE_POWERED_MV_THRESHOLD;
+}


### PR DESCRIPTION
Closes the three MeshCore follow-ups deferred during the Device Health epic (#4558). `nodeRebooted`, `batteryTrend`, and `nodePowerChanged` now fire for **MeshCore** nodes, not only Meshtastic.

## Why its own PR

MeshCore has no single telemetry-save choke-point (uptime/battery arrive from the **local poller** and the **remote scheduler**) and identifies nodes by **public key**, not `nodeNum`. New shared seam `src/server/services/meshcoreDeviceHealth.ts` mirrors the Meshtastic detectors and is called from both services.

## The three triggers on MeshCore

- **Reboot** — reads the prior uptime row (`mc_uptime_secs` / `mc_status_uptime_secs`) before insert, compares via the shared `isUptimeReboot`, emits `node:rebooted`.
- **Battery trend** — `runBatteryTrendCheck` now includes MeshCore nodes, reading `mc_battery_volts` / `mc_status_battery_volts` (volts). Since MeshCore battery is volts not %, `minDropPercent` is interpreted as a **relative % decline**: `(startV − latestV)/startV × 100`.
- **Power (⚠️ EXPERIMENTAL on MeshCore)** — derives powered from battery voltage via `isPoweredMv` (`batteryMv >= 4200`), emits `node:powerChanged` on a transition. **Labelled experimental in the UI**: the firmware has no powered flag, so a full/charging battery (~4.2 V) is indistinguishable from wall power — **false lost/restored alerts are expected**. Shipped at maintainer request; Meshtastic's `battery_level==101` path is unchanged and remains the reliable one.

## Identity wiring

The `nodeNum`-only emit → dispatch → context path was widened to carry a pubkey (`nodeNum: null` + `publicKey`), setting `subjectNodeKey` like `buildNodeStaleContext`, so per-node cooldown keys off the pubkey. Meshtastic callers pass `publicKey: null`, unchanged.

## Mesh impact

Zero airtime — all detection reads durable DB telemetry (restart-safe; first sighting only baselines), no packets.

## Tests

70/70 across `nodeRebooted` / `batteryTrend` / `nodePowerChanged` / `meshcoreDeviceHealth`; full suite 0 failures; server tsc clean; `lint:ci` clean.

With this, all of #4558's use cases are covered on **both** Meshtastic and MeshCore (with the documented protocol caveats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)