### PR TITLE
perf(map): polish 3D controls and node memoization

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -30,6 +30,8 @@ const mocks = vi.hoisted(() => ({
   // #4704: terrain capabilities gate the 2D/3D toggle. Default unavailable so
   // existing tests stay on the 2D BaseMap; the 3D tests flip it on.
   terrainCaps: { enabled: false, terrainTiles: false, isLoading: false },
+  rendered3DNodes: [] as unknown[][],
+  geoJsonLayers: [] as Array<{ id: string; name: string; visible: boolean; style: { color: string } }>,
 }));
 
 // ---------------------------------------------------------------------------
@@ -47,15 +49,18 @@ const mocks = vi.hoisted(() => ({
 // assert on. Also short-circuit basemap3d/init so DashboardMap's unconditional
 // 3D-basemap derivation and `appBasename` import don't pull real modules.
 vi.mock('../map/Map3DView', () => ({
-  Map3DView: ({ nodes, sourceIds, showNeighbors, showTraceroutes }: any) => (
-    <div
-      data-testid="map-3d-view"
-      data-node-count={nodes.length}
-      data-source-ids={JSON.stringify(sourceIds)}
-      data-show-neighbors={String(showNeighbors)}
-      data-show-traceroutes={String(showTraceroutes)}
-    />
-  ),
+  Map3DView: ({ nodes, sourceIds, showNeighbors, showTraceroutes }: any) => {
+    mocks.rendered3DNodes.push(nodes);
+    return (
+      <div
+        data-testid="map-3d-view"
+        data-node-count={nodes.length}
+        data-source-ids={JSON.stringify(sourceIds)}
+        data-show-neighbors={String(showNeighbors)}
+        data-show-traceroutes={String(showTraceroutes)}
+      />
+    );
+  },
 }));
 vi.mock('../../config/basemap3d', () => ({
   resolve3DBasemap: () => ({ tiles: [], attribution: '', maxZoom: 19, usedFallback: false }),
@@ -147,7 +152,10 @@ vi.mock('../../hooks/useCsrfFetch', () => ({
   useCsrfFetch: () => vi.fn().mockResolvedValue({ ok: true }),
 }));
 vi.mock('../../services/api', () => ({
-  default: { getBaseUrl: vi.fn().mockResolvedValue('') },
+  default: {
+    getBaseUrl: vi.fn().mockResolvedValue(''),
+    get: vi.fn().mockImplementation(() => Promise.resolve(mocks.geoJsonLayers)),
+  },
 }));
 
 // The marker popup (DashboardNodePopup) reads time/date format from
@@ -355,6 +363,8 @@ describe('DashboardMap', () => {
     mocks.settings.activeStyleJson = null;
     // Default: terrain unavailable ⇒ no 3D toggle, stays on 2D BaseMap.
     mocks.terrainCaps = { enabled: false, terrainTiles: false, isLoading: false };
+    mocks.rendered3DNodes.length = 0;
+    mocks.geoJsonLayers.length = 0;
   });
 
   // --- Default Map Center vs auto-fit (issue #4125) ---------------------------
@@ -883,6 +893,52 @@ describe('DashboardMap', () => {
     fireEvent.click(toggle);
     expect(screen.getByTestId('map-3d-view')).toBeInTheDocument();
     expect(screen.queryByTestId('map-container')).not.toBeInTheDocument();
+  });
+
+  it('disables 2D-only controls with a clear tooltip while 3D is active (#4794)', async () => {
+    mocks.terrainCaps = { enabled: true, terrainTiles: true, isLoading: false };
+    mocks.geoJsonLayers.push({
+      id: 'coverage',
+      name: 'Coverage overlay',
+      visible: true,
+      style: { color: '#ff0000' },
+    });
+    const secondNode = {
+      ...nodeWithPosition,
+      user: { id: 'node-2', shortName: 'N2', longName: 'Node Two' },
+      position: { latitude: 35.1, longitude: -80.1 },
+    };
+    render(<DashboardMap {...defaultProps} nodes={[nodeWithPosition, secondNode]} />);
+
+    const controlNames = [
+      'Measure Distance',
+      'Show Accuracy Regions',
+      'Show Waypoints',
+      'Show ATAK Contacts',
+      'Show Polar Grid',
+      'Show Legend',
+      'Coverage overlay',
+    ];
+    await screen.findByLabelText('Coverage overlay');
+    fireEvent.click(screen.getByLabelText('3D Terrain'));
+
+    for (const name of controlNames) {
+      const control = screen.getByLabelText(name) as HTMLInputElement;
+      expect(control.disabled).toBe(true);
+      expect(control.closest('label')?.getAttribute('title')).toBe('Not available in 3D');
+    }
+  });
+
+  it('keeps the 3D node input stable across unrelated parent rerenders (#4794)', () => {
+    mocks.terrainCaps = { enabled: true, terrainTiles: true, isLoading: false };
+    const stableNodes = [nodeWithPosition];
+    const { rerender } = render(<DashboardMap {...defaultProps} nodes={stableNodes} />);
+    fireEvent.click(screen.getByLabelText('3D Terrain'));
+    const first3DNodes = mocks.rendered3DNodes.at(-1);
+
+    rerender(<DashboardMap {...defaultProps} nodes={stableNodes} isLoading />);
+
+    expect(mocks.rendered3DNodes.at(-1)).toBe(first3DNodes);
   });
 
   it('forces 2D when terrain capabilities are lost after selecting 3D', () => {

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -267,6 +267,7 @@ export default function DashboardMap({
   const canUse3D = !terrainCaps.isLoading && terrainCaps.enabled && terrainCaps.terrainTiles;
   const [viewMode, setViewMode] = useState<'2d' | '3d'>('2d');
   const effective3D = viewMode === '3d' && canUse3D;
+  const unavailableIn3DTitle = effective3D ? 'Not available in 3D' : undefined;
   const basemap3D = useMemo(
     () => resolve3DBasemap(tilesetId, customTilesets),
     [tilesetId, customTilesets],
@@ -342,47 +343,51 @@ export default function DashboardMap({
     }).catch(err => console.error('Failed to get base URL:', err));
   };
 
-  // Build array of nodes that have valid positions, with their resolved lat/lng.
-  // Mirrors NodesTab's processedNodes pipeline (App.tsx): ignored hidden, age cutoff
-  // bypassed by favorites, transport-class filter from the Map Features panel.
-  // Single "now" for this render so every marker's age fade (#3886) shares one
-  // reference instead of drifting per-node inside the marker map loop below.
-  const nowMs = Date.now();
-  const cutoffTime = nowMs / 1000 - effectiveMaxAge * 60 * 60;
-  const infraCutoffTime = nowMs / 1000 - effectiveInfraMaxAge * 60 * 60;
-  // #4899: per-node age gate — MeshCore infrastructure (advType 2/3) uses the
-  // infra window (or never expires when it's 0); everything else uses the
-  // companion window. Favorites bypass both, as before.
-  const passesAgeGate = (n: typeof nodes[number]): boolean => {
-    if (n.isFavorite) return true;
-    if (n.lastHeard == null) return false;
-    if (n.isMeshCore && isMeshCoreInfrastructureAdvType(n.advType)) {
-      return infraNever || n.lastHeard >= infraCutoffTime;
-    }
-    return n.lastHeard >= cutoffTime;
-  };
-  const nodesWithTruePos = nodes
-    .filter((n) => !n.isIgnored)
-    .filter((n) => !n.hideFromMap) // #3549: per-node "Hide from Map" suppresses the marker only
-    .filter(passesAgeGate)
-    .filter((n) => nodePassesTransportFilter(n, { showRfNodes, showUdpNodes, showMqttNodes }, cutoffTime))
-    .map((n) => ({ node: n, truePos: getNodeLatLng(n) }))
-    .filter((e): e is { node: any; truePos: { lat: number; lng: number } } => e.truePos !== null);
+  // Build the positioned-node array only when one of its real inputs changes.
+  // Besides avoiding the filtering/precision-offset work on unrelated renders,
+  // this keeps every downstream 3D GeoJSON input referentially stable (#4794).
+  // The age reference advances whenever node polling or a filter setting changes,
+  // which is when the visible set can meaningfully change.
+  const { nodesWithPosition, nowMs, cutoffTime } = useMemo(() => {
+    const referenceNowMs = Date.now();
+    const ageCutoffTime = referenceNowMs / 1000 - effectiveMaxAge * 60 * 60;
+    const infraCutoffTime = referenceNowMs / 1000 - effectiveInfraMaxAge * 60 * 60;
+    // #4899: per-node age gate — MeshCore infrastructure (advType 2/3) uses the
+    // infra window (or never expires when it's 0); everything else uses the
+    // companion window. Favorites bypass both, as before.
+    const passesAgeGate = (n: typeof nodes[number]): boolean => {
+      if (n.isFavorite) return true;
+      if (n.lastHeard == null) return false;
+      if (n.isMeshCore && isMeshCoreInfrastructureAdvType(n.advType)) {
+        return infraNever || n.lastHeard >= infraCutoffTime;
+      }
+      return n.lastHeard >= ageCutoffTime;
+    };
+    const nodesWithTruePos = nodes
+      .filter((n) => !n.isIgnored)
+      .filter((n) => !n.hideFromMap) // #3549: per-node "Hide from Map" suppresses the marker only
+      .filter(passesAgeGate)
+      .filter((n) => nodePassesTransportFilter(n, { showRfNodes, showUdpNodes, showMqttNodes }, ageCutoffTime))
+      .map((n) => ({ node: n, truePos: getNodeLatLng(n) }))
+      .filter((e): e is { node: any; truePos: { lat: number; lng: number } } => e.truePos !== null);
 
-  // #4016/#4155: offset obscured low-precision markers within their accuracy cell
-  // via the shared occupancy-gated helper — lone nodes stay centered, 2+ same-cell
-  // nodes spread — identical to every other map surface. `pos` (used by the marker,
-  // neighbor/traceroute endpoints, and the measurement tool) thus declutters. The
-  // accuracy rectangle below recomputes the TRUE center from the node, so it stays put.
-  const nodesWithPosition = applyPrecisionCellOffsets(
-    nodesWithTruePos.map(({ node, truePos }) => ({
-      item: node,
-      id: unifiedNodeKey(node) ?? String(node.nodeNum),
-      latLng: [truePos.lat, truePos.lng] as [number, number],
-      bits: node.positionPrecisionBits,
-      isOverride: node.positionIsOverride,
-    })),
-  ).map(({ item: node, latLng }) => ({ node, pos: { lat: latLng[0], lng: latLng[1] } }));
+    // #4016/#4155: offset obscured low-precision markers within their accuracy cell
+    // via the shared occupancy-gated helper — lone nodes stay centered, 2+ same-cell
+    // nodes spread — identical to every other map surface. `pos` (used by the marker,
+    // neighbor/traceroute endpoints, and the measurement tool) thus declutters. The
+    // accuracy rectangle below recomputes the TRUE center from the node, so it stays put.
+    const positionedNodes = applyPrecisionCellOffsets(
+      nodesWithTruePos.map(({ node, truePos }) => ({
+        item: node,
+        id: unifiedNodeKey(node) ?? String(node.nodeNum),
+        latLng: [truePos.lat, truePos.lng] as [number, number],
+        bits: node.positionPrecisionBits,
+        isOverride: node.positionIsOverride,
+      })),
+    ).map(({ item: node, latLng }) => ({ node, pos: { lat: latLng[0], lng: latLng[1] } }));
+
+    return { nodesWithPosition: positionedNodes, nowMs: referenceNowMs, cutoffTime: ageCutoffTime };
+  }, [nodes, effectiveMaxAge, effectiveInfraMaxAge, infraNever, showRfNodes, showUdpNodes, showMqttNodes]);
 
   // Array form of node positions for MapBoundsUpdater (fit bounds).
   const nodePositions: [number, number][] = nodesWithPosition.map((e) => [e.pos.lat, e.pos.lng]);
@@ -910,11 +915,11 @@ export default function DashboardMap({
           <>
           {/* #3636: node-to-node LOS distance measurement toggle. Needs at least
               two positioned nodes to be meaningful. */}
-          <label className="map-control-item" title="Measure straight-line distance between two nodes">
+          <label className="map-control-item" title={unavailableIn3DTitle ?? 'Measure straight-line distance between two nodes'}>
             <input
               type="checkbox"
               checked={measureActive}
-              disabled={measurePoints.length < 2}
+              disabled={effective3D || measurePoints.length < 2}
               onChange={(e) => setMeasureActive(e.target.checked)}
             />
             <span>Measure Distance</span>
@@ -993,10 +998,11 @@ export default function DashboardMap({
             />
             <span>Show Neighbors</span>
           </label>
-          <label className="map-control-item">
+          <label className="map-control-item" title={unavailableIn3DTitle}>
             <input
               type="checkbox"
               checked={showAccuracyRegions}
+              disabled={effective3D}
               onChange={(e) => setShowAccuracyRegions(e.target.checked)}
             />
             <span>Show Accuracy Regions</span>
@@ -1025,30 +1031,32 @@ export default function DashboardMap({
             />
             <span>Show MQTT</span>
           </label>
-          <label className="map-control-item">
+          <label className="map-control-item" title={unavailableIn3DTitle}>
             <input
               type="checkbox"
               checked={showWaypoints}
+              disabled={effective3D}
               onChange={(e) => setShowWaypoints(e.target.checked)}
             />
             <span>Show Waypoints</span>
           </label>
-          <label className="map-control-item">
+          <label className="map-control-item" title={unavailableIn3DTitle}>
             <input
               type="checkbox"
               checked={showAtakContacts}
+              disabled={effective3D}
               onChange={(e) => setShowAtakContacts(e.target.checked)}
             />
             <span>Show ATAK Contacts</span>
           </label>
-          <label className="map-control-item">
+          <label className="map-control-item" title={unavailableIn3DTitle}>
             <input
               type="checkbox"
               checked={showPolarGrid && hasOwnNode}
-              disabled={!hasOwnNode}
+              disabled={effective3D || !hasOwnNode}
               onChange={(e) => setShowPolarGrid(e.target.checked)}
             />
-            <span title={!hasOwnNode ? 'No source has a known own-node position' : undefined}>
+            <span title={unavailableIn3DTitle ?? (!hasOwnNode ? 'No source has a known own-node position' : undefined)}>
               Show Polar Grid
             </span>
           </label>
@@ -1060,20 +1068,22 @@ export default function DashboardMap({
             />
             <span>Show Tile Selection</span>
           </label>
-          <label className="map-control-item">
+          <label className="map-control-item" title={unavailableIn3DTitle}>
             <input
               type="checkbox"
               checked={showLegend}
+              disabled={effective3D}
               onChange={(e) => setShowLegend(e.target.checked)}
             />
             <span>Show Legend</span>
           </label>
           {/* GeoJSON overlay layers — per-layer on/off, mirroring NodesTab. */}
           {geoJsonLayers.map(layer => (
-            <label key={layer.id} className="map-control-item">
+            <label key={layer.id} className="map-control-item" title={unavailableIn3DTitle}>
               <input
                 type="checkbox"
                 checked={layer.visible}
+                disabled={effective3D}
                 onChange={(e) => toggleGeoJsonLayer(layer.id, e.target.checked)}
               />
               <span style={{ display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
@@ -1088,7 +1098,7 @@ export default function DashboardMap({
           </>
         </div>
         {/* Hops legend + tileset picker now live in the same sidebar (#4909). */}
-        {showLegend && <MapLegend embedded />}
+        {!effective3D && showLegend && <MapLegend embedded />}
         {showTileSelector && (
           <TilesetSelector selectedTilesetId={tilesetId} onTilesetChange={setMapTileset} embedded />
         )}

--- a/src/components/NodesTab.test.tsx
+++ b/src/components/NodesTab.test.tsx
@@ -23,6 +23,36 @@ import {
 import type { DeviceInfo } from '../types/device';
 
 describe('NodesTab', () => {
+  // NodesTab's full map surface depends on Leaflet plus a large context stack,
+  // so this pins the control wiring at the source boundary (the same strategy
+  // used for the node-row contracts below). DashboardMap has the corresponding
+  // runtime DOM coverage for this shared 3D behavior.
+  describe('2D-only map controls are gated while 3D is active (#4794)', () => {
+    const src = readFileSync(resolve('src/components/NodesTab.tsx'), 'utf8');
+
+    const expectDisabledIn3D = (checkedExpression: string): void => {
+      const checkedAt = src.indexOf(`checked={${checkedExpression}}`);
+      expect(checkedAt, `${checkedExpression} control is missing`).toBeGreaterThan(-1);
+      const inputTail = src.slice(checkedAt, src.indexOf('/>', checkedAt));
+      expect(inputTail, `${checkedExpression} must be disabled in 3D`).toContain('disabled={effective3D');
+    };
+
+    it('gates every control whose layer is absent from the 3D surface', () => {
+      expectDisabledIn3D('measureActive');
+      expectDisabledIn3D('showWaypoints');
+      expectDisabledIn3D('showAtakContacts');
+      expectDisabledIn3D('showAccuracyRegions');
+      expectDisabledIn3D('showPolarGrid');
+      expectDisabledIn3D('showLegend');
+      expectDisabledIn3D('layer.visible');
+    });
+
+    it('uses the 3D-unavailable tooltip and suppresses the 2D legend content', () => {
+      expect(src).toContain("const unavailableIn3DTitle = effective3D ? 'Not available in 3D' : undefined;");
+      expect(src).toContain('{!effective3D && showLegend && (');
+    });
+  });
+
   // #4047 Phase 7 WP11 — pins NodesTab's neighbor-link adapter: the 4-tier
   // SNR→weight/opacity table (deliberately NOT the shared layer's continuous
   // snrToNeighborOpacity curve, see utils/neighborLinks.ts) and the

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -1993,6 +1993,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
 
   // #4704: whether the 3D surface is actually on screen right now.
   const effective3D = viewMode === '3d' && canUse3D;
+  const unavailableIn3DTitle = effective3D ? 'Not available in 3D' : undefined;
 
   return (
     <div ref={splitViewRef} className="nodes-split-view nodes-anchored-view">
@@ -2439,11 +2440,11 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               </div>
                 <>
                   {/* #3636: node-to-node LOS distance measurement toggle. */}
-                  <label className="map-control-item" title="Measure straight-line distance between two nodes">
+                  <label className="map-control-item" title={unavailableIn3DTitle ?? 'Measure straight-line distance between two nodes'}>
                     <input
                       type="checkbox"
                       checked={measureActive}
-                      disabled={measurePoints.length < 2}
+                      disabled={effective3D || measurePoints.length < 2}
                       onChange={(e) => setMeasureActive(e.target.checked)}
                     />
                     <span>Measure Distance</span>
@@ -2558,18 +2559,20 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                     />
                     <span>{t('map.showMqtt')}</span>
                   </label>
-                  <label className="map-control-item">
+                  <label className="map-control-item" title={unavailableIn3DTitle}>
                     <input
                       type="checkbox"
                       checked={showWaypoints}
+                      disabled={effective3D}
                       onChange={(e) => setShowWaypoints(e.target.checked)}
                     />
                     <span>{t('map.showWaypoints', 'Show Waypoints')}</span>
                   </label>
-                  <label className="map-control-item">
+                  <label className="map-control-item" title={unavailableIn3DTitle}>
                     <input
                       type="checkbox"
                       checked={showAtakContacts}
+                      disabled={effective3D}
                       onChange={(e) => setShowAtakContacts(e.target.checked)}
                     />
                     <span>{t('map.showAtakContacts', 'Show ATAK Contacts')}</span>
@@ -2649,22 +2652,23 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                     />
                     <span>{t('map.showEstimatedPositions')}</span>
                   </label>
-                  <label className="map-control-item">
+                  <label className="map-control-item" title={unavailableIn3DTitle}>
                     <input
                       type="checkbox"
                       checked={showAccuracyRegions}
+                      disabled={effective3D}
                       onChange={(e) => setShowAccuracyRegions(e.target.checked)}
                     />
                     <span>{t('map.showAccuracyRegions')}</span>
                   </label>
-                  <label className="map-control-item">
+                  <label className="map-control-item" title={unavailableIn3DTitle}>
                     <input
                       type="checkbox"
                       checked={showPolarGrid}
                       onChange={(e) => setShowPolarGrid(e.target.checked)}
-                      disabled={!ownNodePosition}
+                      disabled={effective3D || !ownNodePosition}
                     />
-                    <span title={!ownNodePosition ? t('map.polarGridDisabledTooltip') : undefined}>
+                    <span title={unavailableIn3DTitle ?? (!ownNodePosition ? t('map.polarGridDisabledTooltip') : undefined)}>
                       {t('map.showPolarGrid')}
                     </span>
                   </label>
@@ -2676,19 +2680,21 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                     />
                     <span>Show Tile Selection</span>
                   </label>
-                  <label className="map-control-item">
+                  <label className="map-control-item" title={unavailableIn3DTitle}>
                     <input
                       type="checkbox"
                       checked={showLegend}
+                      disabled={effective3D}
                       onChange={(e) => setShowLegend(e.target.checked)}
                     />
                     <span>Show Legend</span>
                   </label>
                   {geoJsonLayers.map(layer => (
-                    <label key={layer.id} className="map-control-item">
+                    <label key={layer.id} className="map-control-item" title={unavailableIn3DTitle}>
                       <input
                         type="checkbox"
                         checked={layer.visible}
+                        disabled={effective3D}
                         onChange={(e) => {
                           const newLayers = geoJsonLayers.map(l =>
                             l.id === layer.id ? { ...l, visible: e.target.checked } : l
@@ -2755,7 +2761,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                   )}
                 </>
               </div>
-              {showLegend && (
+              {!effective3D && showLegend && (
                 <MapLegend
                   positionHistory={positionHistoryLegendData}
                   unmappedCount={unmappedCount}


### PR DESCRIPTION
## Summary

- disable the seven 2D-only map controls while the Dashboard and Nodes maps are in 3D mode, with a clear `Not available in 3D` tooltip
- suppress the 2D legend while 3D is active
- memoize DashboardMap's positioned-node pipeline on its real inputs so unrelated renders no longer churn the downstream 3D GeoJSON source
- add runtime DashboardMap coverage and NodesTab wiring-contract coverage for the 3D control behavior

Closes #4794.

## Verification

After rebasing onto current `main`:

- `npm run typecheck`
- `npm run lint:ci`
- `npx vitest run src/components/Dashboard/DashboardMap.test.tsx src/components/NodesTab.test.tsx` — 83/83 passed
- `npm run build`

The pre-rebase implementation run also passed the complete test suite: 1,112 files and 16,343 tests passed (11 files / 825 tests skipped, 21 todo).
