### PR TITLE
feat(meshcore): add telemetry time window selector to node details (#4969)

### DIFF
--- a/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.test.tsx
@@ -45,13 +45,14 @@ vi.mock('../ToastContainer', () => ({
 // met. Stub the heavy graphs component with a sentinel so we don't need
 // ToastProvider / QueryClientProvider / SourceProvider in this test.
 vi.mock('../TelemetryGraphs', () => ({
-  default: (props: { nodeId: string; baseUrl?: string; temperatureUnit?: string; telemetryHours?: number }) => (
+  default: (props: { nodeId: string; baseUrl?: string; temperatureUnit?: string; telemetryHours?: number; showTimeRangeSelector?: boolean }) => (
     <div
       data-testid="telemetry-graphs"
       data-node-id={props.nodeId}
       data-base-url={props.baseUrl ?? ''}
       data-temp-unit={props.temperatureUnit ?? ''}
       data-telemetry-hours={props.telemetryHours ?? ''}
+      data-show-range-selector={props.showTimeRangeSelector ? 'true' : 'false'}
     />
   ),
 }));
@@ -225,6 +226,9 @@ describe('MeshCoreDirectMessagesView — per-node telemetry-config panel', () =>
     // forwarded so the graph isn't hardcoded to Celsius / 24h.
     expect(graphs.getAttribute('data-temp-unit')).toBe('F');
     expect(graphs.getAttribute('data-telemetry-hours')).toBe('48');
+    // #4969: MeshCore node details get the same time-window selector as
+    // Meshtastic node details.
+    expect(graphs.getAttribute('data-show-range-selector')).toBe('true');
   });
 
   it('does NOT mount TelemetryGraphs for a non-real-pubkey peer', () => {

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -596,6 +596,7 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                     temperatureUnit={temperatureUnit}
                     telemetryHours={telemetryVisualizationHours}
                     baseUrl={baseUrl}
+                    showTimeRangeSelector
                   />
                 </>
               )}

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -57,11 +57,10 @@ interface TelemetryGraphsProps {
   /**
    * When true, render a row of time-range buttons (15m … 7d) above the graphs
    * that let the user choose how much history to load. The chosen range is
-   * remembered in localStorage. Used on the Device Info page for the locally
-   * connected node, where telemetry volume is high enough that a fixed window
-   * either truncates the history or floods the chart. Other usages (remote
-   * nodes in the Messages/MeshCore views) leave this off and keep the fixed
-   * `telemetryHours` window.
+   * remembered in localStorage and shared across all surfaces that show the
+   * selector: Device Info, Meshtastic node details, and MeshCore node details
+   * (#4969). Usages that leave this off keep the fixed `telemetryHours`
+   * window.
    */
   showTimeRangeSelector?: boolean;
 }


### PR DESCRIPTION
## Summary

Gives the MeshCore Node Details page the same telemetry time-window selector (15m, 1h, 3h, 6h, 12h, 24h, 48h, 3d, 7d) that Meshtastic node details and Device Info already have. Closes #4969.

## Changes

- `MeshCoreDirectMessagesView` now passes `showTimeRangeSelector` to `TelemetryGraphs`, replacing the fixed `telemetryVisualizationHours` window with the shared button row.
- The selection persists in the same localStorage key the other two surfaces use, so the chosen window follows the user across Device Info, Meshtastic node details, and MeshCore node details.
- Updated the stale `showTimeRangeSelector` prop comment in `TelemetryGraphs.tsx` (it still claimed the Messages view left the selector off).
- Test: the DM-view test now asserts the prop is forwarded.

No backend change needed: the `/api/telemetry/:nodeId` route already parses fractional hours with `parseFloat`, and the averaging system adapts bucket width to the requested window.

## Mesh impact

None. This changes only which stored rows the frontend reads; it sends no packets and arms no timers.

## Verification

- Full Vitest suite: 16,968 passed, 0 failed.
- `lint:ci` clean (in-repo), `tsc` clean.
- Verified live in the dev container: selector renders in MeshCore node details, switching 24h → 3h refetches and re-renders the chart ("Last 3 Hours Telemetry"), and the choice survives in localStorage. Screenshot delivered in the Claude session; drag it here to attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G