### PR TITLE
fix(meshcore): release serial fd on failed connect so USB replug reconnects (#4922)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#c5900ecfe66d076d044fbcec331c0bcfbfac9e9e",
+        "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#148527002ee49b7a6977b01b925182f4a8dc515f",
         "@maplibre/maplibre-gl-leaflet": "^0.1.4",
         "@michaelhart/meshcore-decoder": "^0.3.0",
         "@tanstack/react-query": "^5.101.4",
@@ -3070,8 +3070,8 @@
     },
     "node_modules/@liamcottle/meshcore.js": {
       "version": "1.13.0",
-      "resolved": "git+ssh://git@github.com/Yeraze/meshcore.js.git#c5900ecfe66d076d044fbcec331c0bcfbfac9e9e",
-      "integrity": "sha512-yaeSODX3PM21x7pYWkw43+++Vp4zdwLo3b2JEjKhmcowgLOfBuTpPBH8dFTctPxD3DFYS77+Y5gWhyigKrVu1Q==",
+      "resolved": "git+ssh://git@github.com/Yeraze/meshcore.js.git#148527002ee49b7a6977b01b925182f4a8dc515f",
+      "integrity": "sha512-3SQTR8pR+3k9AQxNgn1e+myozm7+df/UYVWZ5Cs5GrVd4F2M4v0E76pAC/Nd7O5szfY0ET9RcMXycbTqJHH/tg==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#c5900ecfe66d076d044fbcec331c0bcfbfac9e9e",
+    "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#148527002ee49b7a6977b01b925182f4a8dc515f",
     "@maplibre/maplibre-gl-leaflet": "^0.1.4",
     "@michaelhart/meshcore-decoder": "^0.3.0",
     "@tanstack/react-query": "^5.101.4",

--- a/src/server/meshcoreNativeBackend.connectFailure.test.ts
+++ b/src/server/meshcoreNativeBackend.connectFailure.test.ts
@@ -1,0 +1,127 @@
+/**
+ * MeshCore native backend — connect-failure serial teardown (#4922).
+ *
+ * Regression guard for the USB unplug/replug lockup: when the SelfInfo
+ * handshake fails right after the transport opens (the common case right after
+ * a physical replug, while the device is still re-enumerating), the backend
+ * MUST close the underlying connection before rethrowing. Otherwise the serial
+ * fd lingers open, keeps the OS-level device-node lock, and every subsequent
+ * open on the same path fails with "Cannot lock port" until the process
+ * restarts.
+ *
+ * The library-level half of the fix (opening with lock:false + awaiting open)
+ * lives in the pinned Yeraze/meshcore.js fork; this file proves the backend's
+ * own teardown contract, which is what MeshMonitor controls directly.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import { MeshCoreNativeBackend, __setMeshCoreModule } from './meshcoreNativeBackend.js';
+
+const ResponseCodes = {
+  Ok: 0, Err: 1, ContactsStart: 2, Contact: 3, EndOfContacts: 4,
+  SelfInfo: 5, Sent: 6, ContactMsgRecv: 7, ChannelMsgRecv: 8,
+  CurrTime: 9, NoMoreMessages: 10, Stats: 24,
+};
+const PushCodes = {
+  Advert: 0x80, PathUpdated: 0x81, MsgWaiting: 0x83, NewAdvert: 0x8a,
+  BinaryResponse: 0x8c, ControlData: 0x8e,
+};
+const StatsTypes = { Core: 0, Radio: 1, Packets: 2 };
+const SelfAdvertTypes = { ZeroHop: 0, Flood: 1 };
+const BinaryRequestTypes = { GetTelemetryData: 0x03 };
+const AdvType = { None: 0, Chat: 1, Repeater: 2, Room: 3 };
+const TxtTypes = { Plain: 0, CliData: 1, SignedPlain: 2 };
+
+/**
+ * A serial connection whose transport opens but whose SelfInfo handshake
+ * rejects — the exact shape of a device that is present but not yet answering
+ * (mid-reboot after a replug). `close` is a spy so the test can assert the fd
+ * is released on the failure path.
+ */
+class HandshakeFailsConnection extends EventEmitter {
+  connect = vi.fn(async () => { /* transport opens fine */ });
+  close = vi.fn(async () => { /* releases the fd */ });
+  getSelfInfo = vi.fn(async () => {
+    throw new Error('SelfInfo timeout');
+  });
+  emit(eventName: PropertyKey, ...args: unknown[]): boolean {
+    return super.emit(eventName as string | symbol, ...args);
+  }
+}
+
+/** A connection that connects and answers SelfInfo cleanly. */
+class HappyConnection extends EventEmitter {
+  connect = vi.fn(async () => { /* ok */ });
+  close = vi.fn(async () => { /* ok */ });
+  getSelfInfo = vi.fn(async () => ({
+    type: AdvType.Chat,
+    publicKey: Uint8Array.from(Array(32).fill(0)),
+    name: 'TestNode',
+  }));
+  emit(eventName: PropertyKey, ...args: unknown[]): boolean {
+    return super.emit(eventName as string | symbol, ...args);
+  }
+}
+
+let lastConnection: HandshakeFailsConnection | HappyConnection | null = null;
+
+function installMockModule(ConnCtor: new () => EventEmitter): void {
+  // Capture the instance the backend constructs so the test can inspect it.
+  class Capturing extends ConnCtor {
+    constructor() {
+      super();
+      lastConnection = this as unknown as HandshakeFailsConnection | HappyConnection;
+    }
+  }
+  const mod = {
+    NodeJSSerialConnection: Capturing,
+    TCPConnection: Capturing,
+    Constants: {
+      ResponseCodes, PushCodes, StatsTypes, SelfAdvertTypes,
+      BinaryRequestTypes, AdvType, TxtTypes,
+    },
+    CayenneLpp: { parse: () => [] },
+    Packet: {},
+  };
+  // The real meshcore.js module is untyped; cast through `unknown` (not `any`,
+  // to satisfy the no-explicit-any ratchet) to the setter's parameter type.
+  __setMeshCoreModule(mod as unknown as Parameters<typeof __setMeshCoreModule>[0]);
+}
+
+describe('MeshCoreNativeBackend connect-failure teardown (#4922)', () => {
+  beforeEach(() => { lastConnection = null; });
+  afterEach(() => __setMeshCoreModule(null));
+
+  it('closes the serial connection and clears it when the handshake fails', async () => {
+    installMockModule(HandshakeFailsConnection);
+    const backend = new MeshCoreNativeBackend('src-4922', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+
+    await expect(backend.connect()).rejects.toThrow('SelfInfo timeout');
+
+    const conn = lastConnection as HandshakeFailsConnection;
+    expect(conn.connect).toHaveBeenCalledTimes(1);
+    // The fd MUST be released on the failure path — this is the fix.
+    expect(conn.close).toHaveBeenCalledTimes(1);
+    // And the dead connection must not linger on the backend.
+    expect((backend as unknown as { connection: unknown }).connection).toBeNull();
+    expect(backend.isConnected()).toBe(false);
+  });
+
+  it('leaves the connection open on a successful connect', async () => {
+    installMockModule(HappyConnection);
+    const backend = new MeshCoreNativeBackend('src-4922-ok', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+
+    await backend.connect();
+
+    const conn = lastConnection as HappyConnection;
+    expect(conn.connect).toHaveBeenCalledTimes(1);
+    expect(conn.close).not.toHaveBeenCalled();
+    expect(backend.isConnected()).toBe(true);
+  });
+});

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -364,24 +364,45 @@ export class MeshCoreNativeBackend extends EventEmitter {
     // Wire all push handlers BEFORE connect — meshcore.js may emit immediately.
     this.wirePushEvents();
 
-    await this.connection.connect();
-
-    // meshcore.js onConnected() does NOT send AppStart automatically —
-    // we must explicitly request SelfInfo after the transport is open.
-    const selfInfo = await this.connection.getSelfInfo(10_000);
-    this.cachedSelfInfo = {
-      ...selfInfo,
-      // Normalize wire kHz/Hz to MeshMonitor MHz/kHz so every downstream
-      // consumer (selfInfoToBridgeShape → manager → UI) sees consistent units.
-      radioFreq: libFreqToMhz(selfInfo?.radioFreq),
-      radioBw: libBwToKhz(selfInfo?.radioBw),
-    };
-
-    // Listen for connection-side disconnect so callers can react.
+    // Listen for connection-side disconnect BEFORE connecting so a link drop
+    // during or right after the transport opens (e.g. before the SelfInfo
+    // handshake completes) is still observed — not only drops after a fully
+    // established connection.
     this.connection.on('disconnected', () => {
       this.connected = false;
       this.emit('disconnected');
     });
+
+    try {
+      await this.connection.connect();
+
+      // meshcore.js onConnected() does NOT send AppStart automatically —
+      // we must explicitly request SelfInfo after the transport is open.
+      const selfInfo = await this.connection.getSelfInfo(10_000);
+      this.cachedSelfInfo = {
+        ...selfInfo,
+        // Normalize wire kHz/Hz to MeshMonitor MHz/kHz so every downstream
+        // consumer (selfInfoToBridgeShape → manager → UI) sees consistent units.
+        radioFreq: libFreqToMhz(selfInfo?.radioFreq),
+        radioBw: libBwToKhz(selfInfo?.radioBw),
+      };
+    } catch (err) {
+      // A failed connect (e.g. a SelfInfo handshake timeout right after a USB
+      // replug) MUST release the serial fd. Otherwise the OS-level handle
+      // lingers with the port held open and blocks every subsequent open on
+      // the same path with "Cannot lock port" until the process restarts
+      // (#4922). The library close() is best-effort — a port that never
+      // finished opening may throw "Port is not open"; swallow that.
+      try {
+        await this.connection?.close?.();
+      } catch (closeErr) {
+        logger.debug(
+          `[MeshCoreNative:${this.sourceId}] close after failed connect threw: ${(closeErr as Error).message}`,
+        );
+      }
+      this.connection = null;
+      throw err;
+    }
 
     this.connected = true;
     logger.info(`[MeshCoreNative:${this.sourceId}] Connected`);


### PR DESCRIPTION
## Problem
Fixes #4922. A **companion** MeshCore node on USB serial (Synology/Docker, fixed `/dev/ttyUSBx` mapping) could not reconnect after a physical unplug/replug — every attempt looped with:
```
SerialPort Error: Resource temporarily unavailable Cannot lock port
[ERROR] Connection failed: <meshcore.js rejected without an Error...>
SerialPort Error: Port is not open
```
…until the container was restarted.

## Root cause
1. **Library** (`meshcore.js` `NodeJSSerialConnection`): opened the port with node-serialport's default **`lock: true`** (exclusive advisory lock) and called `serialPort.open()` fire-and-forget with a `console.log`-only error handler. After a physical unplug, node-serialport doesn't reliably emit `close`, so the old fd stays open **holding the lock**; every reopen on the same path then fails with `EAGAIN`. Because `open()` wasn't awaited, `connect()` also resolved before the port was really open and swallowed open errors (MeshMonitor only found out via the 10s SelfInfo timeout).
2. **Backend**: on a failed connect the partially-opened connection wasn't closed, so even the current attempt's fd could linger.

## Fix
- **Pinned fork bump** → `Yeraze/meshcore.js@1485270` (PR Yeraze/meshcore.js#2): open with `lock: false` so a leaked/stale fd no longer blocks reconnect, and `await` `open()` rejecting on failure.
- **`meshcoreNativeBackend.ts`**: wire the `disconnected` listener *before* `connect()`, and on any connect failure `await connection.close()` + clear it before rethrowing — the fd is always released even without the library change.

## Test
- New `meshcoreNativeBackend.connectFailure.test.ts` — asserts `close()` runs and the connection is cleared when the handshake fails, and is left open on success (2/2).
- Full vitest suite: **16,341/0**.

## Mesh impact
None — this only affects the local serial link lifecycle (no packets sent, no timers, no notifications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)