### PR TITLE
fix(mqtt-violations): classify private-broker gateways — stop false-positive violations (#4982)

### DIFF
--- a/docs/features/analysis-reports.md
+++ b/docs/features/analysis-reports.md
@@ -135,13 +135,42 @@ One row per offending gateway, identified by its raw `!hexid` rather than a frie
 resolving names would mean an extra request per source for a cosmetic label, so the report
 doesn't do it. Columns: **Gateway**, **Confirmed** violation count, **Suspected** count (only
 shown when the unproven toggle is on), distinct **Originators** affected, which **Sources** saw
-the gateway, and **First seen** / **Last seen** timestamps. The table is sortable by gateway,
-confirmed count, originators, and last seen, and paginated.
+the gateway, a **Broker** badge (see below), and **First seen** / **Last seen** timestamps. The
+table is sortable by gateway, confirmed count, originators, and last seen, and paginated.
+
+### Private-broker false positives
+
+Meshtastic firmware only drops a relayed packet whose `ok_to_mqtt` bit is clear when the
+gateway's configured broker is a **public** address — a broker on a private network
+(`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `100.64.0.0/10`, or
+`127.0.0.1` exactly) relays every packet regardless of the bit, by design. Firmware also
+essentially never enforced this drop at all, on any broker, before version 2.7.20.
+
+Because MeshMonitor sees the relay either way, every row here used to look like the same kind of
+violation whether the gateway's broker was private (expected), public (a real violation), or
+unknowable (a hostname-configured broker, which can't be classified from the address string
+alone). Each row and gateway is now badged with what can actually be determined about the
+**observing source's** configured broker:
+
+- **Expected — private broker**: every source that saw this gateway relay the packet is
+  configured against a literal private address. Not a violation — this is firmware behaving
+  correctly.
+- **Confirmed — public broker**: at least one observing source is the public default server or
+  another literal non-private address. No legitimate reason for that broker to have relayed an
+  opted-out packet — this is a genuine violation.
+- **Unverified — hostname broker**: at least one observing source is configured with a hostname
+  rather than a literal IP, which MeshMonitor can't classify from the address string the way
+  firmware's own address parser can't either. Not proven either way.
+
+A **Hide expected (private broker)** filter on the report hides the `Expected` rows and updates
+the on-screen counts accordingly; it's a client-side toggle over already-loaded results, so it
+takes effect immediately without re-running the scan.
 
 ### Drill-down
 
 Click a gateway row to expand it into that gateway's individual violating packets — time,
-source, originator, channel, port, packet ID, bitfield, and MQTT topic — sortable and paginated
+source, originator, channel, port, packet ID, bitfield, MQTT topic, and the same **Broker**
+badge described above (per-packet, not combined across sources) — sortable and paginated
 independently of the summary table.
 
 ### Result caps

--- a/docs/features/packet-monitor.md
+++ b/docs/features/packet-monitor.md
@@ -208,6 +208,15 @@ deliberate attempt to bypass a node's opt-out. Treat a violation as a configurat
 flagging to the gateway operator, not as evidence of hostile intent.
 :::
 
+The other side of that same private-broker check also produces **false positives**, not just
+missed detections: when the gateway's broker genuinely *is* private, firmware skips the drop
+entirely and relays every packet regardless of the `ok_to_mqtt` bit — by design, not a bug. Every
+row MeshMonitor records still looks the same at capture time (a relayed opt-out), so the
+**ok_to_mqtt Violations** report annotates each one with what can be determined about the
+*observing source's* own configured broker (private / public / unverified) so an expected
+private-broker relay isn't mistaken for a confirmed violation. See [Private-broker false
+positives](/features/analysis-reports#private-broker-false-positives) for details.
+
 #### Settings
 
 Violation detection is controlled by three settings, all with working defaults out of the box —

--- a/src/components/Analysis/MqttViolationsReport.module.css
+++ b/src/components/Analysis/MqttViolationsReport.module.css
@@ -133,3 +133,53 @@
   cursor: pointer;
   color: inherit;
 }
+
+/* Broker-class badge (#4982) — see BrokerClassBadge in MqttViolationsReport.tsx.
+ * Three tones mirroring BrokerClassTone ('ok' | 'warn' | 'neutral'); 'neutral'
+ * has no shared `.reports-pill--*` equivalent so it's defined here rather
+ * than added to the frozen-by-convention shared sheet. */
+.brokerBadge {
+  display: inline-block;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.brokerBadgeOk {
+  background: color-mix(in srgb, var(--color-success) 18%, transparent);
+  color: var(--color-success);
+}
+
+.brokerBadgeWarn {
+  background: color-mix(in srgb, var(--color-error) 18%, transparent);
+  color: var(--color-error);
+}
+
+.brokerBadgeNeutral {
+  background: color-mix(in srgb, var(--color-text-subtle) 18%, transparent);
+  color: var(--color-text-subtle);
+}
+
+.brokerCell {
+  white-space: nowrap;
+}
+
+.brokerFilterField {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.brokerBanner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.brokerBannerList {
+  margin: 0;
+  padding-left: 1.1rem;
+}

--- a/src/components/Analysis/MqttViolationsReport.test.tsx
+++ b/src/components/Analysis/MqttViolationsReport.test.tsx
@@ -825,7 +825,7 @@ describe('MqttViolationsReport', () => {
     expect(mimeType).toBe('text/csv');
     // Name columns sit next to the id they describe, which shifts every later
     // column's position — intentional, see GATEWAY_CSV_COLUMNS.
-    expect(csv.split('\r\n')[0]).toBe('Gateway ID,Gateway Node Num,Gateway Long Name,Gateway Short Name,Violation Count,Suspected Count,Distinct Originators,Source IDs,First Seen,Last Seen');
+    expect(csv.split('\r\n')[0]).toBe('Gateway ID,Gateway Node Num,Gateway Long Name,Gateway Short Name,Violation Count,Suspected Count,Distinct Originators,Source IDs,Broker Class,First Seen,Last Seen');
     expect(csv).toContain('!00000000');
   });
 
@@ -1246,5 +1246,152 @@ describe('MqttViolationsReport', () => {
       // ...and its id remains available beneath the name.
       expect(screen.getByText('!11223344')).toBeInTheDocument();
     });
+  });
+});
+
+// ── #4982: private-broker false-positive annotation ────────────────────────
+describe('MqttViolationsReport — broker classification (#4982)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('badges each gateway row with its brokerClass label', async () => {
+    const user = userEvent.setup();
+    routeApiGet(
+      () =>
+        baseResponse({
+          gateways: [
+            gatewayRow({ gatewayId: '!11111111', brokerClass: 'private' }),
+            gatewayRow({ gatewayId: '!22222222', brokerClass: 'public' }),
+            gatewayRow({ gatewayId: '!33333333', brokerClass: 'unknown' }),
+          ],
+          total: 3,
+        }),
+      () => packetsResponse({ violations: [], total: 0 }),
+    );
+    renderReport();
+    await user.click(screen.getByRole('button', { name: /Run report/i }));
+
+    expect(await screen.findByText('Expected — private broker')).toBeInTheDocument();
+    expect(screen.getByText('Confirmed — public broker')).toBeInTheDocument();
+    expect(screen.getByText('Unverified — hostname broker')).toBeInTheDocument();
+  });
+
+  it('shows the non-dismissible explanatory banner whenever there are results', async () => {
+    const user = userEvent.setup();
+    routeApiGet(
+      () => baseResponse({ gateways: [gatewayRow({ brokerClass: 'public' })], total: 1 }),
+      () => packetsResponse({ violations: [], total: 0 }),
+    );
+    renderReport();
+    await user.click(screen.getByRole('button', { name: /Run report/i }));
+
+    expect(
+      await screen.findByText('Not every relay here is a proven violation'),
+    ).toBeInTheDocument();
+    // No dismiss/close control on this banner — it's explanatory, not a warning to ack.
+    expect(
+      screen.queryByRole('button', { name: /dismiss/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('"Hide expected" filter hides private-broker rows and updates the visible stats, without an extra fetch', async () => {
+    const user = userEvent.setup();
+    routeApiGet(
+      () =>
+        baseResponse({
+          gateways: [
+            gatewayRow({
+              gatewayId: '!11111111',
+              brokerClass: 'private',
+              violationCount: 5,
+            }),
+            gatewayRow({
+              gatewayId: '!22222222',
+              brokerClass: 'public',
+              violationCount: 3,
+            }),
+          ],
+          total: 2,
+        }),
+      () => packetsResponse({ violations: [], total: 0 }),
+    );
+    const { container } = renderReport();
+    await user.click(screen.getByRole('button', { name: /Run report/i }));
+    await screen.findByText('!11111111');
+    expect(screen.getByText('!22222222')).toBeInTheDocument();
+    expect(api.get).toHaveBeenCalledTimes(1);
+
+    const statValues = () =>
+      Array.from(container.querySelectorAll('.reports-stat__value')).map((el) => el.textContent);
+    // Before filtering: Gateways=2, Confirmed=8 (5+3), Originators=4 (2+2).
+    expect(statValues()).toEqual(['2', '8', '4']);
+
+    await user.click(
+      screen.getByRole('checkbox', { name: /Hide expected \(private broker\)/i }),
+    );
+
+    // Purely client-side — no second request fired by toggling the filter.
+    expect(api.get).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('!11111111')).not.toBeInTheDocument();
+    expect(screen.getByText('!22222222')).toBeInTheDocument();
+    // "Gateways" stays the server total (unaffected); Confirmed/Originators
+    // now sum only the visible (public) row: violationCount 3, originators 2.
+    expect(statValues()).toEqual(['2', '3', '2']);
+
+    // Toggling back off restores the hidden row.
+    await user.click(
+      screen.getByRole('checkbox', { name: /Hide expected \(private broker\)/i }),
+    );
+    expect(screen.getByText('!11111111')).toBeInTheDocument();
+    expect(statValues()).toEqual(['2', '8', '4']);
+  });
+
+  it('shows an explanatory empty row when the filter hides every row on the page', async () => {
+    const user = userEvent.setup();
+    routeApiGet(
+      () =>
+        baseResponse({
+          gateways: [gatewayRow({ gatewayId: '!11111111', brokerClass: 'private' })],
+          total: 1,
+        }),
+      () => packetsResponse({ violations: [], total: 0 }),
+    );
+    renderReport();
+    await user.click(screen.getByRole('button', { name: /Run report/i }));
+    await screen.findByText('!11111111');
+
+    await user.click(
+      screen.getByRole('checkbox', { name: /Hide expected \(private broker\)/i }),
+    );
+
+    expect(screen.queryByText('!11111111')).not.toBeInTheDocument();
+    expect(
+      await screen.findByText(/Every gateway on this page is a private-broker relay hidden/i),
+    ).toBeInTheDocument();
+  });
+
+  it('drill-down packet rows are badged with their own brokerClass', async () => {
+    const user = userEvent.setup();
+    routeApiGet(
+      // Gateway row itself is 'unknown' so its own badge can't collide with
+      // the drill-down packet rows' 'private'/'public' badges below.
+      () => baseResponse({ gateways: [gatewayRow({ brokerClass: 'unknown' })], total: 1 }),
+      () =>
+        packetsResponse({
+          violations: [
+            packetRow({ id: 1, packetId: 1, sourceId: 'mqtt-private', brokerClass: 'private' }),
+            packetRow({ id: 2, packetId: 2, sourceId: 'mqtt-public', brokerClass: 'public' }),
+          ],
+          total: 2,
+        }),
+    );
+    renderReport();
+    await user.click(screen.getByRole('button', { name: /Run report/i }));
+    const row = (await screen.findByText('!433e0f28')).closest('tr')!;
+    await user.click(row);
+
+    expect(await screen.findByText('Expected — private broker')).toBeInTheDocument();
+    expect(screen.getByText('Confirmed — public broker')).toBeInTheDocument();
   });
 });

--- a/src/components/Analysis/MqttViolationsReport.tsx
+++ b/src/components/Analysis/MqttViolationsReport.tsx
@@ -49,14 +49,17 @@ import '../MQTT/MqttPacketMonitor.css';
 import {
   API_SCAN_CAP,
   DEFAULT_VIOLATION_FILTERS,
+  brokerClassMeta,
   buildViolationParams,
   formatNodeDisplay,
   formatSuspectedWindow,
+  type BrokerAddressClass,
   type SortDir,
   type ViolationFilters,
   type ViolationGatewayRow,
   type ViolationGatewaySortField,
   type ViolationGatewaysResponse,
+  type ViolationPacketRow,
   type ViolationPacketSortField,
   type ViolationPacketsResponse,
 } from './mqttViolationTypes';
@@ -189,6 +192,12 @@ const MqttViolationsReport: React.FC = () => {
   const [gatewayExportPending, setGatewayExportPending] = useState(false);
   const [drillExportWarning, setDrillExportWarning] = useState<string | null>(null);
   const [drillExportPending, setDrillExportPending] = useState(false);
+  // Pure client-side render filter (#4982) — never sent to the server (not
+  // part of ViolationFilters/buildViolationParams), applies immediately like
+  // sort/page/page-size. Hides rows the server already annotated as
+  // brokerClass 'private': relays that are EXPECTED per firmware's
+  // private-broker exemption, not proven violations.
+  const [hidePrivateBroker, setHidePrivateBroker] = useState(false);
 
   const { data, isLoading, error, refetch } = useQuery<ViolationGatewaysResponse>({
     queryKey: ['mqtt-violations-gateways', applied],
@@ -210,6 +219,16 @@ const MqttViolationsReport: React.FC = () => {
   // every render (whenever `data` is undefined), which react-hooks/exhaustive-deps
   // correctly flags as unstable when used as a dependency below.
   const gateways = useMemo(() => data?.gateways ?? [], [data]);
+
+  // #4982: the rows actually rendered/summed — `gateways` minus any hidden by
+  // hidePrivateBroker. Deliberately NOT what pagination/totals are based on
+  // (those stay server-truth from `data`, unaffected by this client-only
+  // filter) — see the hiddenPrivateGatewayCount hint rendered alongside it.
+  const visibleGateways = useMemo(
+    () => (hidePrivateBroker ? gateways.filter((g) => g.brokerClass !== 'private') : gateways),
+    [gateways, hidePrivateBroker],
+  );
+  const hiddenPrivateGatewayCount = gateways.length - visibleGateways.length;
 
   // The one gateway currently expanded, if any — looked up by the same key
   // the row map uses, so the drill-down query always scopes to the actual
@@ -410,13 +429,17 @@ const MqttViolationsReport: React.FC = () => {
         ? t('analysis.mqtt_violations.window_days', '{{days}} days', { days: windowFmt.days })
         : '';
 
-  const columnCount = 7 + (suspectedShown ? 1 : 0);
+  // +1 for the Broker column (#4982), always present regardless of suspectedShown.
+  const columnCount = 8 + (suspectedShown ? 1 : 0);
 
+  // #4982: sums reflect what's actually visible (i.e. respect hidePrivateBroker),
+  // same page-scoped-not-global-total convention this block already used before
+  // brokerClass existed — only `gatewayCount` below is the server's true total.
   const stats = {
     gatewayCount: data?.total ?? 0,
-    confirmed: gateways.reduce((sum, g) => sum + g.violationCount, 0),
-    suspected: gateways.reduce((sum, g) => sum + g.suspectedCount, 0),
-    originators: gateways.reduce((sum, g) => sum + g.distinctOriginators, 0),
+    confirmed: visibleGateways.reduce((sum, g) => sum + g.violationCount, 0),
+    suspected: visibleGateways.reduce((sum, g) => sum + g.suspectedCount, 0),
+    originators: visibleGateways.reduce((sum, g) => sum + g.distinctOriginators, 0),
   };
 
   const confirmedColTitle = t(
@@ -444,6 +467,12 @@ const MqttViolationsReport: React.FC = () => {
     ? Math.floor(packetsQuery.data.offset / drillLimit) + 1
     : 1;
   const drillViolations = packetsQuery.data?.violations ?? [];
+  // #4982: same client-only filter as the summary table, applied to the
+  // drill-down's own rows.
+  const visibleDrillViolations = hidePrivateBroker
+    ? drillViolations.filter((v: ViolationPacketRow) => v.brokerClass !== 'private')
+    : drillViolations;
+  const hiddenPrivateDrillCount = drillViolations.length - visibleDrillViolations.length;
   const drillHasData = drillViolations.length > 0;
 
   return (
@@ -531,6 +560,24 @@ const MqttViolationsReport: React.FC = () => {
             {t(
               'analysis.mqtt_violations.include_unknown_help',
               'Also count receptions where the ok_to_mqtt bit could not be read. These are not proven violations and come from a much shorter retention window.',
+            )}
+          </span>
+
+          <label className={`reports-controls__field ${styles.brokerFilterField}`}>
+            <input
+              type="checkbox"
+              checked={hidePrivateBroker}
+              onChange={(e) => setHidePrivateBroker(e.target.checked)}
+            />
+            {t(
+              'analysis.mqtt_violations.hide_private_broker',
+              'Hide expected (private broker)',
+            )}
+          </label>
+          <span className={styles.hint}>
+            {t(
+              'analysis.mqtt_violations.hide_private_broker_help',
+              "Hide rows where every observing source is configured with a private broker — firmware relays those regardless of ok_to_mqtt, by design. Applies immediately; doesn't need Run report.",
             )}
           </span>
 
@@ -664,6 +711,46 @@ const MqttViolationsReport: React.FC = () => {
       )}
 
       {run && !isLoading && !error && data && hasData && (
+        <div className={`reports-banner ${styles.brokerBanner}`}>
+          <strong>
+            {t(
+              'analysis.mqtt_violations.broker_banner_title',
+              'Not every relay here is a proven violation',
+            )}
+          </strong>
+          <ul className={styles.brokerBannerList}>
+            <li>
+              {t(
+                'analysis.mqtt_violations.broker_banner_private',
+                'Firmware only drops an ok_to_mqtt=0 packet when uplinking to a PUBLIC broker. A gateway whose broker is a private address (10/8, 172.16/12, 192.168/16, 169.254/16, 100.64/10, or 127.0.0.1 exactly) relays every packet regardless of the bit — that is expected behavior, not a violation, and is badged "Expected — private broker" below.',
+              )}
+            </li>
+            <li>
+              {t(
+                'analysis.mqtt_violations.broker_banner_hostname',
+                "A source configured with a hostname (rather than a literal IP) can't be classified from the address string alone, so those rows are badged \"Unverified — hostname broker\" — not proven either way.",
+              )}
+            </li>
+            <li>
+              {t(
+                'analysis.mqtt_violations.broker_banner_old_firmware',
+                'Firmware before 2.7.20 essentially never enforced this drop at all, on any broker — a relay from an old-firmware gateway can look like a violation here even on a public broker.',
+              )}
+            </li>
+          </ul>
+          {hiddenPrivateGatewayCount > 0 && (
+            <span className={styles.hint}>
+              {t(
+                'analysis.mqtt_violations.broker_banner_hidden_count',
+                '{{count}} private-broker gateway(s) hidden on this page by the "Hide expected" filter.',
+                { count: hiddenPrivateGatewayCount },
+              )}
+            </span>
+          )}
+        </div>
+      )}
+
+      {run && !isLoading && !error && data && hasData && (
         <>
           {capApplied && (
             <div className="reports-banner reports-banner--warning">
@@ -738,6 +825,7 @@ const MqttViolationsReport: React.FC = () => {
                     t={t}
                   />
                   <th>{t('analysis.mqtt_violations.col_sources', 'Sources')}</th>
+                  <th>{t('analysis.mqtt_violations.col_broker', 'Broker')}</th>
                   <th>{t('analysis.mqtt_violations.col_first_seen', 'First seen')}</th>
                   <SortableTh
                     label={t('analysis.mqtt_violations.col_last_seen', 'Last seen')}
@@ -749,7 +837,17 @@ const MqttViolationsReport: React.FC = () => {
                 </tr>
               </thead>
               <tbody>
-                {gateways.map((row) => {
+                {visibleGateways.length === 0 && hiddenPrivateGatewayCount > 0 && (
+                  <tr>
+                    <td colSpan={columnCount} className="reports-banner--empty">
+                      {t(
+                        'analysis.mqtt_violations.all_hidden_by_filter',
+                        'Every gateway on this page is a private-broker relay hidden by the "Hide expected" filter.',
+                      )}
+                    </td>
+                  </tr>
+                )}
+                {visibleGateways.map((row) => {
                   const rowKey = rowKeyOf(row);
                   const isExpanded = expandedGateway === rowKey;
                   const isSuspectedOnly = row.violationCount === 0 && row.suspectedCount > 0;
@@ -835,6 +933,9 @@ const MqttViolationsReport: React.FC = () => {
                                   '{{count}} sources',
                                   { count: row.sourceIds.length },
                                 )}
+                        </td>
+                        <td className={styles.brokerCell}>
+                          <BrokerClassBadge brokerClass={row.brokerClass} t={t} />
                         </td>
                         <td>{new Date(row.firstSeen).toLocaleString()}</td>
                         <td>{new Date(row.lastSeen).toLocaleString()}</td>
@@ -983,10 +1084,21 @@ const MqttViolationsReport: React.FC = () => {
                                             <th>
                                               {t('analysis.mqtt_violations.dcol_rx_time', 'RX time')}
                                             </th>
+                                            <th>{t('analysis.mqtt_violations.col_broker', 'Broker')}</th>
                                           </tr>
                                         </thead>
                                         <tbody>
-                                          {drillViolations.map((v) => {
+                                          {visibleDrillViolations.length === 0 && hiddenPrivateDrillCount > 0 && (
+                                            <tr>
+                                              <td colSpan={11} className="reports-banner--empty">
+                                                {t(
+                                                  'analysis.mqtt_violations.all_hidden_by_filter',
+                                                  'Every gateway on this page is a private-broker relay hidden by the "Hide expected" filter.',
+                                                )}
+                                              </td>
+                                            </tr>
+                                          )}
+                                          {visibleDrillViolations.map((v) => {
                                             const vState = okToMqttState({
                                               okToMqttViolation: v.kind === 'confirmed' ? 1 : 0,
                                               bitfield: v.bitfield,
@@ -1028,6 +1140,9 @@ const MqttViolationsReport: React.FC = () => {
                                                 </td>
                                                 <td>
                                                   {v.rxTime ? new Date(v.rxTime).toLocaleString() : '—'}
+                                                </td>
+                                                <td className={styles.brokerCell}>
+                                                  <BrokerClassBadge brokerClass={v.brokerClass} t={t} />
                                                 </td>
                                               </tr>
                                             );
@@ -1178,6 +1293,32 @@ const SortableTh: React.FC<{
         )}
       </button>
     </th>
+  );
+};
+
+/**
+ * Badge for a row/gateway's {@link BrokerAddressClass} (#4982). Pure
+ * presentation over `brokerClassMeta` — translates its keys/fallbacks and
+ * maps `tone` to the matching CSS module class.
+ */
+const BrokerClassBadge: React.FC<{ brokerClass: BrokerAddressClass; t: TFn }> = ({
+  brokerClass,
+  t,
+}) => {
+  const meta = brokerClassMeta(brokerClass);
+  const toneClass =
+    meta.tone === 'ok'
+      ? styles.brokerBadgeOk
+      : meta.tone === 'warn'
+        ? styles.brokerBadgeWarn
+        : styles.brokerBadgeNeutral;
+  return (
+    <span
+      className={`${styles.brokerBadge} ${toneClass}`}
+      title={t(meta.descriptionKey, meta.descriptionFallback)}
+    >
+      {t(meta.labelKey, meta.labelFallback)}
+    </span>
   );
 };
 

--- a/src/components/Analysis/mqttBrokerClassMeta.test.ts
+++ b/src/components/Analysis/mqttBrokerClassMeta.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { brokerClassMeta, type BrokerAddressClass } from './mqttViolationTypes';
+
+describe('brokerClassMeta', () => {
+  it('private -> ok tone, "Expected — private broker"', () => {
+    const meta = brokerClassMeta('private');
+    expect(meta.tone).toBe('ok');
+    expect(meta.labelFallback).toBe('Expected — private broker');
+    expect(meta.labelKey).toBe('analysis.mqtt_violations.broker_private');
+    expect(meta.descriptionFallback.length).toBeGreaterThan(0);
+  });
+
+  it('public -> warn tone, "Confirmed — public broker"', () => {
+    const meta = brokerClassMeta('public');
+    expect(meta.tone).toBe('warn');
+    expect(meta.labelFallback).toBe('Confirmed — public broker');
+    expect(meta.labelKey).toBe('analysis.mqtt_violations.broker_public');
+  });
+
+  it('unknown -> neutral tone, "Unverified — hostname broker"', () => {
+    const meta = brokerClassMeta('unknown');
+    expect(meta.tone).toBe('neutral');
+    expect(meta.labelFallback).toBe('Unverified — hostname broker');
+    expect(meta.labelKey).toBe('analysis.mqtt_violations.broker_unknown');
+  });
+
+  it('every class has a distinct labelKey/descriptionKey pair', () => {
+    const classes: BrokerAddressClass[] = ['private', 'public', 'unknown'];
+    const labelKeys = new Set(classes.map((c) => brokerClassMeta(c).labelKey));
+    const descKeys = new Set(classes.map((c) => brokerClassMeta(c).descriptionKey));
+    expect(labelKeys.size).toBe(3);
+    expect(descKeys.size).toBe(3);
+  });
+});

--- a/src/components/Analysis/mqttViolationTypes.ts
+++ b/src/components/Analysis/mqttViolationTypes.ts
@@ -10,6 +10,23 @@ export type ViolationGatewaySortField =
 export type ViolationPacketSortField = 'timestamp' | 'fromNode' | 'gatewayId';
 export type SortDir = 'asc' | 'desc';
 
+/**
+ * Classification of the observing MQTT source's configured broker address
+ * (#4982), mirrored from `src/server/utils/privateBrokerAddress.ts`.
+ *
+ * Firmware only gates the `ok_to_mqtt` drop on a PUBLIC broker — a private
+ * broker relays every packet regardless of the bit, by design. So:
+ *  - `'private'` — every source that observed this row is a literal private
+ *    IPv4 (or 127.0.0.1 exactly). The relay is EXPECTED, not a violation.
+ *  - `'public'` — at least one observing source is the public default
+ *    server or another literal non-private IPv4. Confirmed: no legitimate
+ *    reason for that broker to have relayed this packet.
+ *  - `'unknown'` — at least one observing source is configured with a
+ *    hostname (or IPv6), which firmware can't classify deterministically
+ *    from the address string alone. Not proven either way.
+ */
+export type BrokerAddressClass = 'private' | 'public' | 'unknown';
+
 export interface ViolationGatewayRow {
   gatewayId: string | null;
   gatewayNodeNum: number | null;
@@ -26,6 +43,8 @@ export interface ViolationGatewayRow {
   sourceIds: string[];
   firstSeen: number;
   lastSeen: number;
+  /** See {@link BrokerAddressClass}. Combined across every source in `sourceIds`. */
+  brokerClass: BrokerAddressClass;
 }
 
 export interface ViolationPacketRow {
@@ -49,6 +68,8 @@ export interface ViolationPacketRow {
   topic: string | null;
   rxTime: number | null;
   timestamp: number;
+  /** See {@link BrokerAddressClass}. This row's own `sourceId` only — no combining. */
+  brokerClass: BrokerAddressClass;
 }
 
 /** Common tail present on BOTH responses. */
@@ -230,6 +251,56 @@ export function formatNodeDisplay(
     secondary: ref || (num != null ? String(num) : null),
     title: titleParts.join(' '),
   };
+}
+
+/** Visual/semantic weight for a {@link BrokerAddressClass} badge — see {@link brokerClassMeta}. */
+export type BrokerClassTone = 'ok' | 'warn' | 'neutral';
+
+/** i18n key + fallback pair, translated by the caller via `t(key, fallback)`. */
+export interface BrokerClassMeta {
+  tone: BrokerClassTone;
+  labelKey: string;
+  labelFallback: string;
+  descriptionKey: string;
+  descriptionFallback: string;
+}
+
+/**
+ * Badge copy + tone for a {@link BrokerAddressClass} (#4982). Pure — returns
+ * i18n keys/fallbacks for the caller to translate, never a translated string
+ * itself, so it stays testable without a react-i18next context.
+ */
+export function brokerClassMeta(cls: BrokerAddressClass): BrokerClassMeta {
+  switch (cls) {
+    case 'private':
+      return {
+        tone: 'ok',
+        labelKey: 'analysis.mqtt_violations.broker_private',
+        labelFallback: 'Expected — private broker',
+        descriptionKey: 'analysis.mqtt_violations.broker_private_desc',
+        descriptionFallback:
+          "This gateway was only observed via source(s) configured with a private broker address. Firmware only drops ok_to_mqtt=0 packets when uplinking to a PUBLIC broker — a private broker relays every packet by design, so this is expected, not a violation.",
+      };
+    case 'public':
+      return {
+        tone: 'warn',
+        labelKey: 'analysis.mqtt_violations.broker_public',
+        labelFallback: 'Confirmed — public broker',
+        descriptionKey: 'analysis.mqtt_violations.broker_public_desc',
+        descriptionFallback:
+          'At least one observing source is configured with a public broker address (the default server, or another non-private address). Firmware should have dropped this ok_to_mqtt=0 packet there, so this relay is a genuine violation.',
+      };
+    case 'unknown':
+    default:
+      return {
+        tone: 'neutral',
+        labelKey: 'analysis.mqtt_violations.broker_unknown',
+        labelFallback: 'Unverified — hostname broker',
+        descriptionKey: 'analysis.mqtt_violations.broker_unknown_desc',
+        descriptionFallback:
+          "At least one observing source is configured with a hostname (or another address MeshMonitor can't classify from the string alone). It may or may not resolve to a private address, so this relay is not proven either way.",
+      };
+  }
 }
 
 /**

--- a/src/components/Analysis/mqttViolationsCsv.test.ts
+++ b/src/components/Analysis/mqttViolationsCsv.test.ts
@@ -20,6 +20,7 @@ function gatewayRow(overrides: Partial<ViolationGatewayRow> = {}): ViolationGate
     sourceIds: ['mqtt-a'],
     firstSeen: 1753300000000,
     lastSeen: 1753386400000,
+    brokerClass: 'unknown',
     ...overrides,
   };
 }
@@ -41,6 +42,7 @@ function packetRow(overrides: Partial<ViolationPacketRow> = {}): ViolationPacket
     topic: 'msh/US/2/e/LongFast/!433e0f28',
     rxTime: 1753386400,
     timestamp: 1753386400000,
+    brokerClass: 'unknown',
     ...overrides,
   };
 }
@@ -97,6 +99,14 @@ describe('mqttViolationsCsv', () => {
       expect(zeroCells[firstSeenIdx]).toBe('');
       expect(zeroCells[lastSeenIdx]).toBe('');
     });
+
+    it('#4982: emits brokerClass as its own column', () => {
+      const csv = buildGatewaysCsv([gatewayRow({ brokerClass: 'private' })]);
+      const cells = csv.split('\r\n')[1].split(',');
+      const idx = GATEWAY_CSV_COLUMNS.findIndex((c) => c.key === 'brokerClass');
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(cells[idx]).toBe('private');
+    });
   });
 
   describe('buildPacketsCsv', () => {
@@ -117,6 +127,14 @@ describe('mqttViolationsCsv', () => {
       const rxTimeIdx = PACKET_CSV_COLUMNS.findIndex((c) => c.key === 'rxTime');
       expect(cells[timestampIdx]).toBe(new Date(1753386400000).toISOString());
       expect(cells[rxTimeIdx]).toBe('');
+    });
+
+    it('#4982: emits brokerClass as its own column', () => {
+      const csv = buildPacketsCsv([packetRow({ brokerClass: 'public' })]);
+      const cells = csv.split('\r\n')[1].split(',');
+      const idx = PACKET_CSV_COLUMNS.findIndex((c) => c.key === 'brokerClass');
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(cells[idx]).toBe('public');
     });
   });
 

--- a/src/components/Analysis/mqttViolationsCsv.ts
+++ b/src/components/Analysis/mqttViolationsCsv.ts
@@ -22,6 +22,11 @@ export const GATEWAY_CSV_COLUMNS: ReadonlyArray<{ key: string; label: string }> 
   { key: 'suspectedCount', label: 'Suspected Count' },
   { key: 'distinctOriginators', label: 'Distinct Originators' },
   { key: 'sourceIds', label: 'Source IDs' },
+  // See ViolationGatewayRow.brokerClass (#4982) — 'private' means every
+  // observing source's broker is private (expected relay, not a proven
+  // violation); 'public' means at least one is public (confirmed); 'unknown'
+  // means at least one is a hostname MeshMonitor can't classify.
+  { key: 'brokerClass', label: 'Broker Class' },
   { key: 'firstSeen', label: 'First Seen' },
   { key: 'lastSeen', label: 'Last Seen' },
 ];
@@ -43,6 +48,8 @@ export const PACKET_CSV_COLUMNS: ReadonlyArray<{ key: string; label: string }> =
   { key: 'portnum', label: 'Port Num' },
   { key: 'portnumName', label: 'Port Num Name' },
   { key: 'bitfield', label: 'Bitfield' },
+  // See ViolationPacketRow.brokerClass (#4982) — this row's own sourceId only.
+  { key: 'brokerClass', label: 'Broker Class' },
   { key: 'topic', label: 'Topic' },
   { key: 'rxTime', label: 'RX Time' },
 ];
@@ -76,6 +83,7 @@ export function buildGatewaysCsv(rows: ViolationGatewayRow[]): string {
       formatCell(row.suspectedCount),
       formatCell(row.distinctOriginators),
       row.sourceIds.join('; '),
+      formatCell(row.brokerClass),
       formatMs(row.firstSeen),
       formatMs(row.lastSeen),
     ]),
@@ -104,6 +112,7 @@ export function buildPacketsCsv(rows: ViolationPacketRow[]): string {
       formatCell(row.portnum),
       formatCell(row.portnumName),
       formatCell(row.bitfield),
+      formatCell(row.brokerClass),
       formatCell(row.topic),
       formatMs(row.rxTime),
     ]),

--- a/src/server/routes/analysisRoutes.mqttViolations.test.ts
+++ b/src/server/routes/analysisRoutes.mqttViolations.test.ts
@@ -651,3 +651,201 @@ describe('analysisRoutes — GET /mqtt-violations/packets — pagination beyond 
     expect(res.body.data.scanCap).toBe(2000);
   });
 });
+
+// ── #4982: broker-class annotation ──────────────────────────────────────────
+//
+// Private-broker gateways upload ok_to_mqtt=0 packets BY DESIGN (firmware
+// only gates the drop on public brokers) — these tests prove the response
+// annotates each row/gateway with the observing source's brokerClass instead
+// of reporting every relay identically as a "violation". Three extra MQTT
+// sources (private / public / hostname-configured) are seeded on top of the
+// harness's plain `meshtastic_tcp` sourceA/sourceB, which stay 'unknown'
+// (they have no broker of their own) — see the "non-MQTT source" case below.
+describe('analysisRoutes — GET /mqtt-violations/gateways & /packets — broker classification (#4982)', () => {
+  let harness: RouteTestHarness;
+  const SOURCE_PRIVATE = 'rt-source-mqtt-private';
+  const SOURCE_PUBLIC = 'rt-source-mqtt-public';
+  const SOURCE_HOSTNAME = 'rt-source-mqtt-hostname';
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({ mount: (app) => app.use('/', analysisRoutes) });
+
+    for (const id of [SOURCE_PRIVATE, SOURCE_PUBLIC, SOURCE_HOSTNAME]) {
+      await harness.db.sources.deleteSource(id).catch(() => {});
+    }
+    await harness.db.sources.createSource({
+      id: SOURCE_PRIVATE,
+      name: 'MQTT bridge — private broker',
+      type: 'mqtt_bridge',
+      config: { upstream: { url: 'mqtt://192.168.1.5:1883' }, subscriptions: [] },
+      enabled: true,
+    });
+    await harness.db.sources.createSource({
+      id: SOURCE_PUBLIC,
+      name: 'MQTT bridge — public broker',
+      type: 'mqtt_bridge',
+      config: { upstream: { url: 'mqtt://mqtt.meshtastic.org' }, subscriptions: [] },
+      enabled: true,
+    });
+    await harness.db.sources.createSource({
+      id: SOURCE_HOSTNAME,
+      name: 'MQTT bridge — hostname broker',
+      type: 'mqtt_bridge',
+      config: { upstream: { url: 'mqtt://mqtt.example.com' }, subscriptions: [] },
+      enabled: true,
+    });
+
+    await harness.grant(harness.admin.id, 'packetmonitor', 'read', SOURCE_PRIVATE);
+    await harness.grant(harness.admin.id, 'packetmonitor', 'read', SOURCE_PUBLIC);
+    await harness.grant(harness.admin.id, 'packetmonitor', 'read', SOURCE_HOSTNAME);
+
+    // sourceA (plain meshtastic_tcp, no broker of its own): gateway !aaaaaaaa.
+    await harness.db.mqttOkToMqttViolations.insertViolation(
+      makeViolation({
+        sourceId: harness.sourceA,
+        packetId: 5001,
+        gatewayId: '!aaaaaaaa',
+        gatewayNodeNum: 0xaaaaaaaa,
+        timestamp: T0,
+      }),
+    );
+    // Private broker: gateway !bbbbbbbb, seen ONLY on the private source.
+    await harness.db.mqttOkToMqttViolations.insertViolation(
+      makeViolation({
+        sourceId: SOURCE_PRIVATE,
+        packetId: 5002,
+        gatewayId: '!bbbbbbbb',
+        gatewayNodeNum: 0xbbbbbbbb,
+        timestamp: T0,
+      }),
+    );
+    // Public broker: gateway !cccccccc, seen ONLY on the public source.
+    await harness.db.mqttOkToMqttViolations.insertViolation(
+      makeViolation({
+        sourceId: SOURCE_PUBLIC,
+        packetId: 5003,
+        gatewayId: '!cccccccc',
+        gatewayNodeNum: 0xcccccccc,
+        timestamp: T0,
+      }),
+    );
+    // Hostname broker (unclassifiable): gateway !dddddddd.
+    await harness.db.mqttOkToMqttViolations.insertViolation(
+      makeViolation({
+        sourceId: SOURCE_HOSTNAME,
+        packetId: 5004,
+        gatewayId: '!dddddddd',
+        gatewayNodeNum: 0xdddddddd,
+        timestamp: T0,
+      }),
+    );
+    // Same gatewayId relayed via BOTH the private and the public source —
+    // combineBrokerClasses must resolve this to 'public' (any public wins).
+    await harness.db.mqttOkToMqttViolations.insertViolation(
+      makeViolation({
+        sourceId: SOURCE_PRIVATE,
+        packetId: 5005,
+        gatewayId: '!eeeeeeee',
+        gatewayNodeNum: 0xeeeeeeee,
+        timestamp: T0,
+      }),
+    );
+    await harness.db.mqttOkToMqttViolations.insertViolation(
+      makeViolation({
+        sourceId: SOURCE_PUBLIC,
+        packetId: 5006,
+        gatewayId: '!eeeeeeee',
+        gatewayNodeNum: 0xeeeeeeee,
+        timestamp: T0 + 10,
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await harness.db.mqttOkToMqttViolations.deleteAllViolations(harness.sourceA);
+    await harness.db.mqttOkToMqttViolations.deleteAllViolations(SOURCE_PRIVATE);
+    await harness.db.mqttOkToMqttViolations.deleteAllViolations(SOURCE_PUBLIC);
+    await harness.db.mqttOkToMqttViolations.deleteAllViolations(SOURCE_HOSTNAME);
+    for (const id of [SOURCE_PRIVATE, SOURCE_PUBLIC, SOURCE_HOSTNAME]) {
+      await harness.db.sources.deleteSource(id).catch(() => {});
+    }
+    await harness.cleanup();
+  });
+
+  function gatewayRow(body: any, gatewayId: string) {
+    return body.data.gateways.find((g: any) => g.gatewayId === gatewayId);
+  }
+
+  it('gateways: a plain meshtastic_tcp source (no broker of its own) classifies as unknown', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    await harness.grant(harness.admin.id, 'packetmonitor', 'read', harness.sourceA);
+    const res = await agent.get(
+      `/mqtt-violations/gateways?since=0&sources=${harness.sourceA},${SOURCE_PRIVATE},${SOURCE_PUBLIC},${SOURCE_HOSTNAME}`,
+    );
+    expect(res.status).toBe(200);
+    expect(gatewayRow(res.body, '!aaaaaaaa').brokerClass).toBe('unknown');
+  });
+
+  it('gateways: a source configured with a literal private IPv4 upstream classifies as private', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/mqtt-violations/gateways?since=0&sources=${SOURCE_PRIVATE}`);
+    expect(res.status).toBe(200);
+    expect(gatewayRow(res.body, '!bbbbbbbb').brokerClass).toBe('private');
+  });
+
+  it('gateways: a source configured with the default public server classifies as public', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/mqtt-violations/gateways?since=0&sources=${SOURCE_PUBLIC}`);
+    expect(res.status).toBe(200);
+    expect(gatewayRow(res.body, '!cccccccc').brokerClass).toBe('public');
+  });
+
+  it('gateways: a source configured with a hostname classifies as unknown', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/mqtt-violations/gateways?since=0&sources=${SOURCE_HOSTNAME}`);
+    expect(res.status).toBe(200);
+    expect(gatewayRow(res.body, '!dddddddd').brokerClass).toBe('unknown');
+  });
+
+  it('gateways: a gateway seen via both a private and a public source combines to public', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(
+      `/mqtt-violations/gateways?since=0&sources=${SOURCE_PRIVATE},${SOURCE_PUBLIC}`,
+    );
+    expect(res.status).toBe(200);
+    const row = gatewayRow(res.body, '!eeeeeeee');
+    expect(row.sourceIds.sort()).toEqual([SOURCE_PRIVATE, SOURCE_PUBLIC].sort());
+    expect(row.brokerClass).toBe('public');
+  });
+
+  it('gateways: brokerClass is still present (unknown) on the includeUnknown=true merge path', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(
+      `/mqtt-violations/gateways?since=0&includeUnknown=true&sources=${SOURCE_PRIVATE}`,
+    );
+    expect(res.status).toBe(200);
+    expect(gatewayRow(res.body, '!bbbbbbbb').brokerClass).toBe('private');
+  });
+
+  it('packets: each row carries its own sourceId brokerClass, independent of other sources', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(
+      `/mqtt-violations/packets?since=0&sources=${SOURCE_PRIVATE},${SOURCE_PUBLIC},${SOURCE_HOSTNAME}`,
+    );
+    expect(res.status).toBe(200);
+    const byPacketId = new Map(res.body.data.violations.map((v: any) => [v.packetId, v]));
+    expect((byPacketId.get(5002) as any).brokerClass).toBe('private');
+    expect((byPacketId.get(5003) as any).brokerClass).toBe('public');
+    expect((byPacketId.get(5004) as any).brokerClass).toBe('unknown');
+  });
+
+  it('packets: brokerClass is present on the includeUnknown=true merge path too', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(
+      `/mqtt-violations/packets?since=0&includeUnknown=true&sources=${SOURCE_PUBLIC}`,
+    );
+    expect(res.status).toBe(200);
+    const row = res.body.data.violations.find((v: any) => v.packetId === 5003);
+    expect(row.brokerClass).toBe('public');
+  });
+});

