### PR TITLE
fix(mesh-issues): B1 requires client-overlap evidence, not just mutual audibility

### DIFF
--- a/docs/features/mesh-issues-test-reference.md
+++ b/docs/features/mesh-issues-test-reference.md
@@ -104,11 +104,121 @@ evaluate the structure of that graph.
 
 | | |
 | --- | --- |
-| **Fires when** | 2 or more ROUTER/REPEATER-role nodes are mutually audible (within the cluster distance limit) |
+| **Fires when** | 2 or more ROUTER/REPEATER-role nodes are mutually audible (within the cluster distance limit) **and** their non-cluster client neighbors overlap significantly |
 | **Severity** | warning (2–3 nodes) / critical (4+ nodes) / info (inferred-only evidence) |
-| **Threshold** | Cluster size 2 (warning), 4 (critical). Distance guard: **30 km** default, tunable. `[MeshMonitor]` |
-| **Why it matters** | Routers that can hear each other compete for the same traffic. Each one rebroadcasts the same packets, multiplying airtime without improving coverage. A cluster of 4 routers turns one packet into 4+ transmissions in the same RF neighborhood. |
+| **Threshold** | Cluster size 2 (warning), 4 (critical). Distance guard: **30 km** default, tunable. Client overlap: **90%** (same as B2). `[MeshMonitor]` |
+| **Why it matters** | Routers that can hear each other **and serve the same clients** compete for the same traffic. Each one rebroadcasts the same packets, multiplying airtime without improving coverage. |
 | **What to do** | Keep one router in the area and change the others to CLIENT_BASE (if they need to stay powered and connected) or CLIENT. Spread routers so each one covers a distinct area the others can't reach. |
