### PR TITLE
feat(meshcore): separate age timeout for infrastructure nodes (#4899)

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -334,6 +334,7 @@ const defaultProps = {
   defaultCenter: { lat: 35.0, lng: -80.0 },
   sourceId: null,
   maxNodeAgeHours: NODE_DISPLAY_NUMERIC_DEFAULTS.maxNodeAgeHours,
+  maxInfraNodeAgeHours: 720, // #4899 infra window (30 days)
 };
 
 // ---------------------------------------------------------------------------
@@ -440,6 +441,59 @@ describe('DashboardMap', () => {
     // (newer = more transparent) slipping through, which `< fresh` alone would
     // miss for a node heard just inside a wide window.
     expect(staleOpacity).toBeLessThan(0.7);
+  });
+
+  // #4899: MeshCore infrastructure (advType 2/3) uses the separate infra
+  // window on the cross-source Dashboard map, so repeaters/room servers don't
+  // vanish between adverts even though they're past the companion window.
+  describe('MeshCore infrastructure age window (#4899)', () => {
+    const meshcoreRepeaterStale = {
+      user: { id: 'mc-rpt', shortName: 'RPT', longName: 'Repeater' },
+      position: { latitude: 36.1, longitude: -81.1 },
+      hopsAway: 0, role: 0, lastHeard: stale, isMeshCore: true, advType: 2,
+    };
+    const meshcoreCompanionStale = {
+      user: { id: 'mc-cmp', shortName: 'CMP', longName: 'Companion' },
+      position: { latitude: 36.3, longitude: -81.3 },
+      hopsAway: 0, role: 0, lastHeard: stale, isMeshCore: true, advType: 1,
+    };
+
+    it('keeps a stale repeater (past companion window, within infra window) but hides a stale companion', () => {
+      // Defaults: companion 24h, infra 720h. Both nodes are 48h old.
+      render(
+        <DashboardMap
+          {...defaultProps}
+          nodes={[meshcoreRepeaterStale, meshcoreCompanionStale]}
+        />,
+      );
+      expect(screen.getAllByTestId('map-marker')).toHaveLength(1);
+    });
+
+    it('hides even a repeater once it is past the infra window', () => {
+      render(
+        <DashboardMap
+          {...defaultProps}
+          maxInfraNodeAgeHours={24}
+          nodes={[meshcoreRepeaterStale]}
+        />,
+      );
+      expect(screen.queryAllByTestId('map-marker')).toHaveLength(0);
+    });
+
+    it('never hides infrastructure when the infra window is 0 (never)', () => {
+      const ancientRepeater = {
+        ...meshcoreRepeaterStale,
+        lastHeard: nowSeconds - 60 * 60 * 5000, // ~208 days old
+      };
+      render(
+        <DashboardMap
+          {...defaultProps}
+          maxInfraNodeAgeHours={0}
+          nodes={[ancientRepeater]}
+        />,
+      );
+      expect(screen.getAllByTestId('map-marker')).toHaveLength(1);
+    });
   });
 
   it('forwards the configured map pin style to createNodeIcon (issue #3364)', () => {

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -48,6 +48,7 @@ import { nodePassesTransportFilter } from '../../utils/nodeTransport';
 import { shouldDiscardPosition } from '../../utils/nullIsland';
 import { getDiscardInvalidPositions } from '../../utils/positionDisplayConfig';
 import { effectiveMapMaxAgeHours } from '../../utils/mapAge';
+import { isMeshCoreInfrastructureAdvType } from '../MeshCore/meshcoreRole';
 import { ageFilterStops, nearestAgeStopIndex, formatAgeStop } from '../../utils/mapAgeSteps';
 import { resolveMapEndpoint } from '../../utils/nodeHelpers';
 import api from '../../services/api';
@@ -90,6 +91,9 @@ export interface DashboardMapProps {
   sourceId: string | null;
   /** Hours since lastHeard to count a node as "active". Favorites bypass this gate. */
   maxNodeAgeHours: number;
+  /** #4899: separate (usually longer) window for MeshCore infrastructure
+   *  (repeaters/room servers, advType 2/3). `0` = never expire. */
+  maxInfraNodeAgeHours: number;
   /**
    * On the Unified map, called when a node popup's source row is clicked so the
    * page can navigate to that source's Node Details view for the node.
@@ -166,6 +170,7 @@ export default function DashboardMap({
   defaultCenter,
   sourceId,
   maxNodeAgeHours,
+  maxInfraNodeAgeHours,
   onNodeSourceSelect,
   isLoading = false,
 }: DashboardMapProps) {
@@ -274,6 +279,14 @@ export default function DashboardMap({
   // Effective map age cap from the Map Features age slider (#3322), clamped to
   // [1, maxNodeAgeHours]. null = follow the setting, so default is unchanged.
   const effectiveMaxAge = effectiveMapMaxAgeHours(mapMaxAgeHours, maxNodeAgeHours);
+  // #4899: MeshCore infrastructure (repeaters/room servers, advType 2/3) uses a
+  // separate, usually longer window so it doesn't vanish from the Dashboard map
+  // between its infrequent adverts. `0` = never expire. The Map Features age
+  // slider still narrows it when the operator explicitly sets one (an explicit
+  // "show younger than X" is meant to narrow every marker), but at its default
+  // (null → follow the setting) infra nodes get the full infra window.
+  const infraNever = maxInfraNodeAgeHours <= 0;
+  const effectiveInfraMaxAge = effectiveMapMaxAgeHours(mapMaxAgeHours, maxInfraNodeAgeHours);
 
   // GeoJSON overlay layers (global, file-based). Fetched here so the dashboard
   // map can render and toggle them, mirroring the per-source NodesTab map.
@@ -312,10 +325,22 @@ export default function DashboardMap({
   // reference instead of drifting per-node inside the marker map loop below.
   const nowMs = Date.now();
   const cutoffTime = nowMs / 1000 - effectiveMaxAge * 60 * 60;
+  const infraCutoffTime = nowMs / 1000 - effectiveInfraMaxAge * 60 * 60;
+  // #4899: per-node age gate — MeshCore infrastructure (advType 2/3) uses the
+  // infra window (or never expires when it's 0); everything else uses the
+  // companion window. Favorites bypass both, as before.
+  const passesAgeGate = (n: typeof nodes[number]): boolean => {
+    if (n.isFavorite) return true;
+    if (n.lastHeard == null) return false;
+    if (n.isMeshCore && isMeshCoreInfrastructureAdvType(n.advType)) {
+      return infraNever || n.lastHeard >= infraCutoffTime;
+    }
+    return n.lastHeard >= cutoffTime;
+  };
   const nodesWithTruePos = nodes
     .filter((n) => !n.isIgnored)
     .filter((n) => !n.hideFromMap) // #3549: per-node "Hide from Map" suppresses the marker only
-    .filter((n) => n.isFavorite || (n.lastHeard != null && n.lastHeard >= cutoffTime))
+    .filter(passesAgeGate)
     .filter((n) => nodePassesTransportFilter(n, { showRfNodes, showUdpNodes, showMqttNodes }, cutoffTime))
     .map((n) => ({ node: n, truePos: getNodeLatLng(n) }))
     .filter((e): e is { node: any; truePos: { lat: number; lng: number } } => e.truePos !== null);
@@ -346,19 +371,28 @@ export default function DashboardMap({
     // and pinning it to a dep-free `now` avoids re-setData churn (#4808).
     const now = Date.now();
     const cutoffMs = (now / 1000 - effectiveMaxAge * 60 * 60) * 1000;
-    return nodesWithPosition.map(({ node, pos }) => ({
-      key: unifiedNodeKey(node) ?? String(node.nodeNum ?? node.nodeId ?? node.user?.id),
-      lat: pos.lat,
-      lng: pos.lng,
-      label: node.shortName ?? node.user?.shortName ?? undefined,
-      // Match the 2D marker (#4808): hop color + glyph-family category + age dim.
-      color: getHopColor(node.hopsAway ?? 999),
-      category: categoryGlyphFamily(getNodeTypeCategory(node)),
-      opacity: node.isFavorite
+    const infraCutoffMs = (now / 1000 - effectiveInfraMaxAge * 60 * 60) * 1000;
+    return nodesWithPosition.map(({ node, pos }) => {
+      // #4899: dim infra survivors against the infra window (never fully faded
+      // when the window is "never"), so a shown-but-old repeater isn't rendered
+      // near-invisible on the globe.
+      const isInfra = node.isMeshCore && isMeshCoreInfrastructureAdvType(node.advType);
+      const lastHeardMs = node.lastHeard != null ? node.lastHeard * 1000 : null;
+      const opacity = node.isFavorite || (isInfra && infraNever)
         ? 1
-        : markerAgeOpacity(now, cutoffMs, node.lastHeard != null ? node.lastHeard * 1000 : null),
-    }));
-  }, [nodesWithPosition, effectiveMaxAge]);
+        : markerAgeOpacity(now, isInfra ? infraCutoffMs : cutoffMs, lastHeardMs);
+      return {
+        key: unifiedNodeKey(node) ?? String(node.nodeNum ?? node.nodeId ?? node.user?.id),
+        lat: pos.lat,
+        lng: pos.lng,
+        label: node.shortName ?? node.user?.shortName ?? undefined,
+        // Match the 2D marker (#4808): hop color + glyph-family category + age dim.
+        color: getHopColor(node.hopsAway ?? 999),
+        category: categoryGlyphFamily(getNodeTypeCategory(node)),
+        opacity,
+      };
+    });
+  }, [nodesWithPosition, effectiveMaxAge, effectiveInfraMaxAge, infraNever]);
 
   // Visible node numbers for gating the 3D neighbor/traceroute lines to the
   // rendered markers, matching 2D — also keeps a null-sourceId dashboard from

--- a/src/components/MeshCore/MeshCoreNodeDisplaySection.test.tsx
+++ b/src/components/MeshCore/MeshCoreNodeDisplaySection.test.tsx
@@ -201,7 +201,7 @@ describe('MeshCoreNodeDisplaySection', () => {
     await waitFor(() => expect(saveBarCapture.current?.hasChanges).toBe(false));
   });
 
-  it('(6) onSave() POSTs to /api/settings?sourceId=<id> with exactly the four keys, as strings', async () => {
+  it('(6) onSave() POSTs to /api/settings?sourceId=<id> with exactly the five keys, as strings', async () => {
     renderSection(makeQueryClient());
     await waitForHydration();
 
@@ -216,6 +216,7 @@ describe('MeshCoreNodeDisplaySection', () => {
       'inactiveNodeCheckIntervalMinutes',
       'inactiveNodeCooldownHours',
       'inactiveNodeThresholdHours',
+      'maxInfraNodeAgeHours',
       'maxNodeAgeHours',
     ]);
     for (const v of Object.values(body)) {

--- a/src/components/MeshCore/MeshCoreNodeDisplaySection.tsx
+++ b/src/components/MeshCore/MeshCoreNodeDisplaySection.tsx
@@ -9,6 +9,7 @@ import { useNodeDisplaySettings, nodeDisplaySettingsQueryKey } from '../../hooks
 import { writeNodeDisplayLocal } from '../../utils/nodeDisplayStorage';
 import {
   NODE_DISPLAY_RANGES,
+  MAX_INFRA_NODE_AGE_HOURS_RANGE,
   type NodeDisplaySettingKey,
 } from '../../constants/nodeDisplayDefaults';
 
@@ -37,7 +38,17 @@ const MESHCORE_NODE_DISPLAY_KEYS = [
   'inactiveNodeCooldownHours',
 ] as const satisfies readonly NodeDisplaySettingKey[];
 
-type MeshCoreNodeDisplayDraft = Record<typeof MESHCORE_NODE_DISPLAY_KEYS[number], number>;
+/**
+ * #4899: the Infrastructure age cutoff is a standalone per-source setting (NOT
+ * one of the frozen ten Node Display keys), so it rides alongside the four
+ * MeshCore keys in the draft and save body rather than in
+ * `MESHCORE_NODE_DISPLAY_KEYS`.
+ */
+type MeshCoreNodeDisplayDraft =
+  Record<typeof MESHCORE_NODE_DISPLAY_KEYS[number], number>
+  & { maxInfraNodeAgeHours: number };
+
+type MeshCoreNodeDisplayDraftKey = keyof MeshCoreNodeDisplayDraft;
 
 /**
  * MeshCore Node Display settings section (#4412 Phase 4 WP2).
@@ -67,11 +78,13 @@ export const MeshCoreNodeDisplaySection: React.FC<MeshCoreNodeDisplaySectionProp
 
   const buildDraft = useCallback((): MeshCoreNodeDisplayDraft => ({
     maxNodeAgeHours: settings.maxNodeAgeHours,
+    maxInfraNodeAgeHours: settings.maxInfraNodeAgeHours,
     inactiveNodeThresholdHours: settings.inactiveNodeThresholdHours,
     inactiveNodeCheckIntervalMinutes: settings.inactiveNodeCheckIntervalMinutes,
     inactiveNodeCooldownHours: settings.inactiveNodeCooldownHours,
   }), [
     settings.maxNodeAgeHours,
+    settings.maxInfraNodeAgeHours,
     settings.inactiveNodeThresholdHours,
     settings.inactiveNodeCheckIntervalMinutes,
     settings.inactiveNodeCooldownHours,
@@ -91,10 +104,13 @@ export const MeshCoreNodeDisplaySection: React.FC<MeshCoreNodeDisplaySectionProp
   }, [buildDraft]);
 
   useEffect(() => {
-    setHasChanges(MESHCORE_NODE_DISPLAY_KEYS.some((k) => draft[k] !== initial[k]));
+    setHasChanges(
+      MESHCORE_NODE_DISPLAY_KEYS.some((k) => draft[k] !== initial[k])
+      || draft.maxInfraNodeAgeHours !== initial.maxInfraNodeAgeHours,
+    );
   }, [draft, initial]);
 
-  const update = (key: typeof MESHCORE_NODE_DISPLAY_KEYS[number], value: number) => {
+  const update = (key: MeshCoreNodeDisplayDraftKey, value: number) => {
     // Clearing a number input yields `parseInt(...) === NaN` — fall back to
     // the current draft value rather than letting NaN reach state, where it
     // would render as the literal string "NaN" and serialize the same way
@@ -108,9 +124,11 @@ export const MeshCoreNodeDisplaySection: React.FC<MeshCoreNodeDisplaySectionProp
       const res = await csrfFetch(`${baseUrl}/api/settings?sourceId=${encodeURIComponent(sourceId)}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(Object.fromEntries(
-          MESHCORE_NODE_DISPLAY_KEYS.map((k) => [k, String(draft[k])]),
-        )),
+        body: JSON.stringify({
+          ...Object.fromEntries(MESHCORE_NODE_DISPLAY_KEYS.map((k) => [k, String(draft[k])])),
+          // #4899: standalone key, POSTed alongside the four frozen ones.
+          maxInfraNodeAgeHours: String(draft.maxInfraNodeAgeHours),
+        }),
       });
       if (!res.ok) {
         if (res.status === 403) {
@@ -151,6 +169,7 @@ export const MeshCoreNodeDisplaySection: React.FC<MeshCoreNodeDisplaySectionProp
   });
 
   const maxNodeAgeRange = NODE_DISPLAY_RANGES.maxNodeAgeHours!;
+  const infraAgeRange = MAX_INFRA_NODE_AGE_HOURS_RANGE;
   const thresholdRange = NODE_DISPLAY_RANGES.inactiveNodeThresholdHours!;
   const checkIntervalRange = NODE_DISPLAY_RANGES.inactiveNodeCheckIntervalMinutes!;
   const cooldownRange = NODE_DISPLAY_RANGES.inactiveNodeCooldownHours!;
@@ -176,6 +195,28 @@ export const MeshCoreNodeDisplaySection: React.FC<MeshCoreNodeDisplaySectionProp
           max={maxNodeAgeRange.max}
           value={draft.maxNodeAgeHours}
           onChange={(e) => update('maxNodeAgeHours', parseInt(e.target.value, 10))}
+          disabled={!canWrite}
+          className="setting-input"
+        />
+      </div>
+
+      <div className="setting-item">
+        <label htmlFor="maxInfraNodeAge">
+          {t('meshcore.settings.node_display.max_infra_age_label', 'Maximum Age of Infrastructure Nodes (hours)')}
+          <span className="setting-description">
+            {t(
+              'meshcore.settings.node_display.max_infra_age_description',
+              'A separate age window for Repeaters and Room Servers, which advertise infrequently (often days apart) and never send direct messages. Set higher than the companion window above so fixed infrastructure does not vanish from the Nodes list and map between adverts. Use 0 to never hide them.',
+            )}
+          </span>
+        </label>
+        <input
+          id="maxInfraNodeAge"
+          type="number"
+          min={infraAgeRange.min}
+          max={infraAgeRange.max}
+          value={draft.maxInfraNodeAgeHours}
+          onChange={(e) => update('maxInfraNodeAgeHours', parseInt(e.target.value, 10))}
           disabled={!canWrite}
           className="setting-input"
         />

--- a/src/components/MeshCore/MeshCoreNodesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.test.tsx
@@ -84,7 +84,7 @@ function listedNames(): string[] {
 // are all within 3 hours, so they survive it. The per-source age filter
 // suite overrides this per-test where it needs a different cutoff.
 beforeEach(() => {
-  mockUseNodeDisplaySettings.mockReset().mockReturnValue({ maxNodeAgeHours: 24 });
+  mockUseNodeDisplaySettings.mockReset().mockReturnValue({ maxNodeAgeHours: 24, maxInfraNodeAgeHours: 720 });
   meshCoreMapProps.mockClear();
 });
 
@@ -341,6 +341,56 @@ describe('MeshCoreNodesView — per-source age filter (#4412 Phase 4)', () => {
     ];
     render(<MeshCoreNodesView nodes={testNodes} contacts={testContacts} />);
     expect(listedNames()).toEqual([]);
+  });
+
+  // #4899: repeaters (advType 2) and room servers (advType 3) get a SEPARATE,
+  // usually longer age window (`maxInfraNodeAgeHours`) than companions.
+  describe('infrastructure age window (#4899)', () => {
+    const PK_INFRA_REPEATER = '7'.repeat(64);
+    const PK_INFRA_ROOM = '8'.repeat(64);
+    const PK_COMPANION = '9'.repeat(64);
+
+    it('keeps a repeater that is past the companion cutoff but within the infra cutoff', () => {
+      // companion=24h, infra=720h (defaults). A 72h-old repeater would be aged
+      // off the companion window but survives on the infra window — the exact
+      // "repeaters vanish from the map" bug this fixes.
+      mockUseNodeDisplaySettings.mockReturnValue({ maxNodeAgeHours: 24, maxInfraNodeAgeHours: 720 });
+      const testNodes: MeshCoreNode[] = [
+        { publicKey: PK_INFRA_REPEATER, name: 'Repeater', advType: 2, lastHeard: NOW - 72 * HOUR_MS },
+        { publicKey: PK_INFRA_ROOM, name: 'RoomServer', advType: 3, lastHeard: NOW - 72 * HOUR_MS },
+      ];
+      render(<MeshCoreNodesView nodes={testNodes} contacts={[]} />);
+      expect(listedNames().sort()).toEqual(['Repeater', 'RoomServer']);
+    });
+
+    it('still hides a repeater older than the infra cutoff', () => {
+      mockUseNodeDisplaySettings.mockReturnValue({ maxNodeAgeHours: 24, maxInfraNodeAgeHours: 720 });
+      const testNodes: MeshCoreNode[] = [
+        { publicKey: PK_INFRA_REPEATER, name: 'DeadRepeater', advType: 2, lastHeard: NOW - 800 * HOUR_MS },
+      ];
+      render(<MeshCoreNodesView nodes={testNodes} contacts={[]} />);
+      expect(listedNames()).toEqual([]);
+    });
+
+    it('never hides infrastructure when the infra window is 0 (never expire)', () => {
+      mockUseNodeDisplaySettings.mockReturnValue({ maxNodeAgeHours: 24, maxInfraNodeAgeHours: 0 });
+      const testNodes: MeshCoreNode[] = [
+        { publicKey: PK_INFRA_REPEATER, name: 'AncientRepeater', advType: 2, lastHeard: NOW - 5000 * HOUR_MS },
+      ];
+      render(<MeshCoreNodesView nodes={testNodes} contacts={[]} />);
+      expect(listedNames()).toEqual(['AncientRepeater']);
+    });
+
+    it('applies the companion (not infra) window to a companion node', () => {
+      // A companion 72h old with companion=24h/infra=720h must still be hidden —
+      // the infra window must not leak onto advType 1.
+      mockUseNodeDisplaySettings.mockReturnValue({ maxNodeAgeHours: 24, maxInfraNodeAgeHours: 720 });
+      const testNodes: MeshCoreNode[] = [
+        { publicKey: PK_COMPANION, name: 'OldCompanion', advType: 1, lastHeard: NOW - 72 * HOUR_MS },
+      ];
+      render(<MeshCoreNodesView nodes={testNodes} contacts={[]} />);
+      expect(listedNames()).toEqual([]);
+    });
   });
 
   it('falls through a `lastHeard: 0` DB row to the contact\'s lastSeen (merge gap regression, #4433 review)', () => {

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { MeshCoreNode } from './hooks/useMeshCore';
 import { MeshCoreContact } from '../../utils/meshcoreHelpers';
 import { MeshCoreMap } from './MeshCoreMap';
-import { meshcoreRoleIconName, meshcoreRoleLabelKey, meshcoreRoleLabel } from './meshcoreRole';
+import { meshcoreRoleIconName, meshcoreRoleLabelKey, meshcoreRoleLabel, isMeshCoreInfrastructureAdvType } from './meshcoreRole';
 import { useToast } from '../ToastContainer';
 import { useSettings } from '../../contexts/SettingsContext';
 import { useSource } from '../../contexts/SourceContext';
@@ -158,7 +158,7 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
   const { showToast } = useToast();
   const { timeFormat, dateFormat } = useSettings();
   const { sourceId } = useSource();
-  const { maxNodeAgeHours } = useNodeDisplaySettings(sourceId);
+  const { maxNodeAgeHours, maxInfraNodeAgeHours } = useNodeDisplaySettings(sourceId);
   const [favoriteBusy, setFavoriteBusy] = useState<string | null>(null);
 
   const handleToggleFavorite = useCallback(async (publicKey: string, next: boolean) => {
@@ -307,8 +307,22 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
     // nodes/contacts poll (`merged` changes) rather than freezing at mount —
     // the same property useProcessedNodes relies on.
     const cutoffMs = meshcoreAgeCutoffMs(maxNodeAgeHours);
-    return merged.filter(r => isAgeExempt(r) || isWithinMeshcoreAge(r, cutoffMs));
-  }, [merged, maxNodeAgeHours, isAgeExempt]);
+    // #4899: repeaters and room servers (advType 2/3) get a SEPARATE, usually
+    // longer cutoff. They re-flood-advertise on a long, often multi-day
+    // interval and never send DMs, so a stale `lastHeard` doesn't mean the node
+    // left the mesh — aging them off the companion window just makes fixed
+    // infrastructure vanish while its DB row/position stay intact. A value of
+    // 0 means "never expire" (show regardless of age, like favorites).
+    const infraNever = maxInfraNodeAgeHours <= 0;
+    const infraCutoffMs = infraNever ? 0 : meshcoreAgeCutoffMs(maxInfraNodeAgeHours);
+    return merged.filter(r => {
+      if (isAgeExempt(r)) return true;
+      if (isMeshCoreInfrastructureAdvType(r.advType)) {
+        return infraNever || isWithinMeshcoreAge(r, infraCutoffMs);
+      }
+      return isWithinMeshcoreAge(r, cutoffMs);
+    });
+  }, [merged, maxNodeAgeHours, maxInfraNodeAgeHours, isAgeExempt]);
 
   const sorted = useMemo(
     () => sortRows(aged, sortField, sortDirection),

--- a/src/components/MeshCore/meshcoreRole.ts
+++ b/src/components/MeshCore/meshcoreRole.ts
@@ -17,6 +17,19 @@ export const MESHCORE_DEVICE_TYPE_KEYS: Record<number, string> = {
   4: 'meshcore.device_type.sensor',
 };
 
+/**
+ * "Infrastructure" = MeshCore repeaters (advType 2) and room servers (3):
+ * fixed, always-on nodes that re-flood-advertise on a long interval and never
+ * send DMs, so their `lastHeard` staleness means something different from a
+ * mobile companion's. Used by the two-timeout age filter (#4899) to apply the
+ * separate `maxInfraNodeAgeHours` cutoff. Sensors (4) are deliberately NOT
+ * infrastructure here — they use the companion cutoff. Mirrors the inline
+ * advType 2/3 test in utils/meshcorePath.ts.
+ */
+export function isMeshCoreInfrastructureAdvType(advType: number | null | undefined): boolean {
+  return advType === 2 || advType === 3;
+}
+
 /** English fallbacks for the role label (used as the t() default + title text). */
 export const MESHCORE_DEVICE_TYPE_LABELS: Record<number, string> = {
   0: 'Unknown',

--- a/src/constants/nodeDisplayDefaults.test.ts
+++ b/src/constants/nodeDisplayDefaults.test.ts
@@ -18,6 +18,9 @@ import {
   NODE_DISPLAY_RANGES,
   parseNodeDisplayNumber,
   parseNodeDisplayBoolean,
+  MAX_INFRA_NODE_AGE_HOURS_DEFAULT,
+  MAX_INFRA_NODE_AGE_HOURS_RANGE,
+  parseMaxInfraNodeAgeHours,
 } from './nodeDisplayDefaults.js';
 import { NODE_DISPLAY_SEED } from '../server/migrations/131_seed_per_source_node_display.js';
 import {
@@ -149,5 +152,29 @@ describe('parseNodeDisplayBoolean', () => {
   it('both boolean defaults are false', () => {
     expect(NODE_DISPLAY_BOOLEAN_DEFAULTS.hideIncompleteNodes).toBe(false);
     expect(NODE_DISPLAY_BOOLEAN_DEFAULTS.nodeDimmingEnabled).toBe(false);
+  });
+});
+
+// #4899 — standalone Infrastructure age cutoff, kept OUT of the frozen ten.
+describe('maxInfraNodeAgeHours (#4899)', () => {
+  it('is NOT one of the frozen ten Node Display keys (decoupled from migration 131)', () => {
+    expect(NODE_DISPLAY_SETTING_KEYS as readonly string[]).not.toContain('maxInfraNodeAgeHours');
+  });
+
+  it('defaults to 720 (30 days) with a 0..8760 range where 0 = never', () => {
+    expect(MAX_INFRA_NODE_AGE_HOURS_DEFAULT).toBe(720);
+    expect(MAX_INFRA_NODE_AGE_HOURS_RANGE).toEqual({ min: 0, max: 8760, integer: true });
+  });
+
+  it('parses valid values, preserves 0 (never), and clamps invalid/out-of-range to the default', () => {
+    expect(parseMaxInfraNodeAgeHours('168')).toBe(168);
+    expect(parseMaxInfraNodeAgeHours('0')).toBe(0);            // never-expire, preserved
+    expect(parseMaxInfraNodeAgeHours('8760')).toBe(8760);      // max, inclusive
+    expect(parseMaxInfraNodeAgeHours(undefined)).toBe(720);
+    expect(parseMaxInfraNodeAgeHours('')).toBe(720);
+    expect(parseMaxInfraNodeAgeHours('garbage')).toBe(720);
+    expect(parseMaxInfraNodeAgeHours('-1')).toBe(720);         // below min → default
+    expect(parseMaxInfraNodeAgeHours('99999')).toBe(720);      // above max → default
+    expect(parseMaxInfraNodeAgeHours('48.9')).toBe(48);        // truncated to integer
   });
 });

--- a/src/constants/nodeDisplayDefaults.ts
+++ b/src/constants/nodeDisplayDefaults.ts
@@ -117,6 +117,39 @@ export function parseNodeDisplayNumber(
   return n;
 }
 
+/**
+ * Infrastructure age cutoff (#4899). A SECOND per-source age window, applied
+ * only to MeshCore repeaters and room servers (advType 2/3). Kept deliberately
+ * OUTSIDE the frozen ten-key Node Display seed (NODE_DISPLAY_SETTING_KEYS +
+ * migration 131) so those remain byte-identical — this is a later, standalone
+ * per-source setting that falls through to the default below when unstored
+ * (no seed migration needed; parity with the "no runtime global fallback"
+ * rule above).
+ *
+ * Default 720h = 30 days: repeaters re-flood-advertise on a long, often
+ * multi-day interval and never send DMs, so a stale `lastHeard` doesn't mean
+ * the node left the mesh. `0` = never expire (the escape hatch). Range allows
+ * up to a year so operators can pick anything between "same as companions"
+ * and "effectively forever".
+ */
+export const MAX_INFRA_NODE_AGE_HOURS_DEFAULT = 720;
+export const MAX_INFRA_NODE_AGE_HOURS_RANGE = { min: 0, max: 8760, integer: true } as const;
+
+/**
+ * Parse a stored `maxInfraNodeAgeHours` into a usable number. null/empty/NaN/
+ * out-of-range → the default. `0` is a valid stored value meaning "never
+ * expire" and is preserved (it is inside the [0, 8760] range).
+ */
+export function parseMaxInfraNodeAgeHours(raw: string | null | undefined): number {
+  if (raw === null || raw === undefined || raw === '') return MAX_INFRA_NODE_AGE_HOURS_DEFAULT;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return MAX_INFRA_NODE_AGE_HOURS_DEFAULT;
+  if (n < MAX_INFRA_NODE_AGE_HOURS_RANGE.min || n > MAX_INFRA_NODE_AGE_HOURS_RANGE.max) {
+    return MAX_INFRA_NODE_AGE_HOURS_DEFAULT;
+  }
+  return Math.trunc(n);
+}
+
 /** '1' | 'true' → true; '0' | 'false' → false; anything else → the default. */
 export function parseNodeDisplayBoolean(
   key: NodeDisplayBooleanKey,

--- a/src/hooks/useNodeDisplaySettings.test.tsx
+++ b/src/hooks/useNodeDisplaySettings.test.tsx
@@ -17,6 +17,7 @@ import {
   NODE_DISPLAY_NUMERIC_DEFAULTS,
   NODE_DISPLAY_BOOLEAN_DEFAULTS,
   NODE_DISPLAY_STRING_DEFAULTS,
+  MAX_INFRA_NODE_AGE_HOURS_DEFAULT,
 } from '../constants/nodeDisplayDefaults';
 
 vi.mock('../services/api', () => ({
@@ -35,6 +36,7 @@ describe('parseNodeDisplaySettings', () => {
     const result = parseNodeDisplaySettings(undefined);
     expect(result).toEqual({
       maxNodeAgeHours: NODE_DISPLAY_NUMERIC_DEFAULTS.maxNodeAgeHours,
+      maxInfraNodeAgeHours: MAX_INFRA_NODE_AGE_HOURS_DEFAULT,
       inactiveNodeThresholdHours: NODE_DISPLAY_NUMERIC_DEFAULTS.inactiveNodeThresholdHours,
       inactiveNodeCheckIntervalMinutes:
         NODE_DISPLAY_NUMERIC_DEFAULTS.inactiveNodeCheckIntervalMinutes,
@@ -51,6 +53,7 @@ describe('parseNodeDisplaySettings', () => {
   it('parses stored string values through the shared parsers', () => {
     const result = parseNodeDisplaySettings({
       maxNodeAgeHours: '72',
+      maxInfraNodeAgeHours: '168',
       inactiveNodeThresholdHours: '48',
       inactiveNodeCheckIntervalMinutes: '30',
       inactiveNodeCooldownHours: '12',
@@ -63,6 +66,7 @@ describe('parseNodeDisplaySettings', () => {
     });
     expect(result).toEqual({
       maxNodeAgeHours: 72,
+      maxInfraNodeAgeHours: 168,
       inactiveNodeThresholdHours: 48,
       inactiveNodeCheckIntervalMinutes: 30,
       inactiveNodeCooldownHours: 12,

--- a/src/hooks/useNodeDisplaySettings.ts
+++ b/src/hooks/useNodeDisplaySettings.ts
@@ -24,6 +24,7 @@ import {
   parseNodeDisplayNumber,
   parseNodeDisplayBoolean,
   parseMaxInfraNodeAgeHours,
+  MAX_INFRA_NODE_AGE_HOURS_DEFAULT,
 } from '../constants/nodeDisplayDefaults';
 import type { NodeHopsCalculation } from '../contexts/SettingsContext';
 
@@ -132,6 +133,37 @@ export function useNodeDisplaySettings(sourceId: string | null): NodeDisplaySett
 export function maxAcross(values: number[]): number {
   if (values.length === 0) return NODE_DISPLAY_NUMERIC_DEFAULTS.maxNodeAgeHours;
   return Math.max(...values);
+}
+
+/**
+ * Most-permissive `maxInfraNodeAgeHours` across N sources (#4899), for the
+ * cross-source Dashboard map. `0` means "never expire" and is the MOST
+ * permissive value of all, so if ANY source in view sets 0 the combined
+ * window is 0 (never). Otherwise it's the max of the non-zero values. Empty
+ * list → the hardcoded infra default.
+ */
+export function maxInfraAcross(values: number[]): number {
+  if (values.length === 0) return MAX_INFRA_NODE_AGE_HOURS_DEFAULT;
+  if (values.some((v) => v <= 0)) return 0; // 0 = never = most permissive
+  return Math.max(...values);
+}
+
+/** Cross-source most-permissive infra window (#4899). Mirrors
+ *  `useMaxNodeAgeHoursAcross`; a still-loading source is excluded rather than
+ *  treated as its default. */
+export function useMaxInfraNodeAgeHoursAcross(sourceIds: string[]): number {
+  const stableIds = Array.from(new Set(sourceIds)).sort();
+  const results = useQueries({
+    queries: stableIds.map((id) => ({
+      queryKey: nodeDisplaySettingsQueryKey(id),
+      queryFn: () => fetchNodeDisplayRaw(id),
+      staleTime: 60_000,
+    })),
+  });
+  const loadedValues = results
+    .filter((r) => r.data !== undefined)
+    .map((r) => parseMaxInfraNodeAgeHours(r.data?.maxInfraNodeAgeHours));
+  return maxInfraAcross(loadedValues);
 }
 
 /**

--- a/src/hooks/useNodeDisplaySettings.ts
+++ b/src/hooks/useNodeDisplaySettings.ts
@@ -23,11 +23,16 @@ import {
   NODE_DISPLAY_STRING_DEFAULTS,
   parseNodeDisplayNumber,
   parseNodeDisplayBoolean,
+  parseMaxInfraNodeAgeHours,
 } from '../constants/nodeDisplayDefaults';
 import type { NodeHopsCalculation } from '../contexts/SettingsContext';
 
 export interface NodeDisplaySettings {
   maxNodeAgeHours: number;
+  /** #4899: separate age cutoff for MeshCore infrastructure (repeaters/room
+   *  servers, advType 2/3). `0` = never expire. Standalone per-source setting,
+   *  not one of the frozen ten Node Display keys. */
+  maxInfraNodeAgeHours: number;
   inactiveNodeThresholdHours: number;
   inactiveNodeCheckIntervalMinutes: number;
   inactiveNodeCooldownHours: number;
@@ -58,6 +63,7 @@ export function parseNodeDisplaySettings(
 ): NodeDisplaySettings {
   return {
     maxNodeAgeHours: parseNodeDisplayNumber('maxNodeAgeHours', raw?.maxNodeAgeHours),
+    maxInfraNodeAgeHours: parseMaxInfraNodeAgeHours(raw?.maxInfraNodeAgeHours),
     inactiveNodeThresholdHours: parseNodeDisplayNumber(
       'inactiveNodeThresholdHours',
       raw?.inactiveNodeThresholdHours,

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -30,6 +30,7 @@ const dashboardMapMocks = vi.hoisted(() => ({
 
 vi.mock('../hooks/useNodeDisplaySettings', () => ({
   useMaxNodeAgeHoursAcross: vi.fn(() => 24),
+  useMaxInfraNodeAgeHoursAcross: vi.fn(() => 720),
 }));
 
 vi.mock('../hooks/useDashboardData', () => ({

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -22,7 +22,7 @@ import {
   UNIFIED_SOURCE_ID,
 } from '../hooks/useDashboardData';
 import { useMeshCoreNeighbors } from '../hooks/useMapAnalysisData';
-import { useMaxNodeAgeHoursAcross } from '../hooks/useNodeDisplaySettings';
+import { useMaxNodeAgeHoursAcross, useMaxInfraNodeAgeHoursAcross } from '../hooks/useNodeDisplaySettings';
 import type { DashboardSource } from '../hooks/useDashboardData';
 import DashboardSidebar from '../components/Dashboard/DashboardSidebar';
 import DashboardMap from '../components/Dashboard/DashboardMap';
@@ -244,6 +244,9 @@ function DashboardInner() {
   // page would silently fall back to the hardcoded default (24h) since it
   // sits outside SettingsContext's per-source scoping.
   const maxNodeAgeHours = useMaxNodeAgeHoursAcross(sourceIds);
+  // #4899: cross-source Infrastructure window so MeshCore repeaters/room
+  // servers survive on the Dashboard map past the (shorter) companion window.
+  const maxInfraNodeAgeHours = useMaxInfraNodeAgeHoursAcross(sourceIds);
 
   // Apply admin-configured default landing page (issue #2917, expanded
   // for issue #3183 to allow cross-source unified pages). When the user
@@ -1122,6 +1125,7 @@ function DashboardInner() {
           defaultCenter={defaultCenter}
           sourceId={selectedSourceId}
           maxNodeAgeHours={maxNodeAgeHours}
+          maxInfraNodeAgeHours={maxInfraNodeAgeHours}
           onNodeSourceSelect={handleNodeSourceSelect}
           isLoading={sourceData.isLoading}
         />

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -8,6 +8,7 @@
  */
 export const VALID_SETTINGS_KEYS = [
   'maxNodeAgeHours',
+  'maxInfraNodeAgeHours', // #4899 — separate age window for MeshCore repeaters/room servers
   'tracerouteIntervalMinutes',
   'temperatureUnit',
   'distanceUnit',
@@ -497,6 +498,9 @@ export const PER_SOURCE_SETTINGS_KEYS = [
   // the server reads to getSettingForSource(). `localStatsIntervalMinutes` is
   // already listed under "Misc per-source" below — do not duplicate it.
   'maxNodeAgeHours',
+  // #4899 — standalone per-source Infrastructure age cutoff (advType 2/3),
+  // NOT one of the frozen ten Node Display keys / migration-131 seed.
+  'maxInfraNodeAgeHours',
   'inactiveNodeThresholdHours',
   'inactiveNodeCheckIntervalMinutes',
   'inactiveNodeCooldownHours',

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -24,7 +24,7 @@ import { resolveSourceManager } from '../utils/resolveSourceManager.js';
 import { validateFilterNameRegexOnSave } from '../utils/filterNameRegex.js';
 import { positionEstimationScheduler } from '../services/positionEstimationScheduler.js';
 import { autoDeleteByDistanceService } from '../services/autoDeleteByDistanceService.js';
-import { NODE_DISPLAY_RANGES, NODE_DISPLAY_SETTING_KEYS } from '../../constants/nodeDisplayDefaults.js';
+import { NODE_DISPLAY_RANGES, NODE_DISPLAY_SETTING_KEYS, MAX_INFRA_NODE_AGE_HOURS_RANGE } from '../../constants/nodeDisplayDefaults.js';
 import { resolveAppriseServerUrl } from '../services/appriseNotificationService.js';
 
 // ─── Tile URL validation ─────────────────────────────────────────────────
@@ -418,6 +418,17 @@ router.post('/', requirePermission('settings', 'write', { sourceIdFrom: 'query' 
       if (isNaN(hours) || hours < R.min || hours > R.max) {
         return fail(res, 400, 'INVALID_MAX_NODE_AGE_HOURS',
           `maxNodeAgeHours must be between ${R.min} and ${R.max} hours`);
+      }
+    }
+
+    // #4899: separate Infrastructure age window (MeshCore repeaters/room
+    // servers). 0 is valid and means "never expire", so the floor is 0 here.
+    if ('maxInfraNodeAgeHours' in filteredSettings) {
+      const hours = parseInt(filteredSettings.maxInfraNodeAgeHours, 10);
+      const R = MAX_INFRA_NODE_AGE_HOURS_RANGE;
+      if (isNaN(hours) || hours < R.min || hours > R.max) {
+        return fail(res, 400, 'INVALID_MAX_INFRA_NODE_AGE_HOURS',
+          `maxInfraNodeAgeHours must be between ${R.min} and ${R.max} hours (0 = never expire)`);
       }
     }
 

--- a/src/server/server.settings-persistence.test.ts
+++ b/src/server/server.settings-persistence.test.ts
@@ -129,6 +129,7 @@ function validTestValue(key: string, suffix = ''): string {
     autoAckChannels: '0,1',
     autoAckIgnoredNodes: '!b29fa8d4,!a1b2c3d4',
     maxNodeAgeHours: '24',
+    maxInfraNodeAgeHours: '168',
     inactiveNodeThresholdHours: '24',
     inactiveNodeCheckIntervalMinutes: '60',
     inactiveNodeCooldownHours: '24',


### PR DESCRIPTION
Fixes #4899. Supersedes #4900.

## Problem
MeshCore repeaters and room servers age off the Nodes list **and** the map on the same `maxNodeAgeHours` window as mobile companions. But they re-flood-advertise only every few days and never send DMs, so a stale `lastHeard` doesn't mean they left the mesh — they just vanish while their DB row/position stay intact (still visible under Messages).

## Approach (per maintainer direction)
Instead of **totally exempting** repeaters/room servers (PR #4900), give infrastructure its **own configurable per-source age window**, so a genuinely dead repeater still eventually clears.

- **New per-source setting `maxInfraNodeAgeHours`** — default **720h (30 days)**, range **0..8760** where **0 = never expire**. Applied only to advType 2 (Repeater) and 3 (Room Server). Companions and everything else keep `maxNodeAgeHours` (24h default). Sensors (advType 4) intentionally use the companion window.
- Kept **outside** the frozen ten Node Display keys + migration-131 seed (so those stay byte-identical); it falls through to its hardcoded default when unstored, so **no seed migration is needed** — existing sources get 720h immediately.
- `MeshCoreNodesView` age filter now branches on `isMeshCoreInfrastructureAdvType(advType)`; favorites and the local node stay exempt. The map inherits the same filtered set, so list + map are fixed together.
- Second **"Maximum Age of Infrastructure Nodes"** input in the MeshCore Node Display settings section; server-side range validation added (`INVALID_MAX_INFRA_NODE_AGE_HOURS`).

## Files
`nodeDisplayDefaults.ts` (standalone default/range/parser), `useNodeDisplaySettings.ts` (hook field), `meshcoreRole.ts` (predicate), `MeshCoreNodesView.tsx` (two-window filter), `MeshCoreNodeDisplaySection.tsx` (second input), `settings.ts` (allowlists), `settingsRoutes.ts` (validation), + tests.

## Tests
- Filter: repeater/room-server past the companion cutoff but within infra → **kept**; past infra cutoff → **hidden**; infra=0 → **never hidden**; companion past companion cutoff → **hidden** (infra window doesn't leak onto advType 1).
- Parser: valid values, `0` preserved (never), out-of-range clamps to default, truncates to integer.
- Hook shape, settings-section save payload (now 5 keys), and settings round-trip.
- Full affected suite: **281 pass, 0 fail**. Lint ratchet + TypeScript clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)