### PR TITLE
fix(settings): move Carto API key field to the Map section

### DIFF
--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -1935,6 +1935,31 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
             </select>
           </div>
           <CustomTilesetManager />
+          {/* #4934: Carto basemap API key sits with the tileset pickers it
+              affects. Admin-only (server-global setting); the Map section
+              itself is visible to all users, so gate the input explicitly. */}
+          {isAdmin && (
+            <div className="setting-item">
+              <label htmlFor="cartoApiKey">
+                {t('settings.carto_api_key_label', 'Carto Basemap API Key')}
+                <span className="setting-description">
+                  {t('settings.carto_api_key_description', 'Removes the "API key required" watermark on the Dark/Light (Carto) basemaps. Free and instant — request one at ')}
+                  <a href="https://carto.com/basemaps/apikey/" target="_blank" rel="noopener noreferrer">carto.com/basemaps/apikey</a>
+                  {t('settings.carto_api_key_description_suffix', '. Leave empty to use Carto keyless (watermarked) or a non-Carto basemap.')}
+                </span>
+              </label>
+              <input
+                id="cartoApiKey"
+                type="text"
+                value={draft.cartoApiKey}
+                onChange={(e) => updateField('cartoApiKey', e.target.value)}
+                placeholder={t('settings.carto_api_key_placeholder', 'Carto API key')}
+                className="setting-input"
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </div>
+          )}
           <div className="setting-item">
             <label htmlFor="positionHistoryLineStyle">
               {t('settings.position_history_line_style_label')}
@@ -2538,26 +2563,6 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
             <span className="setting-description">
               {t('settings.elevation_enabled_description', 'Turns off the Link Profile tool\'s terrain chart when disabled.')}
             </span>
-          </div>
-          <div className="setting-item">
-            <label htmlFor="cartoApiKey">
-              {t('settings.carto_api_key_label', 'Carto Basemap API Key')}
-              <span className="setting-description">
-                {t('settings.carto_api_key_description', 'Removes the "API key required" watermark on the Dark/Light (Carto) basemaps. Free and instant — request one at ')}
-                <a href="https://carto.com/basemaps/apikey/" target="_blank" rel="noopener noreferrer">carto.com/basemaps/apikey</a>
-                {t('settings.carto_api_key_description_suffix', '. Leave empty to use Carto keyless (watermarked) or a non-Carto basemap.')}
-              </span>
-            </label>
-            <input
-              id="cartoApiKey"
-              type="text"
-              value={draft.cartoApiKey}
-              onChange={(e) => updateField('cartoApiKey', e.target.value)}
-              placeholder={t('settings.carto_api_key_placeholder', 'Carto API key')}
-              className="setting-input"
-              autoComplete="off"
-              spellCheck={false}
-            />
           </div>
           <div className="setting-item">
             <label htmlFor="elevationSourceUrl">


### PR DESCRIPTION
## Summary

Follow-up to #4936. The **Carto Basemap API Key** input landed in the **Elevation / Terrain** settings section (it mirrored the `elevationSourceUrl` admin-field pattern), but it belongs with the tileset pickers it actually affects.

Moves it into the **Map** section, right after the Light/Dark tileset selectors and `CustomTilesetManager`.

## Note on gating

The Map section is visible to **all** users (the Elevation section was admin-only), so the input is now explicitly wrapped in `{isAdmin && …}` — it stays an admin-only server-global setting. No change to the setting's behavior, storage, or wiring; this is a pure UI relocation.

Part of #4934.

## Verification
- `npm run typecheck` — clean
- `npm run lint:ci` — clean
- `npx vitest run src/components/SettingsTab* src/server/server.settings-persistence.test.ts` — 195 passed (settings-persistence guard still green: `cartoApiKey` is still sent by `handleSave` and loaded by `SettingsContext`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)