### PR TITLE
fix: preserve map panning while measuring distance (#4965)

### DIFF
--- a/src/components/MeasureDistanceController.test.tsx
+++ b/src/components/MeasureDistanceController.test.tsx
@@ -50,6 +50,12 @@ function clickAt(x: number, y: number, target: EventTarget = container) {
   });
 }
 
+function pointerAt(type: 'pointerdown' | 'pointermove', x: number, y: number) {
+  act(() => {
+    container.dispatchEvent(new MouseEvent(type, { bubbles: true, clientX: x, clientY: y }));
+  });
+}
+
 describe('MeasureDistanceController', () => {
   beforeEach(() => {
     container.style.cursor = '';
@@ -106,6 +112,28 @@ describe('MeasureDistanceController', () => {
     container.appendChild(zoom);
     clickAt(110, 100, zoom);
     expect(screen.queryByTestId('measure-ring')).toBeNull();
+  });
+
+  it('does not select a node when a click follows a map drag', () => {
+    render(<MeasureDistanceController active points={POINTS} />);
+    pointerAt('pointerdown', 110, 100);
+    pointerAt('pointermove', 130, 100);
+    clickAt(130, 100);
+
+    expect(screen.queryByTestId('measure-ring')).toBeNull();
+
+    // Suppression applies only to the drag-generated click.
+    clickAt(110, 100);
+    expect(screen.getAllByTestId('measure-ring')).toHaveLength(1);
+  });
+
+  it('still selects a node after pointer jitter below the drag threshold', () => {
+    render(<MeasureDistanceController active points={POINTS} />);
+    pointerAt('pointerdown', 110, 100);
+    pointerAt('pointermove', 111, 101);
+    clickAt(111, 101);
+
+    expect(screen.getAllByTestId('measure-ring')).toHaveLength(1);
   });
 
   it('honors the miles preference', () => {

--- a/src/components/MeasureDistanceController.tsx
+++ b/src/components/MeasureDistanceController.tsx
@@ -4,6 +4,8 @@ import { useSettings } from '../contexts/SettingsContext';
 import { nearestPoint, measureLabel, type MeasurePoint } from '../utils/measureDistance';
 import './MeasureDistanceController.css';
 
+const DRAG_THRESHOLD_PX = 3;
+
 export interface MeasureDistanceControllerProps {
   /** When false the tool is inert (no cursor change, no listeners fire visibly). */
   active: boolean;
@@ -45,6 +47,8 @@ const MeasureDistanceController: React.FC<MeasureDistanceControllerProps> = ({
   // re-subscribing on every poll that returns a fresh array.
   const pointsRef = useRef(points);
   pointsRef.current = points;
+  const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
+  const draggedRef = useRef(false);
 
   // Crosshair affordance while measuring; always restore on cleanup.
   useEffect(() => {
@@ -64,11 +68,33 @@ const MeasureDistanceController: React.FC<MeasureDistanceControllerProps> = ({
 
   // Capture-phase click interception. Registered on the map container so it
   // fires before Leaflet's marker/map click handlers — letting a click land on
-  // a node marker without opening its popup.
+  // a node marker without opening its popup. Track pointer movement separately
+  // because a native DOM click can still follow Leaflet's map-drag gesture.
   useEffect(() => {
     if (!enabled) return;
     const container = map.getContainer();
+    const onPointerDown = (e: PointerEvent) => {
+      pointerStartRef.current = { x: e.clientX, y: e.clientY };
+      draggedRef.current = false;
+    };
+    const onPointerMove = (e: PointerEvent) => {
+      const start = pointerStartRef.current;
+      if (!start) return;
+      const dx = e.clientX - start.x;
+      const dy = e.clientY - start.y;
+      if (dx * dx + dy * dy > DRAG_THRESHOLD_PX * DRAG_THRESHOLD_PX) {
+        draggedRef.current = true;
+      }
+    };
+    const onPointerCancel = () => {
+      pointerStartRef.current = null;
+      draggedRef.current = false;
+    };
     const onClick = (e: MouseEvent) => {
+      const followedDrag = draggedRef.current;
+      pointerStartRef.current = null;
+      draggedRef.current = false;
+      if (followedDrag) return;
       // Let map controls (zoom, attribution, tileset toggle) work normally.
       const target = e.target as HTMLElement | null;
       if (target && target.closest('.leaflet-control')) return;
@@ -87,8 +113,16 @@ const MeasureDistanceController: React.FC<MeasureDistanceControllerProps> = ({
         return [picked]; // completed pair -> restart from a new A
       });
     };
+    container.addEventListener('pointerdown', onPointerDown, true);
+    container.addEventListener('pointermove', onPointerMove, true);
+    container.addEventListener('pointercancel', onPointerCancel, true);
     container.addEventListener('click', onClick, true);
-    return () => container.removeEventListener('click', onClick, true);
+    return () => {
+      container.removeEventListener('pointerdown', onPointerDown, true);
+      container.removeEventListener('pointermove', onPointerMove, true);
+      container.removeEventListener('pointercancel', onPointerCancel, true);
+      container.removeEventListener('click', onClick, true);
+    };
   }, [enabled, map]);
 
   // Escape clears / exits.


### PR DESCRIPTION
The Measure Distance controller intercepted the native click emitted after a Leaflet drag and snapped it to a node. I added a 3 px pointer-movement threshold so drag-generated clicks are ignored while ordinary clicks and minor pointer jitter still select nodes.
Regression tests cover drag suppression, suppression applying to only that click, and below-threshold jitter.
