### PR TITLE
feat(map): support a Carto basemap API key (#4934 Phase 1)

### DIFF
--- a/docs/internal/dev-notes/CARTO_API_KEY_PLAN.md
+++ b/docs/internal/dev-notes/CARTO_API_KEY_PLAN.md
@@ -1,0 +1,174 @@
+# Carto Basemap API Key + Vector Basemaps — Implementation Plan
+
+**Issue:** (to be filed) — "Support a Carto basemap API key + add Carto vector basemaps"
+**Status:** Plan / not started
+**Author:** Claude (for Randall)
+
+## Background
+
+Carto is retiring its free, keyless raster basemaps. When a client requests
+`basemaps.cartocdn.com/{dark_all,light_all}/…` without a key, Carto now returns
+tiles stamped with a repeated **"API key required"** watermark (the map still
+works — it's a notice, not an outage). We use exactly those two endpoints for the
+`cartoDark` / `cartoLight` tilesets (`src/config/tilesets.ts:65,73`), which is
+why users see the watermark. `cartoDark` is also the default dark tileset
+(`SettingsContext.tsx:87`).
+
+Carto keys are **free, instant, no account, domain-restricted**. Request at
+<https://carto.com/basemaps/apikey/>. The key attaches as a `?key=YOUR_KEY`
+query parameter on the **same** endpoints — host is unchanged, so our CSP
+(`src/server/middleware/dynamicCsp.ts:114`, `embedMiddleware.ts:48-49`) already
+permits it with no change.
+
+Carto also recommends moving from raster to **vector** GL basemaps
+(sharper, fresher, restyleable):
+| Raster | Vector GL style URL |
+|--------|---------------------|
+| `rastertiles/voyager` | `https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json` |
+| `light_all` | `https://basemaps.cartocdn.com/gl/positron-gl-style/style.json` |
+| `dark_all` | `https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json` |
+
+## Design decisions (settled)
+
+1. **Key scope: server-wide (deployment-global), admin-writable, publicly-readable.**
+   One key per instance, set once by an admin in Settings; delivered to *every*
+   client (including anonymous embed viewers, whose maps must load unwatermarked).
+
+2. **NOT a secret. NOT a tile proxy.** A Carto basemap key is a *publishable,
+   domain-restricted* token (like a Mapbox public token / Google Maps JS key).
+   The browser sends it on every tile request by design — it cannot be hidden
+   while using Carto's CDN, and its protection is the domain allowlist, not
+   secrecy. A server-side tile proxy was explicitly rejected: it would route
+   every basemap tile through MeshMonitor, defeating Carto's CDN and adding large
+   bandwidth/latency for zero security gain. Therefore the key is appended
+   **client-side** and is **not** placed in `SECRET_SETTINGS_KEYS`.
+
+3. **Key attaches via `transformRequest` for vector, `?key=` string-append for raster.**
+   The Leaflet MapLibre adapter forwards all options to `new maplibregl.Map(options)`
+   (`node_modules/@maplibre/maplibre-gl-leaflet/leaflet-maplibre-gl.js:125-131`),
+   so `transformRequest` works in both 2D (via the adapter) and 3D (native). One
+   `transformRequest` hook covers a GL style's style.json + tiles + sprites +
+   glyphs, so we never have to guess whether the key propagates to sub-requests.
+
+4. **Vector-in-3D is deferred** to a follow-up issue. `Base3DMap` renders a
+   *raster* basemap source today; a full GL-vector 3D basemap is a substantial
+   rework. 3D stays on raster-with-key (Phase 1), which already removes the
+   watermark there.
+
+## Phase 1 — Raster key (removes the watermark on every surface)
+
+### 1a. Setting definition — `src/server/constants/settings.ts`
+- Add `'cartoApiKey'` to `VALID_SETTINGS_KEYS` (near the `mapTileset*` keys, ~L95-97).
+- Add `'cartoApiKey'` to `GLOBAL_ONLY_SETTINGS_KEYS` (global/deployment-wide;
+  never written into a source namespace — mirrors `externalUrl`, `elevationEnabled`).
+- **Do NOT** add to `SECRET_SETTINGS_KEYS` and **do not** name it with a
+  `_secret`/`_token`/`_private_key` suffix — it must survive `stripSecretSettings`
+  so anonymous/non-admin clients receive it.
+
+### 1b. Deliver the key to clients
+- **Logged-in / normal app:** the GET `/api/settings` response already flows into
+  `SettingsContext` (`fetch` at `SettingsContext.tsx:1454`, `response.json()` at
+  1459, field reads ~1604). Add a `cartoApiKey: string | null` field to
+  `SettingsContextType` (`SettingsContext.tsx:101+`, near `mapTilesetDark:` L120)
+  and populate it from that settings payload. Expose via `useSettings()`.
+  - Unlike `mapTileset*` (localStorage per-user prefs), this is a **server-loaded
+    global** — load it from the settings fetch, do not persist to localStorage.
+- **Anonymous embed:** the public embed config is built at
+  `src/server/routes/embedPublicRoutes.ts:82` (`tileset: profile.tileset, …`).
+  Add `cartoApiKey` there, read server-side via
+  `databaseService.settings.getSetting('cartoApiKey')`. `EmbedMap` then reads it
+  from `config` (it has no `useSettings()`) and threads it into `BaseMap`.
+
+### 1c. Append helper — new `src/config/cartoKey.ts` (unit-tested)
+```ts
+// Appends ?key= to Carto CDN URLs only; leaves every other host untouched.
+// Safe on both {z}/{x}/{y} raster templates and GL style.json URLs.
+export function withCartoKey(url: string, key: string | null | undefined): string
+```
+- Guard: only touch hosts ending in `basemaps.cartocdn.com`; no-op when `key` is
+  empty. Preserve any existing query string (use `&` vs `?` correctly). Must not
+  collide with `{s}`/`{z}` placeholder substitution (append at the end; the `{…}`
+  tokens are in the path, not the query).
+
+### 1d. Wire the helper at the tile-URL choke points
+Thread the key (from `useSettings()` or embed `config`) to each consumer and wrap
+the URL with `withCartoKey`:
+- `src/components/map/BaseMap.tsx` — raster `<TileLayer url>` (L155) and the
+  `overlayUrl` layer (L175). Add a `cartoApiKey?: string` prop (BaseMap currently
+  takes no settings; keep it prop-driven per its design note L90). Callers pass it.
+- `src/config/basemap3d.ts` `resolve3DBasemap` — the `tiles` array built from
+  `tileset.url` (expandSubdomains, L34-64). Add a `cartoApiKey` param; callers
+  (`NodesTab.tsx:982`, `DashboardMap.tsx:275`, `MapAnalysisCanvas.tsx:221`) pass
+  `settings.cartoApiKey`. Consumed by `Base3DMap.tsx:378-379,641-643`.
+- `src/components/*TracerouteWidget*.tsx` — builds its own `<TileLayer url>` (~L492-496),
+  bypassing BaseMap. Wrap here too.
+- `EmbedMap.tsx` (L414) — pass `cartoApiKey={config.cartoApiKey}` into `BaseMap`.
+
+### 1e. Admin UI — `src/components/SettingsTab.tsx`
+- Add an admin-only text input (masked/password style is nice-to-have; it is not
+  a hard secret) in the map/appearance settings area, loaded + saved directly via
+  the settings API — mirror an existing admin-only server field such as
+  `elevationSourceUrl` / `appriseApiServerUrl`. Include a short helper line with
+  the <https://carto.com/basemaps/apikey/> link and note it's free.
+- Because the value is surfaced through `SettingsContext` (1b), the
+  `server.settings-persistence.test.ts` guard (loaded-OR-in-`SERVER_ONLY_SETTINGS`)
+  is satisfied **without** adding it to `SERVER_ONLY_SETTINGS`. Confirm which side
+  of that guard we land on and adjust exactly one of {context load, SERVER_ONLY list}.
+
+### 1f. Tests (Phase 1)
+- `src/config/cartoKey.test.ts` — append/no-op/existing-query/non-carto-host/empty-key.
+- `resolve3DBasemap` test — carto tileset + key ⇒ every `tiles[]` entry carries `?key=`.
+- `BaseMap` test — raster carto url renders with the key (jsdom: assert the
+  `url` prop passed to `TileLayer`, following the existing BaseMap test style).
+- Embed: `embedPublicRoutes` test — public config includes `cartoApiKey` from
+  global settings; `EmbedMap.test.tsx` — forwards `config.cartoApiKey` to `BaseMap`.
+- Settings persistence test — `cartoApiKey` POST is accepted and round-trips; not
+  stripped for a non-admin GET (unlike the secret keys).
+
+## Phase 2 — Carto vector basemaps (2D)
+
+### 2a. Tileset model — `src/config/tilesets.ts`
+- Carto vector basemaps are **GL style JSON URLs**, not `{z}/{x}/{y}` tile
+  templates. Add a distinct field (e.g. `styleUrl?: string`) so the vector branch
+  knows to hand MapLibre a style URL rather than synthesize a `.pbf` style.
+  `isVectorTileUrl()` keys off `.pbf`/`.mvt` today and must not misclassify these.
+- Add three predefined entries: `cartoVoyager`, `cartoPositron`, `cartoDarkMatter`
+  (styleUrl per the table above), with Carto+OSM attribution.
+
+### 2b. `src/components/VectorTileLayer.tsx`
+- When a `styleUrl` is provided: pass `style: styleUrl` **directly** to
+  `L.maplibreGL({ style, attribution, transformRequest })` (skip the
+  patch-sources / default-style branches, which assume a `.pbf` template).
+- `transformRequest: (u) => u.includes('basemaps.cartocdn.com') ? { url: withCartoKey(u, key) } : undefined`
+  — attaches the key to style.json + tiles + sprites + glyphs in one place.
+- Thread `cartoApiKey` down from `BaseMap` (new prop) → `VectorTileLayer`.
+
+### 2c. Tests (Phase 2)
+- `VectorTileLayer` styleUrl branch — asserts the style URL + a `transformRequest`
+  that rewrites carto hosts and no-ops others. (Mock `L.maplibreGL`.)
+- `tilesets` — new entries resolve, `isVector` true, not misclassified by
+  `isVectorTileUrl`, `validateTileUrl` not applied to styleUrl entries.
+
+## Phase 3 — Vector basemaps in 3D (DEFERRED — separate issue)
+
+`Base3DMap` builds a raster basemap source (`map.addSource('basemap', {type:'raster', tiles})`).
+Supporting a Carto GL vector style in 3D means driving the `maplibregl.Map` from a
+GL `style` (+ `transformRequest`) instead, and re-adding our overlay
+sources/layers on top. Track separately; 3D stays raster-with-key until then.
+
+## Cross-cutting / gotchas
+- **CSP:** no change needed for raster (`?key=` same host). For vector, sprites
+  and glyphs are also under `basemaps.cartocdn.com` — already allowed by
+  `dynamicCsp.ts:114`; verify the embed CSP (`embedMiddleware.ts:48-49`) covers
+  `img-src`/`connect-src` for the style/sprite/glyph fetches (it lists the host).
+- **Attribution stays visible.** Carto terms require the notice/attribution
+  remain; our tilesets already carry CARTO attribution — keep it.
+- **Server ESM import extension rule:** any new server-side `.ts` imported in
+  compiled code needs explicit `.js` in relative specifiers (CLAUDE.md).
+- **No mesh-impact** (no packets/timers/notifications) — checklist N/A.
+- **Multi-DB:** `cartoApiKey` is a plain settings row; no schema/migration.
+
+## Rollout note (optional, not in scope)
+Consider changing the default dark tileset off `cartoDark` only if we do *not*
+ship a bundled key — with this feature the watermark is user-fixable, so the
+default can stay. Decide at PR time.

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -203,6 +203,7 @@ export default function DashboardMap({
   const {
     mapPinStyle,
     setMapTileset,
+    cartoApiKey,
     overlayColors,
     defaultMapCenterLat,
     defaultMapCenterLon,
@@ -269,8 +270,8 @@ export default function DashboardMap({
   const effective3D = viewMode === '3d' && canUse3D;
   const unavailableIn3DTitle = effective3D ? 'Not available in 3D' : undefined;
   const basemap3D = useMemo(
-    () => resolve3DBasemap(tilesetId, customTilesets),
-    [tilesetId, customTilesets],
+    () => resolve3DBasemap(tilesetId, customTilesets, cartoApiKey),
+    [tilesetId, customTilesets, cartoApiKey],
   );
   // `appBasename` is the base-path prefix `ApiService` was seeded with at
   // startup — module-scope constant, never changes.
@@ -795,6 +796,7 @@ export default function DashboardMap({
         center={[defaultCenter.lat, defaultCenter.lng]}
         zoom={hasConfiguredDefaultCenter ? defaultMapCenterZoom : 10}
         tilesetId={tilesetId}
+        cartoApiKey={cartoApiKey}
         customTilesets={customTilesets}
         styleJson={activeStyleJson ?? undefined}
         zoomControl

--- a/src/components/EmbedMap.tsx
+++ b/src/components/EmbedMap.tsx
@@ -19,6 +19,8 @@ interface EmbedConfig {
   id: string;
   channels: number[];
   tileset: string;
+  /** Deployment-wide Carto basemap API key (#4934), or null when unset. */
+  cartoApiKey?: string | null;
   defaultLat: number;
   defaultLng: number;
   defaultZoom: number;
@@ -413,6 +415,7 @@ export function EmbedMap({ profileId }: EmbedMapProps) {
         zoom={centerZoom}
         tilesetId={config.tileset}
         customTilesets={[]}
+        cartoApiKey={config.cartoApiKey ?? null}
         zoomControl
         attributionControl
       >

--- a/src/components/MapAnalysis/MapAnalysisCanvas.tsx
+++ b/src/components/MapAnalysis/MapAnalysisCanvas.tsx
@@ -65,6 +65,7 @@ export default function MapAnalysisCanvas() {
     mapTileset,
     customTilesets,
     setMapTileset,
+    cartoApiKey,
     activeStyleJson,
   } = useSettings();
   const {
@@ -218,8 +219,8 @@ export default function MapAnalysisCanvas() {
     [analysisNodes, hopByKey, config.layers.hopShading.enabled, config.selectedNodeIds, fadeByAge3D, windowStartMs3D, windowEndMs3D],
   );
   const basemap3D = useMemo(
-    () => resolve3DBasemap(mapTileset, customTilesets),
-    [mapTileset, customTilesets],
+    () => resolve3DBasemap(mapTileset, customTilesets, cartoApiKey),
+    [mapTileset, customTilesets, cartoApiKey],
   );
   // `appBasename` is the same base-path prefix `ApiService` was seeded with
   // at startup (`src/init.ts`) — module-scope constant, never changes.
@@ -335,6 +336,7 @@ export default function MapAnalysisCanvas() {
         center={center}
         zoom={zoom}
         tilesetId={mapTileset}
+        cartoApiKey={cartoApiKey}
         customTilesets={customTilesets}
         styleJson={activeStyleJson ?? undefined}
         sidebar={

--- a/src/components/MeshCore/MeshCoreMap.tsx
+++ b/src/components/MeshCore/MeshCoreMap.tsx
@@ -101,7 +101,7 @@ interface MeshCoreMapProps {
 
 export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPublicKey, localNodePosition, onNavigateToDm, isLoading = false, resizeTrigger }) => {
   const { t } = useTranslation();
-  const { mapTileset, customTilesets, setMapTileset, activeStyleJson } = useSettings();
+  const { mapTileset, customTilesets, setMapTileset, cartoApiKey, activeStyleJson } = useSettings();
   const { timeFormat, dateFormat } = useDisplaySettings();
   const { sourceId } = useSource();
   const csrfFetch = useCsrfFetch();
@@ -489,6 +489,7 @@ export const MeshCoreMap: React.FC<MeshCoreMapProps> = ({ contacts, selectedPubl
         zoom={zoom}
         tilesetId={mapTileset}
         customTilesets={customTilesets}
+        cartoApiKey={cartoApiKey}
         styleJson={activeStyleJson ?? undefined}
         resizeTrigger={resizeTrigger}
       >

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -541,6 +541,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
     dateFormat,
     mapTileset,
     setMapTileset,
+    cartoApiKey,
     mapPinStyle,
     nodeListStyle,
     customTilesets,
@@ -975,8 +976,8 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
   const canUse3D = !terrainCaps.isLoading && terrainCaps.enabled && terrainCaps.terrainTiles;
   const [viewMode, setViewMode] = useState<'2d' | '3d'>('2d');
   const basemap3D = useMemo(
-    () => resolve3DBasemap(mapTileset, customTilesets),
-    [mapTileset, customTilesets],
+    () => resolve3DBasemap(mapTileset, customTilesets, cartoApiKey),
+    [mapTileset, customTilesets, cartoApiKey],
   );
   const terrainTileUrl = useMemo(() => buildTerrainTileUrl(appBasename), []);
 
@@ -2844,6 +2845,7 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
               zoom={mapDefaults.zoom}
               tilesetId={activeTileset}
               customTilesets={customTilesets}
+              cartoApiKey={cartoApiKey}
               styleJson={activeStyleJson ?? undefined}
               resizeTrigger={`${showPacketMonitor}-${isNodeListCollapsed}-${packetMonitorHeight}`}
             >

--- a/src/components/Reticulum/ReticulumMap.tsx
+++ b/src/components/Reticulum/ReticulumMap.tsx
@@ -55,7 +55,7 @@ function shortHash(hash: string): string {
 
 export const ReticulumMap: React.FC<ReticulumMapProps> = ({ destinations, paths, loading = false, resizeTrigger }) => {
   const { t } = useTranslation();
-  const { mapTileset, customTilesets, setMapTileset, activeStyleJson } = useSettings();
+  const { mapTileset, customTilesets, setMapTileset, cartoApiKey, activeStyleJson } = useSettings();
 
   const positioned = useMemo(
     () => destinations.filter(d =>
@@ -146,6 +146,7 @@ export const ReticulumMap: React.FC<ReticulumMapProps> = ({ destinations, paths,
         zoom={zoom}
         tilesetId={mapTileset}
         customTilesets={customTilesets}
+        cartoApiKey={cartoApiKey}
         styleJson={activeStyleJson ?? undefined}
         onTilesetChange={setMapTileset}
         resizeTrigger={resizeTrigger}

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -2543,7 +2543,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
             <label htmlFor="cartoApiKey">
               {t('settings.carto_api_key_label', 'Carto Basemap API Key')}
               <span className="setting-description">
-                {t('settings.carto_api_key_description', 'Removes the "API key required" watermark on the Dark/Light (Carto) basemaps. Free and instant — request one at https://carto.com/basemaps/apikey/. Leave empty to use Carto keyless (watermarked) or a non-Carto basemap.')}
+                {t('settings.carto_api_key_description', 'Removes the "API key required" watermark on the Dark/Light (Carto) basemaps. Free and instant — request one at ')}
+                <a href="https://carto.com/basemaps/apikey/" target="_blank" rel="noopener noreferrer">carto.com/basemaps/apikey</a>
+                {t('settings.carto_api_key_description_suffix', '. Leave empty to use Carto keyless (watermarked) or a non-Carto basemap.')}
               </span>
             </label>
             <input

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -130,6 +130,10 @@ interface SettingsDraft {
   externalUrl: string;
   elevationEnabled: boolean;
   elevationSourceUrl: string;
+  // Deployment-wide Carto basemap API key (#4934). Global, admin-set, publicly
+  // readable (NOT a secret) — publishable, domain-restricted token appended to
+  // Carto tile URLs. Mirrors the elevationSourceUrl admin-field pattern.
+  cartoApiKey: string;
   // ATAK/CoT Phase 3 (issue #3691): global singleton plaintext TCP CoT feed
   // server, not per-source — mirrors the elevation fields above.
   cotFeedEnabled: boolean;
@@ -432,6 +436,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     externalUrl: '',
     elevationEnabled: false,
     elevationSourceUrl: '',
+    cartoApiKey: '',
     cotFeedEnabled: false,
     cotFeedPort: 8088,
   }));
@@ -463,6 +468,9 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   // `elevationSourceUrl` (stripSecretSettings returns the full map to admins).
   const [initialElevationEnabled, setInitialElevationEnabled] = useState(false);
   const [initialElevationSourceUrl, setInitialElevationSourceUrl] = useState('');
+  // #4934: deployment-wide Carto API key (no context/prop home, same admin-field
+  // pattern as elevationSourceUrl above). Default '' (unset).
+  const [initialCartoApiKey, setInitialCartoApiKey] = useState('');
   // ATAK/CoT feed server (#3691 Phase 3 WP2). Same pattern as elevation above:
   // global singleton, no context/prop home, default OFF / port 8088.
   const [initialCotFeedEnabled, setInitialCotFeedEnabled] = useState(false);
@@ -620,6 +628,12 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
           updateField('elevationSourceUrl', elevationSourceUrl);
           setInitialElevationSourceUrl(elevationSourceUrl);
 
+          // #4934: deployment-wide Carto basemap API key. Admins receive the
+          // unmasked value (it is not secret-stripped).
+          const cartoApiKey = typeof settings.cartoApiKey === 'string' ? settings.cartoApiKey : '';
+          updateField('cartoApiKey', cartoApiKey);
+          setInitialCartoApiKey(cartoApiKey);
+
           // Load ATAK/CoT feed settings (#3691 Phase 3). Default OFF; absent
           // port key => 8088.
           const cotFeedEnabledOn = settings.cotFeedEnabled === '1' || settings.cotFeedEnabled === 'true';
@@ -720,6 +734,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       externalUrl: initialExternalUrl,
       elevationEnabled: initialElevationEnabled,
       elevationSourceUrl: initialElevationSourceUrl,
+      cartoApiKey: initialCartoApiKey,
       cotFeedEnabled: initialCotFeedEnabled,
       cotFeedPort: initialCotFeedPort,
     };
@@ -733,7 +748,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
       solarMonitoringEnabled, solarMonitoringLatitude, solarMonitoringLongitude, solarMonitoringAzimuth, solarMonitoringDeclination,
       initialPacketMonitorSettings, initialHomoglyphEnabled, initialLocalStatsIntervalMinutes, initialMeshcoreCliTimeoutSeconds, initialAdminRetryAttempts,
       initialAnalyticsProvider, initialAnalyticsConfig, initialAppriseApiServerUrl, initialExternalUrl, initialElevationEnabled, initialElevationSourceUrl,
-      initialCotFeedEnabled, initialCotFeedPort]);
+      initialCartoApiKey, initialCotFeedEnabled, initialCotFeedPort]);
 
   // Re-seed the draft's category-A/B fields whenever the upstream props/context values change.
   // PINNED BEHAVIOR (do not add a dirty-guard here — that would be a behavior change, out of
@@ -914,6 +929,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     setInitialExternalUrl(d.externalUrl.trim());
     setInitialElevationEnabled(d.elevationEnabled);
     setInitialElevationSourceUrl(d.elevationSourceUrl.trim());
+    setInitialCartoApiKey(d.cartoApiKey.trim());
     setInitialCotFeedEnabled(d.cotFeedEnabled);
     setInitialCotFeedPort(d.cotFeedPort);
   }, [setNeighborInfoMinZoom, setDefaultMapCenterLat, setDefaultMapCenterLon, setDefaultMapCenterZoom,
@@ -988,6 +1004,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         externalUrl: draft.externalUrl.trim(),
         elevationEnabled: draft.elevationEnabled ? 'true' : 'false',
         elevationSourceUrl: draft.elevationSourceUrl.trim(),
+        cartoApiKey: draft.cartoApiKey.trim(),
         cotFeedEnabled: draft.cotFeedEnabled ? '1' : '0',
         cotFeedPort: String(draft.cotFeedPort),
       };
@@ -2521,6 +2538,24 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
             <span className="setting-description">
               {t('settings.elevation_enabled_description', 'Turns off the Link Profile tool\'s terrain chart when disabled.')}
             </span>
+          </div>
+          <div className="setting-item">
+            <label htmlFor="cartoApiKey">
+              {t('settings.carto_api_key_label', 'Carto Basemap API Key')}
+              <span className="setting-description">
+                {t('settings.carto_api_key_description', 'Removes the "API key required" watermark on the Dark/Light (Carto) basemaps. Free and instant — request one at https://carto.com/basemaps/apikey/. Leave empty to use Carto keyless (watermarked) or a non-Carto basemap.')}
+              </span>
+            </label>
+            <input
+              id="cartoApiKey"
+              type="text"
+              value={draft.cartoApiKey}
+              onChange={(e) => updateField('cartoApiKey', e.target.value)}
+              placeholder={t('settings.carto_api_key_placeholder', 'Carto API key')}
+              className="setting-input"
+              autoComplete="off"
+              spellCheck={false}
+            />
           </div>
           <div className="setting-item">
             <label htmlFor="elevationSourceUrl">

--- a/src/components/TracerouteWidget.tsx
+++ b/src/components/TracerouteWidget.tsx
@@ -12,6 +12,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { MapContainer, TileLayer, Marker, Tooltip, useMap } from 'react-leaflet';
 import { useSettings } from '../contexts/SettingsContext';
 import { getTilesetById } from '../config/tilesets';
+import { withCartoKey } from '../config/cartoKey';
 import { useTraceroutes } from '../hooks/useTraceroutes';
 import { isUnknownSnr, tracerouteSegmentWeight } from '../utils/mapHelpers';
 import { TraceroutePathsLayer } from './map/layers/TraceroutePathsLayer';
@@ -73,7 +74,7 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
   canEdit = true,
 }) => {
   const { t } = useTranslation();
-  const { mapTileset, customTilesets, overlayColors } = useSettings();
+  const { mapTileset, customTilesets, overlayColors, cartoApiKey } = useSettings();
   const [searchQuery, setSearchQuery] = useState('');
   const [showSearch, setShowSearch] = useState(false);
   const [showMap, setShowMap] = useState(false); // Map hidden by default
@@ -489,8 +490,8 @@ const TracerouteWidget: React.FC<TracerouteWidgetProps> = ({
                     attributionControl={false}
                   >
                     <FitBounds bounds={mapData.bounds} />
-                    <TileLayer 
-                      url={tileset.url}
+                    <TileLayer
+                      url={withCartoKey(tileset.url, cartoApiKey)}
                       attribution={tileset.attribution}
                       maxZoom={tileset.maxZoom}
                     />

--- a/src/components/map/BaseMap.test.tsx
+++ b/src/components/map/BaseMap.test.tsx
@@ -95,6 +95,26 @@ describe('BaseMap', () => {
     expect(screen.queryByTestId('raster-tile')).not.toBeInTheDocument();
   });
 
+  // 2b. Carto API key (#4934)
+  it('appends the Carto API key to a Carto raster tile URL', () => {
+    vi.mocked(getTilesetById).mockReturnValueOnce({
+      id: 'cartoDark',
+      name: 'Dark',
+      url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png',
+      attribution: '',
+      maxZoom: 19,
+    });
+    render(<BaseMap center={[0, 0]} zoom={3} tilesetId="cartoDark" cartoApiKey="KEY123" />);
+    expect(screen.getByTestId('raster-tile').getAttribute('data-url')).toBe(
+      'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png?key=KEY123',
+    );
+  });
+
+  it('leaves a non-Carto raster URL untouched even when a Carto key is set', () => {
+    render(<BaseMap center={[0, 0]} zoom={3} cartoApiKey="KEY123" />);
+    expect(screen.getByTestId('raster-tile').getAttribute('data-url')).toBe(OSM_URL);
+  });
+
   // 3. Unknown-id fallback
   it('falls back to raster osm when given an unknown tileset id', () => {
     render(<BaseMap center={[0, 0]} zoom={3} tilesetId="does-not-exist" />);

--- a/src/components/map/BaseMap.tsx
+++ b/src/components/map/BaseMap.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties, ReactNode, Ref } from 'react';
 import type { Map as LeafletMap } from 'leaflet';
 import { MapContainer, TileLayer } from 'react-leaflet';
 import { getTilesetById, DEFAULT_TILESET_ID, type TilesetId, type CustomTileset } from '../../config/tilesets';
+import { withCartoKey } from '../../config/cartoKey';
 import { VectorTileLayer } from '../VectorTileLayer';
 import { TilesetSelector } from '../TilesetSelector';
 import MapResizeHandler from '../MapResizeHandler';
@@ -25,6 +26,10 @@ export interface BaseMapProps {
   customTilesets?: CustomTileset[];
   /** MapLibre style JSON passthrough for vector tilesets (ignored for raster). */
   styleJson?: Record<string, unknown>;
+  /** Deployment-wide Carto basemap API key (#4934). When set, it is appended as
+   *  `?key=` to Carto CDN tile URLs (no-op for every other host). Omit/null ⇒
+   *  keyless (Carto tiles show the "API key required" watermark). */
+  cartoApiKey?: string | null;
 
   // ---- Optional tileset selector overlay ---------------------------------
   /** Render the TilesetSelector overlay. Default false. */
@@ -106,6 +111,7 @@ export function BaseMap({
   tilesetId,
   customTilesets,
   styleJson,
+  cartoApiKey,
   showTilesetSelector = false,
   onTilesetChange,
   scrollWheelZoom,
@@ -166,7 +172,7 @@ export function BaseMap({
             <>
               <TileLayer
                 key={`raster-${tileset.maxZoom}`}
-                url={tileset.url}
+                url={withCartoKey(tileset.url, cartoApiKey)}
                 attribution={tileset.attribution}
                 maxZoom={tileset.maxZoom}
                 // Damp ESRI World_Imagery's over-saturated synthetic water blue
@@ -186,7 +192,7 @@ export function BaseMap({
               {tileset.overlayUrl && (
                 <TileLayer
                   key={`raster-overlay-${tileset.maxZoom}`}
-                  url={tileset.overlayUrl}
+                  url={withCartoKey(tileset.overlayUrl, cartoApiKey)}
                   attribution={tileset.overlayAttribution ?? tileset.attribution}
                   maxZoom={tileset.maxZoom}
                   zIndex={10}

--- a/src/config/basemap3d.test.ts
+++ b/src/config/basemap3d.test.ts
@@ -37,6 +37,26 @@ describe('resolve3DBasemap', () => {
     expect(result.tiles).toEqual([TILESETS.esriSatellite.url]);
   });
 
+  it('appends the Carto key to every expanded Carto tile URL (#4934)', () => {
+    const result = resolve3DBasemap('cartoDark', [], 'KEY123');
+    expect(result.usedFallback).toBe(false);
+    expect(result.tiles).toEqual([
+      'https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png?key=KEY123',
+      'https://b.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png?key=KEY123',
+      'https://c.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png?key=KEY123',
+    ]);
+  });
+
+  it('leaves non-Carto tiles unkeyed even when a Carto key is supplied (#4934)', () => {
+    const result = resolve3DBasemap('osm', [], 'KEY123');
+    expect(result.tiles.every((u) => !u.includes('key='))).toBe(true);
+  });
+
+  it('does not key Carto tiles when no key is supplied (#4934)', () => {
+    const result = resolve3DBasemap('cartoDark', []);
+    expect(result.tiles.every((u) => !u.includes('key='))).toBe(true);
+  });
+
   it('falls back to osm for a custom vector-only tileset', () => {
     const custom: CustomTileset[] = [
       {

--- a/src/config/basemap3d.ts
+++ b/src/config/basemap3d.ts
@@ -14,6 +14,7 @@
  *    the 2D view is unaffected.
  */
 import { getTilesetById, TILESETS, type TilesetId, type CustomTileset } from './tilesets';
+import { withCartoKey } from './cartoKey';
 
 export interface Basemap3DSource {
   tiles: string[];
@@ -42,7 +43,11 @@ export function expandSubdomains(url: string): string[] {
  * custom) fall back to `TILESETS.osm` with `usedFallback: true` so callers
  * can surface a non-blocking note.
  */
-export function resolve3DBasemap(tilesetId: TilesetId, custom: CustomTileset[] = []): Basemap3DSource {
+export function resolve3DBasemap(
+  tilesetId: TilesetId,
+  custom: CustomTileset[] = [],
+  cartoApiKey?: string | null,
+): Basemap3DSource {
   const tileset = getTilesetById(tilesetId, custom);
 
   if (tileset.isVector) {
@@ -56,7 +61,9 @@ export function resolve3DBasemap(tilesetId: TilesetId, custom: CustomTileset[] =
   }
 
   return {
-    tiles: expandSubdomains(tileset.url),
+    // #4934: append the Carto key to each expanded subdomain URL (no-op for
+    // non-Carto hosts / empty key) so the 3D raster basemap is unwatermarked.
+    tiles: expandSubdomains(tileset.url).map((u) => withCartoKey(u, cartoApiKey)),
     attribution: tileset.attribution,
     maxZoom: tileset.maxZoom,
     usedFallback: false,

--- a/src/config/cartoKey.test.ts
+++ b/src/config/cartoKey.test.ts
@@ -51,6 +51,12 @@ describe('withCartoKey', () => {
     );
   });
 
+  it('handles an existing query string AND a fragment together', () => {
+    expect(withCartoKey('https://basemaps.cartocdn.com/x.json?v=2#hash', 'K')).toBe(
+      'https://basemaps.cartocdn.com/x.json?v=2&key=K#hash',
+    );
+  });
+
   it('is idempotent — does not double-append when a key is already present', () => {
     const keyed = 'https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png?key=EXISTING';
     expect(withCartoKey(keyed, 'NEW')).toBe(keyed);

--- a/src/config/cartoKey.test.ts
+++ b/src/config/cartoKey.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { withCartoKey, isCartoUrl } from './cartoKey';
+
+describe('isCartoUrl', () => {
+  it('recognizes Carto raster tile templates (with {s} placeholder)', () => {
+    expect(isCartoUrl('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png')).toBe(true);
+  });
+
+  it('recognizes Carto GL style JSON URLs', () => {
+    expect(isCartoUrl('https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json')).toBe(true);
+  });
+
+  it('rejects non-Carto hosts', () => {
+    expect(isCartoUrl('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png')).toBe(false);
+    expect(isCartoUrl('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}')).toBe(false);
+  });
+
+  it('rejects a lookalike host that only contains the suffix as a substring', () => {
+    expect(isCartoUrl('https://basemaps.cartocdn.com.evil.example/{z}/{x}/{y}.png')).toBe(false);
+  });
+
+  it('returns false for unparseable input', () => {
+    expect(isCartoUrl('not a url')).toBe(false);
+  });
+});
+
+describe('withCartoKey', () => {
+  const carto = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png';
+
+  it('appends ?key= to a Carto raster template, preserving placeholders', () => {
+    expect(withCartoKey(carto, 'ABC123')).toBe(
+      'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png?key=ABC123',
+    );
+  });
+
+  it('appends ?key= to a Carto style JSON URL', () => {
+    expect(withCartoKey('https://basemaps.cartocdn.com/gl/positron-gl-style/style.json', 'K')).toBe(
+      'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json?key=K',
+    );
+  });
+
+  it('uses & when the URL already has a query string', () => {
+    expect(withCartoKey('https://basemaps.cartocdn.com/x/{z}/{x}/{y}.png?scale=2', 'K')).toBe(
+      'https://basemaps.cartocdn.com/x/{z}/{x}/{y}.png?scale=2&key=K',
+    );
+  });
+
+  it('keeps the key before a URL fragment', () => {
+    expect(withCartoKey('https://basemaps.cartocdn.com/style.json#foo', 'K')).toBe(
+      'https://basemaps.cartocdn.com/style.json?key=K#foo',
+    );
+  });
+
+  it('is idempotent — does not double-append when a key is already present', () => {
+    const keyed = 'https://basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png?key=EXISTING';
+    expect(withCartoKey(keyed, 'NEW')).toBe(keyed);
+  });
+
+  it('url-encodes the key', () => {
+    expect(withCartoKey('https://basemaps.cartocdn.com/style.json', 'a b/c')).toBe(
+      'https://basemaps.cartocdn.com/style.json?key=a%20b%2Fc',
+    );
+  });
+
+  it('is a no-op when the key is empty/nullish', () => {
+    expect(withCartoKey(carto, '')).toBe(carto);
+    expect(withCartoKey(carto, null)).toBe(carto);
+    expect(withCartoKey(carto, undefined)).toBe(carto);
+  });
+
+  it('is a no-op for non-Carto URLs', () => {
+    const osm = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+    expect(withCartoKey(osm, 'K')).toBe(osm);
+  });
+});

--- a/src/config/cartoKey.ts
+++ b/src/config/cartoKey.ts
@@ -46,6 +46,10 @@ export function withCartoKey(url: string, key: string | null | undefined): strin
   if (!key) return url;
   if (!isCartoUrl(url)) return url;
 
+  // Unlike isCartoUrl (which must feed `new URL()`), the string surgery below
+  // needs no `{s}` substitution: `{s}`/`{z}`/`{x}`/`{y}` only ever appear in the
+  // path, never in a query or fragment, so `indexOf('#')`, `includes('?')`, and
+  // the `key=` probe operate on the raw template safely.
   // Split off any fragment first so the key lands before it.
   const hashIndex = url.indexOf('#');
   const fragment = hashIndex >= 0 ? url.slice(hashIndex) : '';

--- a/src/config/cartoKey.ts
+++ b/src/config/cartoKey.ts
@@ -1,0 +1,59 @@
+/**
+ * Carto basemap API key helper.
+ *
+ * Carto is retiring its free, keyless raster basemaps: requests to
+ * `basemaps.cartocdn.com` without a key come back stamped with an
+ * "API key required" watermark. A free, domain-restricted key removes it and is
+ * attached simply as a `?key=` query parameter on the same endpoints.
+ *
+ * The key is a *publishable* token (like a Mapbox public token) — it is sent
+ * from the browser on every tile request by design, so we append it client-side
+ * rather than proxying tiles. See docs/internal/dev-notes/CARTO_API_KEY_PLAN.md.
+ */
+
+/** Host suffix that identifies a Carto basemap CDN URL. */
+const CARTO_HOST_SUFFIX = 'basemaps.cartocdn.com';
+
+/**
+ * Returns true when `url` points at the Carto basemap CDN (raster tiles, GL
+ * style JSON, sprites, or glyphs — all served from that host).
+ *
+ * Tolerant of tile-template placeholders (`{s}`, `{z}`, …) in the URL: it
+ * inspects the host portion only, which never contains a path placeholder.
+ */
+export function isCartoUrl(url: string): boolean {
+  try {
+    // Substitute the subdomain placeholder so the URL parses; other `{…}`
+    // tokens live in the path and don't affect the hostname.
+    const host = new URL(url.replace(/\{s\}/g, 'a')).hostname.toLowerCase();
+    return host === CARTO_HOST_SUFFIX || host.endsWith('.' + CARTO_HOST_SUFFIX);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Appends the Carto `?key=` parameter to a Carto CDN URL. No-op when:
+ * - `key` is empty/nullish,
+ * - `url` is not a Carto CDN URL,
+ * - the URL already carries a `key` parameter.
+ *
+ * Preserves any existing query string (uses `&` when a query already exists)
+ * and any URL fragment, and leaves `{s}`/`{z}`/`{x}`/`{y}` path placeholders
+ * intact so the result is still a valid tile template.
+ */
+export function withCartoKey(url: string, key: string | null | undefined): string {
+  if (!key) return url;
+  if (!isCartoUrl(url)) return url;
+
+  // Split off any fragment first so the key lands before it.
+  const hashIndex = url.indexOf('#');
+  const fragment = hashIndex >= 0 ? url.slice(hashIndex) : '';
+  const base = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
+
+  // Already keyed? Leave it alone (idempotent).
+  if (/[?&]key=/.test(base)) return url;
+
+  const separator = base.includes('?') ? '&' : '?';
+  return `${base}${separator}key=${encodeURIComponent(key)}${fragment}`;
+}

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -119,6 +119,10 @@ interface SettingsContextType {
   mapTileset: TilesetId;
   mapTilesetLight: TilesetId;
   mapTilesetDark: TilesetId;
+  /** Deployment-wide Carto basemap API key (#4934), or null when unset. Loaded
+   *  from the server settings and applied to Carto tile URLs. Read-only here —
+   *  admins set it via SettingsTab / the settings API, not through this context. */
+  cartoApiKey: string | null;
   activeMapTilesetMode: ActiveAppearanceMode;
   overlayScheme: OverlayScheme;
   overlayColors: OverlayColors;
@@ -480,6 +484,9 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
 
   const [mapTilesetLight, setMapTilesetLightState] = useState<TilesetId>(initialMapTilesets.light);
   const [mapTilesetDark, setMapTilesetDarkState] = useState<TilesetId>(initialMapTilesets.dark);
+  // Server-global Carto API key (#4934). Not a per-user pref, so no localStorage
+  // seed — it is populated from the server settings response on load.
+  const [cartoApiKey, setCartoApiKeyState] = useState<string | null>(null);
 
   const [mapPinStyle, setMapPinStyleState] = useState<MapPinStyle>(() => {
     const saved = localStorage.getItem('mapPinStyle');
@@ -1624,6 +1631,13 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
             localStorage.setItem('mapTilesetDark', nextDark);
           }
 
+          // Server-global Carto API key (#4934). Absent/blank ⇒ null (no key).
+          setCartoApiKeyState(
+            typeof settings.cartoApiKey === 'string' && settings.cartoApiKey.length > 0
+              ? settings.cartoApiKey
+              : null,
+          );
+
           if (settings.mapPinStyle) {
             setMapPinStyleState(settings.mapPinStyle as MapPinStyle);
             localStorage.setItem('mapPinStyle', settings.mapPinStyle);
@@ -1949,6 +1963,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     mapTileset,
     mapTilesetLight,
     mapTilesetDark,
+    cartoApiKey,
     activeMapTilesetMode,
     overlayScheme,
     overlayColors,
@@ -2076,6 +2091,7 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children, ba
     mapTileset,
     mapTilesetLight,
     mapTilesetDark,
+    cartoApiKey,
     activeMapTilesetMode,
     overlayScheme,
     overlayColors,

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -95,6 +95,7 @@ export const VALID_SETTINGS_KEYS = [
   'mapTileset',
   'mapTilesetLight',
   'mapTilesetDark',
+  'cartoApiKey',
   'packet_log_enabled',
   'packet_log_max_count',
   'packet_log_max_age_hours',
@@ -597,6 +598,11 @@ export const GLOBAL_ONLY_SETTINGS_KEYS = new Set<string>([
   // getSettingForSource does NOT fall back to the global row (removed in
   // #2839/#2840), so a per-source value here would be stored and never read.
   'externalUrl',
+  // Deployment-wide Carto basemap API key (#4934). One key per install, applied
+  // to Carto tiles for every client incl. anonymous embed viewers. It is a
+  // publishable, domain-restricted token (NOT a secret) so it is deliberately
+  // absent from SECRET_SETTINGS_KEYS — clients must receive it.
+  'cartoApiKey',
   // Documented "global" in this file's own inline comments:
   'pkiDmDecryptionGloballyEnabled',         // :82 master switch, gates every source
   'position_estimation_enabled',            // :141 global batch job (#3271)

--- a/src/server/routes/embedPublicRoutes.test.ts
+++ b/src/server/routes/embedPublicRoutes.test.ts
@@ -390,3 +390,35 @@ describe('GET /api/embed/:profileId/traceroutes', () => {
     expect(res.body.length).toBeLessThanOrEqual(500);
   }, 30000);
 });
+
+describe('GET /api/embed/:profileId/config — Carto API key (#4934)', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  it('includes the deployment-wide Carto API key so anonymous embeds are unwatermarked', async () => {
+    const sourceId = nextSourceId();
+    const profileId = `cfg-carto-${seq}`;
+    await createProfile({ id: profileId, sourceId });
+    databaseService.setSetting('cartoApiKey', 'EMBED_KEY_123');
+    try {
+      const res = await request(app).get(`/api/embed/${profileId}/config`);
+      expect(res.status).toBe(200);
+      expect(res.body.cartoApiKey).toBe('EMBED_KEY_123');
+    } finally {
+      databaseService.setSetting('cartoApiKey', '');
+    }
+  });
+
+  it('returns cartoApiKey: null when no key is configured', async () => {
+    const sourceId = nextSourceId();
+    const profileId = `cfg-carto-none-${seq}`;
+    await createProfile({ id: profileId, sourceId });
+    databaseService.setSetting('cartoApiKey', '');
+    const res = await request(app).get(`/api/embed/${profileId}/config`);
+    expect(res.status).toBe(200);
+    expect(res.body.cartoApiKey).toBeNull();
+  });
+});

--- a/src/server/routes/embedPublicRoutes.ts
+++ b/src/server/routes/embedPublicRoutes.ts
@@ -75,11 +75,17 @@ router.get('/:profileId/config', createEmbedCspMiddleware(), (req: Request, res:
     }
   }
 
+  // Deployment-wide Carto basemap API key (#4934). Publishable, domain-restricted
+  // token applied to Carto tiles so the embed map loads without the "API key
+  // required" watermark. Sent to anonymous embed viewers by design.
+  const cartoApiKey = databaseService.getSetting('cartoApiKey') || null;
+
   // Return only public-facing configuration (exclude admin-only fields like name, allowedOrigins)
   res.json({
     id: profile.id,
     channels: profile.channels,
     tileset: profile.tileset,
+    cartoApiKey,
     defaultLat,
     defaultLng,
     defaultZoom,


### PR DESCRIPTION
## Summary

Fixes the **"API key required"** watermark on the Dark/Light (Carto) basemaps. Carto is retiring its free, keyless raster basemaps (`basemaps.cartocdn.com/{dark_all,light_all}`); requests without a key now come back watermarked. `cartoDark` is our default dark tileset, so users hit it by default.

Adds a deployment-wide **`cartoApiKey`** setting (free, instant key from <https://carto.com/basemaps/apikey/>) and appends it as `?key=` to Carto CDN tile URLs on every map surface + the public embed config.

This is **Phase 1** (raster key) of #4934. Phase 2 (Carto vector basemaps) and Phase 3 (vector-in-3D, deferred) follow.

## Design

- **Server-wide, admin-set, publicly-readable** — one key per install, delivered to *every* client including anonymous embed viewers (their maps must load unwatermarked).
- **Not a secret, no tile proxy.** A Carto basemap key is a publishable, domain-restricted token (like a Mapbox public token) — the browser sends it on every tile request by design, so it is appended client-side and is deliberately **absent from `SECRET_SETTINGS_KEYS`**. A proxy would defeat Carto's CDN for zero gain.
- No CSP change (host unchanged; `?key=` only).

## Changes

- `src/config/cartoKey.ts` — `withCartoKey(url, key)` helper: carto-host-only, idempotent, query/fragment-safe. No-op for non-Carto hosts and empty keys.
- `settings.ts` — `cartoApiKey` added to `VALID_SETTINGS_KEYS` + `GLOBAL_ONLY_SETTINGS_KEYS`.
- `SettingsContext` — loads and exposes `cartoApiKey` to all clients.
- `embedPublicRoutes` — includes `cartoApiKey` in the public embed config.
- `SettingsTab` — admin input (mirrors the `elevationSourceUrl` admin-field pattern).
- Wired at every tile-URL choke point: `BaseMap` raster + overlay, `resolve3DBasemap` (3D), `TracerouteWidget`, `EmbedMap`. The 5 consumers that render a user-selectable tileset thread the key from `useSettings()`; surfaces hardcoded to `osm` need nothing (helper no-ops).

## Verification

- `npm run typecheck` — clean
- `npm run lint:ci` — clean
- `npm run build` — clean
- Targeted + affected suites: **260 passed** (cartoKey, basemap3d, BaseMap, embedPublicRoutes, SettingsTab, SettingsContext, EmbedMap, DashboardMap, NodesTab, settings-persistence guard)

Plan: `docs/internal/dev-notes/CARTO_API_KEY_PLAN.md`

Part of #4934 (Phase 1 of 2 — Phase 2 vector basemaps tracked in the same issue; intentionally does not auto-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
