### PR TITLE
feat(nodes): add "show all" (0 = never) option to Maximum Age of Active Nodes (#4947)

### DIFF
--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -944,11 +944,14 @@ export default function DashboardMap({
           {(() => {
             // Non-linear discrete stops (1h..30d) via mapAgeSteps (#4770),
             // bounded by the per-source maxNodeAgeHours setting.
-            const maxHours = Math.max(1, Math.round(maxNodeAgeHours));
+            // maxNodeAgeHours of 0 = "never / show all" (#4947): keep it 0 so
+            // ageFilterStops/formatAgeStop take their unlimited ("All") branch.
+            const maxHours = maxNodeAgeHours <= 0 ? 0 : Math.max(1, Math.round(maxNodeAgeHours));
             const stops = ageFilterStops(maxHours);
             const topIndex = stops.length - 1;
-            const currentHours = Math.min(Math.max(1, Math.round(effectiveMaxAge)), maxHours);
-            const currentIndex = nearestAgeStopIndex(stops, currentHours);
+            const currentIndex = !Number.isFinite(effectiveMaxAge)
+              ? topIndex
+              : nearestAgeStopIndex(stops, Math.max(1, Math.round(effectiveMaxAge)));
             const label = (idx: number) => formatAgeStop(stops[idx], maxHours);
             return (
               <div className="map-control-item" style={{ flexDirection: 'column', alignItems: 'stretch', gap: '0.25rem' }}>

--- a/src/components/MeshCore/MeshCoreNodeDisplaySection.tsx
+++ b/src/components/MeshCore/MeshCoreNodeDisplaySection.tsx
@@ -184,7 +184,7 @@ export const MeshCoreNodeDisplaySection: React.FC<MeshCoreNodeDisplaySectionProp
           <span className="setting-description">
             {t(
               'meshcore.settings.node_display.max_age_description',
-              'Nodes not heard within this window are hidden from the Nodes list and the map. Favorites and your own node are always shown. This does not change which nodes Auto-Pathfinding targets — see Automations → Target Filter.',
+              'Nodes not heard within this window are hidden from the Nodes list and the map. Favorites and your own node are always shown. Use 0 to show all nodes ever heard (useful for stealthy MeshCore companions that advertise rarely). This does not change which nodes Auto-Pathfinding targets — see Automations → Target Filter.',
             )}
           </span>
         </label>

--- a/src/components/MeshCore/MeshCoreNodesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.test.tsx
@@ -392,6 +392,17 @@ describe('MeshCoreNodesView — per-source age filter (#4412 Phase 4)', () => {
       render(<MeshCoreNodesView nodes={testNodes} contacts={[]} />);
       expect(listedNames()).toEqual([]);
     });
+
+    it('never hides a companion when the companion window is 0 (show all, #4947)', () => {
+      // Stealthy MeshCore companions can go days/weeks between adverts. A
+      // companion window of 0 keeps even a very old companion visible.
+      mockUseNodeDisplaySettings.mockReturnValue({ maxNodeAgeHours: 0, maxInfraNodeAgeHours: 720 });
+      const testNodes: MeshCoreNode[] = [
+        { publicKey: PK_COMPANION, name: 'AncientCompanion', advType: 1, lastHeard: NOW - 5000 * HOUR_MS },
+      ];
+      render(<MeshCoreNodesView nodes={testNodes} contacts={[]} />);
+      expect(listedNames()).toEqual(['AncientCompanion']);
+    });
   });
 
   it('falls through a `lastHeard: 0` DB row to the contact\'s lastSeen (merge gap regression, #4433 review)', () => {

--- a/src/components/MeshCore/MeshCoreNodesView.tsx
+++ b/src/components/MeshCore/MeshCoreNodesView.tsx
@@ -315,12 +315,15 @@ export const MeshCoreNodesView: React.FC<MeshCoreNodesViewProps> = ({
     // 0 means "never expire" (show regardless of age, like favorites).
     const infraNever = maxInfraNodeAgeHours <= 0;
     const infraCutoffMs = infraNever ? 0 : meshcoreAgeCutoffMs(maxInfraNodeAgeHours);
+    // The companion window itself can be "never / show all" (#4947) — stealthy
+    // MeshCore companions may go days/weeks between adverts, so 0 keeps them all.
+    const companionNever = maxNodeAgeHours <= 0;
     return merged.filter(r => {
       if (isAgeExempt(r)) return true;
       if (isMeshCoreInfrastructureAdvType(r.advType)) {
         return infraNever || isWithinMeshcoreAge(r, infraCutoffMs);
       }
-      return isWithinMeshcoreAge(r, cutoffMs);
+      return companionNever || isWithinMeshcoreAge(r, cutoffMs);
     });
   }, [merged, maxNodeAgeHours, maxInfraNodeAgeHours, isAgeExempt]);
 

--- a/src/components/NodesTab.tsx
+++ b/src/components/NodesTab.tsx
@@ -2482,11 +2482,15 @@ const NodesTabComponent: React.FC<NodesTabProps> = ({
                     // Non-linear discrete stops (1h..30d) instead of a linear
                     // per-hour tick — see mapAgeSteps (#4770). Bounded by the
                     // per-source maxNodeAgeHours setting.
-                    const maxHours = Math.max(1, Math.round(maxNodeAgeHours));
+                    // maxNodeAgeHours of 0 = "never / show all" (#4947): the
+                    // stops then include an unlimited ("All") top; keep it 0 so
+                    // ageFilterStops/formatAgeStop take their unlimited branch.
+                    const maxHours = maxNodeAgeHours <= 0 ? 0 : Math.max(1, Math.round(maxNodeAgeHours));
                     const stops = ageFilterStops(maxHours);
                     const topIndex = stops.length - 1;
-                    const currentHours = Math.min(Math.max(1, Math.round(effectiveMapMaxAge)), maxHours);
-                    const currentIndex = nearestAgeStopIndex(stops, currentHours);
+                    const currentIndex = !Number.isFinite(effectiveMapMaxAge)
+                      ? topIndex
+                      : nearestAgeStopIndex(stops, Math.max(1, Math.round(effectiveMapMaxAge)));
                     const label = (idx: number) =>
                       formatAgeStop(stops[idx], maxHours, t('map.maxAgeAll', 'All'));
                     return (

--- a/src/constants/nodeDisplayDefaults.test.ts
+++ b/src/constants/nodeDisplayDefaults.test.ts
@@ -77,7 +77,7 @@ describe('parseNodeDisplayNumber', () => {
     [undefined, 24],
     ['', 24],
     ['abc', 24],
-    ['0', 24], // 0 is below maxNodeAgeHours' min of 1 -> clamps to default
+    ['0', 0], // 0 = never / show all (#4947), now a valid in-range value
     ['-5', 24], // negative is out of range -> clamps to default (NOT '-5' verbatim)
     ['24', 24],
     ['168', 168], // 1 week — still well within the 720h (30d) cap (#4770)

--- a/src/constants/nodeDisplayDefaults.ts
+++ b/src/constants/nodeDisplayDefaults.ts
@@ -86,7 +86,7 @@ export const NODE_DISPLAY_STRING_DEFAULTS = { nodeHopsCalculation: 'nodeinfo' } 
 export const NODE_DISPLAY_RANGES: Readonly<Partial<Record<
   NodeDisplayNumericKey, { min: number; max: number; integer: boolean }
 >>> = {
-  maxNodeAgeHours:                  { min: 1, max: 720,  integer: true },
+  maxNodeAgeHours:                  { min: 0, max: 720,  integer: true }, // 0 = never / show all (#4947)
   inactiveNodeThresholdHours:       { min: 1, max: 720,  integer: true },
   inactiveNodeCheckIntervalMinutes: { min: 1, max: 1440, integer: true },
   inactiveNodeCooldownHours:        { min: 1, max: 720,  integer: true },

--- a/src/hooks/useProcessedNodes.ts
+++ b/src/hooks/useProcessedNodes.ts
@@ -195,7 +195,10 @@ export function useProcessedNodes(options: UseProcessedNodesOptions = {}) {
     // keep browsing tidy — once you're explicitly looking for something
     // by name or id, finding it matters more than freshness.
     const isSearching = textFilter.trim().length > 0;
-    const ageFiltered = isSearching
+    // maxNodeAgeHours of 0 = "never / show all" (#4947): keep every node
+    // regardless of last-heard age, the same escape hatch searching provides.
+    const ageUnlimited = maxNodeAgeHours <= 0;
+    const ageFiltered = isSearching || ageUnlimited
       ? nodes
       : nodes.filter(node => {
           if (node.isFavorite) return true;

--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -291,11 +291,13 @@ export function useTraceroutePaths({
       nodeNums: [number, number];
     }> = [];
 
-    // Filter traceroutes by age using the same maxNodeAgeHours setting
+    // Filter traceroutes by age using the same maxNodeAgeHours setting.
+    // 0 = "never / show all" (#4947) → keep every traceroute regardless of age.
+    const ageUnlimited = maxNodeAgeHours <= 0;
     const cutoffTime = Date.now() - maxNodeAgeHours * 60 * 60 * 1000;
     const recentTraceroutes = traceroutesDigest.filter(tr => {
       const timestamp = tr.timestamp || tr.createdAt || 0;
-      return timestamp >= cutoffTime;
+      return ageUnlimited || timestamp >= cutoffTime;
     });
 
     // Deduplicate: keep only the most recent traceroute per node pair

--- a/src/server/routes/settingsRoutes.test.ts
+++ b/src/server/routes/settingsRoutes.test.ts
@@ -893,7 +893,8 @@ describe('settingsRoutes', () => {
   describe('POST /api/settings — WP2 per-source route hardening (#4412 §6.2 a-g)', () => {
     // (a) maxNodeAgeHours range validation (§3.5)
     describe('(a) maxNodeAgeHours range validation', () => {
-      it.each([0, 721, 'abc', ''])('rejects %s with 400 INVALID_MAX_NODE_AGE_HOURS', async (value) => {
+      // #4947: 0 is now valid ("never / show all"); negatives still rejected.
+      it.each([-1, 721, 'abc', ''])('rejects %s with 400 INVALID_MAX_NODE_AGE_HOURS', async (value) => {
         const app = createApp(adminUser);
         const res = await request(app)
           .post('/api/settings')
@@ -904,7 +905,7 @@ describe('settingsRoutes', () => {
         expect(databaseService.settings.setSettings).not.toHaveBeenCalled();
       });
 
-      it.each([1, 24, 168, 720])('accepts %s with 200', async (value) => {
+      it.each([0, 1, 24, 168, 720])('accepts %s with 200', async (value) => {
         const app = createApp(adminUser);
         await request(app)
           .post('/api/settings')

--- a/src/server/routes/settingsRoutes.ts
+++ b/src/server/routes/settingsRoutes.ts
@@ -408,16 +408,16 @@ router.post('/', requirePermission('settings', 'write', { sourceIdFrom: 'query' 
       }
     }
 
-    // Range-validate the node-age window (client input is min=1 max=168 —
-    // SettingsTab.tsx:1882-1884). Prior to this there was no server-side check
-    // at all, so an API client could store 0 or a negative value and every
-    // consumer's `Date.now() - h*3600e3` window silently inverted.
+    // Range-validate the node-age window. The floor is now 0 (#4947): 0 = "never
+    // / show all", the escape hatch for stealthy MeshCore companions. A negative
+    // value is still rejected — it would invert every `Date.now() - h*3600e3`
+    // window.
     if ('maxNodeAgeHours' in filteredSettings) {
       const hours = parseInt(filteredSettings.maxNodeAgeHours, 10);
       const R = NODE_DISPLAY_RANGES.maxNodeAgeHours!;
       if (isNaN(hours) || hours < R.min || hours > R.max) {
         return fail(res, 400, 'INVALID_MAX_NODE_AGE_HOURS',
-          `maxNodeAgeHours must be between ${R.min} and ${R.max} hours`);
+          `maxNodeAgeHours must be between ${R.min} and ${R.max} hours (0 = show all)`);
       }
     }
 

--- a/src/utils/mapAge.test.ts
+++ b/src/utils/mapAge.test.ts
@@ -23,9 +23,11 @@ describe('effectiveMapMaxAgeHours', () => {
     expect(effectiveMapMaxAgeHours(-5, 24)).toBe(1);
   });
 
-  it('never returns less than 1 even if settings max is invalid', () => {
-    expect(effectiveMapMaxAgeHours(null, 0)).toBe(1);
-    expect(effectiveMapMaxAgeHours(10, 0)).toBe(1);
+  it('treats a 0 settings max as "never / show all" -> unbounded (#4947)', () => {
+    // At the default slider position (null) the map follows the setting, which
+    // is now unbounded; a concrete slider value still narrows it.
+    expect(effectiveMapMaxAgeHours(null, 0)).toBe(Infinity);
+    expect(effectiveMapMaxAgeHours(10, 0)).toBe(10);
   });
 
   it('ignores non-finite slider values', () => {

--- a/src/utils/mapAge.ts
+++ b/src/utils/mapAge.ts
@@ -14,7 +14,12 @@ export function effectiveMapMaxAgeHours(
   mapMaxAgeHours: number | null | undefined,
   settingsMaxAgeHours: number,
 ): number {
-  const settingsMax = Math.max(1, settingsMaxAgeHours);
+  // `maxNodeAgeHours` of 0 means "never / show all" (#4947). The effective cap
+  // is then unbounded (Infinity): the map slider can still narrow it to a finite
+  // value, but its default ("All") position follows the setting = no cutoff.
+  // Downstream cutoffs (`now - hours*3600`) evaluate to -Infinity, so every node
+  // passes without any per-site special-casing.
+  const settingsMax = settingsMaxAgeHours <= 0 ? Infinity : Math.max(1, settingsMaxAgeHours);
   if (mapMaxAgeHours == null || !Number.isFinite(mapMaxAgeHours)) return settingsMax;
   return Math.min(Math.max(1, mapMaxAgeHours), settingsMax);
 }

--- a/src/utils/mapAgeSteps.test.ts
+++ b/src/utils/mapAgeSteps.test.ts
@@ -24,10 +24,14 @@ describe('ageFilterStops', () => {
     expect(ageFilterStops(10)).toEqual([1, 3, 6, 10]);
   });
 
-  it('rounds and floors the cap to at least a single stop', () => {
+  it('rounds and floors a finite cap to at least a single stop', () => {
     expect(ageFilterStops(1)).toEqual([1]);
-    expect(ageFilterStops(0)).toEqual([1]);
     expect(ageFilterStops(2.6)).toEqual([1, 3]); // rounds to 3
+  });
+
+  it('offers every canonical stop plus an unlimited "All" top for a never/0 cap (#4947)', () => {
+    expect(ageFilterStops(0)).toEqual([1, 3, 6, 12, 24, 72, 168, 336, 720, Infinity]);
+    expect(ageFilterStops(Infinity)).toEqual([1, 3, 6, 12, 24, 72, 168, 336, 720, Infinity]);
   });
 });
 
@@ -78,6 +82,14 @@ describe('formatAgeStop', () => {
 
   it('appends trailing hours for non-whole-day stops', () => {
     expect(formatAgeStop(30, 720)).toBe('1d 6h');
+  });
+
+  it('labels the unlimited (Infinity) stop as All, and keeps finite stops labelled under a never/0 cap (#4947)', () => {
+    expect(formatAgeStop(Infinity, 0)).toBe('All');
+    expect(formatAgeStop(Infinity, Infinity, 'Alle')).toBe('Alle');
+    // With a "never" (0) cap, finite stops must NOT all collapse to "All".
+    expect(formatAgeStop(24, 0)).toBe('1d');
+    expect(formatAgeStop(6, 0)).toBe('6h');
   });
 });
 

--- a/src/utils/mapAgeSteps.ts
+++ b/src/utils/mapAgeSteps.ts
@@ -29,6 +29,11 @@ export const AGE_FILTER_STOP_HOURS: readonly number[] = [
  * stop.
  */
 export function ageFilterStops(maxHours: number): number[] {
+  // A "never / show all" setting (0 or non-finite, #4947) offers every canonical
+  // stop PLUS an unlimited top stop (Infinity), rendered "All".
+  if (!Number.isFinite(maxHours) || maxHours <= 0) {
+    return [...AGE_FILTER_STOP_HOURS, Infinity];
+  }
   const cap = Math.max(1, Math.round(maxHours));
   const stops = AGE_FILTER_STOP_HOURS.filter((h) => h < cap);
   stops.push(cap);
@@ -60,7 +65,11 @@ export function nearestAgeStopIndex(stops: number[], hours: number): number {
  * days).
  */
 export function formatAgeStop(hours: number, maxHours: number, allLabel = 'All'): string {
-  if (hours >= maxHours) return allLabel;
+  // The unlimited top stop (Infinity, #4947) is always "All". Otherwise the top
+  // stop is the one at/above a FINITE positive cap. Guarding `maxHours > 0` keeps
+  // a "never" cap (0) from labelling every finite stop as "All".
+  if (!Number.isFinite(hours)) return allLabel;
+  if (Number.isFinite(maxHours) && maxHours > 0 && hours >= maxHours) return allLabel;
   if (hours < 24) return `${hours}h`;
   const days = Math.floor(hours / 24);
   const remainingHours = hours % 24;

--- a/src/utils/markerAgeOpacity.test.ts
+++ b/src/utils/markerAgeOpacity.test.ts
@@ -46,4 +46,11 @@ describe('markerAgeOpacity', () => {
     expect(markerAgeOpacity(stale, fresh, 50_000)).toBe(1);
     expect(markerAgeOpacity(fresh, fresh, 50_000)).toBe(1);
   });
+
+  it('returns 1 (no fade, not NaN) for an unbounded window (#4947)', () => {
+    // A "never / show all" setting makes the stale boundary -Infinity; the old
+    // linear math produced NaN. No node is ever stale, so no fade.
+    expect(markerAgeOpacity(fresh, -Infinity, 50_000)).toBe(1);
+    expect(markerAgeOpacity(Infinity, -Infinity, 50_000)).toBe(1);
+  });
 });

--- a/src/utils/markerAgeOpacity.ts
+++ b/src/utils/markerAgeOpacity.ts
@@ -34,6 +34,9 @@ export function markerAgeOpacity(
   minOpacity: number = MIN_MARKER_OPACITY,
 ): number {
   if (valueMs == null || !Number.isFinite(valueMs)) return 1;
+  // A non-finite stale boundary means an unbounded ("never / show all", #4947)
+  // age window — nothing is ever "stale", so no fade.
+  if (!Number.isFinite(staleMs) || !Number.isFinite(freshMs)) return 1;
   if (!(freshMs > staleMs)) return 1;
   const frac = (valueMs - staleMs) / (freshMs - staleMs);
   const clamped = Math.max(0, Math.min(1, frac));


### PR DESCRIPTION
Closes #4947.

## Problem
Stealthy MeshCore companions advertise infrequently (sometimes days/weeks apart). The `maxNodeAgeHours` window (default 24h, max 720h) aged them off the map and node list even though their DB row/position remained.

## Fix
Mirror the existing `maxInfraNodeAgeHours` **"0 = never expire"** sentinel (#4899) for the companion window: **`maxNodeAgeHours` of 0 now means "show all nodes ever heard"** (no age cutoff). Everything stays editable; the default is unchanged (24h).

- **Setting:** range floor `1 → 0` (0 is valid and preserved by the parser); server validation accepts 0, still rejects negatives; the number input `min` is 0 with a "Use 0 to show all nodes ever heard" description.
- **Read sites** treat 0 as no cutoff: `useProcessedNodes`, `MeshCoreNodesView` (companion branch, alongside the existing infra-never), `useTraceroutePaths`. The Dashboard map goes through `effectiveMapMaxAgeHours`, which now returns `Infinity` for a never setting — so its `now - h*3600` cutoffs become `-Infinity` and every node passes without per-site special-casing.
- **Slider ("add one more value to the time slider for All"):** `effectiveMapMaxAgeHours(0) → Infinity`; `ageFilterStops`/`formatAgeStop` gain an unlimited **"All"** top stop when the cap is never; both slider render blocks (NodesTab + DashboardMap) stop flooring the cap to 1. `markerAgeOpacity` returns 1 (no fade) for an unbounded window instead of `NaN`.

## Tests
Parser keeps 0; `effectiveMapMaxAgeHours`/`ageFilterStops`/`formatAgeStop` unlimited branches; `markerAgeOpacity` unbounded window; a `MeshCoreNodesView` "companion window 0 shows an ancient companion" case; server accept-0 / reject-negative validation. 279 tests across the touched suites pass; `tsc` + `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)