### PR TITLE
fix(meshcore): age stored neighbour "last heard" instead of showing 0s ago

### DIFF
--- a/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx
@@ -26,6 +26,11 @@ vi.mock('../../contexts/SourceContext', () => ({
   useSource: () => ({ sourceId: 'test-source', sourceName: 'Test' }),
 }));
 
+vi.mock('../../services/api', () => ({
+  default: { get: vi.fn().mockRejectedValue(new Error('no stub configured')) },
+}));
+import api from '../../services/api';
+
 const PK = 'a'.repeat(64);
 
 describe('MeshCoreContactDetailPanel', () => {
@@ -571,6 +576,37 @@ describe('MeshCoreContactDetailPanel', () => {
         .map((m) => m[1]);
       expect(unguarded, `unguarded handlers: ${unguarded.join(', ')}`).toEqual([]);
     });
+  });
+
+  /**
+   * #4978 — the auto-loaded neighbours table always showed "0s ago" because
+   * `loadStoredNeighbors` hardcoded `heardSecondsAgo: 0` instead of aging the
+   * stored `lastHeardSecs` (the repeater-reported age as of the poll) by the
+   * time elapsed since that poll (`timestamp`).
+   */
+  it('ages stored neighbour data by time elapsed since the poll instead of showing "0s ago"', async () => {
+    const now = Date.now();
+    vi.mocked(api.get).mockResolvedValue({
+      success: true,
+      data: {
+        items: [
+          {
+            neighborPublicKey: 'ff'.repeat(32),
+            neighborName: 'Neighbor One',
+            snr: 4,
+            lastHeardSecs: 30,
+            timestamp: now - 90_000, // polled 90s ago
+          },
+        ],
+      },
+    });
+
+    const contact: MeshCoreContact = { publicKey: PK, advType: 2 };
+    render(<MeshCoreContactDetailPanel contact={contact} publicKey={PK} />);
+
+    // 30s (age at poll time) + 90s (elapsed since poll) = 120s -> "2m ago".
+    await waitFor(() => expect(screen.getByText('2m ago')).toBeInTheDocument());
+    expect(screen.queryByText('0s ago')).toBeNull();
   });
 
 });

--- a/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
+++ b/src/components/MeshCore/MeshCoreContactDetailPanel.tsx
@@ -225,16 +225,20 @@ export const MeshCoreContactDetailPanel: React.FC<MeshCoreContactDetailPanelProp
     try {
       const resp = await api.get<{
         success: boolean;
-        data: { items: Array<{ neighborPublicKey: string; neighborName: string | null; snr: number | null; timestamp: number }> };
+        data: { items: Array<{ neighborPublicKey: string; neighborName: string | null; snr: number | null; lastHeardSecs: number | null; timestamp: number }> };
       }>(`/api/sources/${sourceId}/meshcore/neighbors?since=0&node=${encodeURIComponent(publicKey)}`);
       if (resp.success && resp.data.items.length > 0) {
         const ts = resp.data.items[0].timestamp;
+        const nowMs = Date.now();
         setNeighboursData({
           total: resp.data.items.length,
           neighbours: resp.data.items.map((n) => ({
             publicKeyPrefix: n.neighborPublicKey.substring(0, 8),
             name: n.neighborName,
-            heardSecondsAgo: 0,
+            // lastHeardSecs is the repeater-reported age as of `timestamp`
+            // (when we polled it); add elapsed time since then so the value
+            // keeps counting up rather than freezing at the poll-time age.
+            heardSecondsAgo: (n.lastHeardSecs ?? 0) + Math.max(0, Math.floor((nowMs - n.timestamp) / 1000)),
             snr: n.snr ?? 0,
           })),
           fetchedAt: ts,

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -1404,7 +1404,7 @@ export class MeshCoreRepository extends BaseRepository {
   async getNeighbors(
     sourceIds: string[],
     sinceMs: number = 0,
-  ): Promise<Array<{ id: number; sourceId: string; publicKey: string; neighborPublicKey: string; snr: number | null; timestamp: number; nodeName: string | null; neighborName: string | null }>> {
+  ): Promise<Array<{ id: number; sourceId: string; publicKey: string; neighborPublicKey: string; snr: number | null; lastHeardSecs: number | null; timestamp: number; nodeName: string | null; neighborName: string | null }>> {
     const { meshcoreNeighbors, meshcoreNodes } = this.tables;
     if (sourceIds.length === 0) return [];
 
@@ -1422,6 +1422,7 @@ export class MeshCoreRepository extends BaseRepository {
         publicKey: meshcoreNeighbors.publicKey,
         neighborPublicKey: meshcoreNeighbors.neighborPublicKey,
         snr: meshcoreNeighbors.snr,
+        lastHeardSecs: meshcoreNeighbors.lastHeardSecs,
         timestamp: meshcoreNeighbors.timestamp,
       })
       .from(meshcoreNeighbors)


### PR DESCRIPTION
## Summary

Fixes #4978 — the Contact Details panel for a MeshCore repeater always showed **"0s ago"** for every entry in its Neighbours table, instead of the real elapsed time.

## Root cause

`MeshCoreContactDetailPanel`'s `loadStoredNeighbors()` auto-loads a repeater's previously-polled neighbour table from the database on open (`GET /api/sources/:id/meshcore/neighbors`). It hardcoded `heardSecondsAgo: 0` for every row instead of computing it from the stored data.

The stored `meshcore_neighbor_info` table actually has what's needed:
- `lastHeardSecs` — the repeater-reported "seconds since heard" *at the time we polled it*.
- `timestamp` — when that poll was stored.

Two bugs combined to produce the always-zero display:
1. `MeshCoreContactDetailPanel.loadStoredNeighbors()` never read `lastHeardSecs` at all — it just wrote a literal `0`.
2. The repository's `getNeighbors()` query (`src/db/repositories/meshcore.ts`) didn't even select the `lastHeardSecs` column, so it wasn't available to the route response in the first place.

(The live "Neighbours" button fetch, via `onGetNeighbours`, was unaffected — it gets a fresh `heardSecondsAgo` directly from the device poll response.)

## Fix

- `src/db/repositories/meshcore.ts`: `getNeighbors()` now selects and returns `lastHeardSecs`.
- `src/components/MeshCore/MeshCoreContactDetailPanel.tsx`: `loadStoredNeighbors()` now computes `heardSecondsAgo = lastHeardSecs + elapsed seconds since the stored poll timestamp`, so the displayed age keeps counting up correctly after the page is opened, rather than freezing at (or hardcoding to) zero.

## Test plan

- [x] Added a regression test in `MeshCoreContactDetailPanel.test.tsx` asserting that a neighbour polled 90s ago with a reported `lastHeardSecs: 30` renders as `2m ago`, not `0s ago`.
- [x] `npx vitest run src/components/MeshCore/MeshCoreContactDetailPanel.test.tsx src/db/repositories/meshcore.test.ts` — 67 passed.
- [x] `npx tsc --noEmit` — no new errors in touched files.
- [x] `npx eslint` on touched files — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VACKoP5364tZwUBEni4rXx)_