### PR TITLE
feat(meshcore): put scope-override and conversation toolbar on one row (#4888)

### DIFF
--- a/src/components/MeshCore/MeshCoreChannelsView.test.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.test.tsx
@@ -957,6 +957,10 @@ describe('MeshCoreChannelsView — delete prunes the fetched backlog', () => {
     );
 
     await waitFor(() => expect(screen.getByText('first')).toBeTruthy());
+    // #4888: the conversation toolbar sits inside the shared horizontal row.
+    const toolbarRow = document.querySelector('.meshcore-toolbar-row');
+    expect(toolbarRow).toBeTruthy();
+    expect(toolbarRow?.querySelector('.meshcore-clear-conversation-btn')).toBeTruthy();
     await act(async () => {
       fireEvent.click(document.querySelector('.meshcore-clear-conversation-btn') as Element);
     });

--- a/src/components/MeshCore/MeshCoreChannelsView.tsx
+++ b/src/components/MeshCore/MeshCoreChannelsView.tsx
@@ -694,6 +694,8 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
             </span>
           </div>
         )}
+        {canSend && (connected || filtered.length > 0) && (
+        <div className="meshcore-toolbar-row">
         {canSend && connected && (
           <div className="mc-scope-override">
             {showScopeOverride ? (
@@ -764,6 +766,8 @@ export const MeshCoreChannelsView: React.FC<MeshCoreChannelsViewProps> = ({
               <UiIcon name="delete" size={15} /> {t('meshcore.clear_channel', 'Clear channel messages')}
             </button>
           </div>
+        )}
+        </div>
         )}
         <MeshCoreMessageStream
           messages={filtered}

--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -694,10 +694,24 @@
 .mc-message-delete:hover { color: var(--color-error); opacity: 1; }
 @media (hover: none) { .mc-message-delete { opacity: 1; } }
 /* Conversation / channel "clear" toolbar above the message stream (#3981). */
+/* Scope-override control and the conversation toolbar share one horizontal
+   row (#4888): scope on the left, toolbar on the right, wrapping on narrow
+   screens. The row owns the padding; the children no longer set their own. */
+.meshcore-toolbar-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem 0;
+}
+
 .meshcore-conversation-toolbar {
   display: flex;
-  justify-content: flex-end;
-  padding: 0.35rem 0.5rem 0;
+  /* Stay right-aligned whether or not the scope control shares the row
+     (a lone flex child sits at the start under space-between). */
+  margin-left: auto;
 }
 .meshcore-clear-conversation-btn {
   background: none;
@@ -1714,7 +1728,11 @@
 
 /* --- Per-message scope override (#3701) ---------------------------------- */
 .mc-scope-override {
-  padding: 0.35rem 0.75rem 0;
+  /* Padding now lives on .meshcore-toolbar-row (#4888). Allow the expanded
+     scope row (label + input + buttons) to shrink so it wraps cleanly on
+     narrow screens instead of overflowing. */
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .mc-scope-override-toggle {
@@ -1736,6 +1754,9 @@
   display: flex;
   align-items: center;
   gap: 0.4rem;
+  /* Let the input (which already sets flex+min-width:0) shrink within the
+     flex row rather than overflow on narrow screens (#4888). */
+  min-width: 0;
 }
 
 .mc-scope-override-label {


### PR DESCRIPTION
Fixes #4888.

## Problem

In the MeshCore channels view, `mc-scope-override` and `meshcore-conversation-toolbar` were two stacked `<div>`s — one left-aligned, one right-aligned, on separate lines. They read as disjoint and waste vertical space, most noticeably on phones.

## Change

Wrap both in a new `.meshcore-toolbar-row` (`display:flex; flex-direction:row; justify-content:space-between; align-items:center; flex-wrap:wrap`), rendered whenever either child would show, so the row collapses entirely when neither is present.

- The row now owns the horizontal padding (removed from the two children).
- `.meshcore-conversation-toolbar` right-aligns via `margin-left:auto` — so it stays right whether or not the scope control shares the row (a lone flex child would otherwise sit at the start under `space-between`).
- `.mc-scope-override` gets `flex:1 1 auto; min-width:0` and the expanded row `min-width:0`, so the label+input+buttons shrink and wrap on narrow screens instead of overflowing.

Channels-view only — the DM view renders the toolbar but has no scope control (scoping is a channel/flood concept).

## Scope / impact

Two files (`MeshCoreChannelsView.tsx`, `MeshCorePage.css`) + a test. Pure layout — no backend/protocol/state changes, no mesh impact.

## Tests

`MeshCoreChannelsView.test.tsx` — added a structural assertion that the conversation toolbar renders inside `.meshcore-toolbar-row`. 31/31 pass; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)