### PR TITLE
fix(meshcore): send truly-unscoped floods, not the node default region (#4932)

### DIFF
--- a/src/server/meshcoreManager.autoAckScope.test.ts
+++ b/src/server/meshcoreManager.autoAckScope.test.ts
@@ -65,8 +65,13 @@ function makeManager(opts: {
   return { manager: m, bridgeCalls };
 }
 
+// #4932: an explicit-unscoped send is now { unscoped: true } (forces public
+// flood, overriding the node default), distinct from { region: null } (clear /
+// inherit the node default). Map the former to the string 'unscoped'.
 const scopeOf = (calls: BridgeCall[]) =>
-  calls.filter(c => c.cmd === 'set_flood_scope').map(c => c.params.region);
+  calls
+    .filter(c => c.cmd === 'set_flood_scope')
+    .map(c => (c.params.unscoped ? 'unscoped' : (c.params.region ?? null)));
 
 function triggerMessage(overrides: Partial<MeshCoreMessage>): MeshCoreMessage {
   return {
@@ -88,14 +93,15 @@ describe('MeshCoreManager — Auto-Ack "trigger" scope mode (#3887)', () => {
     const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: null }, defaultScope: 'berlin' });
     const msg = triggerMessage({ scopeCode: null, scopeName: null });
     await (manager as any).checkAutoAcknowledge(msg, false, 1, null, null);
-    expect(scopeOf(bridgeCalls)).toEqual([null]);
+    // #4932: truly-unscoped, NOT clear/inherit (which would revert to 'berlin').
+    expect(scopeOf(bridgeCalls)).toEqual(['unscoped']);
   });
 
   it('replies unscoped when the trigger arrived explicitly unscoped (scopeCode: 0)', async () => {
     const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: null }, defaultScope: 'berlin' });
     const msg = triggerMessage({ scopeCode: 0, scopeName: null });
     await (manager as any).checkAutoAcknowledge(msg, false, 1, null, null);
-    expect(scopeOf(bridgeCalls)).toEqual([null]);
+    expect(scopeOf(bridgeCalls)).toEqual(['unscoped']);
   });
 
   it('replies on the trigger\'s named scope when resolved', async () => {
@@ -112,6 +118,6 @@ describe('MeshCoreManager — Auto-Ack "trigger" scope mode (#3887)', () => {
     const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: null }, defaultScope: 'berlin' });
     const msg = triggerMessage({ scopeCode: 456, scopeName: null });
     await (manager as any).checkAutoAcknowledge(msg, false, 1, null, null);
-    expect(scopeOf(bridgeCalls)).toEqual([null]);
+    expect(scopeOf(bridgeCalls)).toEqual(['unscoped']);
   });
 });