+
+#### How the detection works
+
+B1 is the most involved rule in the report. It builds on an **RF adjacency
+graph** shared with several other Tier B rules, then runs a two-pass clique
+extraction to find clusters of routers that can all hear each other.
+
+**Step 1 — Build the RF graph.** The graph records which nodes can hear
+which, assembled from three evidence sources:
+
+| Source | Evidence class | Type |
+| --- | --- | --- |
+| **NeighborInfo** | `neighborInfo` | Direct |
+| **Traceroute adjacent-hop links** | `traceroute` | Direct |
+| **MQTT gateway heard a node at 0 hops with real SNR** | `gatewayDirect` | Direct |
+| **Two nodes both directly heard by the same MQTT gateway** | `gatewayCoReception` | Inferred |
+
+The graph maintains two adjacency maps: one with only **direct** edges
+(the first three classes), and one with **all** edges including inferred
+co-reception. NeighborInfo rows are deduped by `(nodeNum, neighborNum,
+timestamp)` to collapse cross-source duplicates (the same packet arriving
+via TCP and via N MQTT gateways).
+
+**Step 2 — Filter to cluster-eligible roles.** Only nodes with role
+ROUTER, ROUTER_CLIENT, or REPEATER are candidates. ROUTER_LATE is
+deliberately excluded — it is the recommended fix, so including it would
+make the remedy re-raise the finding.
+
+**Step 3 — Apply the distance guard.** Before clustering, every edge is
+checked against the `routerClusterMaxLinkKm` threshold (default **30 km**,
+tunable 1–500 km). If both nodes have known positions, the great-circle
+distance must be within the limit. If either node lacks a usable position
+the edge is kept (fail-open). This guard exists because MQTT-bridged
+firmwares can record traceroute "hops" between repeaters 100+ km apart
+that never happened over RF, carrying plausible SNR that no other filter
+can catch.
+
+**Step 4 — Extract cliques (two passes).** The algorithm finds **cliques**,
+not connected components — every member of a cluster must be adjacent to
+every other member. This avoids the transitivity problem where a chain of
+genuine short links could merge far-apart routers into one finding whose
+endpoints never actually hear each other.
+
+The extraction is greedy and deterministic:
+
+1. Compute each candidate's "restricted degree" (count of neighbors also
+   in the candidate set that pass the distance guard).
+2. Sort candidates by restricted degree descending, then by node number
+   ascending (for determinism).
+3. For each unassigned seed in priority order, grow a clique by admitting
+   every unassigned candidate (in the same order) that is adjacent to ALL
+   current members.
+4. Emit cliques of size 2 or larger. Mark all members as assigned — each
+   router appears in at most one finding.
+
+This runs in **two passes**:
+
+- **Pass 1 (direct evidence only):** Extracts cliques over the
+  direct-adjacency map (neighborInfo, traceroute, gatewayDirect edges).
+  These clusters have strong evidence of mutual audibility.
+- **Pass 2 (inferred evidence, leftovers only):** Extracts cliques among
+  nodes not assigned in pass 1, using the full adjacency map (including
+  gatewayCoReception). These clusters are marked `inferredOnly` — the
+  evidence only proves a shared gateway heard both routers, not that the
+  routers hear each other.
+
+**Step 5 — Check client overlap.** Mutual audibility alone does not make a
+cluster redundant. A backbone of well-sited routers that each covers a
+different set of local clients is healthy infrastructure. Before emitting a
+finding, B1 computes the pairwise overlap of each member's **non-cluster
+direct neighbors** (their "clients"):
+
+1. For each member, collect their direct neighbors minus other cluster
+   members.
+2. For each pair where both members have at least 3 clients (the same
+   minimum B2 uses), compute the overlap ratio: shared clients divided by
+   the smaller set's size.
+3. Take the maximum pairwise overlap across all computable pairs.
+
+The outcome depends on this overlap:
+
+- **Max overlap ≥ 90%** (at least one pair serves nearly identical
+  clients): the finding proceeds — this cluster is genuinely redundant.
+- **Max overlap < 90%** and at least one pair was computable: the finding
+  is **suppressed entirely** — the members serve distinct coverage areas.
+- **No pair computable** (not enough non-cluster neighbor data): the
+  finding proceeds as-is — we can't prove the cluster is harmless, so it
+  stays visible.
+
+**Step 6 — Assign severity and confidence.**
+
+| Condition | Severity | Confidence |
+| --- | --- | --- |
+| `inferredOnly` (pass 2 cluster) | info | low |
+| Direct evidence, 4+ members | critical | high or medium |
+| Direct evidence, 2–3 members | warning | high or medium |
+
+Confidence is **high** when every internal edge has neighborInfo or
+traceroute evidence, **medium** when some edges rely only on gatewayDirect.
+
+**Step 7 — Select the best-sited member.** For the recommendation text, the
+rule picks one member to keep as the router — the one with the highest
+direct-adjacency degree (most RF neighbors), ties broken by most positioned
+direct edges, then lowest node number. The others are recommended for
+demotion to CLIENT_BASE or CLIENT.
+
+**Lifecycle:** A cluster's identity key includes its size and a hash of its
+members. If a router is removed or added, the old finding auto-closes after
+the configured clean-run count and a new finding is created for the changed
+cluster.
 
 ### B2 — Redundant router
 

--- a/docs/features/mesh-issues.md
+++ b/docs/features/mesh-issues.md
@@ -72,7 +72,7 @@ matters, and what to do about it — see the
 
 | Rule | Fires when | Threshold | Severity |
 | --- | --- | --- | --- |
-| **B1** Router cluster | ≥2 ROUTER/REPEATER-role nodes are mutually audible | cluster size 2 `[MeshMonitor]` | warning (≥2), critical (≥4), info (inferred-only evidence) |
+| **B1** Router cluster | ≥2 ROUTER/REPEATER-role nodes are mutually audible **and** their non-cluster client neighbors overlap significantly (≥90%) | cluster size 2, 90% client overlap `[MeshMonitor]` | warning (≥2), critical (≥4), info (inferred-only evidence) |
 | **B2** Redundant router | One infra node's direct-neighbor set is ≥90% covered by another's, both with ≥3 neighbors | 90% overlap `[MeshMonitor]` | warning |
 | **B3** Asymmetric link | Directional mean SNR between two nodes differs by more than the ceiling, ≥3 samples per direction | 6 dB `[MeshMonitor]`, tunable | warning (infra endpoint involved) / info |
 | **B4** Idle router | An infra node is heard direct but carries <1% of its area's traceroute hops while a peer carries >10% | 1%/10% split `[MeshMonitor]` | info always |