--- a/src/server/routes/analysisRoutes.ts
+++ b/src/server/routes/analysisRoutes.ts
@@ -36,6 +36,11 @@ import {
 } from '../services/solarAnalysis.js';
 import { parseGatewayNodeNum } from '../utils/okToMqtt.js';
 import { resolvePermittedSourceIds, parseSourcesParam } from '../utils/permittedSources.js';
+import {
+  classifySourceBrokerAddress,
+  combineBrokerClasses,
+  type BrokerAddressClass,
+} from '../utils/privateBrokerAddress.js';
 
 const router = Router();
 router.use(optionalAuth());
@@ -97,6 +102,8 @@ interface ViolationGatewayRow extends MqttViolationGateway {
   sourceIds: string[];
   gatewayLongName: string | null;
   gatewayShortName: string | null;
+  /** See {@link attachBrokerClass} — additive, computed from `sourceIds`. */
+  brokerClass: BrokerAddressClass;
 }
 
 /** Row shape for the merged `/mqtt-violations/packets` response. */
@@ -120,16 +127,20 @@ interface ViolationPacketRow {
   topic: string | null;
   rxTime: number | null;
   timestamp: number;
+  /** See {@link attachBrokerClass} — additive, computed from `sourceId`. */
+  brokerClass: BrokerAddressClass;
 }
 
 function toViolationPacketRow(
   kind: 'confirmed' | 'suspected',
   row: DbMqttOkToMqttViolation | DbMqttPacket,
+  brokerClass: BrokerAddressClass,
 ): ViolationPacketRow {
   return {
     id: row.id,
     kind,
     sourceId: row.sourceId,
+    brokerClass,
     packetId: row.packetId ?? null,
     fromNode: row.fromNode ?? null,
     fromNodeId: row.fromNodeId ?? null,
@@ -224,6 +235,47 @@ async function attachNodeNames<
         : {}),
     };
   });
