### PR TITLE
fix(meshcore): verify set_out_path by device read-back, not the tag-less ack (#4631)

### DIFF
--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -229,11 +229,25 @@ class MockConnection extends EventEmitter {
   public setContactPathCalls: Array<{ contact: any; path: Uint8Array }> = [];
   async setContactPath(contact: any, path: Uint8Array) {
     this.setContactPathCalls.push({ contact, path });
+    // Simulate a device that persists the write, so set_out_path's #4631
+    // read-back verification sees the stored path. Tests that want to model a
+    // lost ack / genuine reject override this method.
+    contact.outPathLen = path.length;
+    contact.outPath = new Uint8Array(64);
+    contact.outPath.set(path.subarray(0, 64));
   }
 
   public addOrUpdateContactCalls: Array<any[]> = [];
   async addOrUpdateContact(...args: any[]) {
     this.addOrUpdateContactCalls.push(args);
+    const [pk, , , outPathLen, outPath] = args;
+    const target = this.contactsResponse.find(
+      (ct: any) => ct.publicKey && Buffer.from(ct.publicKey).equals(Buffer.from(pk)),
+    );
+    if (target) {
+      if (typeof outPathLen === 'number') target.outPathLen = outPathLen;
+      if (outPath) target.outPath = outPath;
+    }
   }
 }
 
@@ -480,6 +494,78 @@ describe('MeshCoreNativeBackend', () => {
     expect(lastAdvert).toBe(42);
     expect(advLat).toBe(1);
     expect(advLon).toBe(2);
+  });
+
+  // #4631: set_out_path must trust the DEVICE read-back, not the tag-less
+  // Ok/Err ack that a concurrent command can cannibalise on a busy WiFi link.
+  describe('set_out_path read-back verification (#4631)', () => {
+    const KEY_HEX = 'abcdef' + '00'.repeat(29);
+    const KEY = Uint8Array.from([0xab, 0xcd, 0xef, ...new Array(29).fill(0)]);
+
+    async function makeBackendWithRepeater() {
+      const backend = new MeshCoreNativeBackend('src-1', {
+        connectionType: 'serial',
+        serialPort: '/dev/ttyUSB0',
+      });
+      await backend.connect();
+      const conn = lastInstanceRef.current as MockConnection;
+      conn.contactsResponse = [
+        { publicKey: KEY, type: AdvType.Repeater, flags: 0xa0, outPathLen: 0xff, outPath: new Uint8Array(64), advName: 'Rptr', lastAdvert: 42, advLat: 1, advLon: 2 },
+      ];
+      return { backend, conn };
+    }
+
+    // Simulate the device persisting the path (mutating the contact record the
+    // mock's getContacts hands back).
+    const storeOnContact = (contact: any, path: Uint8Array) => {
+      contact.outPathLen = path.length;
+      contact.outPath = new Uint8Array(64);
+      contact.outPath.set(path);
+    };
+
+    it('succeeds when the device stored the path AND the ack was clean', async () => {
+      const { backend, conn } = await makeBackendWithRepeater();
+      conn.setContactPath = async (contact: any, path: Uint8Array) => { storeOnContact(contact, path); };
+      const resp = await backend.sendCommand('set_out_path', { public_key: KEY_HEX, out_path: [0xa3, 0x7f], hash_bytes: 1 });
+      expect(resp.success).toBe(true);
+      expect(resp.data).toEqual(expect.objectContaining({ verified: true }));
+    });
+
+    it('succeeds when the write ack ERRORED but the device stored the path anyway (the #4631 bug)', async () => {
+      const { backend, conn } = await makeBackendWithRepeater();
+      // Device applied the write, but its Ok was lost / a foreign Err rejected
+      // the tag-less ack — the exact WiFi-companion failure. Read-back rescues it.
+      conn.setContactPath = async (contact: any, path: Uint8Array) => {
+        storeOnContact(contact, path);
+        throw new Error('Err');
+      };
+      const resp = await backend.sendCommand('set_out_path', { public_key: KEY_HEX, out_path: [0xa3, 0x7f], hash_bytes: 1 });
+      expect(resp.success).toBe(true);
+      expect(resp.data).toEqual(expect.objectContaining({ verified: true }));
+    });
+
+    it('fails honestly when the device did NOT store the path (genuine reject)', async () => {
+      const { backend, conn } = await makeBackendWithRepeater();
+      conn.setContactPath = async () => { throw new Error('Err'); }; // no store
+      const resp = await backend.sendCommand('set_out_path', { public_key: KEY_HEX, out_path: [0xa3, 0x7f], hash_bytes: 1 });
+      expect(resp.success).toBe(false);
+      expect(resp.error).toMatch(/not confirmed on device/i);
+    });
+
+    it('packs the length for a 2-byte hash width and verifies the stored value', async () => {
+      const { backend, conn } = await makeBackendWithRepeater();
+      // 2-byte hashes, 1 hop → packedLen = ((2-1)<<6) | 1 = 0x41. The mock stores
+      // exactly what addOrUpdateContact was handed.
+      conn.addOrUpdateContact = async (...args: any[]) => {
+        const [, , , outPathLen, outPath] = args;
+        const contact = conn.contactsResponse.find((ct: any) => Buffer.from(ct.publicKey).equals(Buffer.from(KEY)));
+        contact.outPathLen = outPathLen;
+        contact.outPath = outPath;
+      };
+      const resp = await backend.sendCommand('set_out_path', { public_key: KEY_HEX, out_path: [0xa3, 0x7f], hash_bytes: 2 });
+      expect(resp.success).toBe(true);
+      expect(resp.data).toEqual(expect.objectContaining({ verified: true }));
+    });
   });
 
   it('set_contact_favorite clears flags bit 0 while preserving the upper bits', async () => {

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -1590,35 +1590,73 @@ export class MeshCoreNativeBackend extends EventEmitter {
         if (path.length % hashBytes !== 0) {
           throw new Error(`out_path length ${path.length} not a multiple of hash_bytes ${hashBytes}`);
         }
-        const contacts: any[] = await c.getContacts();
-        const contact = contacts.find((ct) => {
-          const hex = bytesToHex(ct.publicKey);
-          return hex === bytesToHex(publicKey);
+        // Expected stored `out_path_len` after the write. For hash_bytes===1
+        // the library writes a plain byte count, which equals the packed value
+        // (hash-size bits are 0). For 2/3-byte widths it's the packed encoding.
+        const hopCount = path.length / hashBytes;
+        const expectedLen = path.length === 0
+          ? 0
+          : hashBytes === 1
+            ? path.length
+            : (((hashBytes - 1) << 6) | (hopCount & 0x3f));
+
+        // #4631: CMD_ADD_UPDATE_CONTACT resolves on meshcore.js's tag-less,
+        // uncorrelated global `Ok`/`Err` ack. On a busy WiFi companion a
+        // concurrent command's `Err` cannibalises this write's ack and rejects
+        // it even though the device stored the path — the "always fails, path
+        // never set" symptom. So (a) serialize the whole read-modify-write on
+        // the shared-ack lock every other uncorrelated op uses, and (b) do NOT
+        // trust the ack: swallow a write rejection and confirm by re-reading the
+        // contact. The device's stored out_path is the ground truth — a genuine
+        // firmware reject leaves it empty and still surfaces as a failure.
+        const verified = await this.runExclusiveRadioOp(async () => {
+          const before = (await c.getContacts()) as RawDeviceContact[];
+          const contact = before.find((ct) => bytesToHex(ct.publicKey) === bytesToHex(publicKey));
+          if (!contact) throw new Error('Set-out-path target not in device contact list');
+
+          try {
+            if (hashBytes === 1) {
+              // Default width: keep the proven library path (its plain byte
+              // count == packed length when the hash-size bits are 0).
+              await c.setContactPath(contact, path);
+            } else {
+              // Multi-byte width: pack out_path_len ourselves.
+              const outPath = new Uint8Array(64);
+              outPath.set(path.subarray(0, Math.min(path.length, 64)));
+              await c.addOrUpdateContact(
+                contact.publicKey,
+                contact.type,
+                contact.flags,
+                expectedLen,
+                outPath,
+                contact.advName,
+                contact.lastAdvert,
+                contact.advLat,
+                contact.advLon,
+              );
+            }
+          } catch (writeErr) {
+            // The ack may have been a foreign `Err` (cannibalised) rather than a
+            // real device rejection — the read-back below is authoritative, so
+            // don't fail here.
+            logger.debug(
+              `[MeshCore] set_out_path write ack errored for ${bytesToHex(publicKey)} (${(writeErr as Error).message}); verifying via read-back`,
+            );
+          }
+
+          const after = (await c.getContacts()) as RawDeviceContact[];
+          const updated = after.find((ct) => bytesToHex(ct.publicKey) === bytesToHex(publicKey));
+          return !!updated
+            && updated.outPathLen === expectedLen
+            && bytesToHex(updated.outPath.subarray(0, path.length)) === bytesToHex(path);
         });
-        if (!contact) throw new Error('Set-out-path target not in device contact list');
-        if (hashBytes === 1) {
-          // Default width: keep the proven library path (its plain byte
-          // count == packed length when the hash-size bits are 0).
-          await c.setContactPath(contact, path);
-        } else {
-          // Multi-byte width: pack out_path_len ourselves.
-          const hopCount = path.length / hashBytes;
-          const packedLen = path.length === 0 ? 0 : (((hashBytes - 1) << 6) | (hopCount & 0x3f));
-          const outPath = new Uint8Array(64);
-          outPath.set(path.subarray(0, Math.min(path.length, 64)));
-          await c.addOrUpdateContact(
-            contact.publicKey,
-            contact.type,
-            contact.flags,
-            packedLen,
-            outPath,
-            contact.advName,
-            contact.lastAdvert,
-            contact.advLat,
-            contact.advLon,
-          );
+
+        if (!verified) {
+          // Read-back shows the device did not persist the path — a genuine
+          // failure (not a lost ack). Surfaced to the caller as a hard error.
+          throw new Error('set_out_path not confirmed on device: read-back shows the path was not stored');
         }
-        return { ok: true };
+        return { ok: true, verified: true };
       }
 
       case 'set_contact_favorite': {


### PR DESCRIPTION
Fixes #4631 (follow-up to #4625/#4628).

## Diagnosis (evidence in code)
Setting a MeshCore contact's forward path (`CMD_ADD_UPDATE_CONTACT`, opcode 9) resolves on meshcore.js's **global, tag-less `Ok`/`Err` ack** (`connection.js:1367-1396`) — nothing ties a reply frame to the command that sent it. MeshMonitor built `runExclusiveRadioOp` (`meshcoreNativeBackend.ts`) precisely to serialize such uncorrelated-ack ops, and wraps **every** one — `discover_nodes`, `discover_path`, `request_regions`, `trace_path`, telemetry — **except `set_out_path`**, which fired unguarded, concurrently with poller/Analyzer traffic. On a busy **WiFi** companion a concurrent command's `Err` cannibalises the write's ack and false-rejects it → the reported *"always errors, path never set."*

The competing "large-frame fragmentation over TCP" theory is **not supported**: the inbound reassembly loops in `tcp_connection.js` and `serial_connection.js` are byte-identical (length-prefixed, accumulate-across-reads), and outbound writes are single un-chunked calls. Any real fragmentation weakness would be firmware-side, outside this repo — and the read-back below diagnoses that case too.

## Fix (backend `set_out_path` case only)
1. **Serialize** the read-modify-write on `runExclusiveRadioOp`, matching every sibling uncorrelated-ack op.
2. **Stop trusting the ack.** Swallow a write rejection and **confirm by re-reading the contact** from the device, comparing its stored `out_path`/`out_path_len` to what we sent. The device's stored value is ground truth:
   - lost/foreign `Err` but the path actually landed → now **succeeds**;
   - genuine firmware reject → stored path stays empty → **honest "not confirmed on device" failure** (also diagnoses a real firmware-side rejection).

No manager-layer change needed — a genuine read-back failure surfaces through the existing reject path; the ack-timeout optimistic mirror is unaffected.

## Tests
- clean-ack success; **ack ERRORED but device stored it → success** (the #4631 bug); device did not store it → honest failure; 2-byte hash-width packing verified via read-back. The mock now applies writes so read-back is exercised.
- 331 MeshCore server tests green; typecheck + lint clean.

> Note: this is a diagnosis-to-test, not a hardware-confirmed root cause — I can't run it against the reporter's Heltec WiFi rig. The read-back makes the behaviour truthful regardless of which mechanism dominates, and its failure message will tell the reporter definitively whether the write is landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)