### PR TITLE
chore(release): 4.15.2-rc3

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.15.2-rc2",
+  "version": "4.15.2-rc3",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.15.2-rc2",
+  "version": "4.15.2-rc3",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.15.2-rc2
-appVersion: "4.15.2-rc2"
+version: 4.15.2-rc3
+appVersion: "4.15.2-rc3"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.2-rc2",
+  "version": "4.15.2-rc3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.15.2-rc2",
+      "version": "4.15.2-rc3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.2-rc2",
+  "version": "4.15.2-rc3",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump to `4.15.2-rc3` across all five files (package.json, package-lock.json, helm Chart.yaml, tauri.conf.json, desktop/package.json).

Rolls up everything merged since rc2: #4884, #4886, #4902, #4901, #4904, #4905, #4906.

`system-test` label applied (release version-bump chore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)