### PR TITLE
chore(release): 4.15.2-rc4

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.15.2-rc3",
+  "version": "4.15.2-rc4",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.15.2-rc3",
+  "version": "4.15.2-rc4",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.15.2-rc3
-appVersion: "4.15.2-rc3"
+version: 4.15.2-rc4
+appVersion: "4.15.2-rc4"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.2-rc3",
+  "version": "4.15.2-rc4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.15.2-rc3",
+      "version": "4.15.2-rc4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.2-rc3",
+  "version": "4.15.2-rc4",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Prepares the next release candidate: **4.15.2-rc3 → 4.15.2-rc4**.

Bumps the version across all five files: `package.json`, `package-lock.json`, `helm/meshmonitor/Chart.yaml` (version + appVersion), `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`.

### Included since rc3
- Node/map/DM-list legibility on per-node colored rows — #4928
- Map controls sidebar epic — #4914, #4919, #4920, #4921
- Cycling connection badge (status/battery/airtime) — #4927
- Disconnect/Reconnect moved into System Status popup — #4912
- MeshCore USB unplug/replug serial reconnect fix — #4923
- Per-node colors (Meshtastic app algorithm) — #4924
- Map Analysis semantic-token theming — #4913
- Automation self-targeted reboot fix — #4915

`system-test` label applied (release version-bump chore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)