### PR TITLE
feat(map): add Zoom to Fit to the Unified/Dashboard map (#4898)

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -373,6 +373,21 @@ describe('DashboardMap', () => {
     expect(mocks.fitBounds).not.toHaveBeenCalled();
   });
 
+  // --- Zoom to fit (#4898) ---------------------------------------------------
+
+  it('renders an enabled Zoom to fit button when nodes have positions (#4898)', () => {
+    render(<DashboardMap {...defaultProps} nodes={[nodeWithPosition]} />);
+    const btn = screen.getByLabelText('Zoom to fit all nodes') as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    expect(btn.disabled).toBe(false);
+  });
+
+  it('disables Zoom to fit when no nodes have positions (#4898)', () => {
+    render(<DashboardMap {...defaultProps} nodes={[]} />);
+    const btn = screen.getByLabelText('Zoom to fit all nodes') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
   // --- Features panel collapse (#3912) ---------------------------------------
 
   it('shows the Features panel toggles by default', () => {

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -152,6 +152,31 @@ function MapBoundsUpdater({ positions, sourceId, skip }: MapBoundsUpdaterProps) 
   return null;
 }
 
+/**
+ * One-tap "Zoom to fit" for the Dashboard / Unified map (#4898), mirroring the
+ * classic /nodes map (#4496). `MapBoundsUpdater` only auto-fits once on load
+ * (and not at all when a Default Map Center is set), so this gives an explicit
+ * re-frame that always works. `request` is a monotonic counter so repeated
+ * clicks re-fit even when the node set is unchanged.
+ */
+function FitAllNodesController({ request, positions }: { request: number; positions: Array<[number, number]> }) {
+  const map = useMap();
+  const lastHandled = useRef(0);
+
+  useEffect(() => {
+    if (request === 0 || request === lastHandled.current) return;
+    lastHandled.current = request;
+    if (positions.length === 0) return;
+    if (positions.length === 1) {
+      map.setView(positions[0], Math.max(map.getZoom(), 14), { animate: true });
+      return;
+    }
+    map.fitBounds(positions, { padding: [50, 50], animate: true, duration: 0.5, maxZoom: 15 });
+  }, [request, positions, map]);
+
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // DashboardMap
 // ---------------------------------------------------------------------------
@@ -224,6 +249,9 @@ export default function DashboardMap({
   const [isMapControlsCollapsed, setIsMapControlsCollapsed] = useState(
     () => localStorage.getItem('isMapControlsCollapsed') === 'true',
   );
+  // Monotonic counter driving the "Zoom to fit" button (#4898); each click
+  // increments it so a re-frame fires even when the node set is unchanged.
+  const [fitRequest, setFitRequest] = useState(0);
   useEffect(() => {
     localStorage.setItem('isMapControlsCollapsed', String(isMapControlsCollapsed));
   }, [isMapControlsCollapsed]);
@@ -749,6 +777,7 @@ export default function DashboardMap({
         )}
 
         <MapBoundsUpdater positions={nodePositions} sourceId={sourceId} skip={hasConfiguredDefaultCenter} />
+        <FitAllNodesController request={fitRequest} positions={nodePositions} />
 
         {showLegend && <MapLegend />}
 
@@ -837,6 +866,22 @@ export default function DashboardMap({
         <div className="map-controls-body">
           <div className="map-controls-header">
             <div className="map-controls-title">Features</div>
+            {/* Zoom to fit all nodes (#4898). In the header so it stays reachable
+                when the panel is collapsed — a one-tap re-frame. */}
+            <button
+              className="map-controls-fit-btn"
+              onClick={() => setFitRequest(n => n + 1)}
+              disabled={nodePositions.length === 0}
+              title={
+                nodePositions.length === 0
+                  ? 'No positioned nodes to zoom to'
+                  : `Zoom to fit all ${nodePositions.length} positioned nodes`
+              }
+              aria-label="Zoom to fit all nodes"
+              onMouseDown={(e) => e.stopPropagation()}
+            >
+              <UiIcon name="fitBounds" size={16} />
+            </button>
             <button
               className="map-controls-collapse-btn"
               onClick={() => setIsMapControlsCollapsed(!isMapControlsCollapsed)}


### PR DESCRIPTION
Addresses the **immediate fix** in #4898: the Unified Map was missing the **Zoom to Fit** button that the classic `/nodes` map has.

## Context

The "Unified Map" is `DashboardMap` rendered with `UNIFIED_SOURCE_ID` (same component as the per-source Dashboard map). It only auto-fit **once on load** via `MapBoundsUpdater` — and not at all when a Default Map Center is configured (#4125) — so there was no way to re-frame to all nodes.

## Change (one file + tests)

- New `FitAllNodesController` — a `useMap` child driven by a monotonic request counter (so repeated clicks re-fit even when the node set is unchanged). 1 node → `setView`; many → `fitBounds` with padding + `maxZoom`. It fits `nodePositions` (every visible, positioned node — all sources on the Unified map) and is independent of the once-on-load `MapBoundsUpdater`, so it always works regardless of the Default Map Center setting.
- Button added to the map controls header (reachable while the panel is collapsed), reusing the shared `.map-controls-fit-btn` style + `UiIcon name="fitBounds"` from the #4496 pattern. Disabled when no node has a position.

## Not in this PR — the broader consolidation

#4898 also asks that toolbar controls be **shared via BaseMap** so a control added once appears in every map view. Today `BaseMap` has **no controls/toolbar slot** (only `children` rendered *inside* the Leaflet container, plus a hard-coded `TilesetSelector`); each view renders its own `.map-controls` toolbar as a sibling. Hoisting shared buttons into BaseMap changes its public interface and touches ~12 consumers — a real refactor best done as an epic follow-up (fits the Map Consolidation epic #4047). Flagged for tracking.

## Tests

`DashboardMap.test.tsx` — the fit button renders enabled when nodes have positions, and disabled when none do. 38/38 pass; tsc clean; no mesh impact (client-side map only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)