### PR TITLE
fix(automation): treat a self-targeted deviceReboot as a local reboot (#4847)

### DIFF
--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -706,7 +706,7 @@ export const ACTIONS: BlockDef[] = [
     description: 'Reboot the physical device — e.g. reinitialize a flaky BLE bridge or MQTT proxy on a daily schedule.',
     fields: [
       { name: 'sourceIds', label: 'Reboot which node(s)', kind: 'sendSourceMulti', help: 'The connected node(s) to reboot. Leave none to use the source that triggered the automation — but a source IS required for source-less triggers like Schedules and System events. (MQTT sources have no physical device and are excluded.)' },
-      { name: 'targetNodeNum', label: 'Remote target node #', kind: 'nodeNum', advanced: true, placeholder: 'blank = locally-connected node; 1017730782 or !3ca956de', help: 'Meshtastic remote-admin reboot: leave blank to reboot the locally-connected node; set a node number to reboot a remote node over the mesh (uses the session-passkey admin mechanism — the target must have granted admin access). Accepts a decimal node number or a hex id (!3ca956de). Ignored by MeshCore.' },
+      { name: 'targetNodeNum', label: 'Remote target node #', kind: 'nodeNum', advanced: true, placeholder: 'blank = locally-connected node; 1017730782 or !3ca956de', help: 'Meshtastic remote-admin reboot: leave blank to reboot the locally-connected node; set a node number to reboot a remote node over the mesh (uses the session-passkey admin mechanism — the target must have granted admin access). Setting the connected node’s own number is treated as a local reboot, not a remote one. Accepts a decimal node number or a hex id (!3ca956de). Ignored by MeshCore.' },
       { name: 'seconds', label: 'Reboot delay (seconds)', kind: 'number', advanced: true, placeholder: '10', help: 'Meshtastic: how long the device waits before rebooting (default 10s). Ignored by MeshCore.' },
     ],
   },

--- a/src/server/services/automation/meshActionDeps.test.ts
+++ b/src/server/services/automation/meshActionDeps.test.ts
@@ -367,4 +367,35 @@ describe('createMeshActionDeps rebootDevice — device reboot action (#3995)', (
     await expect(deps.rebootDevice({ sourceId: 'mc', targetNodeNum: 42 }))
       .rejects.toThrow(/remote-admin reboot \(Meshtastic sources only\)/);
   });
+
+  // ── self-target collapses to the local path (#4847) ─────────────────────────
+  it('with a targetNodeNum equal to the source own node, uses the local rebootDevice not sendRebootCommand', async () => {
+    // A directly-connected (e.g. BLE-bridged) node targeted by its own nodeNum is a
+    // LOCAL reboot; the remote-admin passkey handshake would stall and hang Run Now.
+    const sendRebootCommand = vi.fn().mockResolvedValue(undefined);
+    const rebootDevice = vi.fn().mockResolvedValue(undefined);
+    const getLocalNodeInfo = vi.fn().mockReturnValue({ nodeNum: 123456789 });
+    getManager.mockReturnValue({ sendTextMessage: vi.fn(), sendRebootCommand, rebootDevice, getLocalNodeInfo });
+    const deps = createMeshActionDeps();
+
+    const result = await deps.rebootDevice({ sourceId: 'mt', seconds: 15, targetNodeNum: 123456789 });
+
+    expect(rebootDevice).toHaveBeenCalledWith(15);
+    expect(sendRebootCommand).not.toHaveBeenCalled();
+    expect(result).toEqual({ rebooted: true });
+  });
+
+  it('with a targetNodeNum for a DIFFERENT node, still uses the remote sendRebootCommand', async () => {
+    const sendRebootCommand = vi.fn().mockResolvedValue(undefined);
+    const rebootDevice = vi.fn().mockResolvedValue(undefined);
+    const getLocalNodeInfo = vi.fn().mockReturnValue({ nodeNum: 111 });
+    getManager.mockReturnValue({ sendTextMessage: vi.fn(), sendRebootCommand, rebootDevice, getLocalNodeInfo });
+    const deps = createMeshActionDeps();
+
+    const result = await deps.rebootDevice({ sourceId: 'mt', seconds: 20, targetNodeNum: 222 });
+
+    expect(sendRebootCommand).toHaveBeenCalledWith(222, 20);
+    expect(rebootDevice).not.toHaveBeenCalled();
+    expect(result).toEqual({ rebooted: true, targetNodeNum: 222 });
+  });
 });

