### PR TITLE
feat(meshcore): add per-source Default Path Hash Size setting (#4945)

### DIFF
--- a/src/components/MeshCore/MeshCoreSettingsView.discoverResults.test.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.discoverResults.test.tsx
@@ -48,6 +48,8 @@ function makeActions(discoverNodes: ReturnType<typeof vi.fn>) {
     getDiscoverable: vi.fn().mockResolvedValue(false),
     setDiscoverable: vi.fn().mockResolvedValue(true),
     getDefaultScope: vi.fn().mockResolvedValue(''),
+    getDefaultPathHashSize: vi.fn().mockResolvedValue(1),
+    setDefaultPathHashSize: vi.fn().mockResolvedValue(1),
     setDefaultScope: vi.fn().mockResolvedValue(true),
     discoverRegions: vi.fn().mockResolvedValue(null),
     fetchSavedRegions: vi.fn().mockResolvedValue([]),

--- a/src/components/MeshCore/MeshCoreSettingsView.receiveOnly.test.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.receiveOnly.test.tsx
@@ -48,6 +48,8 @@ function makeActions(overrides: Record<string, unknown> = {}) {
     getDiscoverable: vi.fn().mockResolvedValue(false),
     setDiscoverable: vi.fn().mockResolvedValue(true),
     getDefaultScope: vi.fn().mockResolvedValue(''),
+    getDefaultPathHashSize: vi.fn().mockResolvedValue(1),
+    setDefaultPathHashSize: vi.fn().mockResolvedValue(1),
     setDefaultScope: vi.fn().mockResolvedValue('region-x'),
     discoverRegions: vi.fn().mockResolvedValue(null),
     fetchSavedRegions: vi.fn().mockResolvedValue([]),

--- a/src/components/MeshCore/MeshCoreSettingsView.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.tsx
@@ -72,6 +72,9 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
   // persistent NodePrefs. Wider hashes cut path/loop-table collisions on
   // larger meshes.
   const [pathHashSize, setPathHashSizeState] = useState<1 | 2 | 3>(1);
+  // Draft selection; applied to the device only on an explicit Save so an
+  // accidental dropdown change doesn't write persistent firmware state.
+  const [pathHashInput, setPathHashInput] = useState<1 | 2 | 3>(1);
   const [savingPathHash, setSavingPathHash] = useState(false);
   // Region discovery (#3667 phase 3) — names served by nearby repeaters.
   const [discoveredRegions, setDiscoveredRegions] = useState<string[] | null>(null);
@@ -118,7 +121,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
     if (connected && isCompanion) {
       void getDiscoverable().then(setDiscoverableState);
       void getDefaultScope().then((s) => { setDefaultScopeState(s); setScopeInput(s); });
-      void getDefaultPathHashSize().then(setPathHashSizeState);
+      void getDefaultPathHashSize().then((s) => { setPathHashSizeState(s); setPathHashInput(s); });
     }
   }, [connected, isCompanion, getDiscoverable, getDefaultScope, getDefaultPathHashSize]);
 
@@ -131,6 +134,7 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
         return;
       }
       setPathHashSizeState(result);
+      setPathHashInput(result);
       showToast(t('meshcore.path_hash.saved', 'Default path hash size saved'), 'success');
     } finally {
       setSavingPathHash(false);
@@ -507,8 +511,8 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
           </p>
           <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
             <select
-              value={pathHashSize}
-              onChange={(e) => void handleSavePathHashSize(Number(e.target.value) as 1 | 2 | 3)}
+              value={pathHashInput}
+              onChange={(e) => setPathHashInput(Number(e.target.value) as 1 | 2 | 3)}
               disabled={!connected || loading || savingPathHash}
               aria-label={t('meshcore.path_hash.title', 'Default path hash size')}
             >
@@ -516,7 +520,13 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
               <option value={2}>{t('meshcore.path_hash.two', '2 bytes (recommended)')}</option>
               <option value={3}>{t('meshcore.path_hash.three', '3 bytes')}</option>
             </select>
-            {savingPathHash && <span className="hint">{t('common.saving', 'Saving…')}</span>}
+            <button
+              onClick={() => void handleSavePathHashSize(pathHashInput)}
+              disabled={!connected || loading || savingPathHash || pathHashInput === pathHashSize}
+              aria-label={t('meshcore.path_hash.save', 'Save path hash size')}
+            >
+              {savingPathHash ? t('common.saving', 'Saving…') : t('common.save', 'Save')}
+            </button>
           </div>
         </div>
       )}

