### PR TITLE
Exempt MeshCore repeaters/room servers from the map age cutoff

### DIFF
--- a/src/components/MeshCore/MeshCoreNodesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.test.tsx
@@ -284,6 +284,8 @@ describe('MeshCoreNodesView — per-source age filter (#4412 Phase 4)', () => {
   const PK_NO_TIMESTAMP_CONTACT = '4'.repeat(64);
   const PK_ADVERT_ONLY = '5'.repeat(64);
   const PK_ZERO_LAST_HEARD = '6'.repeat(64);
+  const PK_OLD_REPEATER = '7'.repeat(64);
+  const PK_OLD_ROOM_SERVER = '8'.repeat(64);
 
   it('lists a node within the cutoff and excludes one outside it', () => {
     const testNodes: MeshCoreNode[] = [
@@ -330,6 +332,25 @@ describe('MeshCoreNodesView — per-source age filter (#4412 Phase 4)', () => {
     ];
     render(<MeshCoreNodesView nodes={[]} contacts={testContacts} />);
     expect(listedNames()).toEqual([]);
+  });
+
+  it('bypasses the cutoff for a repeater (advType 2), a static infrastructure node (#4899)', () => {
+    // Repeaters only re-flood-advertise on a long, often multi-day interval
+    // and never send DMs, so a stale lastHeard doesn't mean the node left
+    // the mesh — it should stay listed and on the map regardless of age.
+    const testNodes: MeshCoreNode[] = [
+      { publicKey: PK_OLD_REPEATER, name: 'OldRepeater', advType: 2, lastHeard: NOW - 72 * HOUR_MS },
+    ];
+    render(<MeshCoreNodesView nodes={testNodes} contacts={[]} />);
+    expect(listedNames()).toEqual(['OldRepeater']);
+  });
+
+  it('bypasses the cutoff for a room server (advType 3), a static infrastructure node (#4899)', () => {
+    const testNodes: MeshCoreNode[] = [
+      { publicKey: PK_OLD_ROOM_SERVER, name: 'OldRoomServer', advType: 3, lastHeard: NOW - 72 * HOUR_MS },
+    ];
+    render(<MeshCoreNodesView nodes={testNodes} contacts={[]} />);
+    expect(listedNames()).toEqual(['OldRoomServer']);
   });
 
   it('excludes rows with no resolvable timestamp', () => {

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -294,13 +294,23 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
 
   const merged = useMemo(() => mergeNodesAndContacts(nodes, contacts), [nodes, contacts]);
 
-  /** Favorites and the operator's own node are never hidden by the age cutoff
-   *  (parity with useProcessedNodes.ts:194 + #4412 Phase 4 spec §2 D6). Uses
-   *  the `isLocal` flag (#4438), not a name/advName substring match — the
-   *  `(local)` suffix stays as display text, but is no longer the predicate,
-   *  so a stranger who names their device `Foo (local)` is not exempted. */
+  /** Favorites, the operator's own node, and static infrastructure (repeaters
+   *  and room servers, advType 2/3 — see meshcoreRole.ts) are never hidden by
+   *  the age cutoff (parity with useProcessedNodes.ts:194 + #4412 Phase 4 spec
+   *  §2 D6). Uses the `isLocal` flag (#4438), not a name/advName substring
+   *  match — the `(local)` suffix stays as display text, but is no longer the
+   *  predicate, so a stranger who names their device `Foo (local)` is not
+   *  exempted.
+   *
+   *  Repeaters/room servers only re-flood-advertise on a long interval
+   *  (frequently well over 24h, sometimes disabled entirely) and never send
+   *  DMs, so their `lastHeard` can go stale for reasons unrelated to whether
+   *  the node is still part of the mesh. Unlike mobile companion nodes,
+   *  they're fixed infrastructure — aging them off the map has no benefit
+   *  and just makes them vanish while their DB row/position stay intact and
+   *  they remain visible in Messages (#4899). */
   const isAgeExempt = useCallback((r: MergedRow): boolean =>
-    r.isFavorite || r.isLocal, []);
+    r.isFavorite || r.isLocal || r.advType === 2 || r.advType === 3, []);
 
   const aged = useMemo(() => {
     // Date.now() is read inside the memo, so the cutoff refreshes on every


### PR DESCRIPTION
## Summary

- Fixes #4899 — MeshCore repeaters (and room servers) could silently disappear from the Map and its left submenu after enough time passed, even though they remained fully visible under Messages with location data intact.
- Root cause: the per-source "max node age" cutoff (default 24h) is applied to the MeshCore node list/map but not to Messages. Repeaters and room servers are static infrastructure that only re-flood-advertise on a long interval (often well over 24h) and never send DMs, so their `lastHeard` can go stale for reasons unrelated to whether they're still on the mesh.
- Exempts `advType` 2 (Repeater) and 3 (Room Server) from the age cutoff in `MeshCoreNodesView.tsx`, the same way favorites and the operator's own local node already are exempted.

## Test plan

- [x] Added two regression tests: a stale repeater (advType 2) and a stale room server (advType 3) both stay listed and passed through to the map despite exceeding the 24h cutoff.
- [x] `npx vitest run src/components/MeshCore/` — 43 files / 423 tests passing.
- [x] `npm run lint:ci` — clean, no new baseline violations.

---
_Generated by [Claude Code](https://claude.ai/code/session_019NZpUPM8t6bfVCRuzNSpJH)_