+}
+
+/**
+ * Build a `sourceId -> brokerClass` map for one request (#4982), classifying
+ * each source's configured broker address (see `privateBrokerAddress.ts`).
+ * One `getAllSources()` scan regardless of row count — deliberately not a
+ * per-row lookup, mirroring `attachNodeNames`'s batching rationale.
+ *
+ * A source not on record (deleted between the violation being recorded and
+ * this request) is simply absent from the returned map; callers fall back to
+ * `'unknown'` via `?? 'unknown'` when reading it.
+ */
+async function buildBrokerClassMap(sourceIds: string[]): Promise<Map<string, BrokerAddressClass>> {
+  const map = new Map<string, BrokerAddressClass>();
+  if (sourceIds.length === 0) return map;
+
+  const wanted = new Set(sourceIds);
+  let sources: Awaited<ReturnType<typeof databaseService.sources.getAllSources>>;
+  try {
+    sources = await databaseService.sources.getAllSources();
+  } catch (error) {
+    // Broker classification is a display nicety; a lookup failure must not
+    // take down a report that is otherwise fully populated. Every row simply
+    // falls back to 'unknown' via the caller's `?? 'unknown'`.
+    logger.warn('mqtt-violations: source lookup failed, broker class unknown for all rows:', error);
+    return map;
+  }
+
+  for (const source of sources) {
+    if (!wanted.has(source.id)) continue;
+    map.set(source.id, classifySourceBrokerAddress(source.type, source.config));
+  }
+  return map;
+}
+
+/** Combine a gateway row's per-source classes into one — see `combineBrokerClasses`. */
+function gatewayBrokerClass(
+  map: Map<string, BrokerAddressClass>,
+  sourceIds: string[],
+): BrokerAddressClass {
+  return combineBrokerClasses(sourceIds.map((id) => map.get(id) ?? 'unknown'));
 }
 
 /**
@@ -686,10 +738,11 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
       // Only the confirmed table is involved, so there is nothing to merge:
       // push sort/dir/limit/offset straight into SQL. `total` is an exact
       // COUNT and every row at every offset is reachable — no cap, ever.
-      const [gatewayRows, total, sourceIdPairs] = await Promise.all([
+      const [gatewayRows, total, sourceIdPairs, brokerClassMap] = await Promise.all([
         databaseService.mqttOkToMqttViolations.getGatewaySummary({ ...rangeQuery, sort, dir, limit, offset }),
         databaseService.mqttOkToMqttViolations.getGatewaySummaryCount(rangeQuery),
         databaseService.mqttOkToMqttViolations.getGatewaySourceIds(rangeQuery),
+        buildBrokerClassMap(sourceIds),
       ]);
 
       const sourceIdsByGateway = new Map<string, Set<string>>();
@@ -704,13 +757,17 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
       // (every row would come back with sourceIds: []).
       const gatewayPage: ViolationGatewayRow[] = gatewayRows
         .filter((g): g is MqttViolationGateway & { gatewayId: string } => g.gatewayId != null)
-        .map((g) => ({
-          ...g,
-          suspectedCount: 0,
-          sourceIds: Array.from(sourceIdsByGateway.get(g.gatewayId) ?? []),
-          gatewayLongName: null,
-          gatewayShortName: null,
-        }));
+        .map((g) => {
+          const gatewaySourceIds = Array.from(sourceIdsByGateway.get(g.gatewayId) ?? []);
+          return {
+            ...g,
+            suspectedCount: 0,
+            sourceIds: gatewaySourceIds,
+            gatewayLongName: null,
+            gatewayShortName: null,
+            brokerClass: gatewayBrokerClass(brokerClassMap, gatewaySourceIds),
+          };
+        });
       // Named after paging: this slice is already the page being returned.
       const gateways = await attachNodeNames(gatewayPage, sourceIds);
 
@@ -737,9 +794,10 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
     // tables — a SQL UNION was considered and declined for this PR. The
     // confirmed fetch below is capped at API_SCAN_CAP; capApplied reports
     // whether that cap actually dropped rows before the merge.
-    const [confirmedRows, sourceIdPairs] = await Promise.all([
+    const [confirmedRows, sourceIdPairs, brokerClassMap] = await Promise.all([
       databaseService.mqttOkToMqttViolations.getGatewaySummary({ ...rangeQuery, limit: API_SCAN_CAP, offset: 0 }),
       databaseService.mqttOkToMqttViolations.getGatewaySourceIds(rangeQuery),
+      buildBrokerClassMap(sourceIds),
     ]);
 
     // Seeded from the confirmed side; the suspected side (below) unions its
@@ -801,6 +859,7 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
       // row fetched here is counted by both.
       if (!g.gatewayId) continue;
       const suspected = suspectedByGateway.get(g.gatewayId);
+      const gatewaySourceIds = Array.from(sourceIdsByGateway.get(g.gatewayId) ?? []);
       mergedByGateway.set(g.gatewayId, {
         ...g,
         suspectedCount: suspected?.suspectedCount ?? 0,
@@ -809,14 +868,16 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
         // confirmed side's (#4114 code review).
         firstSeen: suspected ? Math.min(g.firstSeen, suspected.firstSeen) : g.firstSeen,
         lastSeen: suspected ? Math.max(g.lastSeen, suspected.lastSeen) : g.lastSeen,
-        sourceIds: Array.from(sourceIdsByGateway.get(g.gatewayId) ?? []),
+        sourceIds: gatewaySourceIds,
         gatewayLongName: null,
         gatewayShortName: null,
+        brokerClass: gatewayBrokerClass(brokerClassMap, gatewaySourceIds),
       });
     }
     // Gateways present only in the suspected set appear with violationCount: 0.
     for (const [gatewayId, suspected] of suspectedByGateway) {
       if (mergedByGateway.has(gatewayId)) continue;
+      const gatewaySourceIds = Array.from(sourceIdsByGateway.get(gatewayId) ?? []);
       mergedByGateway.set(gatewayId, {
         gatewayId,
         gatewayNodeNum: suspected.gatewayNodeNum,
@@ -825,9 +886,10 @@ router.get('/mqtt-violations/gateways', async (req: Request, res: Response) => {
         firstSeen: suspected.firstSeen,
         lastSeen: suspected.lastSeen,
         suspectedCount: suspected.suspectedCount,
-        sourceIds: Array.from(sourceIdsByGateway.get(gatewayId) ?? []),
+        sourceIds: gatewaySourceIds,
         gatewayLongName: null,
         gatewayShortName: null,
+        brokerClass: gatewayBrokerClass(brokerClassMap, gatewaySourceIds),
       });
     }
 
@@ -941,13 +1003,14 @@ router.get('/mqtt-violations/packets', async (req: Request, res: Response) => {
       // Only the confirmed table is involved, so there is nothing to merge:
       // push sort/dir/limit/offset straight into SQL. `total` is an exact
       // COUNT and every row at every offset is reachable — no cap, ever.
-      const [confirmedRows, total] = await Promise.all([
+      const [confirmedRows, total, brokerClassMap] = await Promise.all([
         databaseService.mqttOkToMqttViolations.getViolations({ ...rangeQuery, sort, dir, limit, offset }),
         databaseService.mqttOkToMqttViolations.getViolationCount(rangeQuery),
+        buildBrokerClassMap(sourceIds),
       ]);
 
       const violations = await attachNodeNames(
-        confirmedRows.map((r) => toViolationPacketRow('confirmed', r)),
+        confirmedRows.map((r) => toViolationPacketRow('confirmed', r, brokerClassMap.get(r.sourceId) ?? 'unknown')),
         sourceIds,
       );
 
@@ -977,13 +1040,14 @@ router.get('/mqtt-violations/packets', async (req: Request, res: Response) => {
     // whether either cap actually dropped rows before the merge.
     // The confirmed fetch and the suspectedAvailable check have no data
     // dependency on each other — run them concurrently (#4330 review).
-    const [confirmedRows, suspectedAvailable] = await Promise.all([
+    const [confirmedRows, suspectedAvailable, brokerClassMap] = await Promise.all([
       databaseService.mqttOkToMqttViolations.getViolations({
         ...rangeQuery,
         limit: API_SCAN_CAP,
         offset: 0,
       }),
       mqttPacketLogService.isEnabled(),
+      buildBrokerClassMap(sourceIds),
     ]);
 
     let suspectedWindowMs = 0;
@@ -1000,8 +1064,8 @@ router.get('/mqtt-violations/packets', async (req: Request, res: Response) => {
     }
 
     const merged = [
-      ...confirmedRows.map((r) => toViolationPacketRow('confirmed', r)),
-      ...suspectedRows.map((r) => toViolationPacketRow('suspected', r)),
+      ...confirmedRows.map((r) => toViolationPacketRow('confirmed', r, brokerClassMap.get(r.sourceId) ?? 'unknown')),
+      ...suspectedRows.map((r) => toViolationPacketRow('suspected', r, brokerClassMap.get(r.sourceId) ?? 'unknown')),
     ];
     const dirMultiplier = dir === 'asc' ? 1 : -1;
     merged.sort((a, b) => {

--- a/src/server/utils/privateBrokerAddress.test.ts
+++ b/src/server/utils/privateBrokerAddress.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyBrokerAddress,
+  resolveSourceBrokerAddress,
+  classifySourceBrokerAddress,
+  combineBrokerClasses,
+} from './privateBrokerAddress.js';
+
+describe('classifyBrokerAddress', () => {
+  it('treats null/undefined as unknown', () => {
+    expect(classifyBrokerAddress(null)).toBe('unknown');
+    expect(classifyBrokerAddress(undefined)).toBe('unknown');
+  });
+
+  it('treats an empty string as the public default server', () => {
+    expect(classifyBrokerAddress('')).toBe('public');
+    expect(classifyBrokerAddress('   ')).toBe('public');
+  });
+
+  it('treats mqtt.meshtastic.org (any case, with/without port) as public', () => {
+    expect(classifyBrokerAddress('mqtt.meshtastic.org')).toBe('public');
+    expect(classifyBrokerAddress('MQTT.MESHTASTIC.ORG')).toBe('public');
+    expect(classifyBrokerAddress('mqtt.meshtastic.org:1883')).toBe('public');
+  });
+
+  it('treats other hostnames as unknown', () => {
+    expect(classifyBrokerAddress('mqtt.example.com')).toBe('unknown');
+    expect(classifyBrokerAddress('my-private-broker.local:1883')).toBe('unknown');
+  });
+
+  it('treats IPv6 literals as unknown', () => {
+    expect(classifyBrokerAddress('::1')).toBe('unknown');
+    expect(classifyBrokerAddress('[::1]')).toBe('unknown');
+    expect(classifyBrokerAddress('[::1]:1883')).toBe('unknown');
+    expect(classifyBrokerAddress('[2001:db8::1]:8883')).toBe('unknown');
+  });
+
+  describe('10.0.0.0/8', () => {
+    it('is private', () => {
+      expect(classifyBrokerAddress('10.0.0.0')).toBe('private');
+      expect(classifyBrokerAddress('10.1.2.3')).toBe('private');
+      expect(classifyBrokerAddress('10.255.255.255')).toBe('private');
+      expect(classifyBrokerAddress('10.1.2.3:1883')).toBe('private');
+    });
+  });
+
+  describe('172.16.0.0/12 boundary', () => {
+    it('172.15.x is public (just below the block)', () => {
+      expect(classifyBrokerAddress('172.15.255.255')).toBe('public');
+    });
+    it('172.16.x .. 172.31.x is private', () => {
+      expect(classifyBrokerAddress('172.16.0.0')).toBe('private');
+      expect(classifyBrokerAddress('172.20.1.1')).toBe('private');
+      expect(classifyBrokerAddress('172.31.255.255')).toBe('private');
+    });
+    it('172.32.x is public (just above the block)', () => {
+      expect(classifyBrokerAddress('172.32.0.0')).toBe('public');
+    });
+  });
+
+  describe('192.168.0.0/16', () => {
+    it('is private', () => {
+      expect(classifyBrokerAddress('192.168.0.1')).toBe('private');
+      expect(classifyBrokerAddress('192.168.255.255')).toBe('private');
+    });
+    it('neighboring 192.167.x / 192.169.x are public', () => {
+      expect(classifyBrokerAddress('192.167.0.1')).toBe('public');
+      expect(classifyBrokerAddress('192.169.0.1')).toBe('public');
+    });
+  });
+
+  describe('169.254.0.0/16 (link-local)', () => {
+    it('is private', () => {
+      expect(classifyBrokerAddress('169.254.1.1')).toBe('private');
+    });
+  });
+
+  describe('100.64.0.0/10 boundary (CGNAT)', () => {
+    it('100.63.x is public (just below the block)', () => {
+      expect(classifyBrokerAddress('100.63.255.255')).toBe('public');
+    });
+    it('100.64.x .. 100.127.x is private', () => {
+      expect(classifyBrokerAddress('100.64.0.0')).toBe('private');
+      expect(classifyBrokerAddress('100.100.1.1')).toBe('private');
+      expect(classifyBrokerAddress('100.127.255.255')).toBe('private');
+    });
+    it('100.128.x is public (just above the block)', () => {
+      expect(classifyBrokerAddress('100.128.0.0')).toBe('public');
+    });
+  });
+
+  describe('127.0.0.1/32 quirk', () => {
+    it('127.0.0.1 exactly is private', () => {
+      expect(classifyBrokerAddress('127.0.0.1')).toBe('private');
+      expect(classifyBrokerAddress('127.0.0.1:1883')).toBe('private');
+    });
+    it('127.0.0.2 and the rest of 127.0.0.0/8 are NOT private', () => {
+      expect(classifyBrokerAddress('127.0.0.2')).toBe('public');
+      expect(classifyBrokerAddress('127.0.0.0')).toBe('public');
+      expect(classifyBrokerAddress('127.1.2.3')).toBe('public');
+      expect(classifyBrokerAddress('127.255.255.255')).toBe('public');
+    });
+  });
+
+  describe('literal public IPv4', () => {
+    it('is public, not unknown', () => {
+      expect(classifyBrokerAddress('8.8.8.8')).toBe('public');
+      expect(classifyBrokerAddress('203.0.113.5:8883')).toBe('public');
+    });
+  });
+
+  describe('port suffix handling', () => {
+    it('strips the port on the first colon before classifying', () => {
+      expect(classifyBrokerAddress('192.168.1.5:1883')).toBe('private');
+      expect(classifyBrokerAddress('8.8.8.8:8883')).toBe('public');
+    });
+  });
+
+  describe('malformed IPv4-shaped input', () => {
+    it('out-of-range octets are not treated as a literal IPv4', () => {
+      expect(classifyBrokerAddress('999.1.1.1')).toBe('unknown');
+      expect(classifyBrokerAddress('10.999.0.1')).toBe('unknown');
+    });
+  });
+});
+
+describe('resolveSourceBrokerAddress', () => {
+  it('returns null for non-MQTT source types', () => {
+    expect(resolveSourceBrokerAddress('meshtastic_tcp', { host: '10.0.0.1' })).toBeNull();
+    expect(resolveSourceBrokerAddress('meshcore', {})).toBeNull();
+    expect(resolveSourceBrokerAddress('reticulum', {})).toBeNull();
+    expect(resolveSourceBrokerAddress(null, {})).toBeNull();
+  });
+
+  it('returns null when config is missing', () => {
+    expect(resolveSourceBrokerAddress('mqtt_bridge', null)).toBeNull();
+    expect(resolveSourceBrokerAddress('mqtt_bridge', undefined)).toBeNull();
+  });
+
+  describe('mqtt_bridge', () => {
+    it('extracts host:port from the upstream URL', () => {
+      expect(
+        resolveSourceBrokerAddress('mqtt_bridge', { upstream: { url: 'mqtt://192.168.1.5:1883' } }),
+      ).toBe('192.168.1.5:1883');
+    });
+
+    it('extracts bare host when the URL has no explicit port', () => {
+      expect(
+        resolveSourceBrokerAddress('mqtt_bridge', { upstream: { url: 'mqtts://mqtt.meshtastic.org' } }),
+      ).toBe('mqtt.meshtastic.org');
+    });
+
+    it('returns null for a missing/empty/invalid upstream url', () => {
+      expect(resolveSourceBrokerAddress('mqtt_bridge', {})).toBeNull();
+      expect(resolveSourceBrokerAddress('mqtt_bridge', { upstream: {} })).toBeNull();
+      expect(resolveSourceBrokerAddress('mqtt_bridge', { upstream: { url: '' } })).toBeNull();
+      expect(resolveSourceBrokerAddress('mqtt_bridge', { upstream: { url: 'not a url' } })).toBeNull();
+    });
+  });
+
+  describe('mqtt_broker', () => {
+    it('returns the explicit listener host when it is a real address', () => {
+      expect(
+        resolveSourceBrokerAddress('mqtt_broker', { listener: { port: 1883, host: '192.168.1.5' } }),
+      ).toBe('192.168.1.5');
+    });
+
+    it('returns null for wildcard binds and unset host', () => {
+      expect(resolveSourceBrokerAddress('mqtt_broker', { listener: { port: 1883 } })).toBeNull();
+      expect(
+        resolveSourceBrokerAddress('mqtt_broker', { listener: { port: 1883, host: '0.0.0.0' } }),
+      ).toBeNull();
+      expect(
+        resolveSourceBrokerAddress('mqtt_broker', { listener: { port: 1883, host: '::' } }),
+      ).toBeNull();
+    });
+  });
+});
+
+describe('classifySourceBrokerAddress', () => {
+  it('composes resolveSourceBrokerAddress and classifyBrokerAddress', () => {
+    expect(
+      classifySourceBrokerAddress('mqtt_bridge', { upstream: { url: 'mqtt://192.168.1.5:1883' } }),
+    ).toBe('private');
+    expect(
+      classifySourceBrokerAddress('mqtt_bridge', { upstream: { url: 'mqtt://mqtt.example.com' } }),
+    ).toBe('unknown');
+    expect(
+      classifySourceBrokerAddress('mqtt_bridge', { upstream: { url: 'mqtt://mqtt.meshtastic.org' } }),
+    ).toBe('public');
+    expect(classifySourceBrokerAddress('meshtastic_tcp', {})).toBe('unknown');
+  });
+});
+
+describe('combineBrokerClasses', () => {
+  it('returns unknown for an empty list', () => {
+    expect(combineBrokerClasses([])).toBe('unknown');
+  });
+
+  it('returns private only when every class is private', () => {
+    expect(combineBrokerClasses(['private'])).toBe('private');
+    expect(combineBrokerClasses(['private', 'private'])).toBe('private');
+  });
+
+  it('public wins over everything else', () => {
+    expect(combineBrokerClasses(['private', 'public'])).toBe('public');
+    expect(combineBrokerClasses(['unknown', 'public'])).toBe('public');
+    expect(combineBrokerClasses(['public'])).toBe('public');
+  });
+
+  it('any unknown without a public makes the combination unknown', () => {
+    expect(combineBrokerClasses(['private', 'unknown'])).toBe('unknown');
+    expect(combineBrokerClasses(['unknown'])).toBe('unknown');
+  });
+});

--- a/src/server/utils/privateBrokerAddress.ts
+++ b/src/server/utils/privateBrokerAddress.ts
@@ -1,0 +1,195 @@
+/**
+ * Classifies an MQTT broker address string as `private` / `public` / `unknown`,
+ * mirroring firmware's `isMqttServerAddressPrivate()` (#4982).
+ *
+ * Background (verified against firmware `master`): firmware gates the
+ * `ok_to_mqtt` drop in `MQTT::onSend` on whether the configured broker is a
+ * private IPv4. When it is, uplinking a packet whose originator's
+ * `ok_to_mqtt` bit is clear is EXPECTED BY DESIGN — the drop only applies to
+ * public brokers. MeshMonitor's violation detector (`okToMqtt.ts`) has no
+ * way to know the gateway's broker, so it flags every relayed
+ * `ok_to_mqtt = 0` packet the same way; this module lets callers annotate
+ * those flags with what can actually be known about the observing source's
+ * configured broker, so the report can separate "expected" noise from real
+ * violations.
+ *
+ * Firmware's private set (Firmware `isMqttServerAddressPrivate`, IPv4 only):
+ *   - 10.0.0.0/8
+ *   - 172.16.0.0/12
+ *   - 192.168.0.0/16
+ *   - 169.254.0.0/16 (link-local)
+ *   - 100.64.0.0/10 (carrier-grade NAT)
+ *   - 127.0.0.1/32 EXACTLY — NOT the whole 127.0.0.0/8 loopback block.
+ *     `127.0.0.2` is a normal (non-private, per this check) address.
+ *
+ * Firmware parses the configured address with `IPAddress::fromString`,
+ * which only understands dotted-quad IPv4 literals — never hostnames, never
+ * IPv6. Consequences mirrored here:
+ *   - A literal private IPv4 is DEFINITELY exempt from the drop → `'private'`.
+ *   - A literal non-private IPv4 is DEFINITELY not exempt → `'public'`.
+ *     (It's still a literal IP, so there's no DNS ambiguity — every gateway
+ *     type evaluates it identically.)
+ *   - A hostname (e.g. a self-hosted broker behind a DNS name) makes
+ *     `fromString` fail, so firmware evaluates it as NOT-private at config
+ *     time. Direct-TCP gateways later re-check against the resolved peer
+ *     IP (which could turn out private), but MQTT-client-proxy gateways
+ *     never re-check. Since MeshMonitor can't tell which gateway type
+ *     produced a given reception, a hostname is reported as `'unknown'`
+ *     rather than guessed either way.
+ *   - IPv6 literals aren't handled by firmware's parser either → `'unknown'`.
+ *   - The empty string, or the literal default server `mqtt.meshtastic.org`,
+ *     is firmware's public default → `'public'`.
+ *
+ * Firmware splits the configured address on the FIRST `:` before parsing
+ * (to drop an optional port suffix) — mirrored here exactly, including the
+ * consequence that this is unsafe for unbracketed IPv6 literals. A
+ * bracketed IPv6 literal (`[::1]:1883`) would defeat that naive split, so
+ * it's treated defensively as `'unknown'` rather than mis-parsed.
+ */
+
+export type BrokerAddressClass = 'private' | 'public' | 'unknown';
+
+/** Firmware's default public broker when the configured address is empty. */
+const DEFAULT_MESHTASTIC_MQTT_HOST = 'mqtt.meshtastic.org';
+
+/** Bind-all wildcard hosts — not a real address a client could have been configured with. */
+const WILDCARD_HOSTS = new Set(['0.0.0.0', '::', '']);
+
+/**
+ * Classify a raw broker address string (host, or host:port — no URL scheme)
+ * the way firmware's `isMqttServerAddressPrivate` would. See module doc
+ * comment for the exact rules and their provenance.
+ */
+export function classifyBrokerAddress(
+  address: string | null | undefined,
+): BrokerAddressClass {
+  if (address == null) return 'unknown';
+  const trimmed = address.trim();
+  if (trimmed === '') return 'public'; // firmware default: empty address == mqtt.meshtastic.org
+
+  // Bracketed IPv6 literal (e.g. "[::1]:1883") — firmware's naive first-':'
+  // split would mangle this. Treat defensively as unrecognized.
+  if (trimmed.startsWith('[')) return 'unknown';
+
+  // Mirror firmware: split on the FIRST ':' to drop an optional port suffix.
+  const colonIdx = trimmed.indexOf(':');
+  const host = colonIdx === -1 ? trimmed : trimmed.slice(0, colonIdx);
+  if (host === '') return 'unknown';
+
+  if (host.toLowerCase() === DEFAULT_MESHTASTIC_MQTT_HOST) return 'public';
+
+  if (isLiteralIPv4(host)) {
+    return isPrivateIPv4(host) ? 'private' : 'public';
+  }
+
+  // Hostname (that isn't the default server) or an unbracketed IPv6 literal
+  // (which will simply fail the IPv4 literal test above) — can't be
+  // resolved deterministically from the string alone.
+  return 'unknown';
+}
+
+function isLiteralIPv4(host: string): boolean {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!m) return false;
+  return m.slice(1, 5).every((part) => {
+    const n = Number(part);
+    return n >= 0 && n <= 255;
+  });
+}
+
+/** Exact port of firmware's `isMqttServerAddressPrivate` IPv4 CIDR table. */
+function isPrivateIPv4(host: string): boolean {
+  const octets = host.split('.').map(Number);
+  const [a, b, c, d] = octets;
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10
+  if (a === 127 && b === 0 && c === 0 && d === 1) return true; // 127.0.0.1/32 ONLY
+  return false;
+}
+
+/**
+ * Extract the "broker address" (host, or host:port) a MeshMonitor MQTT
+ * source is configured with, from its `sources.config` JSON. Returns `null`
+ * when the type isn't an MQTT source, or no usable address is on record —
+ * `classifyBrokerAddress(null)` maps that to `'unknown'`, distinct from an
+ * on-record empty string (which firmware treats as the public default).
+ *
+ * - `mqtt_bridge`: the configured `upstream.url` (a full MQTT URL, e.g.
+ *   `mqtt://192.168.1.5:1883`) is what firmware's `config_mqtt.address`
+ *   maps to for THIS bridge's upstream connection — this is the broker the
+ *   bridge (and, in the common case, the same physical gateway node) both
+ *   publish into. The scheme is stripped; `URL.hostname` already strips
+ *   brackets from an IPv6 host, and firmware never handles those anyway
+ *   (see module doc), so no scheme leaks into the returned value.
+ * - `mqtt_broker`: MeshMonitor itself hosts the broker, so there's no
+ *   upstream URL — devices connect directly. The only address on record is
+ *   the listener's OWN bind host, which is not what a device was configured
+ *   with, but if an operator has explicitly bound it to a specific literal
+ *   address that's the closest signal available. A wildcard bind
+ *   (`0.0.0.0`, `::`, unset) carries no information → `null`.
+ * - Any other source type (`meshtastic_tcp`, `meshcore`, `reticulum`) has no
+ *   broker of its own.
+ */
+export function resolveSourceBrokerAddress(
+  type: string | null | undefined,
+  config: Record<string, unknown> | null | undefined,
+): string | null {
+  if (!config) return null;
+
+  if (type === 'mqtt_bridge') {
+    const upstream = config.upstream as { url?: unknown } | undefined;
+    const url = typeof upstream?.url === 'string' ? upstream.url.trim() : '';
+    if (url === '') return null;
+    try {
+      const parsed = new URL(url);
+      return parsed.port ? `${parsed.hostname}:${parsed.port}` : parsed.hostname;
+    } catch {
+      return null;
+    }
+  }
+
+  if (type === 'mqtt_broker') {
+    const listener = config.listener as { host?: unknown } | undefined;
+    const host = typeof listener?.host === 'string' ? listener.host.trim() : '';
+    return WILDCARD_HOSTS.has(host) ? null : host;
+  }
+
+  return null;
+}
+
+/**
+ * Classify the broker a MeshMonitor MQTT source is configured against.
+ * Convenience wrapper composing {@link resolveSourceBrokerAddress} and
+ * {@link classifyBrokerAddress} — see both for the rules.
+ */
+export function classifySourceBrokerAddress(
+  type: string | null | undefined,
+  config: Record<string, unknown> | null | undefined,
+): BrokerAddressClass {
+  return classifyBrokerAddress(resolveSourceBrokerAddress(type, config));
+}
+
+/**
+ * Combine the broker classes of every source that observed one violation
+ * (or one gateway's set of violations) into a single class:
+ *
+ *  - Any `'public'` source in the mix → `'public'`. At least one path is
+ *    known-not-exempt, so the violation is confirmed regardless of what the
+ *    other sources are.
+ *  - No `'public'`, and every source is `'private'` → `'private'`. Every
+ *    known path is exempt by design.
+ *  - Otherwise (any `'unknown'`, with no `'public'`) → `'unknown'`. Can't
+ *    rule out a real violation, so it must not be reported as expected.
+ *  - No sources at all → `'unknown'`.
+ */
+export function combineBrokerClasses(
+  classes: readonly BrokerAddressClass[],
+): BrokerAddressClass {
+  if (classes.length === 0) return 'unknown';
+  if (classes.includes('public')) return 'public';
+  if (classes.every((c) => c === 'private')) return 'private';
+  return 'unknown';
+}