--- a/src/components/MeshCore/MeshCoreSettingsView.tsx
+++ b/src/components/MeshCore/MeshCoreSettingsView.tsx
@@ -57,7 +57,8 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
   // "Be discoverable" toggle — whether we answer inbound discovery requests.
   const [discoverable, setDiscoverableState] = useState(false);
   const {
-    getDiscoverable, setDiscoverable, getDefaultScope, setDefaultScope, discoverRegions,
+    getDiscoverable, setDiscoverable, getDefaultScope, setDefaultScope,
+    getDefaultPathHashSize, setDefaultPathHashSize, discoverRegions,
     fetchSavedRegions, addSavedRegion, deleteSavedRegion,
   } = actions;
 
@@ -66,6 +67,12 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
   const [defaultScope, setDefaultScopeState] = useState('');
   const [scopeInput, setScopeInput] = useState('');
   const [savingScope, setSavingScope] = useState(false);
+
+  // Default path hash size (#4945): 1/2/3 bytes, pushed to the companion's
+  // persistent NodePrefs. Wider hashes cut path/loop-table collisions on
+  // larger meshes.
+  const [pathHashSize, setPathHashSizeState] = useState<1 | 2 | 3>(1);
+  const [savingPathHash, setSavingPathHash] = useState(false);
   // Region discovery (#3667 phase 3) — names served by nearby repeaters.
   const [discoveredRegions, setDiscoveredRegions] = useState<string[] | null>(null);
   const [discoveringRegions, setDiscoveringRegions] = useState(false);
@@ -111,8 +118,24 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
     if (connected && isCompanion) {
       void getDiscoverable().then(setDiscoverableState);
       void getDefaultScope().then((s) => { setDefaultScopeState(s); setScopeInput(s); });
+      void getDefaultPathHashSize().then(setPathHashSizeState);
     }
