### PR TITLE
fix(packet-monitor): add Stop capturing control to all packet monitors (#4957)

### DIFF
--- a/src/components/MQTT/MqttPacketMonitorView.test.tsx
+++ b/src/components/MQTT/MqttPacketMonitorView.test.tsx
@@ -176,6 +176,41 @@ describe('MqttPacketMonitorView', () => {
     });
   });
 
+  it('shows a Stop button in the toolbar while capturing and POSTs 0 to stop (#4957)', async () => {
+    csrfFetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (options?.method === 'POST') return jsonResponse({ success: true });
+      if (url.includes('/gateways')) return jsonResponse(gatewaysEnvelope([]));
+      return jsonResponse(packetsEnvelope([basePacket()], { enabled: true }));
+    });
+    hasPermissionImpl = () => true;
+
+    render(<MqttPacketMonitorView baseUrl={baseUrl} sourceId={sourceId} />);
+    await screen.findByText('hello world');
+
+    fireEvent.click(screen.getByTitle('Stop capturing'));
+
+    await waitFor(() => {
+      const postCall = csrfFetchMock.mock.calls.find(
+        ([, options]) => (options as RequestInit | undefined)?.method === 'POST'
+      );
+      expect(postCall).toBeTruthy();
+      const [url, options] = postCall!;
+      expect(url).toBe(`${baseUrl}/api/settings`);
+      expect(JSON.parse((options as RequestInit).body as string)).toEqual({ mqtt_packet_log_enabled: '0' });
+    });
+  });
+
+  it('hides the Stop button without settings:write (#4957)', async () => {
+    installFetchRouter({ packets: [basePacket()], enabled: true });
+    hasPermissionImpl = (resource) => resource !== 'settings';
+
+    render(<MqttPacketMonitorView baseUrl={baseUrl} sourceId={sourceId} />);
+    await screen.findByText('hello world');
+
+    expect(screen.queryByTitle('Stop capturing')).toBeNull();
+    expect(screen.queryByTitle('Start capturing')).toBeNull();
+  });
+
   it('hides the Clear button without packetmonitor:write', async () => {
     installFetchRouter({ packets: [basePacket()] });
     hasPermissionImpl = (resource) => resource !== 'packetmonitor';

--- a/src/components/MQTT/MqttPacketMonitorView.test.tsx
+++ b/src/components/MQTT/MqttPacketMonitorView.test.tsx
@@ -200,6 +200,31 @@ describe('MqttPacketMonitorView', () => {
     });
   });
 
