### PR TITLE
fix(mesh-issues): B1 router clusters are mutually-audible cliques with a distance guard (#4976)

### DIFF
--- a/docs/internal/dev-notes/MESH_ISSUES_P2_SPEC.md
+++ b/docs/internal/dev-notes/MESH_ISSUES_P2_SPEC.md
@@ -514,12 +514,14 @@ sibling `<field>Truncated: boolean`.
 Subgraph over nodes whose `role ∈ CLUSTER_ROLES`.
 
 > **Amended by #4976:** clusters are now mutually-audible CLIQUES (greedy,
-> deterministic, disjoint) over all edges (direct + inferred), not connected
-> components — components are transitive, so a chain of genuine short links
-> merged far-apart routers into one statewide "cluster" whose endpoints never
-> hear each other. Size ≥ `ROUTER_CLUSTER_WARNING_SIZE` unchanged.
-> Recompute the clique's member set over **direct-only** edges: if it
-> disconnects, it was glued by inferred evidence — `inferredOnly = true`.
+> deterministic, disjoint), not connected components — components are
+> transitive, so a chain of genuine short links merged far-apart routers into
+> one statewide "cluster" whose endpoints never hear each other. Extraction
+> is two-pass: DIRECT-evidence cliques first (`inferredOnly = false`), then
+> full-graph cliques among the leftovers, which hold together only via
+> inferred co-reception edges (`inferredOnly = true`, D2 downgrade) — one
+> gateway hearing two routers is not those routers hearing each other. Size
+> ≥ `ROUTER_CLUSTER_WARNING_SIZE` unchanged.
 
 - severity: `inferredOnly` → `info`; else size ≥ `ROUTER_CLUSTER_CRITICAL_SIZE` → `critical`; else `warning`.
 - confidence: `inferredOnly` → `low`; every internal link has `neighborInfo` or `traceroute` evidence → `high`; else `medium`.

--- a/docs/internal/dev-notes/MESH_ISSUES_P2_SPEC.md
+++ b/docs/internal/dev-notes/MESH_ISSUES_P2_SPEC.md
@@ -511,10 +511,15 @@ sibling `<field>Truncated: boolean`.
 
 **B1 — Router cluster.** *(≥2 ROUTER/REPEATER mutually audible)*
 
-Subgraph over nodes whose `role ∈ CLUSTER_ROLES`. Connected components over
-**all** edges (direct + inferred), size ≥ `ROUTER_CLUSTER_WARNING_SIZE`.
-Recompute components over **direct-only** edges: if the component splits, it was
-glued by inferred evidence — `inferredOnly = true`.
+Subgraph over nodes whose `role ∈ CLUSTER_ROLES`.
+
+> **Amended by #4976:** clusters are now mutually-audible CLIQUES (greedy,
+> deterministic, disjoint) over all edges (direct + inferred), not connected
+> components — components are transitive, so a chain of genuine short links
+> merged far-apart routers into one statewide "cluster" whose endpoints never
+> hear each other. Size ≥ `ROUTER_CLUSTER_WARNING_SIZE` unchanged.
+> Recompute the clique's member set over **direct-only** edges: if it
+> disconnects, it was glued by inferred evidence — `inferredOnly = true`.
 
 - severity: `inferredOnly` → `info`; else size ≥ `ROUTER_CLUSTER_CRITICAL_SIZE` → `critical`; else `warning`.
 - confidence: `inferredOnly` → `low`; every internal link has `neighborInfo` or `traceroute` evidence → `high`; else `medium`.

--- a/src/components/Analysis/MeshIssuesReport.test.tsx
+++ b/src/components/Analysis/MeshIssuesReport.test.tsx
@@ -140,6 +140,7 @@ const DEFAULT_THRESHOLDS: ResolvedMeshIssueThresholds = {
   mobileSpanMeters: 500,
   snrAsymmetryDb: 6,
   overBroadcastSeconds: 300,
+  routerClusterMaxLinkKm: 30,
 };
 
 function lastRunResultFixture(overrides: Partial<MeshIssuesLastRunResult> = {}): MeshIssuesLastRunResult {

--- a/src/components/Analysis/meshIssueTypes.ts
+++ b/src/components/Analysis/meshIssueTypes.ts
@@ -127,6 +127,8 @@ export interface ResolvedMeshIssueThresholds {
   mobileSpanMeters: number;
   snrAsymmetryDb: number;
   overBroadcastSeconds: number;
+  /** km, B1/B6 cluster-adjacency distance guard (#4976). */
+  routerClusterMaxLinkKm: number;
 }
 
 /** The last completed run's summary (`meshIssuesAnalysisService.ts`'s `MeshIssuesRunResult`). */

--- a/src/components/MeshIssuesSection.test.tsx
+++ b/src/components/MeshIssuesSection.test.tsx
@@ -52,6 +52,9 @@ const statusThresholds = {
   mobileSpanMeters: 500,
   snrAsymmetryDb: 6,
   overBroadcastSeconds: 300,
+  // Non-default on purpose (#4976 review): proves the saved POST body carries
+  // the SERVER-provided value, not the client-side ?? 30 fallback.
+  routerClusterMaxLinkKm: 15,
 };
 
 const statusResponse = {
@@ -181,7 +184,7 @@ describe('MeshIssuesSection', () => {
       mesh_issues_snr_asymmetry_db: '6',
       mesh_issues_over_broadcast_seconds: '300',
       mesh_issues_auto_close_runs: '3',
-      mesh_issues_router_cluster_max_link_km: '30',
+      mesh_issues_router_cluster_max_link_km: '15',
     });
     expect(mockShowToast).toHaveBeenCalledWith('Settings saved', 'success');
   });

--- a/src/components/MeshIssuesSection.test.tsx
+++ b/src/components/MeshIssuesSection.test.tsx
@@ -102,8 +102,8 @@ describe('MeshIssuesSection', () => {
     expect(screen.getByText(/12 finding/)).toBeInTheDocument();
     expect(screen.getAllByText('[official]').length).toBe(2);
     // 3 pre-existing MeshMonitor-judgement thresholds + auto-close (#4964
-    // post-epic follow-ups).
-    expect(screen.getAllByText('[MeshMonitor]').length).toBe(4);
+    // post-epic follow-ups) + router-cluster max link km (#4976).
+    expect(screen.getAllByText('[MeshMonitor]').length).toBe(5);
   });
 
   it('defaults auto-close runs to 3 when the field is absent from status (older server, #4964 post-epic follow-ups)', async () => {
@@ -181,6 +181,7 @@ describe('MeshIssuesSection', () => {
       mesh_issues_snr_asymmetry_db: '6',
       mesh_issues_over_broadcast_seconds: '300',
       mesh_issues_auto_close_runs: '3',
+      mesh_issues_router_cluster_max_link_km: '30',
     });
     expect(mockShowToast).toHaveBeenCalledWith('Settings saved', 'success');
   });

