### PR TITLE
chore(release): 4.15.2-rc6

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.15.2-rc5",
+  "version": "4.15.2-rc6",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.15.2-rc5",
+  "version": "4.15.2-rc6",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.15.2-rc5
-appVersion: "4.15.2-rc5"
+version: 4.15.2-rc6
+appVersion: "4.15.2-rc6"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.2-rc5",
+  "version": "4.15.2-rc6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.15.2-rc5",
+      "version": "4.15.2-rc6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.2-rc5",
+  "version": "4.15.2-rc6",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump to **4.15.2-rc6** across all five release files + package-lock + Chart appVersion.

Cuts the next RC pre-release. Changes since rc5:
- #4952 fix(beacons): Beacon Offers Panel hit wrong URL, showed nothing (#4946) — also fixes joining an empty channel slot
- #4951 feat(meshcore): add per-source Default Path Hash Size setting (#4945)
- #4950 feat(firmware): add a Nightly channel for develop (2.8.x) builds
- #4949 feat(nodes): add "show all" (0 = never) option to Maximum Age of Active Nodes (#4947)

🤖 Generated with [Claude Code](https://claude.com/claude-code)