### PR TITLE
feat(map): migrate MeshCore map floating panels into the unified sidebar (#4909)

### DIFF
--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -26,6 +26,8 @@ import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import GeoJsonOverlay from '../GeoJsonOverlay';
 import type { GeoJsonLayer } from '../../server/services/geojsonService.js';
 import MapLegend from '../MapLegend';
+import { TilesetSelector } from '../TilesetSelector';
+import { MapSidebar } from '../map/MapSidebar';
 import MeasureDistanceController from '../MeasureDistanceController';
 import type { MeasurePoint } from '../../utils/measureDistance';
 import { NodeCard } from '../map/popups/NodeCard';
@@ -488,8 +490,6 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
         tilesetId={mapTileset}
         customTilesets={customTilesets}
         styleJson={activeStyleJson ?? undefined}
-        showTilesetSelector={showTileSelector}
-        onTilesetChange={setMapTileset}
         resizeTrigger={resizeTrigger}
       >
         {measureActive && (
@@ -499,7 +499,6 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
             onExit={() => setMeasureActive(false)}
           />
         )}
-        {showLegend && <MapLegend showNodeTypes />}
         {geoJsonLayers.length > 0 && <GeoJsonOverlay layers={geoJsonLayers} />}
         {showPolarGrid && localPos && (
           <PolarGridOverlay center={{ lat: localPos[0], lng: localPos[1] }} />
@@ -534,6 +533,7 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
 
       {isLoading && <MapLoadingOverlay />}
 
+      <MapSidebar storageKey="mm-meshcore-map-sidebar" title="Map controls">
       <div className="map-controls dashboard-map-controls">
         <div className="map-controls-body">
           <div className="map-controls-title">Features</div>
@@ -665,6 +665,15 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
           ))}
         </div>
       </div>
+      {showTileSelector && (
+        <TilesetSelector
+          selectedTilesetId={mapTileset}
+          onTilesetChange={setMapTileset}
+          embedded
+        />
+      )}
+      {showLegend && <MapLegend showNodeTypes embedded />}
+      </MapSidebar>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
Phase 4 (final) of the #4909 map-sidebar epic. The **MeshCore map** was the last surface still using an independently-floating `.map-controls` overlay plus a separately-floating tileset picker and legend. All three now stack in the shared, collapsible `MapSidebar` on the right edge.

- The **Features** checklist (Measure Distance, Show Paths/Neighbors/Position History + retention, Polar Grid, node-type filters, GeoJSON layers) moves into the sidebar unchanged.
- Its **Show Tile Selection** / **Show Legend** toggles now reveal the `TilesetSelector` (`embedded`) and `MapLegend showNodeTypes` (`embedded`) as extra sidebar sections, replacing the floating tileset overlay (`showTilesetSelector`) and the in-map legend child.
- `storageKey="mm-meshcore-map-sidebar"` keeps this surface's collapsed state independent of the other maps.

This completes the epic: Dashboard (#4914), Nodes (#4919), Map Analysis (#4920), and now MeshCore all share `MapSidebar`.

## Test
- `npx tsc` clean; MeshCore suite 425/0; full vitest suite **16,339/0** (incl. the `semanticTokens` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)