### PR TITLE
fix(nodes): keep node text legible on per-node colored rows (#4924)

### DIFF
--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -1252,7 +1252,14 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             className="last-message-preview"
                             style={{
                               fontSize: '0.85rem',
-                              color: selectedDMNode === node.user?.id ? '#000000' : 'var(--color-text-subtle)',
+                              // #4924: on a per-node colored row, inherit the row's
+                              // luminance-picked contrast color instead of the muted
+                              // token (which is illegible on the tint). `inherit`
+                              // beats the CSS but must be set here because this is an
+                              // inline style; the selected-row case keeps its black.
+                              color: nc.background
+                                ? 'inherit'
+                                : selectedDMNode === node.user?.id ? '#000000' : 'var(--color-text-subtle)',
                               fontStyle: 'italic',
                               overflow: 'hidden',
                               textOverflow: 'ellipsis',

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -1177,7 +1177,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                     return (
                     <div
                       key={node.nodeNum}
-                      className={`node-item ${selectedDMNode === node.user?.id ? 'selected' : ''}`}
+                      className={`node-item ${selectedDMNode === node.user?.id ? 'selected' : ''}${nc.background ? ' node-item--colored' : ''}`}
                       style={nc.background ? { background: nc.background, color: nc.text } : undefined}
                       onClick={() => {
                         const nodeId = node.user?.id || '';
@@ -2051,7 +2051,7 @@ const MessagesTab: React.FC<MessagesTabProps> = ({
                             </div>
                           )}
                           <div
-                            className={`message-bubble ${isMine ? 'mine' : 'theirs'}`}
+                            className={`message-bubble ${isMine ? 'mine' : 'theirs'}${senderColor.background ? ' message-bubble--colored' : ''}`}
                             style={senderColor.background ? { background: senderColor.background, color: senderColor.text } : undefined}
                           >
                             <div className="message-text-row">

--- a/src/components/MessagesTab.tsx
+++ b/src/components/MessagesTab.tsx
@@ -136,7 +136,6 @@ const DistanceDisplay = React.memo<{
       title={t('nodes.distance')}
       style={{
         fontSize: '0.75rem',
-        color: 'var(--color-text-subtle)',
         marginLeft: '0.5rem',
       }}
     >

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -2183,7 +2183,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                 return (
                 <div
                   key={node.nodeNum}
-                  className={`node-item ${selectedNodeId === node.user?.id ? 'selected' : ''}`}
+                  className={`node-item ${selectedNodeId === node.user?.id ? 'selected' : ''}${nc.background ? ' node-item--colored' : ''}`}
                   style={nc.background ? { background: nc.background, color: nc.text } : undefined}
                   onClick={handleNodeClick(node)}
                   /* Second path to Node Details, matching MeshCore's node list

--- a/src/styles/messages.css
+++ b/src/styles/messages.css
@@ -254,6 +254,16 @@
   color: var(--color-text-muted);
 }
 
+/* #4880/#4924: an incoming bubble tinted by the per-node color sets a
+   luminance-picked contrast `color` inline; its timestamp must inherit that
+   instead of the muted token, which would be illegible on the tint. Matches
+   the specificity of the `.theirs .message-time` rule above and follows it, so
+   it wins for colored bubbles only. The base `.message-time` opacity keeps it
+   appropriately subdued. */
+.message-bubble--colored.theirs .message-time {
+  color: inherit;
+}
+
 .message-bubble.mine .message-time {
   color: var(--color-chat-bubble-sent-text, var(--color-accent-text));
   opacity: 0.85;

--- a/src/styles/messages.css
+++ b/src/styles/messages.css
@@ -255,11 +255,17 @@
 }
 
 /* #4880/#4924: an incoming bubble tinted by the per-node color sets a
-   luminance-picked contrast `color` inline; its timestamp must inherit that
-   instead of the muted token, which would be illegible on the tint. Matches
-   the specificity of the `.theirs .message-time` rule above and follows it, so
-   it wins for colored bubbles only. The base `.message-time` opacity keeps it
-   appropriately subdued. */
+   luminance-picked contrast `color` inline, but `.message-text` and
+   `.message-time` carry their own token colors (`--color-text` /
+   `--color-text-muted`) that otherwise win over the inherited value and stay
+   illegible on the tint. Force the text/meta/timestamp to inherit the bubble's
+   contrast color. Scoped to text only (not reaction chips, which have their own
+   backgrounds); links keep their more-specific accent rule and their underline.
+   The `.message-time` selector matches the specificity of the base
+   `.theirs .message-time` rule above and follows it, so it wins for colored
+   bubbles; `.message-time`'s own opacity keeps it appropriately subdued. */
+.message-bubble--colored.theirs .message-text,
+.message-bubble--colored.theirs .message-meta,
 .message-bubble--colored.theirs .message-time {
   color: inherit;
 }

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -840,6 +840,8 @@
 .node-item--colored .node-name-text *,
 .node-item--colored .node-details,
 .node-item--colored .node-details *,
+.node-item--colored .node-stats,
+.node-item--colored .node-stats *,
 .node-item--colored .node-time {
   color: inherit;
 }

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -846,6 +846,13 @@
   color: inherit;
 }
 
+/* The DM list's distance stat carries its base muted color here (moved off an
+   inline style) so the colored-row inherit rule above can win on tinted rows
+   while non-colored rows keep the subtle look (#4924). */
+.node-distance {
+  color: var(--color-text-subtle);
+}
+
 .node-header {
   display: flex;
   justify-content: space-between;

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -827,12 +827,15 @@
    status and metric text otherwise keep their muted design-token colors
    (--color-text-muted/subtle/disabled), which are illegible on a bright
    generated background. Force those text blocks to inherit the row's contrast
-   color. Scoped to the name/status block (.node-name-text) and the metrics
-   block (.node-details, .node-time) only — the action buttons, short-name pill
+   color. Scoped to the name/status block (.node-name / .node-name-text — the
+   former carries a global `color: var(--color-text)` that otherwise breaks the
+   inherit chain for the name) and the metrics block (.node-details,
+   .node-time) only — the action buttons, short-name pill
    and favorite star live in .node-actions / .favorite-wrapper and intentionally
    keep their own styling so they don't turn illegible on their own backgrounds.
    `.node-name-text *` reaches the CSS-module status line without depending on
    its hashed class name. */
+.node-item--colored .node-name,
 .node-item--colored .node-name-text,
 .node-item--colored .node-name-text *,
 .node-item--colored .node-details,

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -822,6 +822,25 @@
   color: rgba(0, 0, 0, 0.7);
 }
 
+/* #4880/#4924: a per-node colored row paints the box background inline, with a
+   luminance-picked contrast color set as the row's `color`. The name/role/
+   status and metric text otherwise keep their muted design-token colors
+   (--color-text-muted/subtle/disabled), which are illegible on a bright
+   generated background. Force those text blocks to inherit the row's contrast
+   color. Scoped to the name/status block (.node-name-text) and the metrics
+   block (.node-details, .node-time) only — the action buttons, short-name pill
+   and favorite star live in .node-actions / .favorite-wrapper and intentionally
+   keep their own styling so they don't turn illegible on their own backgrounds.
+   `.node-name-text *` reaches the CSS-module status line without depending on
+   its hashed class name. */
+.node-item--colored .node-name-text,
+.node-item--colored .node-name-text *,
+.node-item--colored .node-details,
+.node-item--colored .node-details *,
+.node-item--colored .node-time {
+  color: inherit;
+}
+
 .node-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Problem
The per-node coloring shipped in #4924 (#4880) paints the whole node box with a generated background, but the **subtitle/role/status and metric text kept their muted design-token colors** (`--color-text-muted/subtle/disabled`) at equal-or-higher specificity — so on bright backgrounds (lime/yellow/cyan) the text was near-invisible. Reported with a screenshot of an illegible Nodes list.

## Fix
When a row is colored, force the **name/status block** and the **metrics block** to inherit the row's luminance-picked contrast `color`:
- New `.node-item--colored` marker class + a scoped rule in `nodes.css`.
- `.node-name-text *` reaches the CSS-module status line without depending on its hashed class name.
- The **action buttons, short-name pill, and favorite star** (in `.node-actions` / `.favorite-wrapper`) are intentionally excluded — they have their own backgrounds and must keep their own colors (a row-wide override would make e.g. the dark short-name pill illegible on a light row).

Applied to every surface the feature colors:
- Nodes tab list (`NodesTab`)
- Messages DM node list (same `.node-item` classes — covered by the same CSS)
- Incoming chat bubbles: timestamp forced to inherit via `.message-bubble--colored.theirs .message-time`

## Verification
Built + deployed the branch and confirmed via screenshot: bright rows now render dark, legible text (name/subtitle/metrics) and dark rows render light text; buttons/pills unchanged. Faint rows in the shot are stale nodes dimmed by the pre-existing opacity treatment, unrelated to this bug.

## Test / impact
- Full vitest suite **16,362/0**. Presentation-only (CSS + a className toggle); the `nodeColor` util that picks the contrast color is already unit-tested. No mesh impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)