--- a/src/server/services/automation/meshActionDeps.ts
+++ b/src/server/services/automation/meshActionDeps.ts
@@ -244,8 +244,8 @@ export function createMeshActionDeps(): ActionDeps {
           throw new Error(`source "${sourceId}" cannot send a remote-admin reboot (Meshtastic sources only)`);
         }
         // sendRebootCommand defaults `seconds` to 10 when undefined.
-        await (seconds != null ? raw.sendRebootCommand(targetNodeNum, seconds) : raw.sendRebootCommand(targetNodeNum));
-        return { rebooted: true, targetNodeNum };
+        await (seconds != null ? raw.sendRebootCommand(effectiveTarget, seconds) : raw.sendRebootCommand(effectiveTarget));
+        return { rebooted: true, targetNodeNum: effectiveTarget };
       }
 
       if (!raw || typeof raw.rebootDevice !== 'function') {

--- a/src/server/services/automation/meshActionDeps.ts
+++ b/src/server/services/automation/meshActionDeps.ts
@@ -218,13 +218,28 @@ export function createMeshActionDeps(): ActionDeps {
       const raw = resolveManager(sourceId) as {
         rebootDevice?: (seconds?: number) => Promise<unknown>;
         sendRebootCommand?: (destinationNodeNum: number, seconds?: number) => Promise<unknown>;
+        getLocalNodeInfo?: () => { nodeNum: number } | null;
       } | undefined;
+
+      // #4847: a `targetNodeNum` that names the source's OWN connected node is not
+      // a remote-admin request — it's a local reboot the UI happened to fill in.
+      // The remote-admin path (`sendRebootCommand`) does a session-passkey handshake
+      // that stalls on a directly-connected (e.g. BLE-bridged) node, so the Run Now
+      // request hangs and the browser reports "Load failed". Collapse self-targets
+      // to the local path, which matches the per-source admin reboot button.
+      let effectiveTarget = targetNodeNum;
+      if (effectiveTarget != null && typeof raw?.getLocalNodeInfo === 'function') {
+        const ownNodeNum = raw.getLocalNodeInfo()?.nodeNum;
+        if (ownNodeNum != null && Number(ownNodeNum) === Number(effectiveTarget)) {
+          effectiveTarget = undefined;
+        }
+      }
 
       // #4126: remote-admin reboot. When a target node is specified, reboot that
       // node over the mesh via the Meshtastic session-passkey admin mechanism
       // (`sendRebootCommand`). This is Meshtastic-only — MeshCore managers have no
       // such method, so a target on a MeshCore source is a clear error.
-      if (targetNodeNum != null) {
+      if (effectiveTarget != null) {
         if (!raw || typeof raw.sendRebootCommand !== 'function') {
           throw new Error(`source "${sourceId}" cannot send a remote-admin reboot (Meshtastic sources only)`);
         }


### PR DESCRIPTION
Fixes #4847.

## Problem
Automation `action.deviceReboot` via **Run Now** fails with "Load failed" for a directly-connected (BLE-bridged) device, while the per-source admin reboot button on the Radio Configuration page works for the same node.

## Root cause
When the automation's `targetNodeNum` names the source's **own** connected node, `meshActionDeps.rebootDevice` took the **remote-admin** path (`sendRebootCommand`). That path does a Meshtastic session-passkey handshake, which stalls on a directly-connected node that isn't cleanly reachable as a *remote* mesh-admin target. `POST /:id/run-now` awaits the whole dispatch, so the request hung past the browser's fetch timeout — surfacing WebKit's generic `TypeError: Load failed` (a network-level failure, not a JSON error from the server).

The admin button never hit this because it always calls the fire-and-forget **local** `rebootDevice(seconds)` path.

## Change
- `src/server/services/automation/meshActionDeps.ts`: before dispatching, if `targetNodeNum` equals the source's own `getLocalNodeInfo().nodeNum`, collapse it to the local reboot path (matching the admin button). Remote reboots of *other* nodes are unchanged; MeshCore behavior is unchanged.
- `src/components/automations/catalog.ts`: clarify the target-node help text that the connected node's own number is treated as a local reboot.

## Mesh impact
None — this does not add or increase any sends. It routes an existing single reboot through the local admin path instead of the remote-admin path (strictly fewer packets: no passkey exchange).

## Tests
Two regression cases in `meshActionDeps.test.ts`: self-target → local `rebootDevice`; different target → remote `sendRebootCommand`. Full file suite: 29/29 passing (`success: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)