+  it('keeps showing Stop when the stop POST fails — no optimistic flip (#4957)', async () => {
+    csrfFetchMock.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (options?.method === 'POST') return jsonResponse({ error: 'boom' }, 500);
+      if (url.includes('/gateways')) return jsonResponse(gatewaysEnvelope([]));
+      return jsonResponse(packetsEnvelope([basePacket()], { enabled: true }));
+    });
+    hasPermissionImpl = () => true;
+
+    render(<MqttPacketMonitorView baseUrl={baseUrl} sourceId={sourceId} />);
+    await screen.findByText('hello world');
+
+    fireEvent.click(screen.getByTitle('Stop capturing'));
+
+    // The POST was attempted…
+    await waitFor(() => {
+      const postCall = csrfFetchMock.mock.calls.find(
+        ([, options]) => (options as RequestInit | undefined)?.method === 'POST'
+      );
+      expect(postCall).toBeTruthy();
+    });
+    // …but since it failed, the control must not flip to "Start capturing".
+    expect(screen.getByTitle('Stop capturing')).toBeTruthy();
+    expect(screen.queryByTitle('Start capturing')).toBeNull();
+  });
+
   it('hides the Stop button without settings:write (#4957)', async () => {
     installFetchRouter({ packets: [basePacket()], enabled: true });
     hasPermissionImpl = (resource) => resource !== 'settings';

--- a/src/components/MQTT/MqttPacketMonitorView.tsx
+++ b/src/components/MQTT/MqttPacketMonitorView.tsx
@@ -225,7 +225,7 @@ export const MqttPacketMonitorView: React.FC<MqttPacketMonitorViewProps> = ({ ba
     return () => clearInterval(id);
   }, [load]);
 
-  const saveSettings = useCallback(async (patch: Record<string, string>) => {
+  const saveSettings = useCallback(async (patch: Record<string, string>): Promise<boolean> => {
     setSavingSettings(true);
     try {
       const res = await csrfFetch(`${baseUrl}/api/settings`, {
@@ -234,17 +234,22 @@ export const MqttPacketMonitorView: React.FC<MqttPacketMonitorViewProps> = ({ ba
         body: JSON.stringify(patch),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return true;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save settings');
+      return false;
     } finally {
       setSavingSettings(false);
     }
   }, [csrfFetch, baseUrl]);
 
   const handleToggleEnabled = useCallback(async () => {
+    // Commit the toggle only after the save succeeds, so a failed POST leaves
+    // the control showing the real capture state instead of an optimistic lie.
     const next = !enabled;
-    setEnabled(next);
-    await saveSettings({ mqtt_packet_log_enabled: next ? '1' : '0' });
+    if (await saveSettings({ mqtt_packet_log_enabled: next ? '1' : '0' })) {
+      setEnabled(next);
+    }
   }, [enabled, saveSettings]);
 
   const handleClear = useCallback(async () => {

--- a/src/components/MQTT/MqttPacketMonitorView.tsx
+++ b/src/components/MQTT/MqttPacketMonitorView.tsx
@@ -23,7 +23,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { Filter, Trash2, Pause, Play, RefreshCw, ChevronDown } from 'lucide-react';
+import { Filter, Trash2, Pause, Play, RefreshCw, ChevronDown, Circle, Square } from 'lucide-react';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { useAuth } from '../../contexts/AuthContext';
 import { useNodes } from '../../hooks/useServerData';
@@ -310,6 +310,18 @@ export const MqttPacketMonitorView: React.FC<MqttPacketMonitorViewProps> = ({ ba
           {total > packets.length ? `${packets.length} / ${total}` : packets.length}
         </span>
         <div className="mqpm-header-controls">
+          {canWriteSettings && (
+            <button
+              className={`mqpm-btn ${enabled ? 'mqpm-btn-danger' : ''}`}
+              onClick={() => void handleToggleEnabled()}
+              disabled={savingSettings}
+              title={enabled
+                ? t('mqtt.packets.stopCapture', 'Stop capturing')
+                : t('mqtt.packets.startCapture', 'Start capturing')}
+            >
+              {enabled ? <Square size={14} /> : <Circle size={14} />}
+            </button>
+          )}
           <button
             className="mqpm-btn"
             onClick={() => setPaused(p => !p)}

--- a/src/components/MeshCore/MeshCorePacketMonitorView.stopButton.test.tsx
+++ b/src/components/MeshCore/MeshCorePacketMonitorView.stopButton.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #4957: the MeshCore Packet Monitor must expose a Stop control in the
+ * always-visible toolbar so a persisted server-side capture can be turned off
+ * without digging into the Filters panel. Capture state is the global
+ * `meshcore_packet_log_enabled` setting, POSTed to /api/settings.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) =>
+      typeof fallback === 'string' ? fallback : key,
+  }),
+}));
+
+let hasPermissionImpl: (resource: string, action: string) => boolean = () => true;
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: (r: string, a: string) => hasPermissionImpl(r, a) }),
+}));
+
+const csrfFetchMock = vi.fn();
+vi.mock('../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => csrfFetchMock,
+}));
+
+vi.mock('../../contexts/WebSocketContext', () => ({
+  useWebSocketContext: () => ({ state: { socket: null } }),
+}));
+
+import { MeshCorePacketMonitorView } from './MeshCorePacketMonitorView';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+const loadResponse = (enabled: boolean) =>
+  jsonResponse({ packets: [], enabled, maxCount: 1000, maxAgeHours: 24 });
+
+describe('MeshCorePacketMonitorView Stop button (#4957)', () => {
+  const baseUrl = '';
+  const sourceId = 'mc-1';
+
+  beforeEach(() => {
+    csrfFetchMock.mockReset();
+    hasPermissionImpl = () => true;
+  });
+
+  it('shows Stop while capturing and POSTs 0 to stop', async () => {
+    csrfFetchMock.mockImplementation(async (_url: string, options?: RequestInit) => {
+      if (options?.method === 'POST') return jsonResponse({ success: true });
+      return loadResponse(true); // /packets load reports capture on
+    });
+
+    render(<MeshCorePacketMonitorView baseUrl={baseUrl} sourceId={sourceId} />);
+
+    const stopBtn = await screen.findByTitle('Stop capturing');
+    fireEvent.click(stopBtn);
+
+    await waitFor(() => {
+      const postCall = csrfFetchMock.mock.calls.find(
+        ([, o]) => (o as RequestInit | undefined)?.method === 'POST'
+      );
+      expect(postCall).toBeTruthy();
+      const [url, options] = postCall!;
+      expect(url).toBe(`${baseUrl}/api/settings`);
+      expect(JSON.parse((options as RequestInit).body as string)).toEqual({ meshcore_packet_log_enabled: '0' });
+    });
+  });
+
+  it('shows Start when capture is off and POSTs 1 to start', async () => {
+    csrfFetchMock.mockImplementation(async (_url: string, options?: RequestInit) => {
+      if (options?.method === 'POST') return jsonResponse({ success: true });
+      return loadResponse(false);
+    });
+
+    render(<MeshCorePacketMonitorView baseUrl={baseUrl} sourceId={sourceId} />);
+
+    const startBtn = await screen.findByTitle('Start capturing');
+    fireEvent.click(startBtn);
+
+    await waitFor(() => {
+      const postCall = csrfFetchMock.mock.calls.find(
+        ([, o]) => (o as RequestInit | undefined)?.method === 'POST'
+      );
+      expect(postCall).toBeTruthy();
+      expect(JSON.parse((postCall![1] as RequestInit).body as string)).toEqual({ meshcore_packet_log_enabled: '1' });
+    });
+  });
+
+  it('hides the Stop/Start control without settings:write', async () => {
+    csrfFetchMock.mockImplementation(async () => loadResponse(true));
+    hasPermissionImpl = (resource) => resource !== 'settings';
+
+    render(<MeshCorePacketMonitorView baseUrl={baseUrl} sourceId={sourceId} />);
+
+    // Wait for the load to settle (Pause control is always present).
+    await screen.findByTitle('Pause');
+    expect(screen.queryByTitle('Stop capturing')).toBeNull();
+    expect(screen.queryByTitle('Start capturing')).toBeNull();
+  });
+});