--- a/src/server/meshcoreManager.scope.test.ts
+++ b/src/server/meshcoreManager.scope.test.ts
@@ -115,8 +115,13 @@ function makeManager(opts: {
   return { manager: m, bridgeCalls, scopeUpdates };
 }
 
+// A set_flood_scope call is one of: force-unscoped ({ unscoped: true } → the
+// string 'unscoped'), a named region ({ region: 'x' } → 'x'), or clear/inherit
+// ({ region: null } → null). #4932 split explicit-unscoped from inherit.
 const scopeOf = (calls: BridgeCall[]) =>
-  calls.filter(c => c.cmd === 'set_flood_scope').map(c => c.params.region);
+  calls
+    .filter(c => c.cmd === 'set_flood_scope')
+    .map(c => (c.params.unscoped ? 'unscoped' : (c.params.region ?? null)));
 
 const cmdSeq = (calls: BridgeCall[]) =>
   calls.filter(c => c.cmd === 'set_flood_scope' || c.cmd === 'send_message').map(c => c.cmd);
@@ -227,10 +232,13 @@ describe('MeshCoreManager — per-message scope override (#3701)', () => {
     expect(scopeOf(bridgeCalls)).toEqual(['BadScope']);
   });
 
-  it('an empty/whitespace override is an explicit unscoped send (null)', async () => {
+  it('an empty/whitespace override forces truly-unscoped, overriding channel + default scope (#4932)', async () => {
     const { manager, bridgeCalls } = makeManager({ channelScopes: { 1: 'muenchen' }, defaultScope: 'berlin' });
     await manager.sendMessage('hi', undefined, 1, '   ');
-    expect(scopeOf(bridgeCalls)).toEqual([null]);
+    // Explicit unscoped must NOT collapse to clear/inherit (which would revert
+    // to the node's default region) — it forces send_unscoped on the device.
+    expect(scopeOf(bridgeCalls)).toEqual(['unscoped']);
+    expect(bridgeCalls.find(c => c.cmd === 'set_flood_scope')!.params).toEqual({ unscoped: true });
   });
 
   it('omitting the override falls back to the channel scope (unchanged behaviour)', async () => {

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -3358,8 +3358,8 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     }
   }
 
-  private static normalizeScopeOverride(scope: string | null | undefined): string | null | undefined {
-    if (scope === undefined || scope === null) return undefined;
+  private static normalizeScopeOverride(scope: string | null | undefined): string | undefined {
+    if (scope === undefined || scope === null) return undefined; // not provided → inherit
     const stripped = scope.trim().replace(/^#/, '');
     const normalized = stripped.replace(/[^0-9A-Za-z-]/g, '');
     if (normalized !== stripped) {
@@ -3368,7 +3368,11 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
         `normalised to "${normalized || '(unscoped)'}"`,
       );
     }
-    return normalized || null;
+    // '' is a meaningful value here: an EXPLICIT "unscoped" choice. It must stay
+    // distinct from `undefined` (inherit) and from a named region so that
+    // applyFloodScope can force truly-unscoped (#4932) rather than collapse it
+    // to the node's default scope.
+    return normalized;
   }
 
   /**
@@ -3402,8 +3406,10 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   /**
    * Resolve the effective MeshCore region/scope for an outbound send (#3667):
    * a channel's own scope overrides the source default scope; otherwise the
-   * source default applies; otherwise unscoped. Returns the plain region name
-   * (no leading '#') or null for unscoped.
+   * source default applies. Returns the plain region name (no leading '#'), or
+   * null when MeshMonitor has no scope configured — in which case the flood
+   * scope is cleared and the node falls back to its OWN persistent default
+   * region (this is "inherit", not forced-unscoped; see applyFloodScope #4932).
    */
   private async resolveScopeForSend(channelIdx?: number): Promise<string | null> {
     if (channelIdx !== undefined) {
@@ -3416,15 +3422,22 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   }
 
   /**
-   * Ensure the device's global flood scope matches `region` (null = unscoped),
-   * sending a `set_flood_scope` bridge command only when it differs from the
-   * cached value. On failure the cached scope is invalidated so the next send
-   * re-asserts, and the error propagates.
+   * Ensure the device's global flood scope matches `region`, sending a
+   * `set_flood_scope` bridge command only when it differs from the cached value.
+   * Three intents (#4932):
+   *   • `''`   → force truly-unscoped (public flood), overriding the node's
+   *              persistent default region (`{ unscoped: true }` → v12+ command).
+   *   • name   → a named region (transport key derived from it).
+   *   • `null` → clear the transient override, i.e. fall back to the node's own
+   *              default region.
+   * On failure the cached scope is invalidated so the next send re-asserts, and
+   * the error propagates.
    */
   private async applyFloodScope(region: string | null): Promise<void> {
     if (this.activeFloodScope === region) return;
     try {
-      const resp = await this.sendBridgeCommand('set_flood_scope', { region });
+      const params = region === '' ? { unscoped: true } : { region };
+      const resp = await this.sendBridgeCommand('set_flood_scope', params);
       if (!resp.success) {
         throw new Error(resp.error || 'set_flood_scope failed');
       }
@@ -3508,7 +3521,9 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
           // reconstructed post-send, and the UI gates the scope row on
           // `scopeName` presence (no magic-number sentinel needed). A normal
           // unscoped send leaves `scopeName` null, so it shows no scope row.
-          scopeName: region ?? null,
+          // `region` is '' for an explicit-unscoped send (#4932) — coalesce that
+          // (and null) to null so unscoped shows no scope row.
+          scopeName: region || null,
         };
         // An auto-retry resend (#3977) must NOT create a second message row or
         // re-emit a `message` event — that would produce a duplicate bubble in

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -142,6 +142,29 @@ class MockConnection extends EventEmitter {
     }, 1);
   }
 
+  // Flood-scope (#3667 / #4932). The [54][0x00][key] forms the library exposes:
+  public clearFloodScopeCalls = 0;
+  public setFloodScopeCalls: Uint8Array[] = [];
+  // Raw frames the backend sends itself (the truly-unscoped [54][0x01] form):
+  public rawFrames: Uint8Array[] = [];
+  public floodScopeErr = false;
+
+  async clearFloodScope() {
+    this.clearFloodScopeCalls++;
+  }
+
+  async setFloodScope(key: Uint8Array) {
+    this.setFloodScopeCalls.push(key);
+  }
+
+  sendToRadioFrame(bytes: Uint8Array) {
+    this.rawFrames.push(bytes);
+    // The backend awaits an Ok/Err after sending the raw unscoped frame.
+    setTimeout(() => {
+      this.emit(this.floodScopeErr ? ResponseCodes.Err : ResponseCodes.Ok, {});
+    }, 1);
+  }
+
   async setAdvertLocPolicy(policy: number) {
     this.setAdvertLocPolicyCalls.push(policy);
   }
@@ -278,6 +301,7 @@ function installMockModule(MockConn: typeof MockConnection): MockConnection {
       BinaryRequestTypes,
       AdvType,
       TxtTypes,
+      CommandCodes: { SetFloodScope: 54 },
     } as any,
     CayenneLpp: {
       parse: (bytes: Uint8Array | number[]) => {
@@ -1418,7 +1442,71 @@ describe('MeshCoreNativeBackend', () => {
     expect(resp.success).toBe(false);
     expect(resp.error).toMatch(/Set-out-path target not in device contact list/);
   });
+
+  // ---- flood scope (#3667 / #4932) ----
+
+  it('set_flood_scope with a named region derives the sha256 transport key', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', { connectionType: 'serial', serialPort: '/dev/ttyUSB0' });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+
+    const resp = await backend.sendCommand('set_flood_scope', { region: 'muenchen' });
+    expect(resp.success).toBe(true);
+    expect(conn.setFloodScopeCalls).toHaveLength(1);
+    expect(conn.setFloodScopeCalls[0]).toHaveLength(16);
+    expect(conn.clearFloodScopeCalls).toBe(0);
+    expect(conn.rawFrames).toHaveLength(0);
+  });
+
+  it('set_flood_scope with null region clears the scope (revert to node default)', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', { connectionType: 'serial', serialPort: '/dev/ttyUSB0' });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+
+    const resp = await backend.sendCommand('set_flood_scope', { region: null });
+    expect(resp.success).toBe(true);
+    expect(conn.clearFloodScopeCalls).toBe(1);
+    expect(conn.rawFrames).toHaveLength(0);
+  });
+
+  it('set_flood_scope unscoped degrades to clear on pre-v12 firmware (#4932)', async () => {
+    // Default mock firmwareVer is 4 — no transient-unscoped command exists, so
+    // it must fall back to clearFloodScope (node default) and report degraded.
+    const backend = new MeshCoreNativeBackend('src-1', { connectionType: 'serial', serialPort: '/dev/ttyUSB0' });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+
+    const resp = await backend.sendCommand('set_flood_scope', { unscoped: true });
+    expect(resp.success).toBe(true);
+    expect(resp.data?.degraded).toBe(true);
+    expect(conn.clearFloodScopeCalls).toBe(1);
+    expect(conn.rawFrames).toHaveLength(0); // no raw [54,1] on old firmware
+  });
+
+  it('set_flood_scope unscoped sends the raw [54,0x01] frame on v12+ firmware (#4932)', async () => {
+    lastInstanceRef = installMockModule(MockConnectionV12) as any;
+    const backend = new MeshCoreNativeBackend('src-1', { connectionType: 'serial', serialPort: '/dev/ttyUSB0' });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+
+    const resp = await backend.sendCommand('set_flood_scope', { unscoped: true });
+    expect(resp.success).toBe(true);
+    expect(resp.data?.unscoped).toBe(true);
+    expect(conn.rawFrames).toHaveLength(1);
+    expect(Array.from(conn.rawFrames[0])).toEqual([54, 0x01]); // CMD_SET_FLOOD_SCOPE, sub-command 1
+    expect(conn.clearFloodScopeCalls).toBe(0);
+    expect(conn.setFloodScopeCalls).toHaveLength(0);
+  });
 });
+
+/** Firmware new enough (companion protocol v12) for the transient unscoped command. */
+class MockConnectionV12 extends MockConnection {
+  public deviceQueryResponse: any = {
+    firmwareVer: 12,
+    firmware_build_date: '01 Jan 2026',
+    manufacturerModel: 'Heltec V3',
+  };
+}
 
 describe('formatOutPath', () => {
   it('returns nulls for the OUT_PATH_UNKNOWN sentinel (0xFF or -1)', () => {

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -247,6 +247,11 @@ export class MeshCoreNativeBackend extends EventEmitter {
   private connection: AnyConnection | null = null;
   private constants: MeshCoreJsModule['Constants'] | null = null;
   private cachedSelfInfo: any = null;
+  // Companion-protocol version of the connected node (DeviceInfo.firmwareVer),
+  // cached at connect. Gates the transient truly-unscoped flood-scope command
+  // (CMD_SET_FLOOD_SCOPE sub-command 0x01), which only exists on v12+ (#4932).
+  // null = unknown (treated as pre-v12).
+  private cachedFirmwareVer: number | null = null;
   private connected: boolean = false;
   private commandSeq: number = 0;
   private drainInFlight: boolean = false;
@@ -386,6 +391,17 @@ export class MeshCoreNativeBackend extends EventEmitter {
         radioFreq: libFreqToMhz(selfInfo?.radioFreq),
         radioBw: libBwToKhz(selfInfo?.radioBw),
       };
+
+      // Cache the companion-protocol version so the flood-scope path can gate
+      // the v12+ truly-unscoped command (#4932). Best-effort — a node/firmware
+      // that doesn't answer DeviceQuery just stays "unknown" (pre-v12).
+      try {
+        const info = await this.connection.deviceQuery(1);
+        this.cachedFirmwareVer = typeof info?.firmwareVer === 'number' ? info.firmwareVer : null;
+      } catch (verErr) {
+        this.cachedFirmwareVer = null;
+        logger.debug(`[MeshCoreNative:${this.sourceId}] deviceQuery for version failed: ${(verErr as Error).message}`);
+      }
     } catch (err) {
       // A failed connect (e.g. a SelfInfo handshake timeout right after a USB
       // replug) MUST release the serial fd. Otherwise the OS-level handle
@@ -419,6 +435,7 @@ export class MeshCoreNativeBackend extends EventEmitter {
       this.connection = null;
     }
     this.cachedSelfInfo = null;
+    this.cachedFirmwareVer = null;
   }
 
   // ---------------- push event wiring ----------------
@@ -1776,8 +1793,49 @@ export class MeshCoreNativeBackend extends EventEmitter {
       case 'set_flood_scope': {
         // MeshCore region/scope (#3667). The device holds a single global flood
         // scope (CMD_SET_FLOOD_SCOPE=54); the manager asserts it before each
-        // send. The transport key is the first 16 bytes of sha256("#region").
-        // An empty/null region clears the scope (back to legacy null '*').
+        // send. Three distinct intents (#4932):
+        //   • unscoped:true  → force truly-unscoped (public flood, no region),
+        //     OVERRIDING the node's persistent default region. This needs the
+        //     v12+ sub-command [54][0x01] (send_unscoped=true); the empty-key
+        //     form below does NOT do this — firmware treats an empty key as
+        //     "revert to the persistent default region", which is exactly the
+        //     bug this fixes.
+        //   • region non-empty → a named region (transport key = first 16 bytes
+        //     of sha256("#region")).
+        //   • else → clear the transient override (revert to the node default).
+        if (params.unscoped === true) {
+          if (this.cachedFirmwareVer != null && this.cachedFirmwareVer >= 12) {
+            // meshcore.js only exposes the [54][0x00][key] form
+            // (setFloodScope/clearFloodScope), so build the truly-unscoped
+            // sub-command frame [54][0x01] (no key) by hand and await the same
+            // Ok/Err the library does. Frame: [CMD_SET_FLOOD_SCOPE=54, 0x01].
+            await new Promise<void>((resolve, reject) => {
+              const onOk = () => {
+                c.off(K.ResponseCodes.Ok, onOk);
+                c.off(K.ResponseCodes.Err, onErr);
+                resolve();
+              };
+              const onErr = () => {
+                c.off(K.ResponseCodes.Ok, onOk);
+                c.off(K.ResponseCodes.Err, onErr);
+                reject(new Error('Device rejected unscoped flood-scope command'));
+              };
+              c.once(K.ResponseCodes.Ok, onOk);
+              c.once(K.ResponseCodes.Err, onErr);
+              c.sendToRadioFrame(Uint8Array.from([K.CommandCodes.SetFloodScope, 0x01]));
+            });
+            return { ok: true, scope: null, unscoped: true };
+          }
+          // Pre-v12 firmware has no transient unscoped command, and the only
+          // alternative (rewriting the node's saved default region via CMD 63)
+          // is destructive, so degrade to the node default and warn (#4932).
+          logger.warn(
+            `[MeshCoreNative:${this.sourceId}] Per-message unscoped flood is unsupported on companion protocol ` +
+            `v${this.cachedFirmwareVer ?? '?'} (needs v12+); falling back to the node's default region.`,
+          );
+          await c.clearFloodScope();
+          return { ok: true, scope: null, unscoped: false, degraded: true };
+        }
         const regionRaw = params.region;
         const region = typeof regionRaw === 'string' ? regionRaw.trim() : '';
         if (!region) {

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -288,10 +288,23 @@ describe('executeAction', () => {
     expect(calls[0].args.scopeOverride).toBe('');
   });
 
-  it('sendMessage: DM send never carries a scope override', async () => {
+  it('sendMessage: DM send honors an explicit scope override (#4932)', async () => {
+    // MeshCore floods DMs under the device global scope, so an explicit
+    // "unscoped" choice must reach the DM send too — it used to be dropped,
+    // forcing the DM onto the source default region.
     const { calls, deps } = recorder();
     await executeAction(
       node('action.sendMessage', { text: 'hi', to: '{{ trigger.from }}', channel: 0, scopeMode: 'unscoped' }),
+      ctx({ from: 777, channel: 0, isDM: true }),
+      deps,
+    );
+    expect(calls[0].args.scopeOverride).toBe('');
+  });
+
+  it('sendMessage: DM send with inherit scope carries no override (unchanged)', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.sendMessage', { text: 'hi', to: '{{ trigger.from }}', channel: 0 }),
       ctx({ from: 777, channel: 0, isDM: true }),
       deps,
     );

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -303,11 +303,12 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
 
         if (destination != null || channelSel.length === 0) {
           // DM, or no unified-channel selection → single send on the fallback channel.
-          // A DM keeps inherit scope: MeshCore reply scope only applies to flooded
-          // channel broadcasts, so dropping the override on a DM is correct, not a leak.
-          // A channel-only fallback send (no `to`) still honors the scope override.
-          const fallbackScope = destination != null ? {} : scopeArg;
-          await pushOrSkipTxDisabled(results, () => deps.sendMessage({ sourceId: sid, text, channel: fallbackChannel, destination, replyId, ...fallbackScope, ...attemptsArg }));
+          // An EXPLICIT scope choice (unscoped / named / trigger) is honored on DMs
+          // too (#4932): MeshCore floods DMs under the device's global scope (path
+          // unknown), so the chosen scope governs a DM's propagation just as it does
+          // a channel broadcast — dropping it forced DMs onto the source default.
+          // 'inherit' still leaves scopeArg empty, so DMs default as before.
+          await pushOrSkipTxDisabled(results, () => deps.sendMessage({ sourceId: sid, text, channel: fallbackChannel, destination, replyId, ...scopeArg, ...attemptsArg }));
           continue;
         }
         const srcChannels = (await ctx.data.getChannels?.(sid)) ?? [];


### PR DESCRIPTION
Closes #4932.

## Symptom
A MeshCore automation set to reply **"Unscoped (flood, no region)"** sent the reply on the node's configured default region (e.g. `rhein-main`) instead of unscoped. It only worked when the node's *own* default region was already set to unscoped via the official app.

## Root cause
MeshMonitor conflated two different intents as `region: null` → `clearFloodScope()`, which issues `CMD_SET_FLOOD_SCOPE` (54) with an **empty transport key**. Per MeshCore firmware, an empty key **clears the transient override and reverts to the node's persistent default region** — it does *not* mean "no region". Truly-unscoped is a separate code path reached by the sub-command byte **`[54][0x01]`** (`send_unscoped=true`), which exists only on **companion protocol v12+**.

## Fix
- **Manager** (`meshcoreManager.ts`): an explicit "unscoped" choice now stays `''` through the pipeline (`normalizeScopeOverride` no longer collapses it to `null`), and `applyFloodScope` maps `''` → `{ unscoped: true }`. `null` still means "clear / inherit the node default"; a named region is unchanged. The sent-message `scopeName` coalesces `''`→`null` so an unscoped send shows no scope row.
- **Native backend** (`meshcoreNativeBackend.ts`): three-way `set_flood_scope` — `unscoped` sends the raw `[54][0x01]` frame (awaiting Ok/Err), **gated to v12+** using the node's companion-protocol version cached from `deviceQuery` at connect. On older firmware it **degrades to the node default and warns** (the only transient alternative, rewriting the saved default via CMD 63, is destructive — per the decision on the issue).
- **Automation** (`actionExecutor.ts`): DM replies now honor an explicit scope override too — MeshCore floods DMs under the device's global scope, so dropping it forced DMs onto the source default. `inherit` still leaves DMs on the default as before.

This also fixes the **same latent bug** in Auto-Acknowledge / Auto-Announce "unscoped" replies, which were silently reverting to the node default (their tests asserted `region: null`, i.e. the bug — now updated to assert unscoped).

## Firmware reference
`CMD_SET_FLOOD_SCOPE` handler in `examples/companion_radio/MyMesh.cpp`: `[54][0x00][<16-byte key>]` sets a region override, `[54][0x00]` (empty) resets it (→ `_prefs.default_scope_key`), `[54][0x01]` sets `send_unscoped=true` (v12+). Send-time precedence: `send_unscoped` > non-null override > persistent default.

## Mesh impact
No change to packet count or cadence — an explicit unscoped send simply floods with no region code, exactly as the user selected.

## Tests
- Manager scope: explicit empty override → `{ unscoped: true }` (was `region: null`); unscoped sent-message keeps `scopeName` null.
- Auto-Ack "trigger" unscoped cases now assert truly-unscoped.
- Executor: DM send honors an explicit override; inherit DM still carries none.
- Native backend: named region → sha256 key; null → clear; unscoped on v4 → degrade+warn; unscoped on v12 → raw `[54,0x01]` frame.

All green: 260+ tests across the touched suites, server `tsc` clean, `lint:ci` ratchet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)