-  }, [connected, isCompanion, getDiscoverable, getDefaultScope]);
+  }, [connected, isCompanion, getDiscoverable, getDefaultScope, getDefaultPathHashSize]);
+
+  const handleSavePathHashSize = async (size: 1 | 2 | 3) => {
+    setSavingPathHash(true);
+    try {
+      const result = await setDefaultPathHashSize(size);
+      if (result === null) {
+        showToast(t('meshcore.path_hash.save_failed', 'Failed to save default path hash size'), 'error');
+        return;
+      }
+      setPathHashSizeState(result);
+      showToast(t('meshcore.path_hash.saved', 'Default path hash size saved'), 'success');
+    } finally {
+      setSavingPathHash(false);
+    }
+  };
 
   // Load the saved-regions catalog (global; not gated on connection).
   useEffect(() => {
@@ -469,6 +492,32 @@ export const MeshCoreSettingsView: React.FC<MeshCoreSettingsViewProps> = ({
               'find this one when this is enabled. Replies are zero-hop (direct range) and rate-limited.')}
           </p>
           <MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />
+        </div>
+      )}
+
+      {isCompanion && (
+        <div className="form-section">
+          <h3>{t('meshcore.path_hash.title', 'Default path hash size')}</h3>
+          <p className="hint">
+            {t('meshcore.path_hash.hint',
+              'Number of bytes used for path/loop-detection hashes on outgoing messages. ' +
+              '1 byte (256 values) is enough for small meshes; 2 bytes (65,536 values) is recommended for ' +
+              'mid-to-large deployments to avoid path-table collisions that drop packets on valid routes. ' +
+              'Applied to the device immediately and re-asserted on reconnect.')}
+          </p>
+          <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+            <select
+              value={pathHashSize}
+              onChange={(e) => void handleSavePathHashSize(Number(e.target.value) as 1 | 2 | 3)}
+              disabled={!connected || loading || savingPathHash}
+              aria-label={t('meshcore.path_hash.title', 'Default path hash size')}
+            >
+              <option value={1}>{t('meshcore.path_hash.one', '1 byte')}</option>
+              <option value={2}>{t('meshcore.path_hash.two', '2 bytes (recommended)')}</option>
+              <option value={3}>{t('meshcore.path_hash.three', '3 bytes')}</option>
+            </select>
+            {savingPathHash && <span className="hint">{t('common.saving', 'Saving…')}</span>}
+          </div>
         </div>
       )}
 

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -235,6 +235,10 @@ export interface MeshCoreActions {
   getDefaultScope: () => Promise<string>;
   /** Set the per-source default region/scope. Returns the normalized value, or null on error. */
   setDefaultScope: (scope: string) => Promise<string | null>;
+  /** Read the per-source default MeshCore path hash size (1/2/3 bytes) (#4945). */
+  getDefaultPathHashSize: () => Promise<1 | 2 | 3>;
+  /** Set the per-source default path hash size. Returns the applied value, or null on error. */
+  setDefaultPathHashSize: (size: 1 | 2 | 3) => Promise<1 | 2 | 3 | null>;
   /** Discover region/scope names served by nearby repeaters (#3667 phase 3). */
   discoverRegions: () => Promise<{ regions: string[]; perRepeater: Array<{ publicKey: string; name: string; regions: string[] }>; noZeroHopRepeaters?: boolean } | null>;
   /** Refresh the global saved-regions catalog (#3770). Returns the list, or null on error. */
@@ -1072,6 +1076,37 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       return typeof data.scope === 'string' ? data.scope : '';
     } catch (_err) {
       setError('Failed to update default scope');
+      return null;
+    }
+  }, [mcPrefix, csrfFetch]);
+
+  const getDefaultPathHashSize = useCallback(async (): Promise<1 | 2 | 3> => {
+    try {
+      const response = await csrfFetch(`${mcPrefix}/config/default-path-hash-size`);
+      const data = await response.json();
+      const n = Number(data?.size);
+      return data?.success && (n === 2 || n === 3) ? n : 1;
+    } catch (_err) {
+      return 1;
+    }
+  }, [mcPrefix, csrfFetch]);
+
+  const setDefaultPathHashSize = useCallback(async (size: 1 | 2 | 3): Promise<1 | 2 | 3 | null> => {
+    try {
+      const response = await csrfFetch(`${mcPrefix}/config/default-path-hash-size`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ size }),
+      });
+      const data = await response.json();
+      if (!data.success) {
+        setError(data.error || 'Failed to update default path hash size');
+        return null;
+      }
+      const n = Number(data.size);
+      return n === 2 || n === 3 ? n : 1;
+    } catch (_err) {
+      setError('Failed to update default path hash size');
       return null;
     }
   }, [mcPrefix, csrfFetch]);