--- a/src/components/MeshCore/MeshCorePacketMonitorView.tsx
+++ b/src/components/MeshCore/MeshCorePacketMonitorView.tsx
@@ -15,7 +15,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { Filter, Trash2, Pause, Play, RefreshCw, Download } from 'lucide-react';
+import { Filter, Trash2, Pause, Play, RefreshCw, Download, Circle, Square } from 'lucide-react';
 import { useCsrfFetch } from '../../hooks/useCsrfFetch';
 import { useWebSocketContext } from '../../contexts/WebSocketContext';
 import { useAuth } from '../../contexts/AuthContext';
@@ -216,6 +216,18 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
         <h3>{t('meshcore.packets.title', 'Packet Monitor')}</h3>
         <span className="mcpm-count">{visiblePackets.length}</span>
         <div className="mcpm-header-controls">
+          {canWriteSettings && (
+            <button
+              className={`mcpm-btn ${enabled ? 'mcpm-btn-danger' : ''}`}
+              onClick={() => void handleToggleEnabled()}
+              disabled={savingSettings}
+              title={enabled
+                ? t('meshcore.packets.stopCapture', 'Stop capturing')
+                : t('meshcore.packets.startCapture', 'Start capturing')}
+            >
+              {enabled ? <Square size={14} /> : <Circle size={14} />}
+            </button>
+          )}
           <button
             className="mcpm-btn"
             onClick={() => setPaused(p => !p)}

--- a/src/components/MeshCore/MeshCorePacketMonitorView.tsx
+++ b/src/components/MeshCore/MeshCorePacketMonitorView.tsx
@@ -145,7 +145,7 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
     });
   }, [packets, payloadFilter, routeFilter]);
 
