### PR TITLE
docs: note known mqtt-proxy TLS field-name bug

### DIFF
--- a/docs/add-ons/mqtt-proxy.md
+++ b/docs/add-ons/mqtt-proxy.md
@@ -222,7 +222,7 @@ The proxy writes a health file at `/tmp/healthy` that Docker uses for health che
 
 - The MQTT Proxy runs inside your Docker network
 - It inherits your node's MQTT credentials (stored on the node)
-- TLS/SSL for MQTT is configured on the node, not the proxy
+- TLS/SSL for MQTT is configured on the node, not the proxy (note: TLS support in the proxy sidecar has a known issue — see [Common Issues](#common-issues))
 - The proxy only forwards messages; it doesn't store or modify them
 
 ## Related Documentation

--- a/docs/add-ons/mqtt-proxy.md
+++ b/docs/add-ons/mqtt-proxy.md
@@ -191,16 +191,11 @@ docker compose logs mqtt-proxy -f
 - Check `HEALTH_CHECK_ACTIVITY_TIMEOUT` setting
 
 #### TLS ignored, proxy connects on port 1883 instead of 8883
-- Known issue in mqtt-proxy v1.6.6: the proxy reads the node's TLS flag as
-  `tlsEnabled`, but the Meshtastic MQTT module config field is `tls_enabled`.
-  Since the attribute is never found, TLS is treated as disabled and the
-  proxy falls back to the default port 1883 even when your broker requires
-  TLS on 8883. This is a bug in the upstream proxy, not in MeshMonitor —
-  MeshMonitor forwards the node's MQTT config to the proxy unchanged, and
-  there is no MeshMonitor-side setting that works around it.
-- Track/report this upstream: [LN4CY/mqtt-proxy issues](https://github.com/LN4CY/mqtt-proxy/issues).
-  If your broker requires TLS, consider the [Embedded MQTT Broker](/features/mqtt-broker)
-  source type instead until the sidecar is fixed.
+- Known issue in mqtt-proxy v1.6.6: the proxy reads the node's TLS flag as `tlsEnabled`, but the Meshtastic MQTT module config field is `tls_enabled`
+- Since the attribute is never found, TLS is treated as disabled and the proxy falls back to port 1883 even when your broker requires TLS on 8883
+- This is a bug in the upstream proxy, not in MeshMonitor — MeshMonitor forwards the node's MQTT config to the proxy unchanged, and there is no MeshMonitor-side setting that works around it
+- Track/report this upstream: [LN4CY/mqtt-proxy issues](https://github.com/LN4CY/mqtt-proxy/issues)
+- If your broker requires TLS, consider the [Embedded MQTT Broker](/features/mqtt-broker) source type instead until the sidecar is fixed
 
 ### Health Status
 

--- a/docs/add-ons/mqtt-proxy.md
+++ b/docs/add-ons/mqtt-proxy.md
@@ -190,6 +190,18 @@ docker compose logs mqtt-proxy -f
 - If your mesh is quiet, the proxy sends periodic probes
 - Check `HEALTH_CHECK_ACTIVITY_TIMEOUT` setting
 
+#### TLS ignored, proxy connects on port 1883 instead of 8883
+- Known issue in mqtt-proxy v1.6.6: the proxy reads the node's TLS flag as
+  `tlsEnabled`, but the Meshtastic MQTT module config field is `tls_enabled`.
+  Since the attribute is never found, TLS is treated as disabled and the
+  proxy falls back to the default port 1883 even when your broker requires
+  TLS on 8883. This is a bug in the upstream proxy, not in MeshMonitor —
+  MeshMonitor forwards the node's MQTT config to the proxy unchanged, and
+  there is no MeshMonitor-side setting that works around it.
+- Track/report this upstream: [LN4CY/mqtt-proxy issues](https://github.com/LN4CY/mqtt-proxy/issues).
+  If your broker requires TLS, consider the [Embedded MQTT Broker](/features/mqtt-broker)
+  source type instead until the sidecar is fixed.
+
 ### Health Status
 
 The proxy writes a health file at `/tmp/healthy` that Docker uses for health checks. The container will restart automatically if the health check fails.


### PR DESCRIPTION
## Summary
- Documents a known TLS-detection bug in the third-party `LN4CY/mqtt-proxy` sidecar (v1.6.6), reported in #4994.
- The proxy's `handlers/mqtt.py` reads the node's TLS flag using the attribute name `tlsEnabled`, but the Meshtastic MQTT module config protobuf field is `tls_enabled`. Since the attribute lookup never matches, the proxy treats TLS as disabled and falls back to port 1883 even when the broker requires TLS on 8883.
- This is a bug in the upstream `LN4CY/mqtt-proxy` project, not in MeshMonitor's own code — MeshMonitor forwards the node's MQTT module config to the proxy unmodified over the Virtual Node TCP interface, and MeshMonitor's own TypeScript code correctly uses `tlsEnabled` (the standard protobufjs camelCase mapping for its own APIs). There is nothing to fix in this repo's code path.
- Added a "Common Issues" entry to `docs/add-ons/mqtt-proxy.md` explaining the bug, noting there's no MeshMonitor-side workaround, linking to the upstream issue tracker, and suggesting the built-in Embedded MQTT Broker as an alternative for users who need TLS today.

## Test plan
- [x] Docs-only change; verified rendered Markdown structure (heading level, list formatting) matches the existing "Common Issues" entries in the same file.

-- Authored by Roger 🤓


---
_Generated by [Claude Code](https://claude.ai/code/session_011GKkAD59owE6V7DeSmsPKy)_