### PR TITLE
feat(map): migrate MapAnalysis floating panels into the unified sidebar (#4909)

### DIFF
--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -337,8 +337,12 @@ export default function MapAnalysisCanvas() {
         tilesetId={mapTileset}
         customTilesets={customTilesets}
         styleJson={activeStyleJson ?? undefined}
-        showTilesetSelector
-        onTilesetChange={setMapTileset}
+        sidebar={
+          <>
+            <MapLegend />
+            <TilesetSelector selectedTilesetId={mapTileset} onTilesetChange={setMapTileset} embedded />
+          </>
+        }
       >
         <MapViewStateController />
         <FollowController />
@@ -422,7 +426,6 @@ export default function MapAnalysisCanvas() {
         </Pane>
       </BaseMap>
       <TimeSliderControl />
-      <MapLegend />
       <FollowResumeButton />
       <LinkProfileDrawer />
       <SitePlannerPanel


### PR DESCRIPTION
## Summary
Phase 3 of the #4909 map-sidebar epic. The **Map Analysis** surface keeps its docked analysis toolbar, but its two floating panels — the Hops **legend** and the **tileset picker** — now live in the shared, collapsible `MapSidebar` (right edge) via the `BaseMap` `sidebar` slot on the 2D map.

- 2D `BaseMap`: `sidebar={<><MapLegend /><TilesetSelector … embedded /></>}`. The legend renders inline (the sidebar CSS neutralizes its float and starts expanded); the tileset uses `embedded` mode.
- Removed the floating `TilesetSelector` overlay (`showTilesetSelector`/`onTilesetChange`) and the sibling `<MapLegend />`.
- 3D branch keeps its single floating tileset — already a documented reduced-control special case from the 3D epic (#3826).
- Docked `MapAnalysisToolbar` is untouched (it's not a floating panel).

## Test
- `npx tsc` clean; MapAnalysis suite 314/0; full vitest suite **16,339/0** (incl. the `semanticTokens` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)