### PR TITLE
feat(packet-monitor): full portnum filter + free-text content search (#4958)

### DIFF
--- a/src/components/PacketMonitorPanel.css
+++ b/src/components/PacketMonitorPanel.css
@@ -147,6 +147,23 @@
   background: var(--color-surface-hover);
 }
 
+/* Free-text content/JSON search (#4958). Wider than the selects since it takes
+ * arbitrary text, and takes the full row so it reads as the primary control. */
+.packet-search-input {
+  flex: 1 1 100%;
+  min-width: 200px;
+  padding: 6px 10px;
+  border: 1px solid var(--color-surface-active);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 13px;
+}
+
+.packet-search-input::placeholder {
+  color: var(--color-text-subtle);
+}
+
 .clear-filters-btn {
   padding: 6px 12px;
   background: var(--color-bg-sunken);

--- a/src/components/PacketMonitorPanel.tsx
+++ b/src/components/PacketMonitorPanel.tsx
@@ -19,6 +19,7 @@ import {
   toMs,
   formatPacketDateColumn,
   formatPacketTimestamp,
+  PORTNUM_NAMES,
 } from '../utils/packetFormat';
 import RelayNodeModal from './RelayNodeModal';
 import SearchableSelect, { type SearchableSelectOption } from './common/SearchableSelect';
@@ -32,6 +33,15 @@ interface PacketMonitorPanelProps {
 }
 
 
+
+// Full portnum filter list, derived from the shared PORTNUM_NAMES map so the
+// dropdown covers every known type (incl. NODE_STATUS and MESH_BEACON) rather
+// than a hardcoded subset (#4958). Sorted by portnum; UNKNOWN(0) and MAX(511)
+// are dropped as they aren't meaningful capture filters.
+const PORTNUM_FILTER_OPTIONS: Array<{ value: number; label: string }> = Object.entries(PORTNUM_NAMES)
+  .map(([num, name]) => ({ value: Number(num), label: name }))
+  .filter(o => o.value !== 0 && o.value !== 511)
+  .sort((a, b) => a.value - b.value);
 
 // Safe JSON parse helper
 const safeJsonParse = <T,>(value: string | null, fallback: T): T => {
@@ -69,6 +79,21 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
   const [hideOwnPackets, setHideOwnPackets] = useState(() =>
     safeJsonParse(localStorage.getItem('packetMonitor.hideOwnPackets'), true)
   );
+
+  // Free-text search across decoded content (#4958). `searchInput` tracks the
+  // field live; a debounced effect commits it to `filters.search` so we don't
+  // refetch on every keystroke. Because the list is virtualized, this
+  // server-side filter is what replaces the broken browser Ctrl+F workflow.
+  const [searchInput, setSearchInput] = useState<string>(() =>
+    safeJsonParse<PacketFilters>(localStorage.getItem('packetMonitor.filters'), {}).search ?? ''
+  );
+  useEffect(() => {
+    const next = searchInput.trim() || undefined;
+    const id = setTimeout(() => {
+      setFilters(f => (f.search === next ? f : { ...f, search: next }));
+    }, 300);
+    return () => clearTimeout(id);
+  }, [searchInput]);
 
   // Relay node filter options (distinct values from packet_log)
   const [relayNodeOptions, setRelayNodeOptions] = useState<RelayNodeOption[]>([]);
@@ -513,19 +538,23 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
 
         {showFilters && (
           <div className="packet-filters">
+            <input
+              type="search"
+              className="packet-search-input"
+              value={searchInput}
+              onChange={e => setSearchInput(e.target.value)}
+              placeholder={t('packet_monitor.filter.search_placeholder', 'Search content / JSON…')}
+              title={t('packet_monitor.filter.search_tooltip', 'Filters packets whose decoded content or metadata JSON contains this text (case-insensitive). Use this instead of the browser find, which cannot see off-screen rows.')}
+              aria-label={t('packet_monitor.filter.search_placeholder', 'Search content / JSON…')}
+            />
             <select
               value={filters.portnum ?? ''}
               onChange={e => setFilters({ ...filters, portnum: e.target.value ? parseInt(e.target.value) : undefined })}
             >
               <option value="">{t('packet_monitor.filter.all_types')}</option>
-              <option value="1">TEXT_MESSAGE</option>
-              <option value="3">POSITION</option>
-              <option value="4">NODEINFO</option>
-              <option value="5">ROUTING</option>
-              <option value="6">ADMIN</option>
-              <option value="67">TELEMETRY</option>
-              <option value="70">TRACEROUTE</option>
-              <option value="71">NEIGHBORINFO</option>
+              {PORTNUM_FILTER_OPTIONS.map(o => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
             </select>
 
             <select
@@ -606,7 +635,7 @@ const PacketMonitorPanel: React.FC<PacketMonitorPanelProps> = ({ onClose, onNode
               <span>{t('packet_monitor.filter.hide_own')}</span>
             </label>
 
-            <button onClick={() => setFilters({})} className="clear-filters-btn">
+            <button onClick={() => { setFilters({}); setSearchInput(''); }} className="clear-filters-btn">
               {t('packet_monitor.filter.clear')}
             </button>
           </div>

--- a/src/db/repositories/packetLog.test.ts
+++ b/src/db/repositories/packetLog.test.ts
@@ -123,6 +123,53 @@ describe('PacketLogRepository - Packet Log Queries', () => {
     });
   });
 
+  describe('getPacketLogs search filter (#4958)', () => {
+    beforeEach(() => {
+      const now = Date.now();
+      // Packet with searchable preview + metadata JSON.
+      db.exec(`INSERT INTO packet_log (packet_id, timestamp, from_node, portnum, portnum_name, direction, created_at, sourceId, encrypted, payload_preview, metadata) VALUES (10, ${now}, 100, 67, 'TELEMETRY_APP', 'rx', ${now}, 'default', 0, 'Battery 87%', '{"voltage":4.1,"room":"Weather Station"}')`);
+      // A different packet that must NOT match the terms below.
+      db.exec(`INSERT INTO packet_log (packet_id, timestamp, from_node, portnum, portnum_name, direction, created_at, sourceId, encrypted, payload_preview, metadata) VALUES (11, ${now}, 200, 3, 'POSITION_APP', 'rx', ${now}, 'default', 0, 'lat=37.77 lon=-122.41', '{"precision":32}')`);
+    });
+
+    it('matches a substring of payload_preview, case-insensitively', async () => {
+      const packets = await repo.getPacketLogs({ search: 'battery' });
+      expect(packets.map(p => p.packet_id)).toEqual([10]);
+    });
+
+    it('matches a substring of the metadata JSON', async () => {
+      const packets = await repo.getPacketLogs({ search: 'Weather' });
+      expect(packets.map(p => p.packet_id)).toEqual([10]);
+    });
+
+    it('returns nothing when no packet contains the term', async () => {
+      const packets = await repo.getPacketLogs({ search: 'nonexistent-zzz' });
+      expect(packets).toEqual([]);
+    });
+
+    it('treats % as a literal (escaped), not a wildcard', async () => {
+      // "87%" matches packet 10's literal "87%". A bare "%" matches ONLY the row
+      // that literally contains a "%" (packet 10) — an unescaped LIKE wildcard
+      // would instead match every row, so this pins the escaping.
+      expect((await repo.getPacketLogs({ search: '87%' })).map(p => p.packet_id)).toEqual([10]);
+      expect((await repo.getPacketLogs({ search: '%' })).map(p => p.packet_id)).toEqual([10]);
+    });
+
+    it('combines with other filters (portnum + search)', async () => {
+      // Only packet 10 is TELEMETRY (67) AND contains "voltage".
+      const packets = await repo.getPacketLogs({ portnum: 67, search: 'voltage' });
+      expect(packets.map(p => p.packet_id)).toEqual([10]);
+      // portnum mismatch → no rows even though the term exists.
+      expect(await repo.getPacketLogs({ portnum: 3, search: 'voltage' })).toEqual([]);
+    });
+
+    it('is ignored when empty', async () => {
+      const all = await repo.getPacketLogs({});
+      const withEmpty = await repo.getPacketLogs({ search: '' });
+      expect(withEmpty.length).toBe(all.length);
+    });
+  });
+
   describe('getPacketLogs keyset cursor (untilTs/untilId)', () => {
     // Insert a block of packets that all share the SAME millisecond timestamp,
     // straddling typical page boundaries. This is the case a bare `timestamp <`

--- a/src/db/repositories/packetLog.ts
+++ b/src/db/repositories/packetLog.ts
@@ -22,7 +22,7 @@ export class PacketLogRepository extends BaseRepository {
    */
   private buildPacketLogWhere(options: PacketLogFilterOptions): { conditions: any[]; } {
     const conditions: any[] = [];
-    const { portnum, from_node, to_node, channel, encrypted, since, relay_node, transport_mechanism, sourceId, untilTs, untilId } = options;
+    const { portnum, from_node, to_node, channel, encrypted, since, relay_node, transport_mechanism, sourceId, untilTs, untilId, search } = options;
 
     if (sourceId !== undefined) conditions.push(sql`pl.${sql.identifier('sourceId')} = ${sourceId}`);
     // Keyset cursor — mirrors ORDER BY pl.timestamp DESC, pl.id DESC so paging never
@@ -49,6 +49,25 @@ export class PacketLogRepository extends BaseRepository {
     }
     if (transport_mechanism !== undefined) {
       conditions.push(sql`pl.transport_mechanism = ${transport_mechanism}`);
+    }
+    // Free-text search across the decoded content (#4958): the human-readable
+    // preview and the serialized-JSON metadata (both plain TEXT in every
+    // backend). Postgres LIKE is case-sensitive, so branch to ILIKE there;
+    // SQLite/MySQL LIKE are case-insensitive by default.
+    //
+    // The user's `%`/`_` must match literally, so they are escaped and an
+    // explicit ESCAPE char is declared (SQLite has no default escape char).
+    // The escape char is `~`, NOT `\`: a backslash escape clause (`ESCAPE '\'`)
+    // is fine for SQLite/Postgres but breaks MySQL, where `\` escapes the
+    // closing quote inside the string literal. `~` is a plain literal in all
+    // three backends.
+    if (search !== undefined && search !== '') {
+      const escaped = search.replace(/[~%_]/g, (c: string) => `~${c}`);
+      const like = `%${escaped}%`;
+      const op = this.isPostgres() ? sql`ILIKE` : sql`LIKE`;
+      conditions.push(
+        sql`(pl.payload_preview ${op} ${like} ESCAPE '~' OR pl.metadata ${op} ${like} ESCAPE '~')`
+      );
     }
 
     return { conditions };
@@ -660,6 +679,8 @@ export interface PacketLogFilterOptions {
   relay_node?: number | 'unknown';
   transport_mechanism?: number;
   sourceId?: string;
+  /** Free-text substring match across payload_preview + metadata (#4958). */
+  search?: string;
   /**
    * Keyset (composite) cursor for descending pagination. When both are provided,
    * only rows strictly "older" than (untilTs, untilId) in the

--- a/src/db/repositories/packetLog.ts
+++ b/src/db/repositories/packetLog.ts
@@ -64,10 +64,13 @@ export class PacketLogRepository extends BaseRepository {
     if (search !== undefined && search !== '') {
       const escaped = search.replace(/[~%_]/g, (c: string) => `~${c}`);
       const like = `%${escaped}%`;
-      const op = this.isPostgres() ? sql`ILIKE` : sql`LIKE`;
-      conditions.push(
-        sql`(pl.payload_preview ${op} ${like} ESCAPE '~' OR pl.metadata ${op} ${like} ESCAPE '~')`
-      );
+      // Branch the whole condition per backend rather than interpolating the
+      // operator keyword, so the generated SQL is unambiguous to read.
+      if (this.isPostgres()) {
+        conditions.push(sql`(pl.payload_preview ILIKE ${like} ESCAPE '~' OR pl.metadata ILIKE ${like} ESCAPE '~')`);
+      } else {
+        conditions.push(sql`(pl.payload_preview LIKE ${like} ESCAPE '~' OR pl.metadata LIKE ${like} ESCAPE '~')`);
+      }
     }
 
     return { conditions };

--- a/src/server/routes/packetRoutes.test.ts
+++ b/src/server/routes/packetRoutes.test.ts
@@ -129,6 +129,10 @@ describe('Packet Routes', () => {
         sql += ' AND timestamp >= ?';
         params.push(options.since);
       }
+      if (options.search) {
+        sql += ' AND (payload_preview LIKE ? OR metadata LIKE ?)';
+        params.push(`%${options.search}%`, `%${options.search}%`);
+      }
 
       sql += ' ORDER BY timestamp DESC, id DESC';
 
@@ -179,6 +183,10 @@ describe('Packet Routes', () => {
       if (options.since !== undefined) {
         sql += ' AND timestamp >= ?';
         params.push(options.since);
+      }
+      if (options.search) {
+        sql += ' AND (payload_preview LIKE ? OR metadata LIKE ?)';
+        params.push(`%${options.search}%`, `%${options.search}%`);
       }
 
       const result = db.prepare(sql).get(...params) as any;
@@ -368,6 +376,29 @@ describe('Packet Routes', () => {
 
       expect(response.body.packets.length).toBe(1);
       expect(response.body.packets[0].portnum).toBe(1);
+    });
+
+    it('should filter by free-text search across content (#4958)', async () => {
+      // Packet 1 has payload_preview 'Test message'; packet 2 does not.
+      const response = await request(app)
+        .get('/api/packets?search=' + encodeURIComponent('Test message'))
+        .set('Authorization', 'Bearer regular')
+        .expect(200);
+
+      expect(response.body.packets.length).toBe(1);
+      expect(response.body.packets[0].packet_id).toBe(1);
+      // The total must reflect the search filter too, not the unfiltered count.
+      expect(response.body.total).toBe(1);
+    });
+
+    it('should return an empty set when the search term matches nothing (#4958)', async () => {
+      const response = await request(app)
+        .get('/api/packets?search=' + encodeURIComponent('no-such-content-zzz'))
+        .set('Authorization', 'Bearer regular')
+        .expect(200);
+
+      expect(response.body.packets.length).toBe(0);
+      expect(response.body.total).toBe(0);
     });
 
     it('should filter by encrypted status', async () => {

--- a/src/server/routes/packetRoutes.test.ts
+++ b/src/server/routes/packetRoutes.test.ts
@@ -130,8 +130,12 @@ describe('Packet Routes', () => {
         params.push(options.since);
       }
       if (options.search) {
-        sql += ' AND (payload_preview LIKE ? OR metadata LIKE ?)';
-        params.push(`%${options.search}%`, `%${options.search}%`);
+        // Mirror the repository's ~-escaping so the mock matches production
+        // behavior for %/_ in the term (escaping is authoritatively tested in
+        // packetLog.test.ts; this keeps the route-level test honest).
+        const escaped = String(options.search).replace(/[~%_]/g, (c: string) => `~${c}`);
+        sql += " AND (payload_preview LIKE ? ESCAPE '~' OR metadata LIKE ? ESCAPE '~')";
+        params.push(`%${escaped}%`, `%${escaped}%`);
       }
 
       sql += ' ORDER BY timestamp DESC, id DESC';
@@ -185,8 +189,12 @@ describe('Packet Routes', () => {
         params.push(options.since);
       }
       if (options.search) {
-        sql += ' AND (payload_preview LIKE ? OR metadata LIKE ?)';
-        params.push(`%${options.search}%`, `%${options.search}%`);
+        // Mirror the repository's ~-escaping so the mock matches production
+        // behavior for %/_ in the term (escaping is authoritatively tested in
+        // packetLog.test.ts; this keeps the route-level test honest).
+        const escaped = String(options.search).replace(/[~%_]/g, (c: string) => `~${c}`);
+        sql += " AND (payload_preview LIKE ? ESCAPE '~' OR metadata LIKE ? ESCAPE '~')";
+        params.push(`%${escaped}%`, `%${escaped}%`);
       }
 
       const result = db.prepare(sql).get(...params) as any;

--- a/src/server/routes/packetRoutes.ts
+++ b/src/server/routes/packetRoutes.ts
@@ -108,8 +108,9 @@ router.get('/', requirePacketPermissions, async (req, res) => {
     const transport_mechanism = req.query.transport_mechanism !== undefined ? parseInt(req.query.transport_mechanism as string, 10) : undefined;
     // Free-text search across decoded content (#4958). Trim and cap length to
     // keep the LIKE bounded; an empty string is treated as no filter.
-    const searchRaw = typeof req.query.search === 'string' ? req.query.search.trim().slice(0, 200) : undefined;
-    const search = searchRaw ? searchRaw : undefined;
+    const search = typeof req.query.search === 'string'
+      ? (req.query.search.trim().slice(0, 200) || undefined)
+      : undefined;
 
     const isAdmin = (req as any).isAdmin;
     const allowedChannels = (req as any).allowedChannels as Set<number>;

--- a/src/server/routes/packetRoutes.ts
+++ b/src/server/routes/packetRoutes.ts
@@ -106,6 +106,10 @@ router.get('/', requirePacketPermissions, async (req, res) => {
     const since = req.query.since ? normalizeSinceToMs(req.query.since as string) : undefined;
     const relay_node = req.query.relay_node === 'unknown' ? 'unknown' as const : req.query.relay_node ? parseInt(req.query.relay_node as string, 10) : undefined;
     const transport_mechanism = req.query.transport_mechanism !== undefined ? parseInt(req.query.transport_mechanism as string, 10) : undefined;
+    // Free-text search across decoded content (#4958). Trim and cap length to
+    // keep the LIKE bounded; an empty string is treated as no filter.
+    const searchRaw = typeof req.query.search === 'string' ? req.query.search.trim().slice(0, 200) : undefined;
+    const search = searchRaw ? searchRaw : undefined;
 
     const isAdmin = (req as any).isAdmin;
     const allowedChannels = (req as any).allowedChannels as Set<number>;
@@ -123,7 +127,8 @@ router.get('/', requirePacketPermissions, async (req, res) => {
       since,
       relay_node,
       transport_mechanism,
-      sourceId
+      sourceId,
+      search
     });
 
     // Filter packets by channel and message permissions
@@ -138,7 +143,8 @@ router.get('/', requirePacketPermissions, async (req, res) => {
       since,
       relay_node,
       transport_mechanism,
-      sourceId
+      sourceId,
+      search
     });
 
     res.json({

--- a/src/server/services/packetLogService.ts
+++ b/src/server/services/packetLogService.ts
@@ -84,6 +84,7 @@ class PacketLogService {
     relay_node?: number | 'unknown';
     transport_mechanism?: number;
     sourceId?: string;
+    search?: string;
     untilTs?: number;
     untilId?: number;
   }): Promise<DbPacketLog[]> {
@@ -131,6 +132,7 @@ class PacketLogService {
     relay_node?: number | 'unknown';
     transport_mechanism?: number;
     sourceId?: string;
+    search?: string;
   }): Promise<number> {
     return databaseService.getPacketLogCountAsync(options || {});
   }

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -4318,7 +4318,7 @@ class DatabaseService {
     offset?: number; limit?: number; portnum?: number; from_node?: number;
     to_node?: number; channel?: number; encrypted?: boolean; since?: number;
     relay_node?: number | 'unknown'; transport_mechanism?: number; sourceId?: string;
-    untilTs?: number; untilId?: number;
+    search?: string; untilTs?: number; untilId?: number;
   }): Promise<DbPacketLog[]> {
     return this.packetLog.getPacketLogs(options);
   }
@@ -4343,7 +4343,7 @@ class DatabaseService {
   async getPacketLogCountAsync(options: {
     portnum?: number; from_node?: number; to_node?: number; channel?: number;
     encrypted?: boolean; since?: number; relay_node?: number | 'unknown';
-    transport_mechanism?: number; sourceId?: string;
+    transport_mechanism?: number; sourceId?: string; search?: string;
   } = {}): Promise<number> {
     return this.packetLog.getPacketLogCount(options);
   }

--- a/src/services/packetApi.ts
+++ b/src/services/packetApi.ts
@@ -51,6 +51,9 @@ export const getPackets = async (
   if (filters?.sourceId !== undefined) {
     params.append('sourceId', filters.sourceId);
   }
+  if (filters?.search) {
+    params.append('search', filters.search);
+  }
 
   return api.get<PacketLogResponse>(`/api/packets?${params.toString()}`);
 };

--- a/src/types/packet.ts
+++ b/src/types/packet.ts
@@ -68,6 +68,8 @@ export interface PacketFilters {
   relay_node?: number | 'unknown';
   transport_mechanism?: number;
   sourceId?: string;
+  /** Free-text substring match across decoded content (payload + metadata JSON). */
+  search?: string;
 }
 
 /** Filters accepted by the unified packet stream (no offset — keyset cursor). */


### PR DESCRIPTION
Fixes #4958.

Three related asks from the reporter, all on the Meshtastic Packet Monitor, delivered as one PR (per the issue discussion).

## 1. Packet-type filter now lists every type (incl. Beacon / Status)

The portnum dropdown was hardcoded to 8 options and was missing the ones the reporter wanted — `NODE_STATUS` (36) and `MESH_BEACON` (37). It's now generated from the shared `PORTNUM_NAMES` map, so all known types are selectable (`UNKNOWN`/`MAX` dropped as noise).

## 2. Free-text search across the decoded content / JSON

A debounced search box in the filter bar threads a `search` param through `packetApi → packetRoutes → packetLogService → packetLog` repository, which adds a **case-insensitive substring match** over `payload_preview` **and** `metadata` (the serialized-JSON column).

Cross-backend details (verified on real Postgres **and** MySQL, not just SQLite):
- Postgres uses `ILIKE` (its `LIKE` is case-sensitive); SQLite/MySQL `LIKE` are case-insensitive by default.
- The `ESCAPE` char is **`~`, not `\`** — a backslash escape clause (`ESCAPE '\'`) works on SQLite/Postgres but breaks MySQL, where `\` escapes the closing quote inside the string literal. `~` is a plain literal in all three. User `%`/`_` are escaped so they match literally.
- The filtered `total` uses the same search param, so the count stays correct.

## 3. Browser Ctrl+F "can't find rows on other pages"

The list is virtualized (`@tanstack/react-virtual`) — only visible rows exist in the DOM, so native browser find can't see off-screen rows. Rather than de-virtualizing (which hurts large captures), the new search box **replaces** that workflow: it narrows the list server-side across all pages. Confirmed with the reporter's preferred direction.

## Testing

- **Repository** (`packetLog.test.ts`): case-insensitive preview match, metadata-JSON match, literal-`%` escaping (a bare `%` matches only rows literally containing `%`), combination with `portnum`, and empty-string ignored.
- **Route** (`packetRoutes.test.ts`): `?search=` threads through and the filter-aware `total` is asserted.
- Verified the generated `ILIKE/LIKE … ESCAPE '~'` SQL directly against Postgres 16 and MySQL 8.4 containers.
- Verified **live** in the dev container: dropdown shows Beacon/Status; a no-match term empties the virtualized list, a real term (`Position`) narrows it to matching packets. Screenshot below.
- Full Vitest suite, typecheck, and `lint:ci` clean.

Scope: the single-source Meshtastic Packet Monitor (`PacketMonitorPanel`), per the issue. The Unified / MeshCore / MQTT monitors have separate filter systems and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
