### PR TITLE
feat(scripts): Installed Scripts inventory in global settings (#4942)

### DIFF
--- a/src/components/SettingsTab.elevation.test.tsx
+++ b/src/components/SettingsTab.elevation.test.tsx
@@ -182,6 +182,7 @@ vi.mock('./ChannelSoundPicker', () => ({ default: () => null }));
 vi.mock('./PkiDmGlobalToggle', () => ({ default: () => null }));
 vi.mock('./configuration/SystemBackupSection', () => ({ default: () => null }));
 vi.mock('./configuration/DatabaseMaintenanceSection', () => ({ default: () => null }));
+vi.mock('./settings/ScriptsSection', () => ({ default: () => null }));
 vi.mock('./configuration/FirmwareUpdateSection', () => ({ default: () => null }));
 vi.mock('./configuration/ChannelDatabaseSection', () => ({ default: () => null }));
 vi.mock('./CustomThemeManagement', () => ({ CustomThemeManagement: () => null }));

--- a/src/components/SettingsTab.nodeDisplay.perSource.test.tsx
+++ b/src/components/SettingsTab.nodeDisplay.perSource.test.tsx
@@ -161,6 +161,7 @@ vi.mock('./ChannelSoundPicker', () => ({ default: () => null }));
 vi.mock('./PkiDmGlobalToggle', () => ({ default: () => null }));
 vi.mock('./configuration/SystemBackupSection', () => ({ default: () => null }));
 vi.mock('./configuration/DatabaseMaintenanceSection', () => ({ default: () => null }));
+vi.mock('./settings/ScriptsSection', () => ({ default: () => null }));
 vi.mock('./configuration/FirmwareUpdateSection', () => ({ default: () => null }));
 vi.mock('./configuration/ChannelDatabaseSection', () => ({ default: () => null }));
 vi.mock('./CustomThemeManagement', () => ({ CustomThemeManagement: () => null }));

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -17,6 +17,7 @@ import ChannelSoundPicker from './ChannelSoundPicker';
 import PkiDmGlobalToggle from './settings/PkiDmGlobalToggle';
 import SystemBackupSection from './configuration/SystemBackupSection';
 import DatabaseMaintenanceSection from './configuration/DatabaseMaintenanceSection';
+import ScriptsSection from './settings/ScriptsSection';
 import FirmwareUpdateSection from './configuration/FirmwareUpdateSection';
 import ChannelDatabaseSection from './configuration/ChannelDatabaseSection';
 import { CustomThemeManagement } from './CustomThemeManagement';
@@ -242,6 +243,7 @@ const GLOBAL_SECTIONS = new Set([
   'settings-security',
   'settings-remote-admin',
   'settings-apprise-server', 'settings-elevation', 'settings-atak-cot', 'settings-backup', 'settings-channel-database',
+  'settings-scripts',
   'settings-maintenance', 'settings-analytics',
   // Position estimation is a single global, cross-source batch job (issue
   // #3271) — it belongs in global Settings, not the per-source Automation tab.
@@ -2661,6 +2663,8 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         {show('settings-channel-database') && isAdmin && <div id="settings-channel-database">
           <ChannelDatabaseSection isAdmin={isAdmin} />
         </div>}
+
+        {show('settings-scripts') && isAdmin && <ScriptsSection baseUrl={baseUrl} canWrite={canWriteSettings} />}
 
         {show('settings-maintenance') && <DatabaseMaintenanceSection />}
 

--- a/src/components/settings/ScriptsSection.module.css
+++ b/src/components/settings/ScriptsSection.module.css
@@ -1,0 +1,206 @@
+/* Scripts inventory section (issue #4942). CSS module — do not move these
+ * rules into the global sheets (CLAUDE.md CSS containment rule). Colors use
+ * the semantic var(--color-*) tokens with no fallback, per the theme system. */
+
+.description {
+  color: var(--color-text-subtle);
+  font-size: 0.85rem;
+  margin-top: -0.25rem;
+}
+
+.toolbar {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.75rem 0;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.importBtn {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  background: var(--color-accent);
+  color: var(--color-bg);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.importBtn:disabled {
+  background: var(--color-surface-active);
+  color: var(--color-text-subtle);
+  cursor: not-allowed;
+}
+
+.searchInput {
+  flex: 1 1 160px;
+  min-width: 140px;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.85rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 4px;
+}
+
+.filterSelect {
+  padding: 0.45rem 0.6rem;
+  font-size: 0.85rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 4px;
+}
+
+.galleryLink {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  background: var(--color-accent-alt);
+  color: var(--color-bg);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+}
+
+.emptyState {
+  padding: 1rem;
+  text-align: center;
+  color: var(--color-text-subtle);
+  font-style: italic;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.card {
+  padding: 0.75rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 4px;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.scriptName {
+  flex: 1;
+  min-width: 0;
+}
+
+.scriptTitle {
+  font-size: 0.95rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.scriptMeta {
+  font-size: 0.78rem;
+  color: var(--color-text-subtle);
+  margin-top: 0.15rem;
+}
+
+.badge {
+  flex-shrink: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+}
+
+.badgeInUse {
+  background: var(--color-success);
+  color: var(--color-bg);
+}
+
+.badgeUnused {
+  background: var(--color-surface-active);
+  color: var(--color-text-subtle);
+}
+
+.deleteBtn {
+  flex-shrink: 0;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+  background: var(--color-error);
+  color: var(--color-bg);
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  font-weight: bold;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.deleteBtn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.usageList {
+  margin: 0.5rem 0 0;
+  padding-left: 1.1rem;
+  font-size: 0.78rem;
+  color: var(--color-text);
+}
+
+.confirmBox {
+  margin-top: 0.6rem;
+  padding: 0.6rem;
+  background: var(--color-surface-hover);
+  border: 1px solid var(--color-error);
+  border-radius: 4px;
+}
+
+.confirmText {
+  font-size: 0.82rem;
+  margin-bottom: 0.5rem;
+}
+
+.confirmActions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.confirmDeleteBtn {
+  padding: 0.3rem 0.75rem;
+  font-size: 0.78rem;
+  background: var(--color-error);
+  color: var(--color-bg);
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.cancelBtn {
+  padding: 0.3rem 0.75rem;
+  font-size: 0.78rem;
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.confirmDeleteBtn:disabled,
+.cancelBtn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}

--- a/src/components/settings/ScriptsSection.test.tsx
+++ b/src/components/settings/ScriptsSection.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Scripts inventory section (issue #4942): renders scripts with usage badges,
+ * flags orphaned scripts as Unused, and gates delete behind a confirm step.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockShowToast = vi.hoisted(() => vi.fn());
+vi.mock('../ToastContainer', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const mockCsrfFetch = vi.hoisted(() => vi.fn());
+vi.mock('../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => mockCsrfFetch,
+}));
+
+const mockApiGet = vi.hoisted(() => vi.fn());
+vi.mock('../../services/api', () => ({
+  default: { get: mockApiGet },
+}));
+
+// Stub the icons and the dependencies panel so the test stays focused on this
+// section's own behavior (the panel fetches on mount otherwise).
+vi.mock('../icons', () => ({
+  UiIcon: () => null,
+}));
+vi.mock('../auto-responder/ScriptDependenciesPanel', () => ({
+  default: () => null,
+}));
+
+import ScriptsSection from './ScriptsSection';
+
+const inventory = {
+  scripts: [
+    {
+      path: '/data/scripts/weather.py',
+      filename: 'weather.py',
+      name: 'Weather',
+      language: 'Python',
+      version: '2.1',
+      author: 'Alice',
+      sizeBytes: 512,
+      lastModified: 1_700_000_000_000,
+      usedBy: [
+        { type: 'auto-responder', protocol: 'meshtastic', sourceId: 's1', sourceName: 'Node A', triggerId: 't1', triggerName: 'weather', enabled: true },
+      ],
+    },
+    {
+      path: '/data/scripts/orphan.sh',
+      filename: 'orphan.sh',
+      language: 'Shell',
+      sizeBytes: 20,
+      lastModified: 1_700_000_000_000,
+      usedBy: [],
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockApiGet.mockResolvedValue(inventory);
+  mockCsrfFetch.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+});
+
+describe('ScriptsSection', () => {
+  it('renders scripts with in-use and unused badges', async () => {
+    render(<ScriptsSection baseUrl="" />);
+
+    await waitFor(() => expect(screen.getByText('Weather')).toBeInTheDocument());
+    expect(screen.getAllByText('orphan.sh').length).toBeGreaterThan(0);
+    // "In use"/"Unused" also appear as filter <option> labels, so match >= 1.
+    expect(screen.getAllByText('In use').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Unused').length).toBeGreaterThan(0);
+    // Usage reference is described.
+    expect(screen.getByText(/Auto Responder "weather" · Node A/)).toBeInTheDocument();
+  });
+
+  it('filters to unused scripts', async () => {
+    render(<ScriptsSection baseUrl="" />);
+    await waitFor(() => expect(screen.getByText('Weather')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'unused' } });
+
+    expect(screen.queryByText('Weather')).not.toBeInTheDocument();
+    expect(screen.getAllByText('orphan.sh').length).toBeGreaterThan(0);
+  });
+
+  it('requires confirmation before deleting and warns when in use', async () => {
+    render(<ScriptsSection baseUrl="" />);
+    await waitFor(() => expect(screen.getByText('Weather')).toBeInTheDocument());
+
+    // Click the delete button on the in-use script's row.
+    const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+    fireEvent.click(deleteButtons[0]);
+
+    // Warning mentions it is in use, and no request has fired yet.
+    expect(screen.getByText(/used by 1 automation/i)).toBeInTheDocument();
+    expect(mockCsrfFetch).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /delete anyway/i }));
+
+    await waitFor(() =>
+      expect(mockCsrfFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/scripts/weather.py'),
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    );
+  });
+
+  it('hides write controls when canWrite is false', async () => {
+    render(<ScriptsSection baseUrl="" canWrite={false} />);
+    await waitFor(() => expect(screen.getByText('Weather')).toBeInTheDocument());
+
+    expect(screen.queryByRole('button', { name: /import script/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/settings/ScriptsSection.test.tsx
+++ b/src/components/settings/ScriptsSection.test.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 
 const mockShowToast = vi.hoisted(() => vi.fn());
 vi.mock('../ToastContainer', () => ({
@@ -94,9 +94,9 @@ describe('ScriptsSection', () => {
     render(<ScriptsSection baseUrl="" />);
     await waitFor(() => expect(screen.getByText('Weather')).toBeInTheDocument());
 
-    // Click the delete button on the in-use script's row.
-    const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
-    fireEvent.click(deleteButtons[0]);
+    // Click Delete on weather.py's row specifically (order-independent).
+    const weatherCard = screen.getByText('Weather').closest('[class*="card"]') as HTMLElement;
+    fireEvent.click(within(weatherCard).getByRole('button', { name: /delete/i }));
 
     // Warning mentions it is in use, and no request has fired yet.
     expect(screen.getByText(/used by 1 automation/i)).toBeInTheDocument();

--- a/src/components/settings/ScriptsSection.test.tsx
+++ b/src/components/settings/ScriptsSection.test.tsx
@@ -34,6 +34,7 @@ vi.mock('../auto-responder/ScriptDependenciesPanel', () => ({
 
 import ScriptsSection from './ScriptsSection';
 
+// Endpoint returns the shared envelope: { success, data: { scripts } }.
 const inventory = {
   scripts: [
     {
@@ -62,7 +63,7 @@ const inventory = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockApiGet.mockResolvedValue(inventory);
+  mockApiGet.mockResolvedValue({ success: true, data: inventory });
   mockCsrfFetch.mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
 });
 

--- a/src/components/settings/ScriptsSection.tsx
+++ b/src/components/settings/ScriptsSection.tsx
@@ -4,6 +4,7 @@ import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { useToast } from '../ToastContainer';
 import { UiIcon, type UiIconName } from '../icons';
 import ScriptDependenciesPanel from '../auto-responder/ScriptDependenciesPanel';
+import styles from './ScriptsSection.module.css';
 
 /**
  * Scripts inventory (issue #4942).
@@ -108,8 +109,10 @@ const ScriptsSection: React.FC<ScriptsSectionProps> = ({ baseUrl, canWrite = tru
 
   const fetchInventory = useCallback(async () => {
     try {
-      const data = await apiService.get<{ scripts?: InventoryScript[] }>('/api/scripts/inventory');
-      setScripts(data.scripts ?? []);
+      // The endpoint uses the shared envelope: { success, data: { scripts } }.
+      // apiService.get returns the raw body and does not unwrap `data`.
+      const body = await apiService.get<{ data?: { scripts?: InventoryScript[] } }>('/api/scripts/inventory');
+      setScripts(body.data?.scripts ?? []);
     } catch (error) {
       console.error('Failed to load script inventory:', error);
       showToast('Failed to load script inventory', 'error');
@@ -195,7 +198,7 @@ const ScriptsSection: React.FC<ScriptsSectionProps> = ({ baseUrl, canWrite = tru
   return (
     <div id="settings-scripts" className="settings-section">
       <h3><UiIcon name="list" size={18} style={{ marginRight: '0.4rem', verticalAlign: 'text-bottom' }} /> Scripts</h3>
-      <p style={{ color: 'var(--color-text-subtle)', fontSize: '0.85rem', marginTop: '-0.25rem' }}>
+      <p className={styles.description}>
         Scripts in <code>/data/scripts/</code> available to Auto Responders, Timers, and Geofences.
         {scripts.length > 0 && ` ${scripts.length} installed, ${usedCount} in use.`}
       </p>
@@ -208,57 +211,25 @@ const ScriptsSection: React.FC<ScriptsSectionProps> = ({ baseUrl, canWrite = tru
         onChange={handleFileSelected}
       />
 
-      <div style={{ display: 'flex', gap: '0.5rem', margin: '0.75rem 0', flexWrap: 'wrap', alignItems: 'center' }}>
+      <div className={styles.toolbar}>
         {canWrite && (
-          <button
-            onClick={handleImportClick}
-            disabled={isImporting}
-            style={{
-              padding: '0.5rem 1rem',
-              fontSize: '0.875rem',
-              background: isImporting ? 'var(--color-surface-active)' : 'var(--color-accent)',
-              color: isImporting ? 'var(--color-text-subtle)' : 'var(--color-bg)',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: isImporting ? 'not-allowed' : 'pointer',
-              fontWeight: 'bold',
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: '0.35rem',
-            }}
-          >
+          <button className={styles.importBtn} onClick={handleImportClick} disabled={isImporting}>
             {isImporting ? 'Importing…' : <><UiIcon name="import" size={15} /> Import Script</>}
           </button>
         )}
 
         <input
+          className={styles.searchInput}
           type="text"
           value={search}
           onChange={e => setSearch(e.target.value)}
           placeholder="Search scripts…"
-          style={{
-            flex: '1 1 160px',
-            minWidth: '140px',
-            padding: '0.45rem 0.6rem',
-            fontSize: '0.85rem',
-            background: 'var(--color-surface)',
-            color: 'var(--color-text)',
-            border: '1px solid var(--color-border-subtle)',
-            borderRadius: '4px',
-          }}
         />
 
         <select
+          className={styles.filterSelect}
           value={statusFilter}
           onChange={e => setStatusFilter(e.target.value as StatusFilter)}
-          style={{
-            padding: '0.45rem 0.6rem',
-            fontSize: '0.85rem',
-            background: 'var(--color-surface)',
-            color: 'var(--color-text)',
-            border: '1px solid var(--color-border-subtle)',
-            borderRadius: '4px',
-          }}
         >
           <option value="all">All</option>
           <option value="used">In use</option>
@@ -266,61 +237,37 @@ const ScriptsSection: React.FC<ScriptsSectionProps> = ({ baseUrl, canWrite = tru
         </select>
 
         <a
+          className={styles.galleryLink}
           href="https://meshmonitor.org/user-scripts.html"
           target="_blank"
           rel="noopener noreferrer"
-          style={{
-            padding: '0.5rem 1rem',
-            fontSize: '0.875rem',
-            background: 'var(--color-accent-alt)',
-            color: 'var(--color-bg)',
-            border: 'none',
-            borderRadius: '4px',
-            cursor: 'pointer',
-            fontWeight: 'bold',
-            textDecoration: 'none',
-            display: 'inline-flex',
-            alignItems: 'center',
-          }}
         >
           Script Gallery
         </a>
       </div>
 
       {loading ? (
-        <div style={{ padding: '1rem', color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>Loading…</div>
+        <div className={styles.emptyState}>Loading…</div>
       ) : scripts.length === 0 ? (
-        <div style={{ padding: '1rem', textAlign: 'center', color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>
-          No scripts found in /data/scripts/
-        </div>
+        <div className={styles.emptyState}>No scripts found in /data/scripts/</div>
       ) : filtered.length === 0 ? (
-        <div style={{ padding: '1rem', textAlign: 'center', color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>
-          No scripts match the current filter.
-        </div>
+        <div className={styles.emptyState}>No scripts match the current filter.</div>
       ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <div className={styles.list}>
           {filtered.map(script => {
             const inUse = script.usedBy.length > 0;
             const isConfirming = confirmDelete === script.filename;
             return (
-              <div
-                key={script.path}
-                style={{
-                  padding: '0.75rem',
-                  background: 'var(--color-surface)',
-                  border: '1px solid var(--color-border-subtle)',
-                  borderRadius: '4px',
-                }}
-              >
-                <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.75rem' }}>
-                  <span style={{ flex: 1, minWidth: 0 }}>
-                    <span style={{ fontSize: '0.95rem', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }}>
+              <div key={script.path} className={styles.card}>
+                <div className={styles.cardHeader}>
+                  <span className={styles.scriptName}>
+                    <span className={styles.scriptTitle}>
                       {script.emoji
                         ? <span>{script.emoji}</span>
                         : <UiIcon name={getLanguageIcon(script.language)} size={15} />}
                       {script.name || script.filename}
                     </span>
-                    <div style={{ fontSize: '0.78rem', color: 'var(--color-text-subtle)', marginTop: '0.15rem' }}>
+                    <div className={styles.scriptMeta}>
                       <code>{script.filename}</code>
                       {' · '}{script.language}
                       {script.version ? ` · v${script.version}` : ''}
@@ -330,38 +277,15 @@ const ScriptsSection: React.FC<ScriptsSectionProps> = ({ baseUrl, canWrite = tru
                     </div>
                   </span>
 
-                  <span
-                    style={{
-                      flexShrink: 0,
-                      fontSize: '0.72rem',
-                      fontWeight: 700,
-                      padding: '0.15rem 0.5rem',
-                      borderRadius: '999px',
-                      background: inUse ? 'var(--color-success)' : 'var(--color-surface-active)',
-                      color: inUse ? 'var(--color-bg)' : 'var(--color-text-subtle)',
-                    }}
-                  >
+                  <span className={`${styles.badge} ${inUse ? styles.badgeInUse : styles.badgeUnused}`}>
                     {inUse ? 'In use' : 'Unused'}
                   </span>
 
                   {canWrite && !isConfirming && (
                     <button
+                      className={styles.deleteBtn}
                       onClick={() => setConfirmDelete(script.filename)}
                       disabled={isDeleting === script.filename}
-                      style={{
-                        flexShrink: 0,
-                        padding: '0.25rem 0.6rem',
-                        fontSize: '0.75rem',
-                        background: 'var(--color-error)',
-                        color: 'var(--color-bg)',
-                        border: 'none',
-                        borderRadius: '3px',
-                        cursor: 'pointer',
-                        fontWeight: 'bold',
-                        display: 'inline-flex',
-                        alignItems: 'center',
-                        gap: '0.25rem',
-                      }}
                     >
                       <UiIcon name="delete" size={13} /> Delete
                     </button>
@@ -369,7 +293,7 @@ const ScriptsSection: React.FC<ScriptsSectionProps> = ({ baseUrl, canWrite = tru
                 </div>
 
                 {inUse && (
-                  <ul style={{ margin: '0.5rem 0 0', paddingLeft: '1.1rem', fontSize: '0.78rem', color: 'var(--color-text)' }}>
+                  <ul className={styles.usageList}>
                     {script.usedBy.map((ref, i) => (
                       <li key={`${ref.sourceId}-${ref.type}-${ref.triggerId ?? i}`}>{describeRef(ref)}</li>
                     ))}
@@ -377,16 +301,8 @@ const ScriptsSection: React.FC<ScriptsSectionProps> = ({ baseUrl, canWrite = tru
                 )}
 
                 {isConfirming && (
-                  <div
-                    style={{
-                      marginTop: '0.6rem',
-                      padding: '0.6rem',
-                      background: 'var(--color-surface-hover)',
-                      border: '1px solid var(--color-error)',
-                      borderRadius: '4px',
-                    }}
-                  >
-                    <div style={{ fontSize: '0.82rem', marginBottom: '0.5rem' }}>
+                  <div className={styles.confirmBox}>
+                    <div className={styles.confirmText}>
                       {inUse ? (
                         <>Delete <strong>{script.filename}</strong>? It is used by {script.usedBy.length}{' '}
                         automation{script.usedBy.length === 1 ? '' : 's'} listed above, which will break until reconfigured.</>
@@ -394,35 +310,18 @@ const ScriptsSection: React.FC<ScriptsSectionProps> = ({ baseUrl, canWrite = tru
                         <>Delete <strong>{script.filename}</strong>? This cannot be undone.</>
                       )}
                     </div>
-                    <div style={{ display: 'flex', gap: '0.5rem' }}>
+                    <div className={styles.confirmActions}>
                       <button
+                        className={styles.confirmDeleteBtn}
                         onClick={() => handleDelete(script.filename)}
                         disabled={isDeleting === script.filename}
-                        style={{
-                          padding: '0.3rem 0.75rem',
-                          fontSize: '0.78rem',
-                          background: 'var(--color-error)',
-                          color: 'var(--color-bg)',
-                          border: 'none',
-                          borderRadius: '3px',
-                          cursor: 'pointer',
-                          fontWeight: 'bold',
-                        }}
                       >
                         {isDeleting === script.filename ? 'Deleting…' : inUse ? 'Delete Anyway' : 'Delete'}
                       </button>
                       <button
+                        className={styles.cancelBtn}
                         onClick={() => setConfirmDelete(null)}
                         disabled={isDeleting === script.filename}
-                        style={{
-                          padding: '0.3rem 0.75rem',
-                          fontSize: '0.78rem',
-                          background: 'var(--color-surface-hover)',
-                          color: 'var(--color-text)',
-                          border: '1px solid var(--color-border-subtle)',
-                          borderRadius: '3px',
-                          cursor: 'pointer',
-                        }}
                       >
                         Cancel
                       </button>

--- a/src/components/settings/ScriptsSection.tsx
+++ b/src/components/settings/ScriptsSection.tsx
@@ -1,0 +1,443 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import apiService from '../../services/api';
+import { useCsrfFetch } from '../../hooks/useCsrfFetch';
+import { useToast } from '../ToastContainer';
+import { UiIcon, type UiIconName } from '../icons';
+import ScriptDependenciesPanel from '../auto-responder/ScriptDependenciesPanel';
+
+/**
+ * Scripts inventory (issue #4942).
+ *
+ * A global-settings section that lists every script in /data/scripts/, shows
+ * which Auto Responders / Timers / Geofences use each one (or flags it as
+ * unused), and lets an admin import or delete scripts. This is the read-only
+ * inventory half of the proposed extension manager; remote gallery install and
+ * Docker add-on management are intentionally out of scope.
+ */
+
+type ScriptTriggerType = 'auto-responder' | 'timer' | 'geofence';
+type ScriptProtocol = 'meshtastic' | 'meshcore';
+
+interface ScriptUsageRef {
+  type: ScriptTriggerType;
+  protocol: ScriptProtocol;
+  sourceId: string;
+  sourceName?: string;
+  triggerId?: string;
+  triggerName?: string;
+  enabled: boolean;
+}
+
+interface InventoryScript {
+  path: string;
+  filename: string;
+  name?: string;
+  emoji?: string;
+  language: string;
+  version?: string;
+  author?: string;
+  sizeBytes?: number;
+  lastModified?: number;
+  usedBy: ScriptUsageRef[];
+}
+
+type StatusFilter = 'all' | 'used' | 'unused';
+
+const VALID_EXTENSIONS = ['.js', '.mjs', '.py', '.sh'];
+
+const getLanguageIcon = (language: string): UiIconName => {
+  switch (language.toLowerCase()) {
+    case 'shell': return 'terminal';
+    case 'python':
+    case 'javascript': return 'code';
+    default: return 'fileCode';
+  }
+};
+
+const formatBytes = (bytes?: number): string => {
+  if (bytes === undefined) return '—';
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
+  return `${(bytes / Math.pow(k, i)).toFixed(i === 0 ? 0 : 1)} ${sizes[i]}`;
+};
+
+const formatDate = (ms?: number): string => {
+  if (!ms) return '—';
+  try {
+    return new Date(ms).toLocaleDateString();
+  } catch {
+    return '—';
+  }
+};
+
+const TRIGGER_LABEL: Record<ScriptTriggerType, string> = {
+  'auto-responder': 'Auto Responder',
+  timer: 'Timer',
+  geofence: 'Geofence',
+};
+
+const describeRef = (ref: ScriptUsageRef): string => {
+  const kind = TRIGGER_LABEL[ref.type];
+  const proto = ref.protocol === 'meshcore' ? 'MeshCore ' : '';
+  const name = ref.triggerName ? ` "${ref.triggerName}"` : '';
+  const source = ref.sourceName ? ` · ${ref.sourceName}` : '';
+  const disabled = ref.enabled ? '' : ' (disabled)';
+  return `${proto}${kind}${name}${source}${disabled}`;
+};
+
+interface ScriptsSectionProps {
+  baseUrl: string;
+  /** When false, import/delete controls are hidden (read-only view). */
+  canWrite?: boolean;
+}
+
+const ScriptsSection: React.FC<ScriptsSectionProps> = ({ baseUrl, canWrite = true }) => {
+  const csrfFetch = useCsrfFetch();
+  const { showToast } = useToast();
+
+  const [scripts, setScripts] = useState<InventoryScript[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isImporting, setIsImporting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const fetchInventory = useCallback(async () => {
+    try {
+      const data = await apiService.get<{ scripts?: InventoryScript[] }>('/api/scripts/inventory');
+      setScripts(data.scripts ?? []);
+    } catch (error) {
+      console.error('Failed to load script inventory:', error);
+      showToast('Failed to load script inventory', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast]);
+
+  useEffect(() => {
+    void fetchInventory();
+  }, [fetchInventory]);
+
+  const handleImportClick = () => fileInputRef.current?.click();
+
+  const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = ''; // allow re-selecting the same file
+    if (!file) return;
+
+    const ext = file.name.slice(file.name.lastIndexOf('.')).toLowerCase();
+    if (!VALID_EXTENSIONS.includes(ext)) {
+      showToast(`Unsupported file type. Allowed: ${VALID_EXTENSIONS.join(', ')}`, 'error');
+      return;
+    }
+
+    setIsImporting(true);
+    try {
+      const body = await file.arrayBuffer();
+      const response = await csrfFetch(`${baseUrl}/api/scripts/import`, {
+        method: 'POST',
+        headers: { 'x-filename': file.name, 'Content-Type': 'application/octet-stream' },
+        body,
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err.error || 'Failed to import script');
+      }
+      showToast(`Imported ${file.name}`, 'success');
+      await fetchInventory();
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : 'Failed to import script', 'error');
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  const handleDelete = async (filename: string) => {
+    setIsDeleting(filename);
+    try {
+      const response = await csrfFetch(`${baseUrl}/api/scripts/${encodeURIComponent(filename)}`, {
+        method: 'DELETE',
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err.error || 'Failed to delete script');
+      }
+      showToast(`Deleted ${filename}`, 'success');
+      setConfirmDelete(null);
+      await fetchInventory();
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : 'Failed to delete script', 'error');
+    } finally {
+      setIsDeleting(null);
+    }
+  };
+
+  const usedCount = useMemo(() => scripts.filter(s => s.usedBy.length > 0).length, [scripts]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return scripts.filter(s => {
+      if (statusFilter === 'used' && s.usedBy.length === 0) return false;
+      if (statusFilter === 'unused' && s.usedBy.length > 0) return false;
+      if (!q) return true;
+      return (
+        s.filename.toLowerCase().includes(q) ||
+        (s.name?.toLowerCase().includes(q) ?? false) ||
+        (s.author?.toLowerCase().includes(q) ?? false)
+      );
+    });
+  }, [scripts, search, statusFilter]);
+
+  return (
+    <div id="settings-scripts" className="settings-section">
+      <h3><UiIcon name="list" size={18} style={{ marginRight: '0.4rem', verticalAlign: 'text-bottom' }} /> Scripts</h3>
+      <p style={{ color: 'var(--color-text-subtle)', fontSize: '0.85rem', marginTop: '-0.25rem' }}>
+        Scripts in <code>/data/scripts/</code> available to Auto Responders, Timers, and Geofences.
+        {scripts.length > 0 && ` ${scripts.length} installed, ${usedCount} in use.`}
+      </p>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={VALID_EXTENSIONS.join(',')}
+        style={{ display: 'none' }}
+        onChange={handleFileSelected}
+      />
+
+      <div style={{ display: 'flex', gap: '0.5rem', margin: '0.75rem 0', flexWrap: 'wrap', alignItems: 'center' }}>
+        {canWrite && (
+          <button
+            onClick={handleImportClick}
+            disabled={isImporting}
+            style={{
+              padding: '0.5rem 1rem',
+              fontSize: '0.875rem',
+              background: isImporting ? 'var(--color-surface-active)' : 'var(--color-accent)',
+              color: isImporting ? 'var(--color-text-subtle)' : 'var(--color-bg)',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: isImporting ? 'not-allowed' : 'pointer',
+              fontWeight: 'bold',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '0.35rem',
+            }}
+          >
+            {isImporting ? 'Importing…' : <><UiIcon name="import" size={15} /> Import Script</>}
+          </button>
+        )}
+
+        <input
+          type="text"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Search scripts…"
+          style={{
+            flex: '1 1 160px',
+            minWidth: '140px',
+            padding: '0.45rem 0.6rem',
+            fontSize: '0.85rem',
+            background: 'var(--color-surface)',
+            color: 'var(--color-text)',
+            border: '1px solid var(--color-border-subtle)',
+            borderRadius: '4px',
+          }}
+        />
+
+        <select
+          value={statusFilter}
+          onChange={e => setStatusFilter(e.target.value as StatusFilter)}
+          style={{
+            padding: '0.45rem 0.6rem',
+            fontSize: '0.85rem',
+            background: 'var(--color-surface)',
+            color: 'var(--color-text)',
+            border: '1px solid var(--color-border-subtle)',
+            borderRadius: '4px',
+          }}
+        >
+          <option value="all">All</option>
+          <option value="used">In use</option>
+          <option value="unused">Unused</option>
+        </select>
+
+        <a
+          href="https://meshmonitor.org/user-scripts.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            padding: '0.5rem 1rem',
+            fontSize: '0.875rem',
+            background: 'var(--color-accent-alt)',
+            color: 'var(--color-bg)',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontWeight: 'bold',
+            textDecoration: 'none',
+            display: 'inline-flex',
+            alignItems: 'center',
+          }}
+        >
+          Script Gallery
+        </a>
+      </div>
+
+      {loading ? (
+        <div style={{ padding: '1rem', color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>Loading…</div>
+      ) : scripts.length === 0 ? (
+        <div style={{ padding: '1rem', textAlign: 'center', color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>
+          No scripts found in /data/scripts/
+        </div>
+      ) : filtered.length === 0 ? (
+        <div style={{ padding: '1rem', textAlign: 'center', color: 'var(--color-text-subtle)', fontStyle: 'italic' }}>
+          No scripts match the current filter.
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          {filtered.map(script => {
+            const inUse = script.usedBy.length > 0;
+            const isConfirming = confirmDelete === script.filename;
+            return (
+              <div
+                key={script.path}
+                style={{
+                  padding: '0.75rem',
+                  background: 'var(--color-surface)',
+                  border: '1px solid var(--color-border-subtle)',
+                  borderRadius: '4px',
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'flex-start', gap: '0.75rem' }}>
+                  <span style={{ flex: 1, minWidth: 0 }}>
+                    <span style={{ fontSize: '0.95rem', fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }}>
+                      {script.emoji
+                        ? <span>{script.emoji}</span>
+                        : <UiIcon name={getLanguageIcon(script.language)} size={15} />}
+                      {script.name || script.filename}
+                    </span>
+                    <div style={{ fontSize: '0.78rem', color: 'var(--color-text-subtle)', marginTop: '0.15rem' }}>
+                      <code>{script.filename}</code>
+                      {' · '}{script.language}
+                      {script.version ? ` · v${script.version}` : ''}
+                      {script.author ? ` · ${script.author}` : ''}
+                      {' · '}{formatBytes(script.sizeBytes)}
+                      {' · '}updated {formatDate(script.lastModified)}
+                    </div>
+                  </span>
+
+                  <span
+                    style={{
+                      flexShrink: 0,
+                      fontSize: '0.72rem',
+                      fontWeight: 700,
+                      padding: '0.15rem 0.5rem',
+                      borderRadius: '999px',
+                      background: inUse ? 'var(--color-success)' : 'var(--color-surface-active)',
+                      color: inUse ? 'var(--color-bg)' : 'var(--color-text-subtle)',
+                    }}
+                  >
+                    {inUse ? 'In use' : 'Unused'}
+                  </span>
+
+                  {canWrite && !isConfirming && (
+                    <button
+                      onClick={() => setConfirmDelete(script.filename)}
+                      disabled={isDeleting === script.filename}
+                      style={{
+                        flexShrink: 0,
+                        padding: '0.25rem 0.6rem',
+                        fontSize: '0.75rem',
+                        background: 'var(--color-error)',
+                        color: 'var(--color-bg)',
+                        border: 'none',
+                        borderRadius: '3px',
+                        cursor: 'pointer',
+                        fontWeight: 'bold',
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: '0.25rem',
+                      }}
+                    >
+                      <UiIcon name="delete" size={13} /> Delete
+                    </button>
+                  )}
+                </div>
+
+                {inUse && (
+                  <ul style={{ margin: '0.5rem 0 0', paddingLeft: '1.1rem', fontSize: '0.78rem', color: 'var(--color-text)' }}>
+                    {script.usedBy.map((ref, i) => (
+                      <li key={`${ref.sourceId}-${ref.type}-${ref.triggerId ?? i}`}>{describeRef(ref)}</li>
+                    ))}
+                  </ul>
+                )}
+
+                {isConfirming && (
+                  <div
+                    style={{
+                      marginTop: '0.6rem',
+                      padding: '0.6rem',
+                      background: 'var(--color-surface-hover)',
+                      border: '1px solid var(--color-error)',
+                      borderRadius: '4px',
+                    }}
+                  >
+                    <div style={{ fontSize: '0.82rem', marginBottom: '0.5rem' }}>
+                      {inUse ? (
+                        <>Delete <strong>{script.filename}</strong>? It is used by {script.usedBy.length}{' '}
+                        automation{script.usedBy.length === 1 ? '' : 's'} listed above, which will break until reconfigured.</>
+                      ) : (
+                        <>Delete <strong>{script.filename}</strong>? This cannot be undone.</>
+                      )}
+                    </div>
+                    <div style={{ display: 'flex', gap: '0.5rem' }}>
+                      <button
+                        onClick={() => handleDelete(script.filename)}
+                        disabled={isDeleting === script.filename}
+                        style={{
+                          padding: '0.3rem 0.75rem',
+                          fontSize: '0.78rem',
+                          background: 'var(--color-error)',
+                          color: 'var(--color-bg)',
+                          border: 'none',
+                          borderRadius: '3px',
+                          cursor: 'pointer',
+                          fontWeight: 'bold',
+                        }}
+                      >
+                        {isDeleting === script.filename ? 'Deleting…' : inUse ? 'Delete Anyway' : 'Delete'}
+                      </button>
+                      <button
+                        onClick={() => setConfirmDelete(null)}
+                        disabled={isDeleting === script.filename}
+                        style={{
+                          padding: '0.3rem 0.75rem',
+                          fontSize: '0.78rem',
+                          background: 'var(--color-surface-hover)',
+                          color: 'var(--color-text)',
+                          border: '1px solid var(--color-border-subtle)',
+                          borderRadius: '3px',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <ScriptDependenciesPanel />
+    </div>
+  );
+};
+
+export default ScriptsSection;

--- a/src/server/routes/scriptRoutes.inventory.test.ts
+++ b/src/server/routes/scriptRoutes.inventory.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// A real temp scripts directory so collectScripts() reads genuine files.
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mm-scripts-inv-'));
+const scriptsDir = path.join(tmpRoot, 'scripts');
+fs.mkdirSync(scriptsDir, { recursive: true });
+process.env.DATA_DIR = tmpRoot;
+
+vi.mock('../config/environment.js', () => ({
+  getEnvironmentConfig: vi.fn().mockReturnValue({ isDevelopment: false }),
+}));
+
+vi.mock('../utils/scriptRunner.js', () => ({
+  scriptDependencyEnv: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../utils/autoResponderUtils.js', () => ({
+  normalizeTriggerPatterns: vi.fn((t: any) => (Array.isArray(t) ? t : [t])),
+}));
+
+vi.mock('../utils/ssrfGuard.js', () => ({
+  safeFetch: vi.fn(),
+  SsrfBlockedError: class extends Error {},
+}));
+
+vi.mock('../services/scriptDependencyService.js', () => ({
+  getDependencyStatus: vi.fn(),
+  installDependencies: vi.fn(),
+}));
+
+vi.mock('../auth/authMiddleware.js', () => ({
+  requirePermission: () => (req: any, _res: any, next: any) => { req.user = { id: 1, isAdmin: true }; next(); },
+}));
+
+const mockDb = vi.hoisted(() => ({
+  sources: { getAllSources: vi.fn() },
+  settings: { getSettingForSources: vi.fn() },
+}));
+vi.mock('../../services/database.js', () => ({ default: mockDb }));
+
+import scriptRoutes from './scriptRoutes.js';
+
+const app = express();
+app.use(express.json());
+app.use('/', scriptRoutes);
+
+beforeAll(() => {
+  // weather.py used by a Meshtastic auto-responder; orphan.sh used by nothing.
+  fs.writeFileSync(
+    path.join(scriptsDir, 'weather.py'),
+    '# mm_meta:\n#   name: Weather\n#   version: 2.1\n#   author: Alice\nprint("hi")\n'
+  );
+  fs.writeFileSync(path.join(scriptsDir, 'orphan.sh'), 'echo hi\n');
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('GET /scripts/inventory', () => {
+  it('reports usedBy for referenced scripts and empty for orphans', async () => {
+    mockDb.sources.getAllSources.mockResolvedValue([{ id: 'src1', name: 'Node A', type: 'meshtastic_tcp' }]);
+    mockDb.settings.getSettingForSources.mockImplementation(async (_ids: string[], key: string) => {
+      if (key === 'autoResponderTriggers') {
+        return new Map([[
+          'src1',
+          JSON.stringify([
+            { id: 't1', trigger: 'weather', responseType: 'script', response: '/data/scripts/weather.py' },
+          ]),
+        ]]);
+      }
+      return new Map();
+    });
+
+    const res = await request(app).get('/scripts/inventory');
+    expect(res.status).toBe(200);
+
+    const scripts: any[] = res.body.scripts;
+    const weather = scripts.find(s => s.filename === 'weather.py');
+    const orphan = scripts.find(s => s.filename === 'orphan.sh');
+
+    expect(weather).toBeDefined();
+    expect(weather.name).toBe('Weather');
+    expect(weather.version).toBe('2.1');
+    expect(weather.author).toBe('Alice');
+    expect(typeof weather.sizeBytes).toBe('number');
+    expect(typeof weather.lastModified).toBe('number');
+    expect(weather.usedBy).toHaveLength(1);
+    expect(weather.usedBy[0]).toMatchObject({
+      type: 'auto-responder',
+      protocol: 'meshtastic',
+      sourceId: 'src1',
+      sourceName: 'Node A',
+      triggerName: 'weather',
+    });
+
+    expect(orphan).toBeDefined();
+    expect(orphan.usedBy).toEqual([]);
+  });
+
+  it('works with no sources configured', async () => {
+    mockDb.sources.getAllSources.mockResolvedValue([]);
+    mockDb.settings.getSettingForSources.mockResolvedValue(new Map());
+
+    const res = await request(app).get('/scripts/inventory');
+    expect(res.status).toBe(200);
+    expect(res.body.scripts.every((s: any) => s.usedBy.length === 0)).toBe(true);
+  });
+
+  it('returns 500 with an empty list when the DB throws', async () => {
+    mockDb.sources.getAllSources.mockRejectedValue(new Error('boom'));
+
+    const res = await request(app).get('/scripts/inventory');
+    expect(res.status).toBe(500);
+    expect(res.body.scripts).toEqual([]);
+  });
+});

--- a/src/server/routes/scriptRoutes.inventory.test.ts
+++ b/src/server/routes/scriptRoutes.inventory.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 import fs from 'fs';
@@ -62,6 +62,10 @@ afterAll(() => {
   fs.rmSync(tmpRoot, { recursive: true, force: true });
 });
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe('GET /scripts/inventory', () => {
   it('reports usedBy for referenced scripts and empty for orphans', async () => {
     mockDb.sources.getAllSources.mockResolvedValue([{ id: 'src1', name: 'Node A', type: 'meshtastic_tcp' }]);
@@ -79,8 +83,9 @@ describe('GET /scripts/inventory', () => {
 
     const res = await request(app).get('/scripts/inventory');
     expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
 
-    const scripts: any[] = res.body.scripts;
+    const scripts: any[] = res.body.data.scripts;
     const weather = scripts.find(s => s.filename === 'weather.py');
     const orphan = scripts.find(s => s.filename === 'orphan.sh');
 
@@ -103,20 +108,22 @@ describe('GET /scripts/inventory', () => {
     expect(orphan.usedBy).toEqual([]);
   });
 
-  it('works with no sources configured', async () => {
+  it('works with no sources configured and skips the per-key query', async () => {
     mockDb.sources.getAllSources.mockResolvedValue([]);
     mockDb.settings.getSettingForSources.mockResolvedValue(new Map());
 
     const res = await request(app).get('/scripts/inventory');
     expect(res.status).toBe(200);
-    expect(res.body.scripts.every((s: any) => s.usedBy.length === 0)).toBe(true);
+    expect(res.body.data.scripts.every((s: any) => s.usedBy.length === 0)).toBe(true);
+    // The sourceIds.length guard must short-circuit the settings query.
+    expect(mockDb.settings.getSettingForSources).not.toHaveBeenCalled();
   });
 
-  it('returns 500 with an empty list when the DB throws', async () => {
+  it('returns a fail envelope when the DB throws', async () => {
     mockDb.sources.getAllSources.mockRejectedValue(new Error('boom'));
 
     const res = await request(app).get('/scripts/inventory');
     expect(res.status).toBe(500);
-    expect(res.body.scripts).toEqual([]);
+    expect(res.body).toMatchObject({ success: false, code: 'SCRIPT_INVENTORY_ERROR' });
   });
 });

--- a/src/server/routes/scriptRoutes.test.ts
+++ b/src/server/routes/scriptRoutes.test.ts
@@ -37,6 +37,15 @@ vi.mock('../auth/authMiddleware.js', () => ({
   requirePermission: () => (req: any, _res: any, next: any) => { req.user = { id: 1, isAdmin: true }; next(); },
 }));
 
+// scriptRoutes imports the database singleton (for the inventory endpoint);
+// stub it so importing the router doesn't spin up the real DatabaseService.
+vi.mock('../../services/database.js', () => ({
+  default: {
+    sources: { getAllSources: vi.fn().mockResolvedValue([]) },
+    settings: { getSettingForSources: vi.fn().mockResolvedValue(new Map()) },
+  },
+}));
+
 // fs is exercised only by paths we don't reach in these validation-focused tests.
 import scriptRoutes, { scriptsEndpoint } from './scriptRoutes.js';
 

--- a/src/server/routes/scriptRoutes.ts
+++ b/src/server/routes/scriptRoutes.ts
@@ -12,6 +12,7 @@ import { safeFetch, SsrfBlockedError } from '../utils/ssrfGuard.js';
 import { getDependencyStatus, installDependencies } from '../services/scriptDependencyService.js';
 import databaseService from '../../services/database.js';
 import { computeScriptUsage, type SourceTriggers } from '../utils/scriptUsage.js';
+import { ok, fail } from '../utils/apiResponse.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -280,7 +281,11 @@ router.get('/scripts/inventory', requirePermission('settings', 'read'), async (_
     const sources = await databaseService.sources.getAllSources();
     const sourceIds = sources.map(s => s.id);
 
-    // One prefix-scoped query per key across all sources.
+    // One prefix-scoped query per key across all sources — a fixed 5 round
+    // trips (the USAGE_SETTING_KEYS count), NOT per-source, since each call
+    // fans out over every sourceId in a single IN query. Key order is
+    // irrelevant; results are merged into sourceTriggers regardless. If the
+    // key list grows large, batch these into one query instead.
     const perKey: Record<string, Map<string, string>> = {};
     for (const key of USAGE_SETTING_KEYS) {
       perKey[key] = sourceIds.length
@@ -305,10 +310,10 @@ router.get('/scripts/inventory', requirePermission('settings', 'read'), async (_
       usedBy: usage.get(script.filename) ?? [],
     }));
 
-    res.json({ scripts: enriched });
+    ok(res, { scripts: enriched });
   } catch (error) {
     logger.error('❌ Error building script inventory:', error);
-    res.status(500).json({ error: 'Failed to build script inventory', scripts: [] });
+    fail(res, 500, 'SCRIPT_INVENTORY_ERROR', 'Failed to build script inventory');
   }
 });
 

--- a/src/server/routes/scriptRoutes.ts
+++ b/src/server/routes/scriptRoutes.ts
@@ -10,6 +10,8 @@ import { compileUserRegex } from '../../utils/safeRegex.js';
 import { normalizeTriggerPatterns } from '../../utils/autoResponderUtils.js';
 import { safeFetch, SsrfBlockedError } from '../utils/ssrfGuard.js';
 import { getDependencyStatus, installDependencies } from '../services/scriptDependencyService.js';
+import databaseService from '../../services/database.js';
+import { computeScriptUsage, type SourceTriggers } from '../utils/scriptUsage.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -77,6 +79,10 @@ interface ScriptMetadata {
   name?: string;          // Human-readable name from mm_meta
   emoji?: string;         // Emoji icon from mm_meta
   language: string;       // Inferred from extension or mm_meta
+  version?: string;       // Version string from mm_meta, when provided
+  author?: string;        // Author from mm_meta, when provided
+  sizeBytes?: number;     // File size on disk
+  lastModified?: number;  // mtime as unix ms (proxy for "last updated")
 }
 
 /**
@@ -132,6 +138,18 @@ const parseScriptMetadata = (content: string, _filename: string): Partial<Script
     if (langMatch) {
       metadata.language = sanitizeMetadataValue(langMatch[1], 20);
     }
+
+    // Parse version (sanitize, max 20 chars)
+    const versionMatch = metaBlock.match(/^[#/]{1,2}\s+version:\s*(.+)$/m);
+    if (versionMatch) {
+      metadata.version = sanitizeMetadataValue(versionMatch[1], 20);
+    }
+
+    // Parse author (sanitize, max 60 chars)
+    const authorMatch = metaBlock.match(/^[#/]{1,2}\s+author:\s*(.+)$/m);
+    if (authorMatch) {
+      metadata.author = sanitizeMetadataValue(authorMatch[1], 60);
+    }
   }
 
   return metadata;
@@ -151,68 +169,77 @@ const getLanguageFromExtension = (filename: string): string => {
   }
 };
 
+/**
+ * Enumerate the scripts on disk with their parsed mm_meta metadata plus size
+ * and mtime. Shared by the public listing endpoint and the authenticated
+ * inventory endpoint. Returns [] when the directory is absent.
+ */
+export const collectScripts = (): ScriptMetadata[] => {
+  const scriptsDir = getScriptsDirectory();
+
+  if (!fs.existsSync(scriptsDir)) {
+    logger.debug(`📁 Scripts directory does not exist: ${scriptsDir}`);
+    return [];
+  }
+
+  const files = fs.readdirSync(scriptsDir);
+  const validExtensions = ['.js', '.mjs', '.py', '.sh'];
+
+  const scriptFiles = files
+    .filter(file => validExtensions.includes(path.extname(file).toLowerCase()))
+    .sort();
+
+  return scriptFiles.map(file => {
+    const filePath = path.join(scriptsDir, file);
+    const scriptPath = `/data/scripts/${file}`;
+
+    const script: ScriptMetadata = {
+      path: scriptPath,
+      filename: file,
+      language: getLanguageFromExtension(file),
+    };
+
+    // Size + mtime for the inventory view. Errors leave the fields undefined.
+    try {
+      const stat = fs.statSync(filePath);
+      script.sizeBytes = stat.size;
+      script.lastModified = stat.mtimeMs;
+    } catch {
+      // ignore — fields stay undefined
+    }
+
+    // Parse mm_meta from the first 1KB (performance optimization).
+    try {
+      const fd = fs.openSync(filePath, 'r');
+      const buffer = Buffer.alloc(1024);
+      const bytesRead = fs.readSync(fd, buffer, 0, 1024, 0);
+      fs.closeSync(fd);
+
+      const content = buffer.toString('utf8', 0, bytesRead);
+      const metadata = parseScriptMetadata(content, file);
+
+      if (metadata.name) script.name = metadata.name;
+      if (metadata.emoji) script.emoji = metadata.emoji;
+      if (metadata.language) script.language = metadata.language;
+      if (metadata.version) script.version = metadata.version;
+      if (metadata.author) script.author = metadata.author;
+    } catch (readError) {
+      logger.debug(`📜 Could not read metadata from ${file}: ${readError}`);
+    }
+
+    return script;
+  });
+};
+
 // Public endpoint to list available scripts (no CSRF or auth required).
 // Exported so server.ts can mount it directly on the app (bypassing the
 // apiRouter's CSRF protection) at /api/scripts.
 export const scriptsEndpoint = (_req: any, res: any) => {
   try {
-    const scriptsDir = getScriptsDirectory();
-
-    // Check if directory exists
-    if (!fs.existsSync(scriptsDir)) {
-      logger.debug(`📁 Scripts directory does not exist: ${scriptsDir}`);
-      return res.json({ scripts: [] });
-    }
-
-    // Read directory and filter for valid script extensions
-    const files = fs.readdirSync(scriptsDir);
-    const validExtensions = ['.js', '.mjs', '.py', '.sh'];
-
-    const scriptFiles = files
-      .filter(file => {
-        const ext = path.extname(file).toLowerCase();
-        return validExtensions.includes(ext);
-      })
-      .sort();
-
-    // Build script metadata for each file
-    const scripts: ScriptMetadata[] = scriptFiles.map(file => {
-      const filePath = path.join(scriptsDir, file);
-      const scriptPath = `/data/scripts/${file}`;
-
-      // Start with defaults
-      const script: ScriptMetadata = {
-        path: scriptPath,
-        filename: file,
-        language: getLanguageFromExtension(file),
-      };
-
-      // Try to read and parse metadata from file
-      try {
-        // Only read first 1KB to find metadata block (performance optimization)
-        const fd = fs.openSync(filePath, 'r');
-        const buffer = Buffer.alloc(1024);
-        const bytesRead = fs.readSync(fd, buffer, 0, 1024, 0);
-        fs.closeSync(fd);
-
-        const content = buffer.toString('utf8', 0, bytesRead);
-        const metadata = parseScriptMetadata(content, file);
-
-        if (metadata.name) script.name = metadata.name;
-        if (metadata.emoji) script.emoji = metadata.emoji;
-        if (metadata.language) script.language = metadata.language;
-      } catch (readError) {
-        // Silently ignore read errors - script will just use defaults
-        logger.debug(`📜 Could not read metadata from ${file}: ${readError}`);
-      }
-
-      return script;
-    });
-
+    const scripts = collectScripts();
     if (env.isDevelopment && scripts.length > 0) {
-      logger.debug(`📜 Found ${scripts.length} script(s) in ${scriptsDir}`);
+      logger.debug(`📜 Found ${scripts.length} script(s)`);
     }
-
     res.json({ scripts });
   } catch (error) {
     logger.error('❌ Error listing scripts:', error);
@@ -221,6 +248,69 @@ export const scriptsEndpoint = (_req: any, res: any) => {
 };
 
 const router: Router = express.Router();
+
+// Trigger settings scanned for script usage. Meshtastic auto-responder/timer/
+// geofence plus the MeshCore auto-responder/timer variants (no MeshCore
+// geofence). All are stored per-source.
+const USAGE_SETTING_KEYS = [
+  'autoResponderTriggers',
+  'timerTriggers',
+  'geofenceTriggers',
+  'meshcoreAutoResponderTriggers',
+  'meshcoreTimerTriggers',
+] as const;
+
+const safeParseArray = (json: string | undefined): unknown => {
+  if (!json) return undefined;
+  try {
+    return JSON.parse(json);
+  } catch {
+    return undefined;
+  }
+};
+
+// Authenticated inventory endpoint (issue #4942): the scripts on disk enriched
+// with the automations that use each one, so orphaned/unused scripts are
+// obvious. Requires settings:read since it reads every source's automation
+// configuration.
+router.get('/scripts/inventory', requirePermission('settings', 'read'), async (_req: Request, res: Response) => {
+  try {
+    const scripts = collectScripts();
+
+    const sources = await databaseService.sources.getAllSources();
+    const sourceIds = sources.map(s => s.id);
+
+    // One prefix-scoped query per key across all sources.
+    const perKey: Record<string, Map<string, string>> = {};
+    for (const key of USAGE_SETTING_KEYS) {
+      perKey[key] = sourceIds.length
+        ? await databaseService.settings.getSettingForSources(sourceIds, key)
+        : new Map();
+    }
+
+    const sourceTriggers: SourceTriggers[] = sources.map(s => ({
+      sourceId: s.id,
+      sourceName: s.name,
+      autoResponderTriggers: safeParseArray(perKey.autoResponderTriggers.get(s.id)),
+      timerTriggers: safeParseArray(perKey.timerTriggers.get(s.id)),
+      geofenceTriggers: safeParseArray(perKey.geofenceTriggers.get(s.id)),
+      meshcoreAutoResponderTriggers: safeParseArray(perKey.meshcoreAutoResponderTriggers.get(s.id)),
+      meshcoreTimerTriggers: safeParseArray(perKey.meshcoreTimerTriggers.get(s.id)),
+    }));
+
+    const usage = computeScriptUsage(sourceTriggers);
+
+    const enriched = scripts.map(script => ({
+      ...script,
+      usedBy: usage.get(script.filename) ?? [],
+    }));
+
+    res.json({ scripts: enriched });
+  } catch (error) {
+    logger.error('❌ Error building script inventory:', error);
+    res.status(500).json({ error: 'Failed to build script inventory', scripts: [] });
+  }
+});
 
 // Script test endpoint - allows testing script execution with sample parameters
 // Supports triggerType: 'auto-responder' (default), 'geofence', or 'timer'

--- a/src/server/utils/scriptUsage.test.ts
+++ b/src/server/utils/scriptUsage.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { computeScriptUsage, scriptKey, type SourceTriggers } from './scriptUsage.js';
+
+describe('scriptKey', () => {
+  it('reduces a stored path to its filename', () => {
+    expect(scriptKey('/data/scripts/weather.py')).toBe('weather.py');
+    expect(scriptKey('weather.py')).toBe('weather.py');
+    expect(scriptKey('C:\\scripts\\a.sh')).toBe('a.sh');
+  });
+});
+
+describe('computeScriptUsage', () => {
+  it('returns an empty map when no source uses scripts', () => {
+    const sources: SourceTriggers[] = [
+      { sourceId: 's1', autoResponderTriggers: [{ id: 'a', responseType: 'text', response: 'hi' }] },
+    ];
+    expect(computeScriptUsage(sources).size).toBe(0);
+  });
+
+  it('detects a Meshtastic auto-responder script by its response path', () => {
+    const sources: SourceTriggers[] = [
+      {
+        sourceId: 's1',
+        sourceName: 'Node A',
+        autoResponderTriggers: [
+          { id: 'a1', trigger: ['weather', 'weather {q}'], responseType: 'script', response: '/data/scripts/weather.py' },
+        ],
+      },
+    ];
+    const usage = computeScriptUsage(sources);
+    const refs = usage.get('weather.py');
+    expect(refs).toHaveLength(1);
+    expect(refs![0]).toMatchObject({
+      type: 'auto-responder',
+      protocol: 'meshtastic',
+      sourceId: 's1',
+      sourceName: 'Node A',
+      triggerId: 'a1',
+      triggerName: 'weather, weather {q}',
+      enabled: true,
+    });
+  });
+
+  it('detects a timer script (default responseType) and honors enabled flag', () => {
+    const sources: SourceTriggers[] = [
+      {
+        sourceId: 's1',
+        timerTriggers: [
+          { id: 't1', name: 'Nightly', scriptPath: '/data/scripts/report.js', enabled: false },
+          { id: 't2', name: 'Text only', responseType: 'text', response: 'yo', scriptPath: '/data/scripts/ignored.js' },
+        ],
+      },
+    ];
+    const usage = computeScriptUsage(sources);
+    expect(usage.get('report.js')).toMatchObject([{ type: 'timer', triggerName: 'Nightly', enabled: false }]);
+    // A text-mode timer must not count its residual scriptPath as usage.
+    expect(usage.has('ignored.js')).toBe(false);
+  });
+
+  it('detects a geofence script only when responseType is script', () => {
+    const sources: SourceTriggers[] = [
+      {
+        sourceId: 's1',
+        geofenceTriggers: [
+          { id: 'g1', name: 'Zone', responseType: 'script', scriptPath: '/data/scripts/zone.sh' },
+          { id: 'g2', name: 'Text', responseType: 'text', scriptPath: '/data/scripts/nope.sh' },
+        ],
+      },
+    ];
+    const usage = computeScriptUsage(sources);
+    expect(usage.get('zone.sh')).toHaveLength(1);
+    expect(usage.has('nope.sh')).toBe(false);
+  });
+
+  it('detects MeshCore auto-responder and timer variants', () => {
+    const sources: SourceTriggers[] = [
+      {
+        sourceId: 'mc1',
+        sourceName: 'MeshCore',
+        meshcoreAutoResponderTriggers: [
+          { id: 'ma1', trigger: 'ping', responseType: 'script', response: '/data/scripts/ping.py' },
+        ],
+        meshcoreTimerTriggers: [
+          { id: 'mt1', name: 'Beacon', scriptPath: '/data/scripts/beacon.py' },
+        ],
+      },
+    ];
+    const usage = computeScriptUsage(sources);
+    expect(usage.get('ping.py')![0]).toMatchObject({ type: 'auto-responder', protocol: 'meshcore' });
+    expect(usage.get('beacon.py')![0]).toMatchObject({ type: 'timer', protocol: 'meshcore' });
+  });
+
+  it('aggregates references for one script used across multiple sources and types', () => {
+    const sources: SourceTriggers[] = [
+      {
+        sourceId: 's1',
+        autoResponderTriggers: [{ id: 'a1', trigger: 'x', responseType: 'script', response: '/data/scripts/shared.py' }],
+      },
+      {
+        sourceId: 's2',
+        timerTriggers: [{ id: 't1', name: 'T', scriptPath: '/data/scripts/shared.py' }],
+      },
+    ];
+    const refs = computeScriptUsage(sources).get('shared.py');
+    expect(refs).toHaveLength(2);
+    expect(refs!.map(r => r.sourceId).sort()).toEqual(['s1', 's2']);
+  });
+
+  it('ignores malformed trigger data without throwing', () => {
+    const sources: SourceTriggers[] = [
+      { sourceId: 's1', autoResponderTriggers: 'not-an-array', timerTriggers: null, geofenceTriggers: undefined },
+      { sourceId: 's2', timerTriggers: [{ id: 't', responseType: 'script' /* no scriptPath */ }] },
+    ];
+    expect(() => computeScriptUsage(sources)).not.toThrow();
+    expect(computeScriptUsage(sources).size).toBe(0);
+  });
+});

--- a/src/server/utils/scriptUsage.ts
+++ b/src/server/utils/scriptUsage.ts
@@ -1,0 +1,142 @@
+/**
+ * Script usage computation (issue #4942).
+ *
+ * Cross-references the scripts on disk against every trigger that can invoke a
+ * script — Meshtastic auto-responders, timers, and geofences, plus the MeshCore
+ * auto-responder and timer variants — so the Scripts inventory can show which
+ * automations (if any) use each script and flag orphaned/unused scripts.
+ *
+ * Pure and side-effect free: the route reads the settings, this file just maps
+ * parsed trigger arrays to usage references keyed by script filename.
+ */
+
+export type ScriptTriggerType = 'auto-responder' | 'timer' | 'geofence';
+export type ScriptProtocol = 'meshtastic' | 'meshcore';
+
+export interface ScriptUsageRef {
+  /** Which kind of trigger references the script. */
+  type: ScriptTriggerType;
+  /** Which stack the trigger belongs to. */
+  protocol: ScriptProtocol;
+  /** Source that owns the trigger. */
+  sourceId: string;
+  sourceName?: string;
+  /** The trigger's own id, when it has one. */
+  triggerId?: string;
+  /** Human-readable label: trigger pattern (auto-responder) or name (timer/geofence). */
+  triggerName?: string;
+  /** Whether the trigger itself is enabled. Auto-responders have no per-trigger
+   *  flag, so they report `true` (the responder-level toggle governs them). */
+  enabled: boolean;
+}
+
+/**
+ * One source's already-parsed trigger arrays. The route parses the JSON; this
+ * module never touches the database or JSON.parse so it stays trivially
+ * testable.
+ */
+export interface SourceTriggers {
+  sourceId: string;
+  sourceName?: string;
+  autoResponderTriggers?: unknown;
+  timerTriggers?: unknown;
+  geofenceTriggers?: unknown;
+  meshcoreAutoResponderTriggers?: unknown;
+  meshcoreTimerTriggers?: unknown;
+}
+
+/** Reduce a stored script path to its filename for robust matching. */
+export const scriptKey = (p: string): string => {
+  const parts = String(p).split(/[\\/]/);
+  return parts[parts.length - 1] || String(p);
+};
+
+const asArray = (v: unknown): Record<string, unknown>[] =>
+  Array.isArray(v) ? (v as Record<string, unknown>[]) : [];
+
+const pushRef = (
+  map: Map<string, ScriptUsageRef[]>,
+  path: unknown,
+  ref: ScriptUsageRef
+): void => {
+  if (typeof path !== 'string' || path.length === 0) return;
+  const key = scriptKey(path);
+  if (!key) return;
+  const arr = map.get(key);
+  if (arr) arr.push(ref);
+  else map.set(key, [ref]);
+};
+
+/**
+ * Build a map of `filename -> usage references` across every source's triggers.
+ */
+export function computeScriptUsage(
+  sources: SourceTriggers[]
+): Map<string, ScriptUsageRef[]> {
+  const usage = new Map<string, ScriptUsageRef[]>();
+
+  for (const src of sources) {
+    const base = { sourceId: src.sourceId, sourceName: src.sourceName };
+
+    // Auto-responders (Meshtastic + MeshCore): script path lives in `response`
+    // when responseType === 'script'.
+    const addAuto = (list: unknown, protocol: ScriptProtocol) => {
+      for (const t of asArray(list)) {
+        if (t.responseType === 'script') {
+          pushRef(usage, t.response, {
+            ...base,
+            type: 'auto-responder',
+            protocol,
+            triggerId: typeof t.id === 'string' ? t.id : undefined,
+            triggerName: Array.isArray(t.trigger)
+              ? (t.trigger as unknown[]).join(', ')
+              : typeof t.trigger === 'string'
+                ? t.trigger
+                : undefined,
+            enabled: true,
+          });
+        }
+      }
+    };
+
+    // Timers (Meshtastic + MeshCore): default responseType is 'script', so a
+    // timer uses a script unless it explicitly opts into 'text'.
+    const addTimer = (list: unknown, protocol: ScriptProtocol) => {
+      for (const t of asArray(list)) {
+        if (t.responseType !== 'text') {
+          pushRef(usage, t.scriptPath, {
+            ...base,
+            type: 'timer',
+            protocol,
+            triggerId: typeof t.id === 'string' ? t.id : undefined,
+            triggerName: typeof t.name === 'string' ? t.name : undefined,
+            enabled: t.enabled !== false,
+          });
+        }
+      }
+    };
+
+    addAuto(src.autoResponderTriggers, 'meshtastic');
+    addTimer(src.timerTriggers, 'meshtastic');
+
+    // Geofences (Meshtastic only): script path in `scriptPath` when
+    // responseType === 'script'.
+    for (const t of asArray(src.geofenceTriggers)) {
+      if (t.responseType === 'script') {
+        pushRef(usage, t.scriptPath, {
+          ...base,
+          type: 'geofence',
+          protocol: 'meshtastic',
+          triggerId: typeof t.id === 'string' ? t.id : undefined,
+          triggerName: typeof t.name === 'string' ? t.name : undefined,
+          enabled: t.enabled !== false,
+        });
+      }
+    }
+
+    addAuto(src.meshcoreAutoResponderTriggers, 'meshcore');
+    addTimer(src.meshcoreTimerTriggers, 'meshcore');
+  }
+
+  return usage;
+}


### PR DESCRIPTION
## Summary

Implements **Phase 1 of #4942** — an **Installed Scripts inventory** on the Global Settings page. A new **Scripts** section lists every script in `/data/scripts/` with its metadata and shows which automations use each one, so orphaned/unused scripts are obvious at a glance. Import and delete are available inline; delete asks for confirmation and warns when the script is still referenced.

Scoped deliberately to the inventory. The remote-gallery install/update and Docker/Community-Add-on management (Phases 2–7 in the issue) are **out of scope** per the issue triage — MeshMonitor still never fetches or executes network code, and never manages containers. No new attack surface.

## What it shows

Per script: emoji/name, filename, language, optional `mm_meta` version/author, file size, last-modified date, an **In use / Unused** badge, and — when in use — the list of automations that reference it (trigger type, name, source, disabled state).

Usage is computed across **every source** and **every script-capable trigger**:
- Meshtastic auto-responder, timer, and geofence triggers
- MeshCore auto-responder and timer variants

## Changes

**Backend**
- `GET /api/scripts/inventory` (requires `settings:read`): scripts on disk enriched with a `usedBy[]` list.
- `computeScriptUsage()` — pure, unit-tested helper (`src/server/utils/scriptUsage.ts`).
- `collectScripts()` refactor; `mm_meta` now parses optional `version`/`author`; listing adds `sizeBytes` + `lastModified`. The public `GET /api/scripts` response gains these optional fields (backward compatible).

**Frontend**
- `ScriptsSection` component (search, In use/Unused filter, usage list, import, confirm-delete) wired into `SettingsTab` as a global-only section, admin-gated; write controls gated on `settings:write`.

## Testing

- `scriptUsage.test.ts` — 8 cases (each trigger type, MeshCore variants, cross-source aggregation, malformed input).
- `scriptRoutes.inventory.test.ts` — endpoint: usedBy populated for referenced scripts, empty for orphans, no-sources case, DB-error case.
- `ScriptsSection.test.tsx` — badges, filter, confirm-before-delete + in-use warning, `canWrite=false` hides controls.
- Full Vitest suite green (the two `SettingsTab.*` suites gained a `ScriptsSection` mock, matching the existing pattern for sibling sections). Typecheck + `lint:ci` clean.

Verified live in the dev container — see screenshot below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
