### PR TITLE
fix(telemetry): send sourceId on purge so MeshCore purges succeed (#4963)

### DIFF
--- a/src/components/TelemetryGraphs.test.tsx
+++ b/src/components/TelemetryGraphs.test.tsx
@@ -155,6 +155,30 @@ describe('TelemetryGraphs Component', () => {
     });
   });
 
+  it('purges telemetry with the resolved sourceId in the DELETE URL (#4963)', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    renderWithProviders(<TelemetryGraphs nodeId={mockNodeId} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('telemetry.title')).toBeInTheDocument();
+    });
+
+    // Open the first widget's context menu and click Purge Data.
+    fireEvent.click(screen.getAllByLabelText('telemetry.more_options')[0]);
+    fireEvent.click(screen.getByText('telemetry.purge_data'));
+
+    // The DELETE endpoint requires a sourceId; omitting it 400s and every
+    // purge fails with the generic error toast (#4963).
+    await waitFor(() => {
+      const deleteCall = (global.fetch as Mock).mock.calls.find(
+        ([, init]: [string, RequestInit?]) => init?.method === 'DELETE'
+      );
+      expect(deleteCall).toBeDefined();
+      expect(deleteCall![0]).toContain(`/api/telemetry/${mockNodeId}/`);
+      expect(deleteCall![0]).toContain('sourceId=src-test');
+    });
+  });
+
   it('should display telemetry title when data is available', async () => {
     renderWithProviders(<TelemetryGraphs nodeId={mockNodeId} />);
 

--- a/src/components/TelemetryGraphs.tsx
+++ b/src/components/TelemetryGraphs.tsx
@@ -15,6 +15,7 @@ import { ChartData } from '../types/ui';
 import { useWidgetMode } from '../hooks/useWidgetMode';
 import { useWidgetRange } from '../hooks/useWidgetRange';
 import { useSource } from '../contexts/SourceContext';
+import { useResolvedSourceId } from '../hooks/useResolvedSourceId';
 import { getLatestValue } from '../utils/telemetry';
 import { telemetryDisplayScale } from '../utils/telemetryFormat';
 import TelemetryGauge from './TelemetryGauge';
@@ -523,6 +524,10 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
     // matching the general unscoped gate used elsewhere in this component tree.
     const canEditSettings = hasPermission('settings', 'write', { anySource: true });
     const { sourceId } = useSource();
+    // The telemetry endpoints require a sourceId; mirror useTelemetry's
+    // fallback so purge targets the same source the charts read (#4963).
+    const fallbackSourceId = useResolvedSourceId();
+    const effectiveSourceId = sourceId ?? fallbackSourceId;
     const [openMenu, setOpenMenu] = useState<string | null>(null);
     const [menuPosition, setMenuPosition] = useState<{
       x: number;
@@ -725,9 +730,17 @@ const TelemetryGraphs: React.FC<TelemetryGraphsProps> = React.memo(
       }
 
       try {
-        const response = await csrfFetch(`${baseUrl}/api/telemetry/${nodeId}/${telemetryType}`, {
-          method: 'DELETE',
-        });
+        // The DELETE endpoint rejects requests without a sourceId (400
+        // MISSING_SOURCE_ID), which surfaced as "Failed to purge" on every
+        // purge attempt (#4963).
+        if (!effectiveSourceId) {
+          showToast(t('telemetry.purge_failed'), 'error');
+          return;
+        }
+        const response = await csrfFetch(
+          `${baseUrl}/api/telemetry/${nodeId}/${telemetryType}?sourceId=${encodeURIComponent(effectiveSourceId)}`,
+          { method: 'DELETE' },
+        );
 
         if (!response.ok) {
           if (response.status === 403) {


### PR DESCRIPTION
## Summary

Fixes #4963 — purging telemetry from a node's charts always failed with "Failed to purge telemetry data. Please try again."

## Root cause

`DELETE /api/telemetry/:nodeId/:telemetryType` has a strict `requireSourceId('query')` guard, but `handlePurgeData` in `TelemetryGraphs` never sent a `sourceId`, so every purge got a 400 `MISSING_SOURCE_ID` and the generic failure toast. This hit all sources, not just MeshCore — MeshCore users noticed first because that surface has no alternate purge path. (The issue's guess at `purgeAllTelemetryAsync` was a red herring; that path is fine.)

Verified against the live dev container: without `sourceId` the route returns 400; with it, the route handles MeshCore 64-hex pubkeys and Meshtastic ids alike.

## Fix

- Resolve the sourceId in `TelemetryGraphs` exactly the way the charts' GET does (`useSource()` with the `useResolvedSourceId()` fallback) and append it to the DELETE URL.
- Guard the no-sourceId case with the failure toast instead of sending a request that will 400.
- Regression test: purging from the widget menu asserts the DELETE URL carries `sourceId`.

## Verification

- Full Vitest suite: 17,014 passed, 0 failed.
- `lint:ci` clean (in-repo), `tsc` clean.
- Live in the dev container: purged a MeshCore node's battery chart through the real UI — the DELETE went out as `/api/telemetry/<64-hex pubkey>/mc_battery_volts_ch1?sourceId=<meshcore source>` and the data was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G