@@ -1950,6 +1985,8 @@ export function useMeshCore(options: UseMeshCoreOptions): UseMeshCoreState {
       setDiscoverable,
       getDefaultScope,
       setDefaultScope,
+      getDefaultPathHashSize,
+      setDefaultPathHashSize,
       discoverRegions,
       fetchSavedRegions,
       addSavedRegion,

--- a/src/server/constants/meshcoreTx.test.ts
+++ b/src/server/constants/meshcoreTx.test.ts
@@ -125,8 +125,8 @@ describe('meshcoreTx denylist completeness (#4547)', () => {
 
   it('pins the current classification sizes (deliberate, like PER_SOURCE_KEYS_NOT_POSTABLE.size)', () => {
     expect(RF_BRIDGE_COMMANDS.size).toBe(14);
-    expect(SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(30);
-    expect(RF_BRIDGE_COMMANDS.size + SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(44);
+    expect(SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(31); // +set_path_hash_mode (#4945)
+    expect(RF_BRIDGE_COMMANDS.size + SERIAL_ONLY_BRIDGE_COMMANDS.size).toBe(45);
   });
 });
 

--- a/src/server/constants/meshcoreTx.ts
+++ b/src/server/constants/meshcoreTx.ts
@@ -38,6 +38,7 @@ export const SERIAL_ONLY_BRIDGE_COMMANDS: ReadonlySet<string> = new Set([
   'export_private_key', 'import_private_key',
   'set_name', 'set_radio', 'set_tx_power', 'set_coords',
   'set_advert_loc_policy', 'set_other_params', 'set_flood_scope', 'set_out_path',
+  'set_path_hash_mode', // #4945: writes NodePrefs.path_hash_mode, no RF TX
   'set_telemetry_mode_base', 'set_telemetry_mode_loc', 'set_telemetry_mode_env',
   'get_stats', 'get_device_time', 'set_device_time', 'device_query',
   'reboot', 'shutdown', 'ping',

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -315,6 +315,10 @@ export const VALID_SETTINGS_KEYS = [
   // traffic (DMs, adverts, requests) unless a channel overrides it. Empty =
   // unscoped (legacy '*' / null region).
   'meshcoreDefaultScope',
+  // MeshCore default path hash size (#4945) — per source. 1/2/3 bytes; pushed
+  // to the companion firmware's persistent path_hash_mode (CMD 61). Wider hashes
+  // reduce path/loop-table collisions on larger meshes.
+  'meshcoreDefaultPathHashSize',
   // MeshCore strict receive-only mode (#4547) — per source. Blocks every
   // RF-transmitting command/scheduler on this MeshCore source when true.
   'meshcoreReceiveOnly',
@@ -493,6 +497,8 @@ export const PER_SOURCE_SETTINGS_KEYS = [
   'meshcoreTimerTriggers',
   // MeshCore default region/scope (#3667) — per source (per node)
   'meshcoreDefaultScope',
+  // MeshCore default path hash size (#4945) — per source (per node)
+  'meshcoreDefaultPathHashSize',
   // MeshCore strict receive-only mode (#4547) — per source (#4547 §2.1)
   'meshcoreReceiveOnly',
   // Node Display (#4412 / per-source node display epic). All ten keys in the

--- a/src/server/meshcoreManager.pathHashSize.test.ts
+++ b/src/server/meshcoreManager.pathHashSize.test.ts
@@ -1,0 +1,84 @@
+/**
+ * MeshCore default path hash size (#4945).
+ *
+ * The width is a per-source setting pushed to the companion firmware's
+ * persistent NodePrefs (CMD_SET_PATH_HASH_MODE=61). These tests prove the
+ * manager's get/set/push plumbing without a real device or DB.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const getSettingForSource = vi.fn().mockResolvedValue(undefined);
+const setSourceSetting = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    settings: {
+      getSettingForSource: (...a: unknown[]) => getSettingForSource(...a),
+      setSourceSetting: (...a: unknown[]) => setSourceSetting(...a),
+    },
+  },
+}));
+
+import { MeshCoreManager } from './meshcoreManager.js';
+
+function makeManager(): { manager: MeshCoreManager; bridge: ReturnType<typeof vi.fn> } {
+  const m = new MeshCoreManager('src-1');
+  const bridge = vi.fn().mockResolvedValue({ id: '1', success: true, data: {} });
+  (m as any).sendBridgeCommand = bridge;
+  // applyDefaultPathHashSize is Companion/native only.
+  (m as any).nativeBackend = {};
+  return { manager: m, bridge };
+}
+
+describe('MeshCoreManager — default path hash size (#4945)', () => {
+  beforeEach(() => {
+    getSettingForSource.mockReset().mockResolvedValue(undefined);
+    setSourceSetting.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('getDefaultPathHashSize defaults to 1 and preserves 2/3', async () => {
+    const { manager } = makeManager();
+    getSettingForSource.mockResolvedValueOnce(undefined);
+    expect(await manager.getDefaultPathHashSize()).toBe(1);
+    getSettingForSource.mockResolvedValueOnce('2');
+    expect(await manager.getDefaultPathHashSize()).toBe(2);
+    getSettingForSource.mockResolvedValueOnce('3');
+    expect(await manager.getDefaultPathHashSize()).toBe(3);
+    // Out-of-range / garbage -> 1.
+    getSettingForSource.mockResolvedValueOnce('4');
+    expect(await manager.getDefaultPathHashSize()).toBe(1);
+  });
+
+  it('setDefaultPathHashSize persists the value and pushes it to the device', async () => {
+    const { manager, bridge } = makeManager();
+    const applied = await manager.setDefaultPathHashSize(2);
+    expect(applied).toBe(2);
+    expect(setSourceSetting).toHaveBeenCalledWith('src-1', 'meshcoreDefaultPathHashSize', '2');
+    expect(bridge).toHaveBeenCalledWith('set_path_hash_mode', { size: 2 });
+  });
+
+  it('clamps an invalid size to 1 before persisting/pushing', async () => {
+    const { manager, bridge } = makeManager();
+    const applied = await manager.setDefaultPathHashSize(9);
+    expect(applied).toBe(1);
+    expect(setSourceSetting).toHaveBeenCalledWith('src-1', 'meshcoreDefaultPathHashSize', '1');
+    expect(bridge).toHaveBeenCalledWith('set_path_hash_mode', { size: 1 });
+  });
+
+  it('a device rejection is non-fatal — the setting is still persisted', async () => {
+    const { manager, bridge } = makeManager();
+    bridge.mockResolvedValueOnce({ id: '1', success: false, error: 'nope' });
+    const applied = await manager.setDefaultPathHashSize(3);
+    expect(applied).toBe(3); // does not throw
+    expect(setSourceSetting).toHaveBeenCalledWith('src-1', 'meshcoreDefaultPathHashSize', '3');
+    expect(bridge).toHaveBeenCalledWith('set_path_hash_mode', { size: 3 });
+  });
+
+  it('does not push to a non-native (repeater) backend', async () => {
+    const { manager, bridge } = makeManager();
+    (manager as any).nativeBackend = null;
+    await manager.setDefaultPathHashSize(2);
+    expect(setSourceSetting).toHaveBeenCalledWith('src-1', 'meshcoreDefaultPathHashSize', '2');
+    expect(bridge).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -1321,6 +1321,11 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       // Safe to call for any device type — it no-ops for non-Companion.
       this.startDeviceTimeSync();
 
+      // Push the configured default path hash size to the companion's persistent
+      // NodePrefs (#4945). Best-effort and Companion-only; a reconnect re-asserts
+      // it so the device always matches the MeshMonitor setting.
+      void this.applyDefaultPathHashSize();
+
       // Start the Virtual Node server (opt-in) now that the local node identity
       // is known — the server synthesizes SelfInfo from it. Non-fatal on error.
       await this.startVirtualNodeServer();
@@ -4258,6 +4263,47 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     void this.refreshKnownScopes();
     logger.info(`[MeshCore:${this.sourceId}] Default scope set to ${normalized || '(unscoped)'}`);
     return normalized;
+  }
+
+  /**
+   * The per-source default MeshCore path hash size (#4945): 1, 2, or 3 bytes.
+   * Controls the width the companion firmware stamps on every outgoing flood's
+   * path. Wider hashes cut path/loop-table collisions on larger meshes. Default
+   * 1 (firmware default, backwards-compatible). Unset/invalid → 1.
+   */
+  async getDefaultPathHashSize(): Promise<1 | 2 | 3> {
+    const raw = await databaseService.settings.getSettingForSource(this.sourceId, 'meshcoreDefaultPathHashSize');
+    const n = Number(raw);
+    return n === 2 || n === 3 ? n : 1;
+  }
+
+  /**
+   * Set the per-source default path hash size AND push it to the companion's
+   * persistent NodePrefs (CMD_SET_PATH_HASH_MODE=61) so it takes effect at once.
+   */
+  async setDefaultPathHashSize(size: number): Promise<1 | 2 | 3> {
+    const clamped: 1 | 2 | 3 = size === 2 || size === 3 ? size : 1;
+    await databaseService.settings.setSourceSetting(this.sourceId, 'meshcoreDefaultPathHashSize', String(clamped));
+    await this.applyDefaultPathHashSize(clamped);
+    logger.info(`[MeshCore:${this.sourceId}] Default path hash size set to ${clamped} byte(s)`);
+    return clamped;
+  }
+
+  /**
+   * Push the configured default path hash size to the device (Companion/native
+   * only — it is a companion NodePrefs setting). Best-effort: a device that
+   * rejects it (e.g. firmware too old to know CMD 61) is logged, never thrown,
+   * so it can't block connect or a settings save.
+   */
+  private async applyDefaultPathHashSize(size?: 1 | 2 | 3): Promise<void> {
+    if (!this.nativeBackend) return;
+    const width = size ?? await this.getDefaultPathHashSize();
+    try {
+      const resp = await this.sendBridgeCommand('set_path_hash_mode', { size: width });
+      if (!resp.success) throw new Error(resp.error || 'set_path_hash_mode failed');
+    } catch (err) {
+      logger.warn(`[MeshCore:${this.sourceId}] Could not apply default path hash size ${width}: ${(err as Error).message}`);
+    }
   }
 
   /**

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -1497,6 +1497,34 @@ describe('MeshCoreNativeBackend', () => {
     expect(conn.clearFloodScopeCalls).toBe(0);
     expect(conn.setFloodScopeCalls).toHaveLength(0);
   });
+
+  // ---- default path hash size (#4945) ----
+
+  it('set_path_hash_mode sends the raw [61,0,size-1] frame', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', { connectionType: 'serial', serialPort: '/dev/ttyUSB0' });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+
+    for (const [size, mode] of [[1, 0], [2, 1], [3, 2]] as const) {
+      conn.rawFrames.length = 0;
+      const resp = await backend.sendCommand('set_path_hash_mode', { size });
+      expect(resp.success).toBe(true);
+      expect(resp.data?.size).toBe(size);
+      expect(conn.rawFrames).toHaveLength(1);
+      // CMD_SET_PATH_HASH_MODE=61, reserved 0, mode=size-1.
+      expect(Array.from(conn.rawFrames[0])).toEqual([61, 0, mode]);
+    }
+  });
+
+  it('set_path_hash_mode rejects an out-of-range size without sending a frame', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', { connectionType: 'serial', serialPort: '/dev/ttyUSB0' });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+
+    const resp = await backend.sendCommand('set_path_hash_mode', { size: 4 });
+    expect(resp.success).toBe(false);
+    expect(conn.rawFrames).toHaveLength(0);
+  });
 });
 
 /** Firmware new enough (companion protocol v12) for the transient unscoped command. */

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -1848,6 +1848,36 @@ export class MeshCoreNativeBackend extends EventEmitter {
         return { ok: true, scope: region };
       }
 
+      case 'set_path_hash_mode': {
+        // MeshCore default path hash size (#4945). Persistent device preference
+        // (NodePrefs.path_hash_mode) set via CMD_SET_PATH_HASH_MODE=61; firmware
+        // then stamps every outgoing flood with this width. Wire value is
+        // size-1 (mode 0/1/2 → 1/2/3 bytes); mode 3 is rejected by firmware.
+        // meshcore.js has no wrapper, so hand-build [61][0x00][mode] and await
+        // Ok/Err. The reserved second byte MUST be 0 or the firmware ignores it.
+        const size = Number(params.size);
+        if (![1, 2, 3].includes(size)) {
+          throw new Error(`Invalid path hash size: ${params.size} (must be 1, 2, or 3)`);
+        }
+        const mode = size - 1;
+        await new Promise<void>((resolve, reject) => {
+          const onOk = () => {
+            c.off(K.ResponseCodes.Ok, onOk);
+            c.off(K.ResponseCodes.Err, onErr);
+            resolve();
+          };
+          const onErr = () => {
+            c.off(K.ResponseCodes.Ok, onOk);
+            c.off(K.ResponseCodes.Err, onErr);
+            reject(new Error('Device rejected set_path_hash_mode command'));
+          };
+          c.once(K.ResponseCodes.Ok, onOk);
+          c.once(K.ResponseCodes.Err, onErr);
+          c.sendToRadioFrame(Uint8Array.from([61, 0x00, mode]));
+        });
+        return { ok: true, size };
+      }
+
       case 'send_advert':
         await c.sendAdvert(K.SelfAdvertTypes.Flood);
         return { sent: true };

--- a/src/server/routes/meshcoreConfigRoutes.ts
+++ b/src/server/routes/meshcoreConfigRoutes.ts
@@ -154,6 +154,7 @@ router.post(
         return res.status(400).json({ success: false, error: 'size must be 1, 2, or 3' });
       }
       const applied = await managerFor(req, res).setDefaultPathHashSize(size);
+      auditMeshcoreEvent(req, 'meshcore_set_path_hash_size', 'configuration', { size: applied });
       res.json({ success: true, size: applied });
     } catch (error) {
       logger.error('[API] Error setting default path hash size:', error);

--- a/src/server/routes/meshcoreConfigRoutes.ts
+++ b/src/server/routes/meshcoreConfigRoutes.ts
@@ -119,6 +119,50 @@ router.post(
 );
 
 /**
+ * GET /api/sources/:id/meshcore/config/default-path-hash-size
+ * The per-source default MeshCore path hash size (#4945): 1, 2, or 3 bytes.
+ */
+router.get(
+  '/config/default-path-hash-size',
+  requireAuth(),
+  requirePermission('configuration', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const size = await managerFor(req, res).getDefaultPathHashSize();
+      res.json({ success: true, size });
+    } catch (error) {
+      logger.error('[API] Error reading default path hash size:', error);
+      res.status(500).json({ success: false, error: 'Failed to read setting' });
+    }
+  },
+);
+
+/**
+ * Per-source MeshCore default path hash size (#4945) — 1/2/3 bytes. Persists the
+ * setting and pushes it to the companion firmware's NodePrefs so it applies at
+ * once (and re-asserts on every reconnect).
+ */
+router.post(
+  '/config/default-path-hash-size',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('configuration', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const size = Number(req.body?.size);
+      if (![1, 2, 3].includes(size)) {
+        return res.status(400).json({ success: false, error: 'size must be 1, 2, or 3' });
+      }
+      const applied = await managerFor(req, res).setDefaultPathHashSize(size);
+      res.json({ success: true, size: applied });
+    } catch (error) {
+      logger.error('[API] Error setting default path hash size:', error);
+      res.status(500).json({ success: false, error: 'Failed to update setting' });
+    }
+  },
+);
+
+/**
  * Saved regions catalog (#3770) — a GLOBAL, user-maintained list of MeshCore
  * region names used to populate scope dropdowns (channel settings + per-message
  * override) so users don't have to type/remember scopes. The catalog is not


### PR DESCRIPTION
Closes #4945.

## What
Adds a per-source MeshCore **"Default Path Hash Size"** setting (1 / 2 / 3 bytes), matching the official companion app. Larger meshes need wider hashes: 1 byte (256 values) collides in the firmware's path/loop-detection table and drops packets on valid routes; 2 bytes (65,536) is effectively required mid-to-large.

## Firmware behaviour (verified against ripplebiz/MeshCore)
It's a **persistent device preference** (`NodePrefs.path_hash_mode`), set with the dedicated command **`CMD_SET_PATH_HASH_MODE = 61`** (payload `[61, 0, size-1]`); the firmware then stamps the width on every outgoing flood via `sendFlood(..., path_hash_mode + 1)`. It is **not** a per-send parameter — `CMD_SEND_TXT_MSG` / `CMD_SEND_CHANNEL_TXT_MSG` carry no hash byte, and `SetOtherParams` has no path-hash field. So MeshMonitor pushes the config once and re-asserts it on reconnect.

## Implementation
- **Setting:** `meshcoreDefaultPathHashSize` registered in `VALID_SETTINGS_KEYS` + `PER_SOURCE_SETTINGS_KEYS`; default **1** (backwards-compatible).
- **Native backend:** `set_path_hash_mode` bridge command hand-builds the raw `[61, 0, mode]` frame (meshcore.js has no wrapper) and awaits Ok/Err — same technique as the flood-scope frame.
- **Manager:** `get`/`setDefaultPathHashSize` + `applyDefaultPathHashSize`, pushed on connect (Companion-only, best-effort — a device that rejects it is logged, never fatal) and immediately on a settings save.
- **Route + hook + UI:** `GET`/`POST /api/sources/:id/meshcore/config/default-path-hash-size`, `useMeshCore` methods, and a 1/2/3 `<select>` in the MeshCore settings view (mirrors the Default Scope control).

## Tests
Native backend emits `[61, 0, size-1]` for 1/2/3 and rejects out-of-range; manager get/set/push, invalid-size clamp, non-fatal device rejection, and repeater no-op. Server + frontend `tsc` clean, `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)