### PR DESCRIPTION
## Summary
Fixes #4982. The ok_to_mqtt Violations report flagged private-broker gateways as violators, but the Meshtastic firmware **intentionally skips the ok_to_mqtt check for private brokers** — uploading everything there is designed behavior, not misbehavior. The report now classifies each violation by the observing source's broker address and presents expected/confirmed/unverified classes with an explanatory banner and filter.

## Firmware semantics mirrored (verified against firmware master)
- Private = exactly the firmware's CIDR set: 10/8, 172.16/12, 192.168/16, 169.254/16 (link-local), 100.64/10 (CGNAT/Tailscale), and **127.0.0.1/32 only** (127.0.0.2 is not private).
- IPv4 literals only: the firmware's config-time check fails on hostnames, so a hostname-configured broker can't be assumed private from its address (only the affirmative direction is certain) → classified **unverified**, not expected.
- `mqtt.meshtastic.org` / empty = the default public server.
- Version nuance in the banner: firmware < 2.7.20 never actually enforced the drop anywhere (inverted memcmp since 2.5.0); 2.5.7 introduced the private exemption.

## Changes
- New pure `classifyBrokerAddress()` util (+ `resolveSourceBrokerAddress` for mqtt_bridge/mqtt_broker source configs, `combineBrokerClasses` for multi-source rows) — exhaustive boundary tests (172.15 vs .16 vs .32, 127.0.0.1 vs .2, 100.63 vs .64, port suffixes, bracketed IPv6 → unknown).
- `/api/analysis/mqtt-violations/gateways` and `/packets` annotate each row with `brokerClass` (one `getAllSources()` scan per request; additive wire change).
- Report UI: Broker column + badges ("Expected — private broker" / "Confirmed — public broker" / "Unverified — hostname broker"), explanatory banner, client-side "Hide expected" filter (no refetch on toggle), CSV exports gain a Broker Class column.
- Docs: private-broker caveat added to the analysis-reports and packet-monitor pages.

## Issues Resolved
Fixes #4982

## Testing
- [x] Full Vitest suite green: 18267 passed / 0 failed (PG/MySQL container suites skipped locally — no schema/SQL touched; CI runs them)
- [x] 154 targeted tests across util/route/CSV/component incl. real-harness route tests seeding private vs hostname broker sources
- [x] Typecheck (app + server configs) and lint ratchet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AWn4GQVv7bBy7rTKLZBcQ