### PR TITLE
perf/robustness(gnss): DOP grid yielding, TLE resync, panel time anchor (#4797)

### DIFF
--- a/src/components/MapAnalysis/GnssDopPanel.test.tsx
+++ b/src/components/MapAnalysis/GnssDopPanel.test.tsx
@@ -37,11 +37,27 @@ describe('GnssDopPanel', () => {
   });
 
   it('the time scrubber drives the timeMs param the layer consumes', () => {
+    // Anchor is the wall clock at mount (#4797(3)); pin it to BASE_TIME so the
+    // +3h offset resolves to BASE_TIME + 3h.
+    vi.spyOn(Date, 'now').mockReturnValue(BASE_TIME);
     render(<GnssDopPanel open params={params()} meta={null} onChange={onChange} onClose={onClose} />);
     fireEvent.change(screen.getByTestId('gnss-dop-time'), { target: { value: '3' } });
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ timeMs: BASE_TIME + 3 * HOUR_MS }),
     );
+    vi.restoreAllMocks();
+  });
+
+  it('anchors the offset to the real wall clock, not the preserved timeMs (#4797)', () => {
+    // Simulate remounting 2h after the preserved time was set: `Date.now()` is
+    // BASE_TIME + 2h but the param still holds BASE_TIME. The scrubber must read
+    // -2h (the true drift), NOT 0/"now" — the old `useRef(params.timeMs)`
+    // anchored to the stale time and always showed offset 0.
+    vi.spyOn(Date, 'now').mockReturnValue(BASE_TIME + 2 * HOUR_MS);
+    render(<GnssDopPanel open params={params({ timeMs: BASE_TIME })} meta={null} onChange={onChange} onClose={onClose} />);
+    const scrubber = screen.getByTestId('gnss-dop-time') as HTMLInputElement;
+    expect(scrubber.value).toBe('-2');
+    vi.restoreAllMocks();
   });
 
   it('the Now button re-anchors the time to the present', () => {

--- a/src/components/MapAnalysis/GnssDopPanel.tsx
+++ b/src/components/MapAnalysis/GnssDopPanel.tsx
@@ -56,9 +56,13 @@ const LEGEND_STOPS: Array<{ gdop: number; label: string }> = [
 export default function GnssDopPanel({ open, params, meta, onChange, onClose }: GnssDopPanelProps) {
   const { t } = useTranslation();
 
-  // Anchor "now" once so dragging the scrubber is stable within a session; the
-  // Now button re-anchors and returns to offset 0.
-  const anchorRef = useRef<number>(params.timeMs);
+  // Anchor "now" to the real wall clock at mount, so the scrubber offset is
+  // measured from the actual current time and stays stable while dragging; the
+  // Now button re-anchors and returns to offset 0. #4797(3): anchoring to
+  // `params.timeMs` instead meant that on remount (leave Map Analysis and come
+  // back) the anchor became whatever time was preserved in context — so a stale
+  // preserved time read as offset 0 / "now" when it was actually in the past.
+  const anchorRef = useRef<number>(Date.now());
   const offsetHours = Math.round(((params.timeMs - anchorRef.current) / HOUR_MS) * 10) / 10;
 
   const setTimeOffset = (hours: number) => {

--- a/src/server/routes/gnssRoutes.ts
+++ b/src/server/routes/gnssRoutes.ts
@@ -41,6 +41,14 @@ const DEFAULT_ELEVATION_MASK_DEG = 5;
  */
 const MAX_GRID_CELLS = 2500;
 
+/**
+ * #4797(1): yield to the event loop after this many computed DOP cells so a
+ * large grid can't monopolise the main thread. ~32 SGP4 propagations per cell,
+ * so 200 cells ≈ a few ms of blocking CPU between yields — small enough that
+ * other requests interleave, large enough that the yield overhead is noise.
+ */
+const DOP_GRID_YIELD_EVERY = 200;
+
 function isFiniteNumber(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v);
 }
@@ -270,6 +278,11 @@ router.post('/dop', optionalAuth(), gnssLimiter, async (req: Request, res: Respo
     const nLon = Math.floor(lonSpan / stepDeg) + 1;
     const points: Array<{ lat: number; lon: number; gdop: number | null }> = [];
 
+    // #4797(1): each cell runs SGP4 over the whole constellation synchronously,
+    // so a full grid is up to MAX_GRID_CELLS × ~32 propagations of blocking CPU.
+    // Yield to the event loop every DOP_GRID_YIELD_EVERY cells so a big grid
+    // can't stall other requests for a few hundred ms at a stretch.
+    let computed = 0;
     for (let i = 0; i < nLat; i++) {
       const lat = bbox.minLat + i * stepDeg;
       for (let j = 0; j < nLon; j++) {
@@ -281,6 +294,9 @@ router.post('/dop', optionalAuth(), gnssLimiter, async (req: Request, res: Respo
           elevationMaskDeg: mResult.mask,
         });
         points.push({ lat, lon, gdop: sky.dop ? sky.dop.gdop : null });
+        if (++computed % DOP_GRID_YIELD_EVERY === 0) {
+          await new Promise<void>((resolve) => setImmediate(resolve));
+        }
       }
     }
 

--- a/src/server/services/gnss/tleService.test.ts
+++ b/src/server/services/gnss/tleService.test.ts
@@ -80,6 +80,24 @@ describe('parseTleText', () => {
   it('returns [] for garbage input', () => {
     expect(parseTleText('not a tle at all\njust some text')).toEqual([]);
   });
+
+  it('resyncs past a stray header/comment line instead of dropping the rest (#4797)', () => {
+    // A leading header line AND a stray line between two valid triples. The old
+    // `break`-on-misalign parser stopped at the first offset misalignment and
+    // returned []; the resync parser skips the stray lines and keeps both sats.
+    const withStrays = [
+      '# CelesTrak GPS elements (retrieved ...)',
+      'GPS BIIR-5  (PRN 22)',
+      '1 26407U 00040A   26230.62233409  .00000059  00000+0  00000+0 0  9997',
+      '2 26407  54.8442 212.6831 0119403 303.2745  60.7622  2.00558203191204',
+      '--- unexpected divider ---',
+      'GPS BIIR-8  (PRN 16)',
+      '1 27663U 03005A   26229.94485694  .00000054  00000+0  00000+0 0  9999',
+      '2 27663  54.8743 212.5159 0149230  53.3719 317.7217  2.00557285172551',
+    ].join('\n');
+    const tles = parseTleText(withStrays);
+    expect(tles.map((t) => t.name)).toEqual(['GPS BIIR-5  (PRN 22)', 'GPS BIIR-8  (PRN 16)']);
+  });
 });
 
 describe('celestrakUrl', () => {

--- a/src/server/services/gnss/tleService.ts
+++ b/src/server/services/gnss/tleService.ts
@@ -69,17 +69,26 @@ export function parseTleText(text: string): Tle[] {
     .filter((l) => l.length > 0);
 
   const tles: Tle[] = [];
-  for (let i = 0; i + 2 < lines.length; i += 3) {
+  // #4797(2): resync on a misaligned triple instead of stopping. CelesTrak's
+  // 3-line format is `name / "1 …" / "2 …"`, but a stray header/comment line
+  // (or a blank the trim didn't catch) would shift every subsequent triple by
+  // one and, under the old `break`, silently drop the entire rest of the set.
+  // Here a line that isn't the start of a valid `1 …`/`2 …` pair is skipped and
+  // scanning resumes, so one stray line costs at most one satellite, not all of
+  // them.
+  let i = 0;
+  while (i + 2 < lines.length) {
     const name = lines[i];
     const line1 = lines[i + 1];
     const line2 = lines[i + 2];
-    // A well-formed TLE has line1 starting "1 " and line2 starting "2 ".
-    if (!line1 || !line2) break;
-    if (!line1.startsWith('1 ') || !line2.startsWith('2 ')) {
-      // Not a valid triple at this offset — stop rather than misalign.
-      break;
+    if (line1.startsWith('1 ') && line2.startsWith('2 ')) {
+      tles.push({ name: name.trim(), line1, line2 });
+      i += 3;
+    } else {
+      // Not a well-formed triple at this offset — drop the stray line at `i`
+      // and re-test from the next one.
+      i += 1;
     }
-    tles.push({ name: name.trim(), line1, line2 });
   }
   return tles;
 }


### PR DESCRIPTION
Closes #4797 — the three non-blocking follow-ups deferred from the #4796 GNSS constellation overlay review.

### 1. DOP grid no longer blocks the event loop
`POST /gnss/dop` runs `computeSkyView` (SGP4 over the whole constellation, ~32 propagations) synchronously per grid cell — up to `MAX_GRID_CELLS` (2500) cells. It now yields to the event loop via `setImmediate` every `DOP_GRID_YIELD_EVERY` (200) computed cells, so a large grid can't stall other requests for a few hundred ms at a stretch. Output is unchanged.

### 2. `parseTleText` resyncs instead of dropping the rest
A misaligned triple (stray header/comment/blank line) used to `break` on the first offset that didn't start `1 `/`2 `, silently dropping every satellite after it. It now skips the stray line and resumes scanning, so one bad line costs at most one satellite. CelesTrak's 3-line format is stable today; this just makes it robust if a header/comment ever appears.

### 3. `GnssDopPanel` scrubber anchors to the real "now"
`anchorRef` captured `params.timeMs` at mount, so remounting (leave Map Analysis and come back) re-anchored to whatever `timeMs` was preserved in context — a stale time then read as offset 0 / "now". It now anchors to `Date.now()` at mount, so the offset reflects the true drift and a preserved past time correctly reads as negative rather than "now". Dragging stays stable within a session; the Now button still re-anchors to offset 0.

## Tests
- TLE: resyncs past a leading header + a mid-set divider and keeps both sats.
- Panel: offset is measured from the wall clock (renders a 2h-old preserved time as `-2`, not `0`); the existing scrubber test pins `Date.now()` so its `+3h` assertion holds.
- All GNSS suites green (50 tests); lint + typecheck clean.

Refs #4729, #4796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)