### PR TITLE
fix(scripts): add Scripts to the settings section nav (#4942)

### DIFF
--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -1521,6 +1521,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
         ...(isAdmin ? [{ id: 'settings-elevation', label: t('settings.elevation_section', 'Elevation / Terrain') }] : []),
         { id: 'settings-backup', label: t('settings.system_backup', 'System Backup') },
         ...(isAdmin ? [{ id: 'settings-channel-database', label: t('channel_database.title', 'Channel Database') }] : []),
+        ...(isAdmin ? [{ id: 'settings-scripts', label: t('settings.scripts_section', 'Scripts') }] : []),
         // Only show Database Maintenance for SQLite - it uses SQLite-specific features like VACUUM
         ...(databaseType === 'sqlite' ? [{ id: 'settings-maintenance', label: t('maintenance.title', 'Database Maintenance') }] : []),
         ...(isAdmin && firmwareOtaEnabled ? [{ id: 'settings-firmware', label: t('firmware.title', 'Firmware Updates') }] : []),


### PR DESCRIPTION
Follow-up to #4956 (issue #4942).

The Scripts inventory section was added to `GLOBAL_SECTIONS` and rendered, but I forgot to add it to the settings page's **top section-nav** — so there was no "Scripts" chip to jump to it (you could only reach the section by scrolling).

Adds an admin-gated `settings-scripts` nav item, placed next to Channel Database / Database Maintenance to match where the section actually renders. One line.

Verified live: the **Scripts** chip now appears in the nav and scrolls to the section on click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
