### PR TITLE
fix(key-security): scope keyMismatch reads by source; clear stale flags

### DIFF
--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -169,6 +169,7 @@ import { migration as createMessageEventsMigration, runMigration151Postgres, run
 import { migration as createMeshtasticHeardRepeatersMigration, runMigration152Postgres, runMigration152Mysql } from '../server/migrations/152_create_meshtastic_heard_repeaters.js';
 import { migration as meshcoreNodeNeighborsConfigMigration, runMigration153Postgres, runMigration153Mysql } from '../server/migrations/153_meshcore_node_neighbors_config.js';
 import { migration as createMeshIssuesMigration, runMigration154Postgres, runMigration154Mysql } from '../server/migrations/154_create_mesh_issues.js';
+import { migration as clearStaleKeyMismatchMigration, runMigration155Postgres, runMigration155Mysql } from '../server/migrations/155_clear_stale_key_mismatch.js';
 
 // ============================================================================
 // Registry
@@ -2470,4 +2471,21 @@ registry.register({
   sqlite: (db) => createMeshIssuesMigration.up(db),
   postgres: (client) => runMigration154Postgres(client),
   mysql: (pool) => runMigration154Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 155: clear stale `keyMismatchDetected` flags left behind by the
+// source-blind read bug in `meshtasticManager.ts` (fixed in this branch).
+// Only clears flags on rows whose fingerprint matches the PKI-error path
+// (`lastMeshReceivedKey IS NULL`); a legitimate current PKI failure re-sets
+// the flag on the next failed DM.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 155,
+  name: 'clear_stale_key_mismatch',
+  settingsKey: 'migration_155_clear_stale_key_mismatch',
+  sqlite: (db) => clearStaleKeyMismatchMigration.up(db),
+  postgres: (client) => runMigration155Postgres(client),
+  mysql: (pool) => runMigration155Mysql(pool),
 });

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -7510,8 +7510,13 @@ class MeshtasticManager implements ISourceManager {
           nodeData.keySecurityIssueDetails = null;
         }
 
-        // Check if this node had a key mismatch that is now fixed
-        const existingNode = await databaseService.nodes.getNode(fromNum);
+        // Check if this node had a key mismatch that is now fixed.
+        // MUST scope to this.sourceId — `keyMismatchDetected` is per-source
+        // (writes below use `upsertNodeAsync(..., this.sourceId)`). An
+        // unscoped read returns whichever row Drizzle picks first (often
+        // an MQTT-ingested row with a different snapshot), producing both
+        // false-positive mismatches AND stuck flags that never clear.
+        const existingNode = await databaseService.nodes.getNode(fromNum, this.sourceId);
 
         // --- Proactive key mismatch detection ---
         let newMismatchDetected = false;
@@ -8745,7 +8750,9 @@ class MeshtasticManager implements ISourceManager {
           // NO_CHANNEL from the target node (it couldn't decrypt our request)
           // Skip if the target is our own local node — we can't have a key mismatch with ourselves
           if (errorReason === RoutingError.NO_CHANNEL && fromNodeId === toNodeId && toNodeId !== localNodeId) {
-            const existingNode = await databaseService.nodes.getNode(toNum);
+            // Scope to this.sourceId — the write below is per-source, and an
+            // unscoped read of `keyMismatchDetected` returns the wrong source's row.
+            const existingNode = await databaseService.nodes.getNode(toNum, this.sourceId);
             if (!existingNode?.keyMismatchDetected) {
               const errorDescription = 'NO_CHANNEL error on request - target node rejected the message. ' +
                 'Possible key or channel mismatch. Use "Exchange Node Info" or purge node data to refresh keys.';
@@ -8807,8 +8814,9 @@ class MeshtasticManager implements ISourceManager {
 
           logger.warn(`🔐 NO_CHANNEL on DM detected for node ${targetNodeId}: ${errorDescription}`);
 
-          // Flag the node with the key security issue (if not already flagged)
-          const existingNode = await databaseService.nodes.getNode(targetNodeNum);
+          // Flag the node with the key security issue (if not already flagged).
+          // Scope to this.sourceId — the write below is per-source.
+          const existingNode = await databaseService.nodes.getNode(targetNodeNum, this.sourceId);
           if (!existingNode?.keyMismatchDetected) {
             await databaseService.upsertNodeAsync({
               nodeNum: targetNodeNum,

--- a/src/server/migrations/155_clear_stale_key_mismatch.test.ts
+++ b/src/server/migrations/155_clear_stale_key_mismatch.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Migration 155 tests — clear stale keyMismatchDetected flags left by the
+ * source-blind read bug in `meshtasticManager.ts`.
+ */
+import Database from 'better-sqlite3';
+import { describe, expect, it, vi } from 'vitest';
+import { migration, runMigration155Postgres, runMigration155Mysql } from './155_clear_stale_key_mismatch.js';
+
+function bootstrapNodesTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE nodes (
+      nodeNum INTEGER NOT NULL,
+      sourceId TEXT NOT NULL,
+      publicKey TEXT,
+      lastMeshReceivedKey TEXT,
+      keyIsLowEntropy INTEGER,
+      duplicateKeyDetected INTEGER,
+      keyMismatchDetected INTEGER,
+      keySecurityIssueDetails TEXT,
+      PRIMARY KEY (nodeNum, sourceId)
+    )
+  `);
+}
+
+function insertNode(
+  db: Database.Database,
+  row: {
+    nodeNum: number;
+    sourceId: string;
+    publicKey?: string | null;
+    lastMeshReceivedKey?: string | null;
+    keyIsLowEntropy?: 0 | 1;
+    duplicateKeyDetected?: 0 | 1;
+    keyMismatchDetected?: 0 | 1;
+    keySecurityIssueDetails?: string | null;
+  },
+): void {
+  db.prepare(`
+    INSERT INTO nodes
+      (nodeNum, sourceId, publicKey, lastMeshReceivedKey,
+       keyIsLowEntropy, duplicateKeyDetected, keyMismatchDetected,
+       keySecurityIssueDetails)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    row.nodeNum,
+    row.sourceId,
+    row.publicKey ?? null,
+    row.lastMeshReceivedKey ?? null,
+    row.keyIsLowEntropy ?? 0,
+    row.duplicateKeyDetected ?? 0,
+    row.keyMismatchDetected ?? 0,
+    row.keySecurityIssueDetails ?? null,
+  );
+}
+
+describe('Migration 155 — clear stale keyMismatchDetected flags', () => {
+  describe('SQLite', () => {
+    it('clears the flag on PKI-error rows (lastMeshReceivedKey NULL) and their details string', () => {
+      const db = new Database(':memory:');
+      bootstrapNodesTable(db);
+      insertNode(db, {
+        nodeNum: 100,
+        sourceId: 'tcp-source',
+        publicKey: 'AAA',
+        lastMeshReceivedKey: null,
+        keyMismatchDetected: 1,
+        keySecurityIssueDetails: 'PKI encryption failed — advisory',
+      });
+
+      migration.up(db);
+
+      const row = db.prepare(`SELECT * FROM nodes WHERE nodeNum = 100`).get() as any;
+      expect(row.keyMismatchDetected).toBe(0);
+      expect(row.keySecurityIssueDetails).toBeNull();
+      db.close();
+    });
+
+    it('leaves NodeInfo-mismatch rows alone (lastMeshReceivedKey non-null is real evidence)', () => {
+      const db = new Database(':memory:');
+      bootstrapNodesTable(db);
+      insertNode(db, {
+        nodeNum: 200,
+        sourceId: 'tcp-source',
+        publicKey: 'OLD',
+        lastMeshReceivedKey: 'NEW',
+        keyMismatchDetected: 1,
+        keySecurityIssueDetails: 'Key mismatch: node broadcast key NEW... but device has OLD...',
+      });
+
+      migration.up(db);
+
+      const row = db.prepare(`SELECT * FROM nodes WHERE nodeNum = 200`).get() as any;
+      expect(row.keyMismatchDetected).toBe(1);
+      expect(row.keySecurityIssueDetails).toContain('Key mismatch');
+      db.close();
+    });
+
+    it('preserves details when the row also carries a low-entropy or duplicate flag', () => {
+      const db = new Database(':memory:');
+      bootstrapNodesTable(db);
+      insertNode(db, {
+        nodeNum: 300,
+        sourceId: 'tcp-source',
+        publicKey: 'LOWENT',
+        lastMeshReceivedKey: null,
+        keyMismatchDetected: 1,
+        keyIsLowEntropy: 1,
+        keySecurityIssueDetails: 'Known low-entropy key detected',
+      });
+      insertNode(db, {
+        nodeNum: 301,
+        sourceId: 'tcp-source',
+        publicKey: 'DUPKEY',
+        lastMeshReceivedKey: null,
+        keyMismatchDetected: 1,
+        duplicateKeyDetected: 1,
+        keySecurityIssueDetails: 'Key shared with nodes: 999',
+      });
+
+      migration.up(db);
+
+      const lowE = db.prepare(`SELECT * FROM nodes WHERE nodeNum = 300`).get() as any;
+      expect(lowE.keyMismatchDetected).toBe(0);
+      expect(lowE.keySecurityIssueDetails).toBe('Known low-entropy key detected');
+
+      const dup = db.prepare(`SELECT * FROM nodes WHERE nodeNum = 301`).get() as any;
+      expect(dup.keyMismatchDetected).toBe(0);
+      expect(dup.keySecurityIssueDetails).toBe('Key shared with nodes: 999');
+      db.close();
+    });
+
+    it('touches only rows with keyMismatchDetected = 1', () => {
+      const db = new Database(':memory:');
+      bootstrapNodesTable(db);
+      insertNode(db, {
+        nodeNum: 400,
+        sourceId: 'tcp-source',
+        publicKey: 'X',
+        lastMeshReceivedKey: null,
+        keyMismatchDetected: 0,
+        keySecurityIssueDetails: 'unrelated',
+      });
+
+      migration.up(db);
+
+      const row = db.prepare(`SELECT * FROM nodes WHERE nodeNum = 400`).get() as any;
+      expect(row.keySecurityIssueDetails).toBe('unrelated');
+      db.close();
+    });
+
+    it('is idempotent — a second run clears nothing new', () => {
+      const db = new Database(':memory:');
+      bootstrapNodesTable(db);
+      insertNode(db, {
+        nodeNum: 500,
+        sourceId: 'tcp-source',
+        publicKey: 'K',
+        lastMeshReceivedKey: null,
+        keyMismatchDetected: 1,
+        keySecurityIssueDetails: 'advisory',
+      });
+
+      migration.up(db);
+      const afterFirst = db.prepare(`SELECT keyMismatchDetected, keySecurityIssueDetails FROM nodes WHERE nodeNum = 500`).get();
+      expect(() => migration.up(db)).not.toThrow();
+      const afterSecond = db.prepare(`SELECT keyMismatchDetected, keySecurityIssueDetails FROM nodes WHERE nodeNum = 500`).get();
+      expect(afterSecond).toEqual(afterFirst);
+      db.close();
+    });
+  });
+
+  describe('PostgreSQL', () => {
+    it('runs an UPDATE scoped to PKI-error rows', async () => {
+      const client = { query: vi.fn().mockResolvedValue({ rowCount: 42 }) };
+      await runMigration155Postgres(client as any);
+
+      const sql = client.query.mock.calls.map((c: any[]) => String(c[0])).join('\n');
+      expect(sql).toMatch(/UPDATE nodes/);
+      expect(sql).toMatch(/"keyMismatchDetected" = FALSE/);
+      expect(sql).toMatch(/"lastMeshReceivedKey" IS NULL/);
+      expect(sql).toMatch(/"keyIsLowEntropy" = TRUE OR "duplicateKeyDetected" = TRUE/);
+    });
+  });
+
+  describe('MySQL', () => {
+    it('runs an UPDATE scoped to PKI-error rows', async () => {
+      const pool = { query: vi.fn().mockResolvedValue([{ affectedRows: 17 }, []]) };
+      await runMigration155Mysql(pool as any);
+
+      const sql = pool.query.mock.calls.map((c: any[]) => String(c[0])).join('\n');
+      expect(sql).toMatch(/UPDATE nodes/);
+      expect(sql).toMatch(/keyMismatchDetected = 0/);
+      expect(sql).toMatch(/lastMeshReceivedKey IS NULL/);
+      expect(sql).toMatch(/keyIsLowEntropy = 1 OR duplicateKeyDetected = 1/);
+    });
+  });
+});

--- a/src/server/migrations/155_clear_stale_key_mismatch.ts
+++ b/src/server/migrations/155_clear_stale_key_mismatch.ts
@@ -1,0 +1,84 @@
+/**
+ * Migration 155: clear stale `keyMismatchDetected` flags left over from the
+ * source-blind read bug fixed in this branch.
+ *
+ * Before the fix, three call sites in `meshtasticManager.ts` read the
+ * "existing node" row without scoping to `sourceId`, so a NodeInfo or PKI
+ * error observed on one source (e.g. `meshtastic_tcp`) could compare against
+ * a different source's stored key. That produced both false-positive
+ * `keyMismatchDetected=1` writes AND stuck flags whose clear-branch was
+ * blocked by looking at another source's row.
+ *
+ * We clear the flag only on rows that fit the "PKI-error-path" fingerprint:
+ * `lastMeshReceivedKey IS NULL`. The NodeInfo-mismatch path always writes
+ * `lastMeshReceivedKey = <the newly received key>` alongside the flag, so a
+ * non-null value there is genuine evidence we heard a different key over the
+ * air. Rows without that value came from the PKI-error paths (routing error
+ * NO_KEY / PKI_FAILED / NO_CHANNEL) which set the flag but no evidence key.
+ * Those are advisory — a legitimate current failure re-sets the flag on the
+ * next failed DM.
+ *
+ * `keySecurityIssueDetails` is cleared only when the row has NO other reason
+ * to carry a details string (not low-entropy, not duplicate).
+ *
+ * Idempotent across all three backends — a re-run flips nothing since we
+ * gate on `keyMismatchDetected = 1` (SQLite/MySQL) / `TRUE` (PostgreSQL).
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 155';
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): clearing stale keyMismatchDetected flags…`);
+
+    const info = db.prepare(`
+      UPDATE nodes
+      SET keyMismatchDetected = 0,
+          keySecurityIssueDetails = CASE
+            WHEN (keyIsLowEntropy = 1 OR duplicateKeyDetected = 1) THEN keySecurityIssueDetails
+            ELSE NULL
+          END
+      WHERE keyMismatchDetected = 1
+        AND lastMeshReceivedKey IS NULL
+    `).run();
+
+    logger.info(`${LABEL} complete (SQLite): cleared ${info.changes} row(s)`);
+  },
+};
+
+export async function runMigration155Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): clearing stale keyMismatchDetected flags…`);
+
+  const result = await client.query(`
+    UPDATE nodes
+    SET "keyMismatchDetected" = FALSE,
+        "keySecurityIssueDetails" = CASE
+          WHEN ("keyIsLowEntropy" = TRUE OR "duplicateKeyDetected" = TRUE) THEN "keySecurityIssueDetails"
+          ELSE NULL
+        END
+    WHERE "keyMismatchDetected" = TRUE
+      AND "lastMeshReceivedKey" IS NULL
+  `);
+
+  logger.info(`${LABEL} complete (PostgreSQL): cleared ${result.rowCount ?? 0} row(s)`);
+}
+
+export async function runMigration155Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): clearing stale keyMismatchDetected flags…`);
+
+  const [result] = await pool.query(`
+    UPDATE nodes
+    SET keyMismatchDetected = 0,
+        keySecurityIssueDetails = CASE
+          WHEN (keyIsLowEntropy = 1 OR duplicateKeyDetected = 1) THEN keySecurityIssueDetails
+          ELSE NULL
+        END
+    WHERE keyMismatchDetected = 1
+      AND lastMeshReceivedKey IS NULL
+  `);
+
+  const affected = (result as { affectedRows?: number }).affectedRows ?? 0;
+  logger.info(`${LABEL} complete (MySQL): cleared ${affected} row(s)`);
+}


### PR DESCRIPTION
## Summary

Three sites in `meshtasticManager.ts` fetch the "existing node" row with `getNode(nodeNum)` — no `sourceId` — then compare its `publicKey` and `keyMismatchDetected` against a packet observed on `this.sourceId`. Writes ARE scoped (`upsertNodeAsync(..., this.sourceId)`), so the read/write asymmetry produces:

1. **False positives** — an unscoped read returns whichever row Drizzle picks first (often an MQTT-ingested snapshot), so a stale snapshot on that row differs from the just-arrived TCP packet and flags the TCP row.
2. **Stuck flags** — the clear-branch reads `existingNode.keyMismatchDetected` from any-source (usually false), so the TCP row's flag never clears even after keys reconverge.

Observed on a live install:
- 230 rows carry `keyMismatchDetected=1`, all on `meshtastic_tcp` sources.
- All 230 have `lastMeshReceivedKey IS NULL` (i.e. set via the PKI-error paths, not the NodeInfo-mismatch path).
- 99 of 120 flagged nodes on one source now have **identical keys across every source** but stay flagged.

## Fix

- **`meshtasticManager.ts:7514, 8748, 8811`** — pass `this.sourceId` to `getNode()`.
- **Migration 155** — one-shot clear of `keyMismatchDetected` on rows whose fingerprint matches the PKI-error path (`lastMeshReceivedKey IS NULL`). Genuine current PKI failures re-set the flag on the next failed DM. `keySecurityIssueDetails` is preserved when the row also carries a low-entropy or duplicate-key flag.

## Test plan

- [x] `vitest run src/server/migrations/155_clear_stale_key_mismatch.test.ts` — 7 pass (SQLite functional + PG/MySQL SQL assertions)
- [x] `vitest run src/db/migrations.test.ts src/server/migrations/ src/server/meshtasticManager.test.ts` — 530 pass, 0 fail
- [x] `tsc -p tsconfig.server.json --noEmit` — clean
- [ ] After deploy: verify C1_key_security finding count drops to genuine current issues; watch that fresh NodeInfo/PKI failures still flag correctly

## Notes

The three call sites at 8010, 8029, 8974, 8985, and 6055/6448 are also source-blind reads but are outside the key-security path. Not touched in this PR; separate audit warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G