--- a/src/components/MeshIssuesSection.tsx
+++ b/src/components/MeshIssuesSection.tsx
@@ -34,6 +34,9 @@ interface MeshIssuesThresholds {
    * uses.
    */
   autoCloseCleanRuns?: number;
+  /** km, B1/B6 cluster-adjacency distance guard (#4976). Optional for the
+   *  same server-drift reason as `autoCloseCleanRuns`; falls back to 30. */
+  routerClusterMaxLinkKm?: number;
 }
 
 interface MeshIssuesRunResult {
@@ -106,6 +109,7 @@ const MeshIssuesSection: React.FC<MeshIssuesSectionProps> = ({ baseUrl }) => {
   const [snrAsymmetryDb, setSnrAsymmetryDb] = useState(6);
   const [overBroadcastSeconds, setOverBroadcastSeconds] = useState(300);
   const [autoCloseRuns, setAutoCloseRuns] = useState(3);
+  const [clusterMaxLinkKm, setClusterMaxLinkKm] = useState(30);
 
   // Local (dirty) mirrors
   const [localEnabled, setLocalEnabled] = useState(true);
@@ -122,6 +126,7 @@ const MeshIssuesSection: React.FC<MeshIssuesSectionProps> = ({ baseUrl }) => {
   const [localSnrAsymmetryDb, setLocalSnrAsymmetryDb] = useState(6);
   const [localOverBroadcastSeconds, setLocalOverBroadcastSeconds] = useState(300);
   const [localAutoCloseRuns, setLocalAutoCloseRuns] = useState(3);
+  const [localClusterMaxLinkKm, setLocalClusterMaxLinkKm] = useState(30);
 
   const [status, setStatus] = useState<MeshIssuesStatus | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -143,6 +148,7 @@ const MeshIssuesSection: React.FC<MeshIssuesSectionProps> = ({ baseUrl }) => {
     setSnrAsymmetryDb(data.thresholds.snrAsymmetryDb);
     setOverBroadcastSeconds(data.thresholds.overBroadcastSeconds);
     setAutoCloseRuns(data.thresholds.autoCloseCleanRuns ?? 3);
+    setClusterMaxLinkKm(data.thresholds.routerClusterMaxLinkKm ?? 30);
 
     setLocalEnabled(data.enabled);
     setLocalFrequencyHours(data.frequencyHours);
@@ -158,6 +164,7 @@ const MeshIssuesSection: React.FC<MeshIssuesSectionProps> = ({ baseUrl }) => {
     setLocalSnrAsymmetryDb(data.thresholds.snrAsymmetryDb);
     setLocalOverBroadcastSeconds(data.thresholds.overBroadcastSeconds);
     setLocalAutoCloseRuns(data.thresholds.autoCloseCleanRuns ?? 3);
+    setLocalClusterMaxLinkKm(data.thresholds.routerClusterMaxLinkKm ?? 30);
   }, []);
 
   const fetchStatus = useCallback(async () => {
@@ -192,7 +199,8 @@ const MeshIssuesSection: React.FC<MeshIssuesSectionProps> = ({ baseUrl }) => {
     localMobileSpanMeters !== mobileSpanMeters ||
     localSnrAsymmetryDb !== snrAsymmetryDb ||
     localOverBroadcastSeconds !== overBroadcastSeconds ||
-    localAutoCloseRuns !== autoCloseRuns;
+    localAutoCloseRuns !== autoCloseRuns ||
+    localClusterMaxLinkKm !== clusterMaxLinkKm;
 
   const handleSave = useCallback(async () => {
     setIsSaving(true);
@@ -215,6 +223,7 @@ const MeshIssuesSection: React.FC<MeshIssuesSectionProps> = ({ baseUrl }) => {
           mesh_issues_snr_asymmetry_db: String(localSnrAsymmetryDb),
           mesh_issues_over_broadcast_seconds: String(localOverBroadcastSeconds),
           mesh_issues_auto_close_runs: String(localAutoCloseRuns),
+          mesh_issues_router_cluster_max_link_km: String(localClusterMaxLinkKm),
         }),
       });
       if (response.ok) {
@@ -246,6 +255,7 @@ const MeshIssuesSection: React.FC<MeshIssuesSectionProps> = ({ baseUrl }) => {
     localSnrAsymmetryDb,
     localOverBroadcastSeconds,
     localAutoCloseRuns,
+    localClusterMaxLinkKm,
     csrfFetch,
     baseUrl,
     showToast,
@@ -268,6 +278,7 @@ const MeshIssuesSection: React.FC<MeshIssuesSectionProps> = ({ baseUrl }) => {
     setLocalSnrAsymmetryDb(snrAsymmetryDb);
     setLocalOverBroadcastSeconds(overBroadcastSeconds);
     setLocalAutoCloseRuns(autoCloseRuns);
+    setLocalClusterMaxLinkKm(clusterMaxLinkKm);
   }, [
     enabled,
     frequencyHours,
@@ -283,6 +294,7 @@ const MeshIssuesSection: React.FC<MeshIssuesSectionProps> = ({ baseUrl }) => {
     snrAsymmetryDb,
     overBroadcastSeconds,
     autoCloseRuns,
+    clusterMaxLinkKm,
   ]);
 
   useSaveBar({
@@ -649,6 +661,30 @@ const MeshIssuesSection: React.FC<MeshIssuesSectionProps> = ({ baseUrl }) => {
           <p style={{ fontSize: '12px', color: 'var(--color-text-subtle)', margin: '0.35rem 0 0 0' }}>
             {t('automation.mesh_issues.auto_close_runs_help',
               'Runs without re-detection before an issue auto-closes.')}
+          </p>
+        </div>
+
+        <div className="setting-item" style={{ marginTop: '1rem' }}>
+          <label>
+            {t('automation.mesh_issues.cluster_max_link_km', 'Router cluster max link (km)')}
+            <span style={badgeStyle('ours')}>{t('automation.mesh_issues.badge_meshmonitor', '[MeshMonitor]')}</span>
+          </label>
+          <input
+            type="number"
+            min={1}
+            max={500}
+            step={1}
+            value={localClusterMaxLinkKm}
+            onChange={(e) => {
+              const v = parseFloat(e.target.value);
+              setLocalClusterMaxLinkKm(Number.isFinite(v) ? v : 30);
+            }}
+            disabled={!localEnabled}
+            className="setting-input"
+          />
+          <p style={{ fontSize: '12px', color: 'var(--color-text-subtle)', margin: '0.35rem 0 0 0' }}>
+            {t('automation.mesh_issues.cluster_max_link_km_help',
+              'Positioned routers farther apart than this never count as one Router Cluster. Filters MQTT-bridged "hops" that never happened over RF.')}
           </p>
         </div>
 

--- a/src/components/MeshIssuesSection.tsx
+++ b/src/components/MeshIssuesSection.tsx
@@ -684,7 +684,7 @@ const MeshIssuesSection: React.FC<MeshIssuesSectionProps> = ({ baseUrl }) => {
           />
           <p style={{ fontSize: '12px', color: 'var(--color-text-subtle)', margin: '0.35rem 0 0 0' }}>
             {t('automation.mesh_issues.cluster_max_link_km_help',
-              'Positioned routers farther apart than this never count as one Router Cluster. Filters MQTT-bridged "hops" that never happened over RF.')}
+              'Positioned routers farther apart than this never count as one Router Cluster or as redundant coverage. Filters MQTT-bridged "hops" that never happened over RF.')}
           </p>
         </div>
 

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -168,6 +168,9 @@ export const VALID_SETTINGS_KEYS = [
   // Consecutive clean runs before an open finding auto-closes (post-epic
   // follow-up #4964) — default 3, clamp 1-20, resolved via resolveThresholds.
   'mesh_issues_auto_close_runs',
+  // Max km between positioned nodes for B1/B6 cluster adjacency (#4976) —
+  // default 30, clamp 1-500, resolved via resolveThresholds.
+  'mesh_issues_router_cluster_max_link_km',
   'mesh_issues_last_run_summary',
   'autoKeyManagementEnabled',
   'autoKeyManagementIntervalMinutes',

--- a/src/server/services/meshIssues/rulesTierB.test.ts
+++ b/src/server/services/meshIssues/rulesTierB.test.ts
@@ -290,6 +290,32 @@ describe('evaluateB1 — router cluster', () => {
     expect(findings.every((f) => f.severity !== 'critical')).toBe(true);
   });
 
+  it('co-reception edges never inflate a direct clique nor form a warning/critical one (#4976)', () => {
+    // A-B genuinely hear each other (direct). C, D, E are only glued to
+    // everything by co-reception (one MQTT gateway heard them all) — a full
+    // inferred clique among {A..E}. Direct pass must report exactly {A,B};
+    // the leftovers {C,D,E} form an inferred-only info group.
+    const nodes = [1, 2, 3, 4, 5].map((n) => makeNode({ nodeNum: n, role: DeviceRole.ROUTER }));
+    const inferred = (a: number, b: number) =>
+      makeEdge({ a, b, direct: false, evidenceClasses: ['gatewayCoReception'] });
+    const edges = [directEdge(1, 2)];
+    for (let a = 1; a <= 5; a++) for (let b = a + 1; b <= 5; b++) {
+      if (!(a === 1 && b === 2)) edges.push(inferred(a, b));
+    }
+    const ctx = makeCtx({ nodes: nodeMap(nodes), graph: makeGraph(edges) });
+
+    const findings = evaluateB1(ctx);
+
+    expect(findings).toHaveLength(2);
+    const direct = findings.find((f) => f.evidence.inferredOnly === false)!;
+    const inferredGroup = findings.find((f) => f.evidence.inferredOnly === true)!;
+    expect((direct.evidence.members as Array<{ nodeNum: number }>).map((m) => m.nodeNum)).toEqual([1, 2]);
+    expect(direct.severity).toBe('warning');
+    expect((inferredGroup.evidence.members as Array<{ nodeNum: number }>).map((m) => m.nodeNum)).toEqual([3, 4, 5]);
+    expect(inferredGroup.severity).toBe('info');
+    expect(inferredGroup.confidence).toBe('low');
+  });
+
   it('downgrades an inferred-only-glued cluster to info/low (D2) and falls back sourceIds to the member union', () => {
     const n1 = makeNode({ nodeNum: 1, role: DeviceRole.ROUTER, sourceIds: ['src-x'] });
     const n2 = makeNode({ nodeNum: 2, role: DeviceRole.ROUTER, sourceIds: ['src-y'] });

--- a/src/server/services/meshIssues/rulesTierB.test.ts
+++ b/src/server/services/meshIssues/rulesTierB.test.ts
@@ -290,6 +290,35 @@ describe('evaluateB1 — router cluster', () => {
     expect(findings.every((f) => f.severity !== 'critical')).toBe(true);
   });
 
+  it('ignores edges between positioned nodes farther apart than routerClusterMaxLinkKm (#4976)', () => {
+    // A and B sit together; C is ~110 km north but has a recorded "direct"
+    // traceroute edge to both (MQTT-bridged hop that never happened over
+    // RF). The distance guard must keep C out of the cluster.
+    const A = makeNode({ nodeNum: 1, role: DeviceRole.ROUTER, latitude: 26.0, longitude: -80.2 });
+    const B = makeNode({ nodeNum: 2, role: DeviceRole.ROUTER, latitude: 26.01, longitude: -80.21 });
+    const C = makeNode({ nodeNum: 3, role: DeviceRole.ROUTER, latitude: 27.0, longitude: -80.2 });
+    const graph = makeGraph([directEdge(1, 2), directEdge(1, 3), directEdge(2, 3)]);
+    const ctx = makeCtx({ nodes: nodeMap([A, B, C]), graph });
+
+    const findings = evaluateB1(ctx);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].evidence.size).toBe(2);
+    const members = (findings[0].evidence.members as Array<{ nodeNum: number }>).map((m) => m.nodeNum);
+    expect(members).toEqual([1, 2]);
+  });
+
+  it('keeps edges with an unpositioned endpoint regardless of the distance guard (fail-open, #4976)', () => {
+    const A = makeNode({ nodeNum: 1, role: DeviceRole.ROUTER, latitude: 26.0, longitude: -80.2 });
+    const B = makeNode({ nodeNum: 2, role: DeviceRole.ROUTER }); // unpositioned
+    const ctx = makeCtx({ nodes: nodeMap([A, B]), graph: makeGraph([directEdge(1, 2)]) });
+
+    const findings = evaluateB1(ctx);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].evidence.size).toBe(2);
+  });
+
   it('co-reception edges never inflate a direct clique nor form a warning/critical one (#4976)', () => {
     // A-B genuinely hear each other (direct). C, D, E are only glued to
     // everything by co-reception (one MQTT gateway heard them all) — a full

--- a/src/server/services/meshIssues/rulesTierB.test.ts
+++ b/src/server/services/meshIssues/rulesTierB.test.ts
@@ -494,6 +494,20 @@ describe('evaluateB2 — redundant router', () => {
     return { graph, nodes };
   }
 
+  it('does NOT report a router as covered by one beyond routerClusterMaxLinkKm (#4976)', () => {
+    // Identical (MQTT-fabricated) neighbor sets, but the routers sit ~110 km
+    // apart — they cannot cover the same area, so B2 must stay silent.
+    const { graph, nodes } = buildOverlapFixture(9, 1, 2);
+    const positioned = nodes.map((n) => {
+      if (n.nodeNum === 1) return { ...n, latitude: 26.0, longitude: -80.2 };
+      if (n.nodeNum === 2) return { ...n, latitude: 27.0, longitude: -80.2 };
+      return n;
+    });
+    const ctx = makeCtx({ nodes: nodeMap(positioned), graph });
+
+    expect(evaluateB2(ctx)).toHaveLength(0);
+  });
+
   it('fires on the smaller router at 90% overlap', () => {
     // A: 9 shared + 1 aOnly = 10. B: 9 shared + 2 bOnly = 11 (strictly larger
     // than A so B itself does not also qualify as a candidate).

--- a/src/server/services/meshIssues/rulesTierB.test.ts
+++ b/src/server/services/meshIssues/rulesTierB.test.ts
@@ -250,10 +250,14 @@ describe('evaluateB1 — router cluster', () => {
     expect(byNum.get(2)!.longitude).toBeNull();
   });
 
-  it('fires critical for a 4-router cluster (chain, still >= ROUTER_CLUSTER_CRITICAL_SIZE)', () => {
+  it('fires critical for a 4-router clique (>= ROUTER_CLUSTER_CRITICAL_SIZE, all mutually audible)', () => {
     expect(ROUTER_CLUSTER_CRITICAL_SIZE).toBe(4);
     const nodes = [1, 2, 3, 4].map((n) => makeNode({ nodeNum: n, role: DeviceRole.ROUTER }));
-    const graph = makeGraph([directEdge(1, 2), directEdge(2, 3), directEdge(3, 4)]);
+    // K4: every pair adjacent.
+    const graph = makeGraph([
+      directEdge(1, 2), directEdge(1, 3), directEdge(1, 4),
+      directEdge(2, 3), directEdge(2, 4), directEdge(3, 4),
+    ]);
     const ctx = makeCtx({ nodes: nodeMap(nodes), graph });
 
     const findings = evaluateB1(ctx);
@@ -261,6 +265,29 @@ describe('evaluateB1 — router cluster', () => {
     expect(findings).toHaveLength(1);
     expect(findings[0].evidence.size).toBe(4);
     expect(findings[0].severity).toBe('critical');
+  });
+
+  it('does NOT merge a chain of routers into one cluster — clusters are mutually-audible cliques (#4976)', () => {
+    // 1-2-3-4-5-6 path: each link is a genuine RF observation, but the
+    // endpoints never hear each other. Component semantics reported one
+    // 6-router "cluster" spanning the whole chain; clique semantics must
+    // report only mutually-audible pairs, and never a group of 3+.
+    const nodes = [1, 2, 3, 4, 5, 6].map((n) => makeNode({ nodeNum: n, role: DeviceRole.ROUTER }));
+    const graph = makeGraph([
+      directEdge(1, 2), directEdge(2, 3), directEdge(3, 4), directEdge(4, 5), directEdge(5, 6),
+    ]);
+    const ctx = makeCtx({ nodes: nodeMap(nodes), graph });
+
+    const findings = evaluateB1(ctx);
+
+    expect(findings.length).toBeGreaterThan(0);
+    for (const f of findings) {
+      expect(f.evidence.size).toBe(2);
+      const members = (f.evidence.members as Array<{ nodeNum: number }>).map((m) => m.nodeNum);
+      // Every reported pair must actually be adjacent.
+      expect(Math.abs(members[0] - members[1])).toBe(1);
+    }
+    expect(findings.every((f) => f.severity !== 'critical')).toBe(true);
   });
 
   it('downgrades an inferred-only-glued cluster to info/low (D2) and falls back sourceIds to the member union', () => {
@@ -317,7 +344,8 @@ describe('evaluateB1 — router cluster', () => {
     const n1 = makeNode({ nodeNum: 1, role: DeviceRole.ROUTER });
     const n2 = makeNode({ nodeNum: 2, role: DeviceRole.ROUTER });
     const n3 = makeNode({ nodeNum: 3, role: DeviceRole.ROUTER });
-    const graph = makeGraph([directEdge(1, 2), directEdge(2, 3)]);
+    // Triangle so all three land in one clique under #4976 semantics.
+    const graph = makeGraph([directEdge(1, 2), directEdge(2, 3), directEdge(1, 3)]);
 
     const ctxForward = makeCtx({ nodes: nodeMap([n1, n2, n3]), graph });
     const ctxReversed = makeCtx({ nodes: nodeMap([n3, n2, n1]), graph });
@@ -353,9 +381,11 @@ describe('evaluateB1 — router cluster', () => {
   });
 
   it('caps members/edges at EVIDENCE_MEMBER_LIST_CAP and reports the true pre-cap total (#4964 Phase 3 WP3 §4.2)', () => {
-    // A 30-router chain: 30 members, 29 internal edges — both over the cap.
-    const nodes = Array.from({ length: 30 }, (_, i) => makeNode({ nodeNum: i + 1, role: DeviceRole.ROUTER }));
-    const edges = Array.from({ length: 29 }, (_, i) => directEdge(i + 1, i + 2));
+    // A 30-router CLIQUE (every pair adjacent, #4976): 30 members, 435
+    // internal edges — both over the cap.
+    const nums = Array.from({ length: 30 }, (_, i) => i + 1);
+    const nodes = nums.map((n) => makeNode({ nodeNum: n, role: DeviceRole.ROUTER }));
+    const edges = nums.flatMap((a) => nums.filter((b) => b > a).map((b) => directEdge(a, b)));
     const ctx = makeCtx({ nodes: nodeMap(nodes), graph: makeGraph(edges) });
 
     const findings = evaluateB1(ctx);
@@ -367,7 +397,7 @@ describe('evaluateB1 — router cluster', () => {
     expect((findings[0].evidence.members as unknown[]).length).toBe(EVIDENCE_MEMBER_LIST_CAP);
 
     expect(findings[0].evidence.edgesTruncated).toBe(true);
-    expect(findings[0].evidence.edgesTotal).toBe(29);
+    expect(findings[0].evidence.edgesTotal).toBe(435);
     expect((findings[0].evidence.edges as unknown[]).length).toBe(EVIDENCE_MEMBER_LIST_CAP);
   });
 });

--- a/src/server/services/meshIssues/rulesTierB.ts
+++ b/src/server/services/meshIssues/rulesTierB.ts
@@ -104,10 +104,11 @@ export interface RuleSkip {
  *  finding's claim and its demote-all-but-one recommendation. */
 export interface RouterCluster {
   /** Sorted, deduped. Size >= ROUTER_CLUSTER_WARNING_SIZE. Pairwise
-   *  adjacent over the full (direct + inferred) RF graph. */
+   *  adjacent: over DIRECT edges when `inferredOnly` is false, over the
+   *  full graph otherwise. */
   members: number[];
   /** True when the clique only holds together via inferred (co-reception)
-   *  edges — direct-only recomputation disconnects it (D2). */
+   *  edges — extracted in the second, full-graph pass (D2). */
   inferredOnly: boolean;
 }
 
@@ -175,47 +176,55 @@ function countPositionedDirectNeighbors(ctx: TierBRuleContext, nodeNum: number):
 // Router-cluster components (shared by B1 and B6)
 // ---------------------------------------------------------------------------
 
-/** BFS connected components of `nodeSet`, following only edges in
- *  `adjacency` whose OTHER endpoint is also in `nodeSet`. Deterministic:
- *  both the start-node order and each node's neighbour order are irrelevant
- *  to the final (sorted) membership of each component. */
-function computeComponents(nodeSet: ReadonlySet<number>, adjacency: Map<number, Set<number>>): number[][] {
-  const visited = new Set<number>();
-  const components: number[][] = [];
-  const startNodes = sortNumbers(nodeSet);
+/**
+ * Greedy, deterministic, DISJOINT clique extraction over one adjacency map.
+ * Seeds are processed by (restricted degree desc, nodeNum asc); each seed
+ * grows a clique by admitting, in the same priority order, every unassigned
+ * candidate adjacent to ALL current members. Greedy rather than exact
+ * maximum-clique: exact is exponential in the worst case, while this is
+ * O(n · d²), order-stable across runs, and each emitted group still
+ * satisfies the property the finding asserts — every member is adjacent to
+ * every other member. Disjointness keeps one router from being
+ * demote-recommended in two findings at once. Mutates `assigned`.
+ */
+function extractCliques(
+  candidates: ReadonlySet<number>,
+  adjacency: Map<number, Set<number>>,
+  assigned: Set<number>,
+): number[][] {
+  const restrictedNeighbors = (n: number): number[] => {
+    const nbs = adjacency.get(n);
+    if (!nbs) return [];
+    return Array.from(nbs).filter((nb) => candidates.has(nb));
+  };
+  const degree = new Map<number, number>();
+  for (const n of candidates) degree.set(n, restrictedNeighbors(n).length);
+  const byPriority = (a: number, b: number) => degree.get(b)! - degree.get(a)! || a - b;
+  const adjacent = (a: number, b: number) => adjacency.get(a)?.has(b) ?? false;
 
-  for (const start of startNodes) {
-    if (visited.has(start)) continue;
-    const comp: number[] = [];
-    const queue: number[] = [start];
-    visited.add(start);
-    while (queue.length > 0) {
-      const cur = queue.shift()!;
-      comp.push(cur);
-      const neighbors = adjacency.get(cur);
-      if (!neighbors) continue;
-      for (const nb of neighbors) {
-        if (nodeSet.has(nb) && !visited.has(nb)) {
-          visited.add(nb);
-          queue.push(nb);
-        }
-      }
+  const cliques: number[][] = [];
+  for (const seed of Array.from(candidates).sort(byPriority)) {
+    if (assigned.has(seed)) continue;
+    const clique: number[] = [seed];
+    for (const cand of restrictedNeighbors(seed).filter((n) => !assigned.has(n)).sort(byPriority)) {
+      if (clique.every((m) => adjacent(cand, m))) clique.push(cand);
     }
-    components.push(comp);
+    if (clique.length < ROUTER_CLUSTER_WARNING_SIZE) continue;
+    for (const m of clique) assigned.add(m);
+    cliques.push(sortNumbers(clique));
   }
-  return components;
+  return cliques;
 }
 
 /**
- * Greedy, deterministic, DISJOINT clique extraction (#4976). Seeds are
- * processed by (restricted degree desc, nodeNum asc); each seed grows a
- * clique by admitting, in the same priority order, every unassigned
- * cluster-role neighbour adjacent to ALL current members. Greedy rather than
- * exact maximum-clique: exact is exponential in the worst case, while this
- * is O(n · d²), order-stable across runs, and each emitted group still
- * satisfies the property the finding asserts — every member hears every
- * other member. Disjointness keeps one router from being demote-recommended
- * in two findings at once.
+ * Two passes (#4976): DIRECT-evidence cliques first (mutual audibility a
+ * device actually reported — neighborInfo/traceroute/gateway-direct), then
+ * full-graph cliques among the leftovers, which by construction hold
+ * together only via inferred co-reception edges ("the same MQTT gateway
+ * heard both") and are flagged `inferredOnly` so B1 downgrades them to
+ * info/low (D2). Co-reception is NOT mutual audibility — one gateway on a
+ * hill hears routers 150 km apart — so it must never inflate a
+ * warning/critical cluster's membership.
  */
 function findRouterClustersCore(ctx: TierBRuleContext): RouterCluster[] {
   const clusterNodeNums = new Set<number>();
@@ -224,33 +233,15 @@ function findRouterClustersCore(ctx: TierBRuleContext): RouterCluster[] {
   }
   if (clusterNodeNums.size === 0) return [];
 
-  const restrictedNeighbors = (n: number): number[] => {
-    const nbs = ctx.graph.adjacency.get(n);
-    if (!nbs) return [];
-    return Array.from(nbs).filter((nb) => clusterNodeNums.has(nb));
-  };
-  const degree = new Map<number, number>();
-  for (const n of clusterNodeNums) degree.set(n, restrictedNeighbors(n).length);
-  const byPriority = (a: number, b: number) => degree.get(b)! - degree.get(a)! || a - b;
-  const adjacent = (a: number, b: number) => ctx.graph.adjacency.get(a)?.has(b) ?? false;
-
   const assigned = new Set<number>();
   const clusters: RouterCluster[] = [];
-  for (const seed of Array.from(clusterNodeNums).sort(byPriority)) {
-    if (assigned.has(seed)) continue;
-    const clique: number[] = [seed];
-    for (const cand of restrictedNeighbors(seed).filter((n) => !assigned.has(n)).sort(byPriority)) {
-      if (clique.every((m) => adjacent(cand, m))) clique.push(cand);
-    }
-    if (clique.length < ROUTER_CLUSTER_WARNING_SIZE) continue;
-    for (const m of clique) assigned.add(m);
-    const memberSet = new Set(clique);
-    // Recompute over DIRECT-only edges (D2): if this same member set no
-    // longer forms a single connected component, it was glued together by
-    // inferred (co-reception) evidence alone.
-    const directComponents = computeComponents(memberSet, ctx.graph.directAdjacency);
-    const inferredOnly = !(directComponents.length === 1 && directComponents[0].length === memberSet.size);
-    clusters.push({ members: sortNumbers(memberSet), inferredOnly });
+  for (const members of extractCliques(clusterNodeNums, ctx.graph.directAdjacency, assigned)) {
+    clusters.push({ members, inferredOnly: false });
+  }
+  // Any direct pair among the leftovers would have formed a pass-1 clique
+  // (WARNING_SIZE is 2), so pass-2 groups are inferred-glued by construction.
+  for (const members of extractCliques(clusterNodeNums, ctx.graph.adjacency, assigned)) {
+    clusters.push({ members, inferredOnly: true });
   }
 
   clusters.sort((a, b) => a.members[0] - b.members[0]);

--- a/src/server/services/meshIssues/rulesTierB.ts
+++ b/src/server/services/meshIssues/rulesTierB.ts
@@ -95,13 +95,19 @@ export interface RuleSkip {
   reason: string;
 }
 
-/** A connected component of `CLUSTER_ROLES` nodes over the RF graph. Shared
- *  by B1 (fires on it) and B6 (checks adjacency to it) — see spec §2.6. */
+/** A MUTUALLY-AUDIBLE group of `CLUSTER_ROLES` nodes over the RF graph:
+ *  every member is adjacent to every other member (a clique). Shared by B1
+ *  (fires on it) and B6 (checks adjacency to it). Amends spec §2.6's
+ *  connected-component definition (#4976): components are transitive, so a
+ *  chain of genuine short links merged far-apart routers into one statewide
+ *  "cluster" whose endpoints never hear each other — invalidating both the
+ *  finding's claim and its demote-all-but-one recommendation. */
 export interface RouterCluster {
-  /** Sorted, deduped. Size >= ROUTER_CLUSTER_WARNING_SIZE. */
+  /** Sorted, deduped. Size >= ROUTER_CLUSTER_WARNING_SIZE. Pairwise
+   *  adjacent over the full (direct + inferred) RF graph. */
   members: number[];
-  /** True when the component only stays connected via inferred
-   *  (co-reception) edges — direct-only recomputation splits it (D2). */
+  /** True when the clique only holds together via inferred (co-reception)
+   *  edges — direct-only recomputation disconnects it (D2). */
   inferredOnly: boolean;
 }
 
@@ -200,6 +206,17 @@ function computeComponents(nodeSet: ReadonlySet<number>, adjacency: Map<number, 
   return components;
 }
 
+/**
+ * Greedy, deterministic, DISJOINT clique extraction (#4976). Seeds are
+ * processed by (restricted degree desc, nodeNum asc); each seed grows a
+ * clique by admitting, in the same priority order, every unassigned
+ * cluster-role neighbour adjacent to ALL current members. Greedy rather than
+ * exact maximum-clique: exact is exponential in the worst case, while this
+ * is O(n · d²), order-stable across runs, and each emitted group still
+ * satisfies the property the finding asserts — every member hears every
+ * other member. Disjointness keeps one router from being demote-recommended
+ * in two findings at once.
+ */
 function findRouterClustersCore(ctx: TierBRuleContext): RouterCluster[] {
   const clusterNodeNums = new Set<number>();
   for (const node of ctx.nodes.values()) {
@@ -207,12 +224,27 @@ function findRouterClustersCore(ctx: TierBRuleContext): RouterCluster[] {
   }
   if (clusterNodeNums.size === 0) return [];
 
-  const allComponents = computeComponents(clusterNodeNums, ctx.graph.adjacency);
-  const clusters: RouterCluster[] = [];
+  const restrictedNeighbors = (n: number): number[] => {
+    const nbs = ctx.graph.adjacency.get(n);
+    if (!nbs) return [];
+    return Array.from(nbs).filter((nb) => clusterNodeNums.has(nb));
+  };
+  const degree = new Map<number, number>();
+  for (const n of clusterNodeNums) degree.set(n, restrictedNeighbors(n).length);
+  const byPriority = (a: number, b: number) => degree.get(b)! - degree.get(a)! || a - b;
+  const adjacent = (a: number, b: number) => ctx.graph.adjacency.get(a)?.has(b) ?? false;
 
-  for (const comp of allComponents) {
-    if (comp.length < ROUTER_CLUSTER_WARNING_SIZE) continue;
-    const memberSet = new Set(comp);
+  const assigned = new Set<number>();
+  const clusters: RouterCluster[] = [];
+  for (const seed of Array.from(clusterNodeNums).sort(byPriority)) {
+    if (assigned.has(seed)) continue;
+    const clique: number[] = [seed];
+    for (const cand of restrictedNeighbors(seed).filter((n) => !assigned.has(n)).sort(byPriority)) {
+      if (clique.every((m) => adjacent(cand, m))) clique.push(cand);
+    }
+    if (clique.length < ROUTER_CLUSTER_WARNING_SIZE) continue;
+    for (const m of clique) assigned.add(m);
+    const memberSet = new Set(clique);
     // Recompute over DIRECT-only edges (D2): if this same member set no
     // longer forms a single connected component, it was glued together by
     // inferred (co-reception) evidence alone.

--- a/src/server/services/meshIssues/rulesTierB.ts
+++ b/src/server/services/meshIssues/rulesTierB.ts
@@ -191,16 +191,17 @@ function extractCliques(
   candidates: ReadonlySet<number>,
   adjacency: Map<number, Set<number>>,
   assigned: Set<number>,
+  edgeAllowed: (a: number, b: number) => boolean,
 ): number[][] {
   const restrictedNeighbors = (n: number): number[] => {
     const nbs = adjacency.get(n);
     if (!nbs) return [];
-    return Array.from(nbs).filter((nb) => candidates.has(nb));
+    return Array.from(nbs).filter((nb) => candidates.has(nb) && edgeAllowed(n, nb));
   };
   const degree = new Map<number, number>();
   for (const n of candidates) degree.set(n, restrictedNeighbors(n).length);
   const byPriority = (a: number, b: number) => degree.get(b)! - degree.get(a)! || a - b;
-  const adjacent = (a: number, b: number) => adjacency.get(a)?.has(b) ?? false;
+  const adjacent = (a: number, b: number) => (adjacency.get(a)?.has(b) ?? false) && edgeAllowed(a, b);
 
   const cliques: number[][] = [];
   for (const seed of Array.from(candidates).sort(byPriority)) {
@@ -233,14 +234,29 @@ function findRouterClustersCore(ctx: TierBRuleContext): RouterCluster[] {
   }
   if (clusterNodeNums.size === 0) return [];
 
+  // Distance guard (#4976): MQTT-bridged firmwares record traceroute "hops"
+  // between repeaters 100+ km apart that never happened over RF, and B1
+  // claims redundant same-spot coverage — so an edge between two POSITIONED
+  // nodes farther apart than routerClusterMaxLinkKm never counts toward
+  // cluster adjacency. Unpositioned endpoints keep the edge (fail-open).
+  const maxLinkKm = ctx.thresholds.routerClusterMaxLinkKm;
+  const edgeAllowed = (a: number, b: number): boolean => {
+    const na = ctx.nodes.get(a);
+    const nb = ctx.nodes.get(b);
+    if (!na || !nb) return true;
+    if (na.latitude == null || na.longitude == null || isBogusPosition(na.latitude, na.longitude, na.positionPrecisionBits)) return true;
+    if (nb.latitude == null || nb.longitude == null || isBogusPosition(nb.latitude, nb.longitude, nb.positionPrecisionBits)) return true;
+    return calculateDistance(na.latitude, na.longitude, nb.latitude, nb.longitude) <= maxLinkKm;
+  };
+
   const assigned = new Set<number>();
   const clusters: RouterCluster[] = [];
-  for (const members of extractCliques(clusterNodeNums, ctx.graph.directAdjacency, assigned)) {
+  for (const members of extractCliques(clusterNodeNums, ctx.graph.directAdjacency, assigned, edgeAllowed)) {
     clusters.push({ members, inferredOnly: false });
   }
   // Any direct pair among the leftovers would have formed a pass-1 clique
   // (WARNING_SIZE is 2), so pass-2 groups are inferred-glued by construction.
-  for (const members of extractCliques(clusterNodeNums, ctx.graph.adjacency, assigned)) {
+  for (const members of extractCliques(clusterNodeNums, ctx.graph.adjacency, assigned, edgeAllowed)) {
     clusters.push({ members, inferredOnly: true });
   }
 

--- a/src/server/services/meshIssues/rulesTierB.ts
+++ b/src/server/services/meshIssues/rulesTierB.ts
@@ -159,6 +159,18 @@ function sourceIdsWithFallback(primary: Iterable<string>, fallbackNodes: Array<P
   return sortedUnique(fallbackNodes.flatMap((n) => n?.sourceIds ?? []));
 }
 
+/** True unless BOTH nodes carry usable positions farther apart than
+ *  `routerClusterMaxLinkKm` (#4976). Shared by B1/B6 cluster adjacency and
+ *  B2's covered-by pairing: MQTT-bridged firmwares fabricate direct edges
+ *  between repeaters 100+ km apart, and both rules assert same-area
+ *  redundancy. Unpositioned endpoints fail open. */
+function withinClusterRange(na: PooledNode | undefined, nb: PooledNode | undefined, maxLinkKm: number): boolean {
+  if (!na || !nb) return true;
+  if (na.latitude == null || na.longitude == null || isBogusPosition(na.latitude, na.longitude, na.positionPrecisionBits)) return true;
+  if (nb.latitude == null || nb.longitude == null || isBogusPosition(nb.latitude, nb.longitude, nb.positionPrecisionBits)) return true;
+  return calculateDistance(na.latitude, na.longitude, nb.latitude, nb.longitude) <= maxLinkKm;
+}
+
 function countPositionedDirectNeighbors(ctx: TierBRuleContext, nodeNum: number): number {
   const neighbors = ctx.graph.directAdjacency.get(nodeNum);
   if (!neighbors) return 0;
@@ -240,14 +252,8 @@ function findRouterClustersCore(ctx: TierBRuleContext): RouterCluster[] {
   // nodes farther apart than routerClusterMaxLinkKm never counts toward
   // cluster adjacency. Unpositioned endpoints keep the edge (fail-open).
   const maxLinkKm = ctx.thresholds.routerClusterMaxLinkKm;
-  const edgeAllowed = (a: number, b: number): boolean => {
-    const na = ctx.nodes.get(a);
-    const nb = ctx.nodes.get(b);
-    if (!na || !nb) return true;
-    if (na.latitude == null || na.longitude == null || isBogusPosition(na.latitude, na.longitude, na.positionPrecisionBits)) return true;
-    if (nb.latitude == null || nb.longitude == null || isBogusPosition(nb.latitude, nb.longitude, nb.positionPrecisionBits)) return true;
-    return calculateDistance(na.latitude, na.longitude, nb.latitude, nb.longitude) <= maxLinkKm;
-  };
+  const edgeAllowed = (a: number, b: number): boolean =>
+    withinClusterRange(ctx.nodes.get(a), ctx.nodes.get(b), maxLinkKm);
 
   const assigned = new Set<number>();
   const clusters: RouterCluster[] = [];
@@ -509,6 +515,10 @@ export function evaluateB2(ctx: TierBRuleContext): MeshIssueFinding[] {
     const candidates: Candidate[] = [];
     for (const nodeB of infraNodes) {
       if (nodeB.nodeNum === nodeA.nodeNum) continue;
+      // "Covered by" asserts same-area redundancy; two positioned routers
+      // beyond the cluster range cannot cover the same area no matter how
+      // similar their (possibly MQTT-fabricated) neighbor sets look (#4976).
+      if (!withinClusterRange(nodeA, nodeB, ctx.thresholds.routerClusterMaxLinkKm)) continue;
       const rawB = ctx.graph.directAdjacency.get(nodeB.nodeNum);
       if (!rawB) continue;
 

--- a/src/server/services/meshIssues/thresholds.test.ts
+++ b/src/server/services/meshIssues/thresholds.test.ts
@@ -135,8 +135,8 @@ describe('resolveThresholds — boolean default-ON toggles', () => {
 });
 
 describe('MESH_ISSUE_THRESHOLD_SETTINGS_KEYS', () => {
-  it('has exactly ten entries — one per user-tunable field', () => {
-    expect(MESH_ISSUE_THRESHOLD_SETTINGS_KEYS).toHaveLength(10);
+  it('has exactly eleven entries — one per user-tunable field', () => {
+    expect(MESH_ISSUE_THRESHOLD_SETTINGS_KEYS).toHaveLength(11);
   });
 
   it('every key round-trips through resolveThresholds without throwing', () => {

--- a/src/server/services/meshIssues/thresholds.test.ts
+++ b/src/server/services/meshIssues/thresholds.test.ts
@@ -17,6 +17,7 @@ import {
   ASYMMETRY_DELTA_DB,
   OVER_BROADCAST_INTERVAL_SECONDS,
   AUTO_CLOSE_CLEAN_RUNS,
+  ROUTER_CLUSTER_MAX_LINK_KM,
 } from './thresholds.js';
 
 describe('resolveThresholds — defaults', () => {
@@ -32,6 +33,7 @@ describe('resolveThresholds — defaults', () => {
     expect(DEFAULT_MESH_ISSUE_THRESHOLDS.snrAsymmetryDb).toBe(ASYMMETRY_DELTA_DB);
     expect(DEFAULT_MESH_ISSUE_THRESHOLDS.overBroadcastSeconds).toBe(OVER_BROADCAST_INTERVAL_SECONDS);
     expect(DEFAULT_MESH_ISSUE_THRESHOLDS.autoCloseCleanRuns).toBe(AUTO_CLOSE_CLEAN_RUNS);
+    expect(DEFAULT_MESH_ISSUE_THRESHOLDS.routerClusterMaxLinkKm).toBe(ROUTER_CLUSTER_MAX_LINK_KM);
   });
 
   it('returns a fresh object each call — mutating the result never affects the shared default', () => {
@@ -58,6 +60,7 @@ describe('resolveThresholds — numeric clamps', () => {
     { key: 'mesh_issues_snr_asymmetry_db', field: 'snrAsymmetryDb', min: 1, max: 30 },
     { key: 'mesh_issues_over_broadcast_seconds', field: 'overBroadcastSeconds', min: 30, max: 3600 },
     { key: 'mesh_issues_auto_close_runs', field: 'autoCloseCleanRuns', min: 1, max: 20 },
+    { key: 'mesh_issues_router_cluster_max_link_km', field: 'routerClusterMaxLinkKm', min: 1, max: 500 },
   ];
 
   for (const { key, field, min, max } of cases) {

--- a/src/server/services/meshIssues/thresholds.ts
+++ b/src/server/services/meshIssues/thresholds.ts
@@ -152,6 +152,13 @@ export const COVERAGE_SHADOW_MAX_RANGE_M = 25_000;
 export const ROUTER_CLUSTER_WARNING_SIZE = 2;
 /** Cluster size at/above which B1 is critical. [ours] */
 export const ROUTER_CLUSTER_CRITICAL_SIZE = 4;
+/** Max km between two POSITIONED nodes for their edge to count toward B1/B6
+ *  cluster adjacency (#4976). B1 claims redundant same-spot coverage, and
+ *  MQTT-bridged firmwares (TRON) record traceroute "hops" between repeaters
+ *  100+ km apart that never happened over RF — carrying plausible SNR, so the
+ *  sentinel filter cannot catch them. Distance is the only robust guard.
+ *  Edges with an unpositioned endpoint are kept (fail-open). [ours] */
+export const ROUTER_CLUSTER_MAX_LINK_KM = 30;
 
 // ── Evidence hygiene ────────────────────────────────────────────────────────
 /** Max entries in any evidence member/edge list. `mesh_issues.evidence` is
@@ -215,6 +222,7 @@ export interface ResolvedMeshIssueThresholds {
   /** dB, [ours] */ snrAsymmetryDb: number;
   /** seconds, [ours] */ overBroadcastSeconds: number;
   /** count, [ours] */ autoCloseCleanRuns: number;
+  /** km, [ours] */ routerClusterMaxLinkKm: number;
 }
 
 export const DEFAULT_MESH_ISSUE_THRESHOLDS: ResolvedMeshIssueThresholds = {
@@ -228,6 +236,7 @@ export const DEFAULT_MESH_ISSUE_THRESHOLDS: ResolvedMeshIssueThresholds = {
   snrAsymmetryDb: ASYMMETRY_DELTA_DB,
   overBroadcastSeconds: OVER_BROADCAST_INTERVAL_SECONDS,
   autoCloseCleanRuns: AUTO_CLOSE_CLEAN_RUNS,
+  routerClusterMaxLinkKm: ROUTER_CLUSTER_MAX_LINK_KM,
 };
 
 /**
@@ -247,6 +256,7 @@ export const MESH_ISSUE_THRESHOLD_SETTINGS_KEYS = [
   'mesh_issues_snr_asymmetry_db',
   'mesh_issues_over_broadcast_seconds',
   'mesh_issues_auto_close_runs',
+  'mesh_issues_router_cluster_max_link_km',
 ] as const;
 
 /** Accepts both a raw settings string and a plain number (tests call this
@@ -335,6 +345,13 @@ export function resolveThresholds(raw: Record<string, unknown>): ResolvedMeshIss
       DEFAULT_MESH_ISSUE_THRESHOLDS.autoCloseCleanRuns,
       1,
       20
+    ),
+    routerClusterMaxLinkKm: resolveClampedNumber(
+      raw,
+      'mesh_issues_router_cluster_max_link_km',
+      DEFAULT_MESH_ISSUE_THRESHOLDS.routerClusterMaxLinkKm,
+      1,
+      500
     ),
   };
 }

--- a/src/server/services/meshIssues/thresholds.ts
+++ b/src/server/services/meshIssues/thresholds.ts
@@ -153,7 +153,8 @@ export const ROUTER_CLUSTER_WARNING_SIZE = 2;
 /** Cluster size at/above which B1 is critical. [ours] */
 export const ROUTER_CLUSTER_CRITICAL_SIZE = 4;
 /** Max km between two POSITIONED nodes for their edge to count toward B1/B6
- *  cluster adjacency (#4976). B1 claims redundant same-spot coverage, and
+ *  cluster adjacency, or for B2 to call one router covered by another
+ *  (#4976). B1 claims redundant same-spot coverage, and
  *  MQTT-bridged firmwares (TRON) record traceroute "hops" between repeaters
  *  100+ km apart that never happened over RF — carrying plausible SNR, so the
  *  sentinel filter cannot catch them. Distance is the only robust guard.


### PR DESCRIPTION
## Summary

Closes #4976. The first Router Cluster finding merged 26 routers spanning Orlando to Jacksonville (345 km) into one "cluster" whose endpoints never hear each other. Three stacked causes, three fixes:

1. **Connected components → cliques.** `findRouterClustersCore` clustered by connected component, which is transitive: a chain of genuine short links merged the state. It now extracts greedy, deterministic, disjoint cliques — every reported member is adjacent to every other member, matching the finding's claim and its demote-all-but-one recommendation. B6's behind-a-cluster check shares the helper.
2. **Co-reception isolation.** Inferred co-reception edges (one MQTT gateway hearing two routers) still glued a 10-member, 162 km clique. Extraction is now two-pass: direct-evidence cliques first (warning/critical), then full-graph cliques among the leftovers, which by construction hold together only via inferred edges and keep the existing `inferredOnly` info/low downgrade.
3. **Distance guard.** MQTT-bridged firmwares (TRON) record traceroute "hops" between repeaters 100+ km apart with plausible SNR, evading the sentinel filter. New user-tunable threshold `mesh_issues_router_cluster_max_link_km` (default 30, clamp 1–500, chosen by the maintainer): edges between positioned nodes farther apart never count toward cluster adjacency; unpositioned endpoints fail open. Exposed in the Mesh Issues settings panel.

Spec §2.6 (P2) carries an amendment note.

## Mesh impact

None — analysis reads passively collected data; no packets, no timers.

## Verification

- Full Vitest suite: 17,023 passed, 0 failed; new regression tests for chain-splitting, co-reception isolation, the distance guard, and fail-open unpositioned members.
- `lint:ci` clean (in-repo), `tsc` clean on both configs.
- Live on the maintainer's data: max cluster spread dropped 345 km → 30 km; findings decomposed into coherent metro pods (e.g. FTL/FXE/POMP G2 within 24 km, the two Jacksonville towers 9 km apart). Screenshot delivered in the Claude session.

Note: pre-fix giant findings auto-close after `mesh_issues_auto_close_runs` clean runs (default 3), or can be dismissed immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G