### PR TITLE
fix(header): hide MeshMonitor logo/wordmark on per-source pages

### DIFF
--- a/src/components/AppHeader/AppHeader.nodeAddress.test.tsx
+++ b/src/components/AppHeader/AppHeader.nodeAddress.test.tsx
@@ -106,3 +106,24 @@ describe('AppHeader — source name is the clickable node-info entry (#4908)', (
     expect(screen.getByText(/Yeraze StationG2/)).toBeTruthy();
   });
 });
+
+describe('AppHeader — logo/wordmark only on the source-list view (#4939)', () => {
+  it('hides the MeshMonitor logo + wordmark on a per-source page (back button present)', () => {
+    render(<AppHeader {...baseProps({
+      onBackToSources: vi.fn(),
+      sourceName: 'Station G2',
+    })} />);
+    // Back-to-sources anchors the header; logo + wordmark are omitted.
+    expect(screen.getByText('Sources')).toBeTruthy();
+    expect(screen.queryByAltText('MeshMonitor Logo')).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'MeshMonitor' })).toBeNull();
+    // The source name still renders.
+    expect(screen.getByText('Station G2')).toBeTruthy();
+  });
+
+  it('shows the MeshMonitor logo + wordmark on the source-list/root view (no back button)', () => {
+    render(<AppHeader {...baseProps()} />);
+    expect(screen.getByAltText('MeshMonitor Logo')).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'MeshMonitor' })).toBeTruthy();
+  });
+});

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -146,8 +146,15 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           </button>
         )}
         <div className="header-title">
-          <img src={`${baseUrl}/logo.png`} alt="MeshMonitor Logo" className="header-logo" />
-          <h1>MeshMonitor</h1>
+          {/* On a per-source page the back-to-sources button already anchors the
+              header, so the MeshMonitor logo + wordmark are redundant between it
+              and the source name — show them only on the source-list/root view. */}
+          {!onBackToSources && (
+            <>
+              <img src={`${baseUrl}/logo.png`} alt="MeshMonitor Logo" className="header-logo" />
+              <h1>MeshMonitor</h1>
+            </>
+          )}
           {/* Show only the source name (#4908) — clickable to open the node-info
               popup, which now carries the full node identity that used to be
               duplicated in a separate gray box beside it. */}

--- a/src/pages/MeshCoreSourcePage.tsx
+++ b/src/pages/MeshCoreSourcePage.tsx
@@ -70,15 +70,12 @@ function MeshCoreSourceInner() {
         >
           <UiIcon name="back" size={16} /> {t('unified.back_to_sources', 'Sources')}
         </button>
+        {/* #4939: the back-to-sources button already anchors the header, so the
+            MeshMonitor logo + wordmark are redundant on a per-source page — show
+            only the source name. */}
         <div className="dashboard-topbar-logo">
-          <img
-            src={`${appBasename}/logo.png`}
-            alt="MeshMonitor"
-            className="dashboard-topbar-logo-img"
-          />
-          <span className="dashboard-topbar-title dashboard-topbar-title-full">MeshMonitor — MeshCore</span>
           {sourceName && (
-            <span className="dashboard-topbar-title dashboard-topbar-title-short">{sourceName}</span>
+            <span className="dashboard-topbar-title">{sourceName}</span>
           )}
         </div>
         {localNodeLabel && (

--- a/src/pages/ReticulumSourcePage.tsx
+++ b/src/pages/ReticulumSourcePage.tsx
@@ -70,15 +70,12 @@ function ReticulumSourceInner() {
         >
           <UiIcon name="back" size={16} /> {t('unified.back_to_sources', 'Sources')}
         </button>
+        {/* #4939: the back-to-sources button already anchors the header, so the
+            MeshMonitor logo + wordmark are redundant on a per-source page — show
+            only the source name. */}
         <div className="dashboard-topbar-logo">
-          <img
-            src={`${appBasename}/logo.png`}
-            alt="MeshMonitor"
-            className="dashboard-topbar-logo-img"
-          />
-          <span className="dashboard-topbar-title dashboard-topbar-title-full">MeshMonitor — Reticulum</span>
           {sourceName && (
-            <span className="dashboard-topbar-title dashboard-topbar-title-short">{sourceName}</span>
+            <span className="dashboard-topbar-title">{sourceName}</span>
           )}
         </div>
         <div className="dashboard-topbar-actions">


### PR DESCRIPTION
## Summary

On a per-source page the header shows: **[← Sources]  [MeshMonitor logo + wordmark]  [source name]**. The back-to-sources button already anchors the header, so the logo + "MeshMonitor" label sitting between it and the source name are redundant.

This hides the logo + `<h1>MeshMonitor</h1>` when the back-to-sources button is present (per-source view), and keeps them on the source-list / root / single-source view (no back button). The source-name span is unchanged.

One-line conditional in `AppHeader.tsx` (`{!onBackToSources && (…)}`).

## Verification
- `npm run typecheck` — clean
- `npm run lint:ci` — clean
- `npx vitest run src/components/AppHeader` — 11 passed

---
**Update:** extended to cover MeshCore and Reticulum source pages. Those route through their own `dashboard-topbar` (`MeshCoreSourcePage` / `ReticulumSourcePage`), not `AppHeader`, so they kept showing the logo + "MeshMonitor — <protocol>" wordmark. Now removed there too (source name shown at all widths). Meshtastic sources use `AppHeader` (first commit); `DashboardPage` (source-list overview) keeps its logo intentionally.