-  const saveSettings = useCallback(async (patch: Record<string, string>) => {
+  const saveSettings = useCallback(async (patch: Record<string, string>): Promise<boolean> => {
     setSavingSettings(true);
     try {
       const res = await csrfFetch(`${baseUrl}/api/settings`, {
@@ -154,17 +154,22 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
         body: JSON.stringify(patch),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return true;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save settings');
+      return false;
     } finally {
       setSavingSettings(false);
     }
   }, [csrfFetch, baseUrl]);
 
   const handleToggleEnabled = useCallback(async () => {
+    // Commit the toggle only after the save succeeds, so a failed POST leaves
+    // the control showing the real capture state instead of an optimistic lie.
     const next = !enabled;
-    setEnabled(next);
-    await saveSettings({ meshcore_packet_log_enabled: next ? '1' : '0' });
+    if (await saveSettings({ meshcore_packet_log_enabled: next ? '1' : '0' })) {
+      setEnabled(next);
+    }
   }, [enabled, saveSettings]);
 
   const handleClear = useCallback(async () => {

--- a/src/components/PacketMonitorPanel.css
+++ b/src/components/PacketMonitorPanel.css
@@ -76,6 +76,19 @@
   cursor: not-allowed;
 }
 
+/* Active server-side capture: the Stop button is outlined in the error color
+ * so a running capture is unmistakable (#4957). */
+.control-btn.danger {
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+
+.control-btn.danger:hover:not(:disabled) {
+  background: var(--color-bg-sunken);
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+
 .close-btn {
   background: transparent;
   border: none;

--- a/src/components/PacketMonitorPanel.tsx
+++ b/src/components/PacketMonitorPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Filter, Trash2, ExternalLink, Download, Pause, Play, Circle, Square } from 'lucide-react';
@@ -88,11 +88,13 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
     return () => { cancelled = true; };
   }, [sourceId]);
 
-  const handleToggleCapture = async () => {
+  const handleToggleCapture = useCallback(async () => {
     const next = !captureEnabled;
     setTogglingCapture(true);
     try {
       // `packet_log_enabled` is global — POST with no sourceId query param.
+      // Commit local state only after the POST resolves, so a failed request
+      // doesn't leave the button showing a state the server never accepted.
       await apiService.post('/api/settings', { packet_log_enabled: next ? '1' : '0' });
       setCaptureEnabled(next);
     } catch (error) {
@@ -100,7 +102,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
     } finally {
       setTogglingCapture(false);
     }
-  };
+  }, [captureEnabled]);
 
   /**
    * Filter options for the two node comboboxes (#4512). `keywords` carries the
@@ -466,7 +468,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
           <div className="header-controls">
             {canWriteSettings && captureEnabled !== null && (
               <button
-                className={`control-btn ${captureEnabled ? 'danger' : ''}`}
+                className={`control-btn${captureEnabled ? ' danger' : ''}`}
                 onClick={handleToggleCapture}
                 disabled={togglingCapture}
                 title={captureEnabled ? t('packet_monitor.stop_capture', 'Stop capturing') : t('packet_monitor.start_capture', 'Start capturing')}

--- a/src/components/PacketMonitorPanel.tsx
+++ b/src/components/PacketMonitorPanel.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { Filter, Trash2, ExternalLink, Download, Pause, Play } from 'lucide-react';
+import { Filter, Trash2, ExternalLink, Download, Pause, Play, Circle, Square } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { PacketLog, PacketFilters } from '../types/packet';
-import { clearPackets, exportPackets, getRelayNodes } from '../services/packetApi';
+import { clearPackets, exportPackets, getRelayNodes, getPacketStats } from '../services/packetApi';
 import { RelayNodeOption } from '../types/packet';
 import apiService from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
@@ -49,6 +49,9 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
   const { hasPermission, authStatus } = useAuth();
   const { timeFormat, dateFormat } = useSettings();
   const { sourceId } = useSource();
+  // `packet_log_enabled` is a global (not per-source) setting, gated by
+  // settings:write. anySource mirrors the unscoped write it toggles.
+  const canWriteSettings = hasPermission('settings', 'write', { anySource: true });
   const { config: deviceInfo } = useDeviceConfig();
   const { nodes } = useNodes();
 
@@ -69,6 +72,35 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
 
   // Relay node filter options (distinct values from packet_log)
   const [relayNodeOptions, setRelayNodeOptions] = useState<RelayNodeOption[]>([]);
+
+  // Server-side capture state (`packet_log_enabled`). null while unknown so the
+  // Stop/Start control doesn't flash the wrong state before the first fetch.
+  // #4957: this control is the only way to stop a persisted server-side capture
+  // — "Pause" below is client-side auto-scroll only.
+  const [captureEnabled, setCaptureEnabled] = useState<boolean | null>(null);
+  const [togglingCapture, setTogglingCapture] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getPacketStats(sourceId ?? undefined)
+      .then(stats => { if (!cancelled) setCaptureEnabled(stats.enabled); })
+      .catch(() => { /* leave unknown; button stays hidden */ });
+    return () => { cancelled = true; };
+  }, [sourceId]);
+
+  const handleToggleCapture = async () => {
+    const next = !captureEnabled;
+    setTogglingCapture(true);
+    try {
+      // `packet_log_enabled` is global — POST with no sourceId query param.
+      await apiService.post('/api/settings', { packet_log_enabled: next ? '1' : '0' });
+      setCaptureEnabled(next);
+    } catch (error) {
+      console.error('Failed to toggle packet capture:', error);
+    } finally {
+      setTogglingCapture(false);
+    }
+  };
 
   /**
    * Filter options for the two node comboboxes (#4512). `keywords` carries the
@@ -432,6 +464,17 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
             {t('packet_monitor.count', { shown: packets.length, total })}
           </div>
           <div className="header-controls">
+            {canWriteSettings && captureEnabled !== null && (
+              <button
+                className={`control-btn ${captureEnabled ? 'danger' : ''}`}
+                onClick={handleToggleCapture}
+                disabled={togglingCapture}
+                title={captureEnabled ? t('packet_monitor.stop_capture', 'Stop capturing') : t('packet_monitor.start_capture', 'Start capturing')}
+                aria-label={captureEnabled ? t('packet_monitor.stop_capture', 'Stop capturing') : t('packet_monitor.start_capture', 'Start capturing')}
+              >
+                {captureEnabled ? <Square size={14} /> : <Circle size={14} />}
+              </button>
+            )}
             <button
               className="control-btn"
               onClick={() => setAutoScroll(!autoScroll)}

--- a/src/pages/UnifiedPacketMonitorPage.tsx
+++ b/src/pages/UnifiedPacketMonitorPage.tsx
@@ -88,13 +88,15 @@ export default function UnifiedPacketMonitorPage() {
   const [togglingCapture, setTogglingCapture] = useState(false);
 
   useEffect(() => {
-    if (!canView) return;
+    // Fetch capture state whenever the user can either view packets or write
+    // the setting — a settings:write-only admin still needs the Stop control.
+    if (!canView && !canWriteSettings) return;
     let cancelled = false;
     getPacketStats()
       .then(stats => { if (!cancelled) setCaptureEnabled(stats.enabled); })
       .catch(() => { /* leave unknown; control stays hidden */ });
     return () => { cancelled = true; };