--- a/src/server/services/meshIssues/rulesTierB.test.ts
+++ b/src/server/services/meshIssues/rulesTierB.test.ts
@@ -455,6 +455,86 @@ describe('evaluateB1 — router cluster', () => {
     expect(findings[0].evidence.edgesTotal).toBe(435);
     expect((findings[0].evidence.edges as unknown[]).length).toBe(EVIDENCE_MEMBER_LIST_CAP);
   });
+
+  it('suppresses a cluster whose members serve distinct non-cluster clients (backbone, not redundancy)', () => {
+    // Two routers hear each other but each serves 4 unique clients —
+    // no overlap at all. This is a backbone link, not redundancy.
+    const r1 = makeNode({ nodeNum: 1, role: DeviceRole.ROUTER });
+    const r2 = makeNode({ nodeNum: 2, role: DeviceRole.ROUTER });
+    const c1 = makeNode({ nodeNum: 10 });
+    const c2 = makeNode({ nodeNum: 11 });
+    const c3 = makeNode({ nodeNum: 12 });
+    const c4 = makeNode({ nodeNum: 13 });
+    const c5 = makeNode({ nodeNum: 20 });
+    const c6 = makeNode({ nodeNum: 21 });
+    const c7 = makeNode({ nodeNum: 22 });
+    const c8 = makeNode({ nodeNum: 23 });
+    const graph = makeGraph([
+      directEdge(1, 2),
+      // R1's unique clients
+      directEdge(1, 10), directEdge(1, 11), directEdge(1, 12), directEdge(1, 13),
+      // R2's unique clients
+      directEdge(2, 20), directEdge(2, 21), directEdge(2, 22), directEdge(2, 23),
+    ]);
+    const ctx = makeCtx({ nodes: nodeMap([r1, r2, c1, c2, c3, c4, c5, c6, c7, c8]), graph });
+
+    const findings = evaluateB1(ctx);
+
+    expect(findings).toHaveLength(0);
+  });
+
+  it('fires on a cluster whose members have high client overlap (true redundancy)', () => {
+    // Two routers hear each other AND serve mostly the same clients.
+    const r1 = makeNode({ nodeNum: 1, role: DeviceRole.ROUTER });
+    const r2 = makeNode({ nodeNum: 2, role: DeviceRole.ROUTER });
+    // 4 shared clients, 0 unique to either → 100% overlap.
+    const shared = [10, 11, 12, 13].map((n) => makeNode({ nodeNum: n }));
+    const graph = makeGraph([
+      directEdge(1, 2),
+      directEdge(1, 10), directEdge(1, 11), directEdge(1, 12), directEdge(1, 13),
+      directEdge(2, 10), directEdge(2, 11), directEdge(2, 12), directEdge(2, 13),
+    ]);
+    const ctx = makeCtx({ nodes: nodeMap([r1, r2, ...shared]), graph });
+
+    const findings = evaluateB1(ctx);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+  });
+
+  it('still fires when members lack enough non-cluster clients to compute overlap (fail-closed)', () => {
+    // Two routers hear each other but have no other known neighbors —
+    // insufficient data to prove distinct coverage, so the finding stands.
+    const r1 = makeNode({ nodeNum: 1, role: DeviceRole.ROUTER });
+    const r2 = makeNode({ nodeNum: 2, role: DeviceRole.ROUTER });
+    const graph = makeGraph([directEdge(1, 2)]);
+    const ctx = makeCtx({ nodes: nodeMap([r1, r2]), graph });
+
+    const findings = evaluateB1(ctx);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+  });
+
+  it('suppresses a large cluster (4+ routers) when all pairs have low client overlap', () => {
+    // 4 routers forming a K4 clique, but each serves 4 unique clients.
+    const routers = [1, 2, 3, 4].map((n) => makeNode({ nodeNum: n, role: DeviceRole.ROUTER }));
+    const clients = Array.from({ length: 16 }, (_, i) => makeNode({ nodeNum: 100 + i }));
+    const edges = [
+      // K4 internal edges
+      directEdge(1, 2), directEdge(1, 3), directEdge(1, 4),
+      directEdge(2, 3), directEdge(2, 4), directEdge(3, 4),
+      // Each router's 4 unique clients
+      ...([1, 2, 3, 4] as number[]).flatMap((r, ri) =>
+        [0, 1, 2, 3].map((ci) => directEdge(r, 100 + ri * 4 + ci)),
+      ),
+    ];
+    const ctx = makeCtx({ nodes: nodeMap([...routers, ...clients]), graph: makeGraph(edges) });
+
+    const findings = evaluateB1(ctx);
+
+    expect(findings).toHaveLength(0);
+  });
 });
 
 describe('findRouterClusters — shared by B1 and B6', () => {

--- a/src/server/services/meshIssues/rulesTierB.ts
+++ b/src/server/services/meshIssues/rulesTierB.ts
@@ -403,6 +403,39 @@ function evaluateB1Impl(ctx: TierBRuleContext, clusters: RouterCluster[]): MeshI
         ? 'critical'
         : 'warning';
 
+    // Pairwise client-overlap check: suppress findings where cluster members
+    // serve distinct coverage areas. A backbone of well-sited routers that
+    // each covers unique local nodes is healthy infrastructure, not
+    // redundancy. Only suppresses when we have enough neighbor data on at
+    // least one pair to make the call; insufficient data keeps the finding.
+    const memberClientSets = new Map<number, Set<number>>();
+    for (const m of members) {
+      const allNbs = ctx.graph.directAdjacency.get(m);
+      const clients = new Set<number>();
+      if (allNbs) {
+        for (const nb of allNbs) {
+          if (!memberSet.has(nb)) clients.add(nb);
+        }
+      }
+      memberClientSets.set(m, clients);
+    }
+    let maxClientOverlap = 0;
+    let overlapComputable = false;
+    for (let i = 0; i < members.length; i++) {
+      for (let j = i + 1; j < members.length; j++) {
+        const cA = memberClientSets.get(members[i])!;
+        const cB = memberClientSets.get(members[j])!;
+        if (cA.size < REDUNDANT_MIN_NEIGHBORS || cB.size < REDUNDANT_MIN_NEIGHBORS) continue;
+        overlapComputable = true;
+        const [smaller, larger] = cA.size <= cB.size ? [cA, cB] : [cB, cA];
+        let shared = 0;
+        for (const x of smaller) if (larger.has(x)) shared++;
+        const ratio = shared / smaller.size;
+        if (ratio > maxClientOverlap) maxClientOverlap = ratio;
+      }
+    }
+    if (overlapComputable && maxClientOverlap < REDUNDANT_OVERLAP_RATIO) continue;
+
     // Best-sited member: highest direct-adjacency degree; ties -> most
     // positioned direct edges; ties -> lowest nodeNum.
     let best: PooledNode | null = null;


### PR DESCRIPTION
## Summary

- B1 (Router Cluster) previously flagged any group of ROUTER/REPEATER-role nodes that were mutually audible. This misclassifies backbone infrastructure: well-sited G2 routers on tall antennas naturally hear each other but each covers a distinct set of local clients, so the coverage is additive, not redundant.
- B1 now checks the pairwise **client overlap** between cluster members (their non-cluster direct neighbors). If any pair reaches the 90% overlap threshold — the same constant B2 uses — the cluster is genuinely redundant and the finding proceeds. If every computable pair falls below the threshold, the cluster serves distinct areas and the finding is suppressed. When no pair has enough neighbor data to compute (< 3 clients on either side), the check **fails-closed** and the finding still fires — we cannot prove the cluster is harmless.
- Docs page (Mesh Issues Test Reference) and the B1 row on the main mesh-issues page updated to reflect the new requirement.

## Test plan

- [x] `vitest run src/server/services/meshIssues/rulesTierB.test.ts` — 67 pass, 0 fail (added 4 new B1 client-overlap cases)
- [x] `tsc -p tsconfig.server.json --noEmit` — clean
- [ ] Verify on the reporter's live mesh (TRON — 7 G2 routers, 100+ ft, South Florida) that the cluster no longer flags
- [ ] Confirm truly-redundant clusters (co-located routers with shared clients) still flag

## Notes

Reuses `REDUNDANT_OVERLAP_RATIO` (0.9) and `REDUNDANT_MIN_NEIGHBORS` (3) from B2 rather than introducing new thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G