### PR TITLE
feat(map): unified map controls sidebar — Phase 1 (DashboardMap) (#4909)

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -396,18 +396,19 @@ describe('DashboardMap', () => {
     expect(screen.getByText('Show Traceroute')).toBeInTheDocument();
   });
 
-  it('hides the Features panel toggles when the collapse button is clicked', () => {
+  it('collapses the map controls sidebar when the collapse button is clicked (#4909)', () => {
     render(<DashboardMap {...defaultProps} />);
-    fireEvent.click(screen.getByTitle('Collapse controls'));
+    fireEvent.click(screen.getByTitle('Hide Map controls'));
     expect(screen.queryByText('Show Traceroute')).not.toBeInTheDocument();
-    expect(screen.getByText('Features')).toBeInTheDocument();
+    // Collapsed → only the reopen toggle remains.
+    expect(screen.getByTitle('Show Map controls')).toBeInTheDocument();
   });
 
-  it('restores a collapsed Features panel from localStorage (shared with the NodesTab map)', () => {
-    localStorage.setItem('isMapControlsCollapsed', 'true');
+  it('restores the collapsed sidebar from localStorage (#4909)', () => {
+    localStorage.setItem('mm-dashboard-map-sidebar', 'true');
     render(<DashboardMap {...defaultProps} />);
     expect(screen.queryByText('Show Traceroute')).not.toBeInTheDocument();
-    fireEvent.click(screen.getByTitle('Expand controls'));
+    fireEvent.click(screen.getByTitle('Show Map controls'));
     expect(screen.getByText('Show Traceroute')).toBeInTheDocument();
   });
 

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -1088,7 +1088,7 @@ export default function DashboardMap({
           </>
         </div>
         {/* Hops legend + tileset picker now live in the same sidebar (#4909). */}
-        {showLegend && <MapLegend />}
+        {showLegend && <MapLegend embedded />}
         {showTileSelector && (
           <TilesetSelector selectedTilesetId={tilesetId} onTilesetChange={setMapTileset} embedded />
         )}

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -1090,7 +1090,7 @@ export default function DashboardMap({
         {/* Hops legend + tileset picker now live in the same sidebar (#4909). */}
         {showLegend && <MapLegend />}
         {showTileSelector && (
-          <TilesetSelector selectedTilesetId={tilesetId} onTilesetChange={setMapTileset} />
+          <TilesetSelector selectedTilesetId={tilesetId} onTilesetChange={setMapTileset} embedded />
         )}
       </MapSidebar>
 

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -54,6 +54,7 @@ import { resolveMapEndpoint } from '../../utils/nodeHelpers';
 import api from '../../services/api';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { BaseMap } from '../map/BaseMap';
+import { MapSidebar } from '../map/MapSidebar';
 import { Map3DView } from '../map/Map3DView';
 import type { Node3DFeature } from '../map/Base3DMap';
 import { TilesetSelector } from '../TilesetSelector';
@@ -251,15 +252,10 @@ export default function DashboardMap({
   // Collapse the Features panel — shares the NodesTab map's localStorage key
   // so the preference is unified across every map surface (issue #3912: on
   // mobile the panel's full checkbox list has no way to be dismissed).
-  const [isMapControlsCollapsed, setIsMapControlsCollapsed] = useState(
-    () => localStorage.getItem('isMapControlsCollapsed') === 'true',
-  );
+  // Collapse state now lives in MapSidebar (its own persisted toggle, #4909).
   // Monotonic counter driving the "Zoom to fit" button (#4898); each click
   // increments it so a re-frame fires even when the node set is unchanged.
   const [fitRequest, setFitRequest] = useState(0);
-  useEffect(() => {
-    localStorage.setItem('isMapControlsCollapsed', String(isMapControlsCollapsed));
-  }, [isMapControlsCollapsed]);
 
   // #3636: node-to-node LOS distance measurement tool.
   const [measureActive, setMeasureActive] = useState(false);
@@ -787,9 +783,6 @@ export default function DashboardMap({
             }}
             onUnsupported={() => setViewMode('2d')}
           />
-          {showTileSelector && (
-            <TilesetSelector selectedTilesetId={tilesetId} onTilesetChange={setMapTileset} />
-          )}
         </>
       ) : (
       <BaseMap
@@ -799,8 +792,6 @@ export default function DashboardMap({
         customTilesets={customTilesets}
         styleJson={activeStyleJson ?? undefined}
         zoomControl
-        showTilesetSelector={showTileSelector}
-        onTilesetChange={setMapTileset}
       >
         {measureActive && (
           <MeasureDistanceController
@@ -812,8 +803,6 @@ export default function DashboardMap({
 
         <MapBoundsUpdater positions={nodePositions} sourceId={sourceId} skip={hasConfiguredDefaultCenter} />
         <FitAllNodesController request={fitRequest} positions={nodePositions} />
-
-        {showLegend && <MapLegend />}
 
         {geoJsonLayers.length > 0 && <GeoJsonOverlay layers={geoJsonLayers} />}
 
@@ -894,9 +883,10 @@ export default function DashboardMap({
         </div>
       )}
 
-      {/* Map Features control panel — mirrors NodesTab's "Features" panel but
-          trimmed to the toggles meaningful on a cross-source map. */}
-      <div className={`map-controls dashboard-map-controls ${isMapControlsCollapsed ? 'collapsed' : ''}`}>
+      {/* Unified map controls sidebar (#4909): Features toggles + Hops legend +
+          tileset picker in one collapsible right-edge panel (full-screen on
+          mobile) instead of independently-floating, overlapping panels. */}
+      <MapSidebar storageKey="mm-dashboard-map-sidebar" title="Map controls">
         <div className="map-controls-body">
           <div className="map-controls-header">
             <div className="map-controls-title">Features</div>
@@ -916,15 +906,7 @@ export default function DashboardMap({
             >
               <UiIcon name="fitBounds" size={16} />
             </button>
-            <button
-              className="map-controls-collapse-btn"
-              onClick={() => setIsMapControlsCollapsed(!isMapControlsCollapsed)}
-              title={isMapControlsCollapsed ? 'Expand controls' : 'Collapse controls'}
-            >
-              <UiIcon name={isMapControlsCollapsed ? 'chevronDown' : 'chevronUp'} size={16} />
-            </button>
           </div>
-          {!isMapControlsCollapsed && (
           <>
           {/* #3636: node-to-node LOS distance measurement toggle. Needs at least
               two positioned nodes to be meaningful. */}
@@ -1104,9 +1086,13 @@ export default function DashboardMap({
             </label>
           ))}
           </>
-          )}
         </div>
-      </div>
+        {/* Hops legend + tileset picker now live in the same sidebar (#4909). */}
+        {showLegend && <MapLegend />}
+        {showTileSelector && (
+          <TilesetSelector selectedTilesetId={tilesetId} onTilesetChange={setMapTileset} />
+        )}
+      </MapSidebar>
 
       {isLoading && <MapLoadingOverlay />}
 

--- a/src/components/MapLegend.css
+++ b/src/components/MapLegend.css
@@ -223,3 +223,17 @@
     max-width: 100%;
   }
 }
+
+/* Embedded in the unified map sidebar (#4909): inline, full column width,
+   no floating frame (the sidebar provides that). */
+.map-legend-wrapper--embedded {
+  position: static;
+  width: 100%;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+.map-legend-wrapper--embedded .map-legend {
+  width: 100%;
+  padding: 0;
+}

--- a/src/components/MapLegend.tsx
+++ b/src/components/MapLegend.tsx
@@ -35,6 +35,12 @@ interface MapLegendProps {
   /** Render the MeshCore node-type glyph legend (issue #3546). Opt-in so the
    *  Meshtastic maps that share this component are unaffected. */
   showNodeTypes?: boolean;
+  /**
+   * Render inline inside the unified map sidebar (#4909) instead of as a
+   * floating/draggable overlay: no drag wrapper, no mobile card, full column
+   * width, starts expanded (the sidebar provides the outer collapse).
+   */
+  embedded?: boolean;
 }
 
 // Default position: top-right, below the Features checkbox panel, right-aligned with it
@@ -45,11 +51,13 @@ const getDefaultPosition = () => ({
   y: 60 + 10 + 250 + 20 // header + features top + features height + gap = 340
 });
 
-const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount, showNodeTypes }) => {
+const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount, showNodeTypes, embedded = false }) => {
   const { t } = useTranslation();
   const { overlayColors } = useSettings();
   const isMobile = useIsMobileViewport();
   const [isCollapsed, setIsCollapsed] = useState(() => {
+    // Embedded in the sidebar: always start expanded (the sidebar collapses).
+    if (embedded) return false;
     const stored = localStorage.getItem('mapLegendCollapsed');
     if (stored !== null) return stored === 'true';
     // Desktop: expanded by default — the panel is draggable and sits clear of
@@ -239,6 +247,14 @@ const MapLegend: React.FC<MapLegendProps> = ({ positionHistory, unmappedCount, s
       {!isCollapsed && (isMobile ? <div className="legend-body">{legendBody}</div> : legendBody)}
     </div>
   );
+
+  // Embedded in the unified map sidebar (#4909): render inline, no drag
+  // overlay and no mobile card (the sidebar owns positioning + full-screen).
+  if (embedded) {
+    return (
+      <div className="map-legend-wrapper map-legend-wrapper--embedded">{panel}</div>
+    );
+  }
 
   // Mobile: a docked, tap-to-expand card instead of the draggable overlay
   // (#4389). `.map-legend-wrapper` used to be `display: none` here while the

--- a/src/components/TilesetSelector.css
+++ b/src/components/TilesetSelector.css
@@ -209,3 +209,30 @@
     max-width: 70px;
   }
 }
+
+/* Embedded in the unified map sidebar (#4909): fit the column, drop the
+   floating panel's own frame (the sidebar provides that). */
+.tileset-selector-wrapper--embedded {
+  position: static;
+  width: 100%;
+}
+.tileset-selector-wrapper--embedded .tileset-selector {
+  width: 100%;
+  padding: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+.tileset-selector-wrapper--embedded .tileset-buttons {
+  grid-template-columns: repeat(2, 1fr);
+}
+.tileset-selector-wrapper--embedded .tileset-button {
+  min-width: 0;
+}
+.tileset-selector-wrapper--embedded .tileset-preview {
+  width: 100%;
+  height: 48px;
+}
+.tileset-selector-wrapper--embedded .tileset-name {
+  max-width: 100%;
+}

--- a/src/components/TilesetSelector.tsx
+++ b/src/components/TilesetSelector.tsx
@@ -10,6 +10,12 @@ import './TilesetSelector.css';
 interface TilesetSelectorProps {
   selectedTilesetId: TilesetId;
   onTilesetChange: (tilesetId: TilesetId) => void;
+  /**
+   * Render inline inside the unified map sidebar (#4909) instead of as a
+   * floating/draggable overlay: no drag wrapper, no mobile bottom-sheet, and
+   * the card grid reflows to fit the sidebar column width. Starts expanded.
+   */
+  embedded?: boolean;
 }
 
 // Default position: top-left, aligned with top of node list, shifted right past node list
@@ -22,12 +28,15 @@ const getDefaultPosition = () => ({
 
 export const TilesetSelector: React.FC<TilesetSelectorProps> = ({
   selectedTilesetId,
-  onTilesetChange
+  onTilesetChange,
+  embedded = false,
 }) => {
   const { t } = useTranslation();
   const { customTilesets, activeMapTilesetMode } = useSettings();
   const tilesets = getAllTilesets(customTilesets);
-  const [isCollapsed, setIsCollapsed] = useState(true);
+  // Floating overlay starts collapsed; embedded-in-sidebar starts expanded
+  // (the sidebar itself provides the outer collapse).
+  const [isCollapsed, setIsCollapsed] = useState(!embedded);
   const isMobile = useIsMobileViewport();
 
   const title =
@@ -81,6 +90,17 @@ export const TilesetSelector: React.FC<TilesetSelectorProps> = ({
       )}
     </div>
   );
+
+  // Embedded in the unified map sidebar (#4909): render the panel inline (the
+  // sidebar handles positioning + mobile full-screen), reflowed to fit the
+  // column. No drag overlay, no separate bottom-sheet.
+  if (embedded) {
+    return (
+      <div className="tileset-selector-wrapper tileset-selector-wrapper--embedded">
+        {panel}
+      </div>
+    );
+  }
 
   // Mobile: a full-width bottom sheet instead of the draggable overlay (#4380).
   // Dragging a floating panel around a phone screen is not useful, and the

--- a/src/components/map/BaseMap.tsx
+++ b/src/components/map/BaseMap.tsx
@@ -5,6 +5,7 @@ import { getTilesetById, DEFAULT_TILESET_ID, type TilesetId, type CustomTileset 
 import { VectorTileLayer } from '../VectorTileLayer';
 import { TilesetSelector } from '../TilesetSelector';
 import MapResizeHandler from '../MapResizeHandler';
+import { MapSidebar } from './MapSidebar';
 import './leafletDefaultIcon';
 import './BaseMap.css';
 
@@ -54,6 +55,16 @@ export interface BaseMapProps {
   /** Markers, draw handlers, overlays, useMap-based controllers. Rendered
    *  inside MapContainer, after the tile layer. */
   children?: ReactNode;
+
+  // ---- Unified controls sidebar (#4909) ----------------------------------
+  /** Map control panels (legend, feature toggles, tileset picker) to stack in
+   *  a single collapsible right-edge sidebar. Rendered as a sibling overlay
+   *  after MapContainer. Omit ⇒ no sidebar. */
+  sidebar?: ReactNode;
+  /** localStorage key for the sidebar's collapsed state (per surface). */
+  sidebarStorageKey?: string;
+  /** Sidebar header/accessible label. */
+  sidebarTitle?: string;
 }
 
 /**
@@ -106,6 +117,9 @@ export function BaseMap({
   resizeTrigger,
   mapRef,
   children,
+  sidebar,
+  sidebarStorageKey,
+  sidebarTitle,
 }: BaseMapProps) {
   const resolvedId = tilesetId ?? DEFAULT_TILESET_ID;
   const tileset = getTilesetById(resolvedId, customTilesets ?? []);
@@ -188,6 +202,11 @@ export function BaseMap({
           selectedTilesetId={resolvedId}
           onTilesetChange={onTilesetChange ?? (() => {})}
         />
+      )}
+      {sidebar && (
+        <MapSidebar storageKey={sidebarStorageKey} title={sidebarTitle}>
+          {sidebar}
+        </MapSidebar>
       )}
     </>
   );

--- a/src/components/map/MapSidebar.css
+++ b/src/components/map/MapSidebar.css
@@ -1,0 +1,109 @@
+/* Unified map controls sidebar (#4909). Right-edge, collapsible, scrollable;
+   full-screen sheet on mobile. Absolutely positioned within the map wrapper
+   (each map pane is position:relative). */
+
+.map-sidebar {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  bottom: 10px;
+  z-index: 1000; /* above Leaflet panes (which top out ~700) */
+  width: 300px;
+  max-width: calc(100% - 20px);
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-hover);
+  border-radius: var(--radius-md, 8px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+}
+
+.map-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-bg-raised, var(--color-surface));
+  border-bottom: 1px solid var(--color-surface-hover);
+  flex-shrink: 0;
+}
+
+.map-sidebar-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+.map-sidebar-collapse-btn,
+.map-sidebar-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-surface-active);
+  color: var(--color-text);
+  border-radius: var(--radius-sm, 6px);
+  cursor: pointer;
+  padding: 0.25rem;
+  transition: background 0.15s, color 0.15s;
+}
+
+.map-sidebar-collapse-btn:hover,
+.map-sidebar-toggle:hover {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-accent-text);
+}
+
+/* The collapsed affordance: a small floating button in the same corner. */
+.map-sidebar-toggle {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 1000;
+  width: 34px;
+  height: 34px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+
+/* Scrollable stack of the control panels. Children (legend, features, tileset)
+   sit flush in the column, separated by a divider. */
+.map-sidebar-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* Neutralize the absolute/floating positioning of legacy panels once they live
+   inside the sidebar column — they become normal stacked blocks. */
+.map-sidebar-body > * {
+  position: static !important;
+  inset: auto !important;
+  margin: 0 !important;
+  max-width: 100% !important;
+  box-shadow: none !important;
+}
+
+.map-sidebar-body > * + * {
+  border-top: 1px solid var(--color-surface-hover);
+  padding-top: 0.75rem;
+}
+
+/* Mobile: the open sidebar takes over the viewport as a full-screen sheet. */
+@media (max-width: 768px) {
+  .map-sidebar {
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    max-width: 100%;
+    border-radius: 0;
+    border: none;
+  }
+}

--- a/src/components/map/MapSidebar.css
+++ b/src/components/map/MapSidebar.css
@@ -24,7 +24,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem 0.75rem;
-  background: var(--color-bg-raised, var(--color-surface));
+  background: var(--color-bg-raised);
   border-bottom: 1px solid var(--color-surface-hover);
   flex-shrink: 0;
 }

--- a/src/components/map/MapSidebar.test.tsx
+++ b/src/components/map/MapSidebar.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #4909: the unified map controls sidebar shell — collapse/expand + persistence.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MapSidebar } from './MapSidebar';
+
+describe('MapSidebar (#4909)', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('renders its children stacked in the panel by default', () => {
+    render(<MapSidebar><div>Legend</div><div>Features</div></MapSidebar>);
+    expect(screen.getByText('Legend')).toBeTruthy();
+    expect(screen.getByText('Features')).toBeTruthy();
+  });
+
+  it('collapses to a toggle button and restores, persisting the state', () => {
+    const { unmount } = render(
+      <MapSidebar storageKey="mm-test-sidebar"><div>Legend</div></MapSidebar>,
+    );
+    // Collapse via the header close button.
+    fireEvent.click(screen.getByLabelText(/Hide/));
+    expect(screen.queryByText('Legend')).toBeNull();
+    expect(localStorage.getItem('mm-test-sidebar')).toBe('true');
+
+    // A fresh mount reads the persisted collapsed state.
+    unmount();
+    render(<MapSidebar storageKey="mm-test-sidebar"><div>Legend</div></MapSidebar>);
+    expect(screen.queryByText('Legend')).toBeNull();
+    // Expand again.
+    fireEvent.click(screen.getByLabelText(/Show/));
+    expect(screen.getByText('Legend')).toBeTruthy();
+    expect(localStorage.getItem('mm-test-sidebar')).toBe('false');
+  });
+});

--- a/src/components/map/MapSidebar.test.tsx
+++ b/src/components/map/MapSidebar.test.tsx
@@ -3,17 +3,41 @@
  *
  * #4909: the unified map controls sidebar shell — collapse/expand + persistence.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MapSidebar } from './MapSidebar';
 
-describe('MapSidebar (#4909)', () => {
-  beforeEach(() => localStorage.clear());
+// Control the viewport-size hook so mobile-vs-desktop defaults are testable
+// without a real matchMedia (jsdom lacks it).
+let mockIsMobile = false;
+vi.mock('../../hooks/useIsMobileViewport', () => ({
+  useIsMobileViewport: () => mockIsMobile,
+}));
 
-  it('renders its children stacked in the panel by default', () => {
+describe('MapSidebar (#4909)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockIsMobile = false;
+  });
+
+  it('renders its children stacked in the panel by default (desktop)', () => {
     render(<MapSidebar><div>Legend</div><div>Features</div></MapSidebar>);
     expect(screen.getByText('Legend')).toBeTruthy();
     expect(screen.getByText('Features')).toBeTruthy();
+  });
+
+  it('starts collapsed on mobile with no saved preference (#4909)', () => {
+    mockIsMobile = true;
+    render(<MapSidebar storageKey="mm-test-mobile"><div>Legend</div></MapSidebar>);
+    expect(screen.queryByText('Legend')).toBeNull();
+    expect(screen.getByTitle(/Show/)).toBeTruthy();
+  });
+
+  it('honors a saved expanded preference even on mobile', () => {
+    mockIsMobile = true;
+    localStorage.setItem('mm-test-mobile2', 'false');
+    render(<MapSidebar storageKey="mm-test-mobile2"><div>Legend</div></MapSidebar>);
+    expect(screen.getByText('Legend')).toBeTruthy();
   });
 
   it('collapses to a toggle button and restores, persisting the state', () => {

--- a/src/components/map/MapSidebar.tsx
+++ b/src/components/map/MapSidebar.tsx
@@ -1,0 +1,87 @@
+import { useState, type ReactNode } from 'react';
+import { UiIcon } from '../icons';
+import './MapSidebar.css';
+
+/**
+ * Unified, collapsible map controls sidebar (#4909).
+ *
+ * Replaces the independently-floating map panels (Hops legend, Features
+ * checklist, Tileset picker) that overlapped each other and the map. Consumers
+ * pass those panels as children; this shell stacks them in a single scrollable,
+ * right-edge column with one collapse toggle.
+ *
+ * - Desktop: a right-edge panel; the toggle collapses it to a small ☰ button,
+ *   with the collapsed state persisted per `storageKey`.
+ * - Mobile (≤768px, handled in CSS): the open panel takes over the viewport as
+ *   a full-screen sheet; the same toggle dismisses it back to the ☰ button.
+ *
+ * Presentational only — it owns layout/collapse, not the controls' content.
+ */
+export interface MapSidebarProps {
+  children: ReactNode;
+  /** localStorage key for the collapsed state (per surface, so views are independent). */
+  storageKey?: string;
+  /** Accessible label / header text. */
+  title?: string;
+}
+
+export function MapSidebar({
+  children,
+  storageKey = 'mm-map-sidebar-collapsed',
+  title = 'Map controls',
+}: MapSidebarProps) {
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(storageKey) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  const toggle = () =>
+    setCollapsed((c) => {
+      const next = !c;
+      try {
+        localStorage.setItem(storageKey, String(next));
+      } catch {
+        /* storage unavailable (private mode) — collapse still works in-memory */
+      }
+      return next;
+    });
+
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        className="map-sidebar-toggle"
+        onClick={toggle}
+        title={`Show ${title}`}
+        aria-label={`Show ${title}`}
+        aria-expanded={false}
+      >
+        <UiIcon name="menu" size={18} />
+      </button>
+    );
+  }
+
+  return (
+    <aside className="map-sidebar" role="region" aria-label={title}>
+      <div className="map-sidebar-header">
+        <span className="map-sidebar-title">{title}</span>
+        <button
+          type="button"
+          className="map-sidebar-collapse-btn"
+          onClick={toggle}
+          title={`Hide ${title}`}
+          aria-label={`Hide ${title}`}
+          aria-expanded={true}
+        >
+          <UiIcon name="close" size={16} />
+        </button>
+      </div>
+      <div className="map-sidebar-body">{children}</div>
+    </aside>
+  );
+}
+
+export default MapSidebar;

--- a/src/components/map/MapSidebar.tsx
+++ b/src/components/map/MapSidebar.tsx
@@ -1,5 +1,6 @@
 import { useState, type ReactNode } from 'react';
 import { UiIcon } from '../icons';
+import { useIsMobileViewport } from '../../hooks/useIsMobileViewport';
 import './MapSidebar.css';
 
 /**
@@ -30,12 +31,17 @@ export function MapSidebar({
   storageKey = 'mm-map-sidebar-collapsed',
   title = 'Map controls',
 }: MapSidebarProps) {
+  const isMobile = useIsMobileViewport();
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try {
-      return localStorage.getItem(storageKey) === 'true';
+      const stored = localStorage.getItem(storageKey);
+      if (stored !== null) return stored === 'true';
     } catch {
-      return false;
+      /* storage unavailable — fall through to the viewport default */
     }
+    // No saved preference: mobile starts collapsed (the open panel is a
+    // full-screen sheet over the map), desktop starts expanded (#4909).
+    return isMobile;
   });
 
   const toggle = () =>


### PR DESCRIPTION
Phase 1 of the map-controls consolidation epic (#4909): replace the independently-floating map panels (Features checklist, Hops legend, Tileset picker) — which overlapped each other and the map — with one **collapsible, scrollable right-edge sidebar** (full-screen sheet on mobile). This PR builds the reusable foundation and migrates the **Dashboard / Unified map**; NodesTab, MapAnalysis, and MeshCore follow in subsequent PRs.

## Foundation
- **`MapSidebar`** (`src/components/map/MapSidebar.tsx`) — right-edge panel with a single collapse toggle (☰), scrollable stacked body; **full-screen on mobile**; collapsed state persisted per `storageKey`. Starts **collapsed on mobile** (no saved pref), expanded on desktop.
- **`BaseMap` `sidebar` slot** — optional `sidebar` prop rendered as a sibling overlay (for the BaseMap-only views migrating later).

## DashboardMap migration
- Features toggles, Hops legend, and tileset picker now live in the sidebar; the standalone `.map-controls` panel, the in-map `MapLegend` child, and the two floating `TilesetSelector`s (2D + 3D) are removed. Zoom-to-fit stays as a header action. The old `isMapControlsCollapsed` state is gone (the sidebar owns collapse).
- **Embedded modes:** `TilesetSelector` and `MapLegend` each gain an `embedded` prop that drops their floating/draggable chrome, start expanded, and reflow to the column (tileset → 2-col grid, full-width previews).

## Tests
- New `MapSidebar.test.tsx` (collapse/expand + persistence + mobile-collapsed default).
- Updated DashboardMap collapse tests to the sidebar mechanism.
- Suites green (MapSidebar/TilesetSelector/MapLegend/DashboardMap: 60+ tests); source tsc + `lint:ci` clean.

## Verified

Built and deployed locally; confirmed on desktop (right-edge collapsible sidebar with Features + legend + tileset, no overlap) and mobile (starts as ☰, opens full-screen).

## Scope

Phase 1 of 4. Follow-ups: migrate NodesTab, MapAnalysis, MeshCore to the same sidebar via the BaseMap slot / MapSidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)