-  }, [canView]);
+  }, [canView, canWriteSettings]);
 
   const handleToggleCapture = useCallback(async () => {
     const next = !captureEnabled;

--- a/src/pages/UnifiedPacketMonitorPage.tsx
+++ b/src/pages/UnifiedPacketMonitorPage.tsx
@@ -17,11 +17,12 @@ import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
-import { Filter, BarChart3, Pause, Play } from 'lucide-react';
+import { Filter, BarChart3, Pause, Play, Circle, Square } from 'lucide-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useAuth } from '../contexts/AuthContext';
 import { useUnifiedPackets } from '../hooks/useUnifiedPackets';
-import { getUnifiedPacketDistribution } from '../services/packetApi';
+import { getUnifiedPacketDistribution, getPacketStats } from '../services/packetApi';
+import apiService from '../services/api';
 import { PacketLog, UnifiedPacketFilters, UnifiedPacketDistribution } from '../types/packet';
 import PacketStatsChart, { DISTRIBUTION_COLORS, ChartDataEntry } from '../components/PacketStatsChart';
 import {
@@ -63,6 +64,9 @@ export default function UnifiedPacketMonitorPage() {
   })();
 
   const canView = hasPermission('packetmonitor', 'read', { anySource: true });
+  // `packet_log_enabled` is a global (cross-source) setting gated by
+  // settings:write — the same capture the single-source panel toggles.
+  const canWriteSettings = hasPermission('settings', 'write', { anySource: true });
 
   const [filters, setFilters] = useState<UnifiedPacketFilters>(() =>
     safeJsonParse<UnifiedPacketFilters>(localStorage.getItem('unifiedPacketMonitor.filters'), {})
@@ -76,6 +80,34 @@ export default function UnifiedPacketMonitorPage() {
   const [paused, setPaused] = useState(false);
   const [selectedPacket, setSelectedPacket] = useState<PacketLog | null>(null);
   const [rangeHours, setRangeHours] = useState<RangeHours>(24);
+
+  // Server-side capture state (#4957). null until the first stats fetch so the
+  // Stop/Start control doesn't flash the wrong label. This toggles the SAME
+  // global `packet_log_enabled` as the single-source panel.
+  const [captureEnabled, setCaptureEnabled] = useState<boolean | null>(null);
+  const [togglingCapture, setTogglingCapture] = useState(false);
+
+  useEffect(() => {
+    if (!canView) return;
+    let cancelled = false;
+    getPacketStats()
+      .then(stats => { if (!cancelled) setCaptureEnabled(stats.enabled); })
+      .catch(() => { /* leave unknown; control stays hidden */ });
+    return () => { cancelled = true; };
+  }, [canView]);
+
+  const handleToggleCapture = useCallback(async () => {
+    const next = !captureEnabled;
+    setTogglingCapture(true);
+    try {
+      await apiService.post('/api/settings', { packet_log_enabled: next ? '1' : '0' });
+      setCaptureEnabled(next);
+    } catch (error) {
+      console.error('Failed to toggle packet capture:', error);
+    } finally {
+      setTogglingCapture(false);
+    }
+  }, [captureEnabled]);
 
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -191,6 +223,17 @@ export default function UnifiedPacketMonitorPage() {
           {t('unified.packets.count', { shown: packets.length })}
         </div>
         <div className="unified-packets-controls">
+          {canWriteSettings && captureEnabled !== null && (
+            <button
+              className={`control-btn${captureEnabled ? ' danger' : ''}`}
+              onClick={handleToggleCapture}
+              disabled={togglingCapture}
+              title={captureEnabled ? t('packet_monitor.stop_capture', 'Stop capturing') : t('packet_monitor.start_capture', 'Start capturing')}
+              aria-label={captureEnabled ? t('packet_monitor.stop_capture', 'Stop capturing') : t('packet_monitor.start_capture', 'Start capturing')}
+            >
+              {captureEnabled ? <Square size={14} /> : <Circle size={14} />}
+            </button>
+          )}
           <button
             className={`control-btn${paused ? '' : ' active'}`}
             onClick={() => setPaused((p) => !p)}


### PR DESCRIPTION
Fixes #4957.

## Problem

Server-side packet capture (the `*_packet_log_enabled` settings) could be **started** from the UI but never **stopped** there. The toolbar's "Pause" button only freezes client-side auto-scroll / polling — the server keeps recording. Because the enabled flag is a persisted global setting, a capture survived page refreshes and container restarts, with no shutdown path short of clearing browser storage (which doesn't help — it's server-side) or editing the DB.

## Fix

Added a visible **Stop / Start capture** toggle to the always-visible toolbar of all four packet monitors, gated on `settings:write`. A record-dot (○) starts capture; a red stop-square (■) stops it.

| Monitor | File | Change |
|---|---|---|
| Meshtastic single-source | `PacketMonitorPanel.tsx` | New: reads capture state via `GET /api/packets/stats`, toggles `packet_log_enabled` via `POST /api/settings` |
| Unified cross-source | `UnifiedPacketMonitorPage.tsx` | Same — toggles the shared global `packet_log_enabled` |
| MeshCore | `MeshCorePacketMonitorView.tsx` | Surfaces the existing `handleToggleEnabled` (was only reachable via a checkbox buried in the Filters panel) |
| MQTT | `MqttPacketMonitorView.tsx` | Same |

All four enabled flags are **global** settings (`POST /api/settings`, no `sourceId`); this PR only surfaces the existing toggle plumbing in the toolbar — no backend changes.

## Testing

- `MqttPacketMonitorView.test.tsx` — new: toolbar Stop POSTs `mqtt_packet_log_enabled:'0'`; hidden without `settings:write`.
- `MeshCorePacketMonitorView.stopButton.test.tsx` — new file: Stop→'0', Start→'1', hidden without `settings:write`.
- The two Meshtastic surfaces (single + unified) are heavy to mount-test (react-query + virtualizer); verified **live** in the dev container instead: clicking **Stop** persisted `packet_log_enabled=0` to the DB and the off state survived a page refresh. Screenshot below.
- Full Vitest suite, typecheck, and `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
