### PR TITLE
chore(release): 4.15.2-rc5

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.15.2-rc4",
+  "version": "4.15.2-rc5",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.15.2-rc4",
+  "version": "4.15.2-rc5",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.15.2-rc4
-appVersion: "4.15.2-rc4"
+version: 4.15.2-rc5
+appVersion: "4.15.2-rc5"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.2-rc4",
+  "version": "4.15.2-rc5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.15.2-rc4",
+      "version": "4.15.2-rc5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.2-rc4",
+  "version": "4.15.2-rc5",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump to **4.15.2-rc5** across all five release files (package.json, package-lock.json, helm/meshmonitor/Chart.yaml, desktop/package.json, desktop/src-tauri/tauri.conf.json).

Cuts the next RC pre-release. Changes since rc4:
- #4940 fix(site-planner): surface why coverage is a circle in the panel (#4727)
- #4939 fix(header): hide MeshMonitor logo/wordmark on per-source pages
- #4938 fix(settings): move Carto API key field to the Map section
- #4937 fix(meshcore): send truly-unscoped floods, not the node default region (#4932)
- #4936 feat(map): support a Carto basemap API key (#4934 Phase 1)
- #4935 fix(backup): surface restore reboot notice from the actual flag (#4926)
- #4933 feat(backup): add Restore button to Device Backup Management (#4926)

🤖 Generated with [Claude Code](https://claude.com/claude-code)