### PR TITLE
docs: audit and update for 4.15.2 release

### DIFF
--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -67,6 +67,11 @@ Every automation has exactly one trigger (the **WHEN**). Each trigger exposes a 
 | **A node enters/leaves a region** | A node crosses a geofence | `Enters` / `Leaves` / `Moves while inside (dwell)`, plus a map region editor |
 | **A watched node becomes mobile** | A hand-selected node flips from stationary → mobile | Multi-select of nodes (stationary candidates highlighted); MeshMonitor’s >100 m position-history heuristic |
 | **A watched node leaves its home position** | A hand-selected node moves farther than a threshold from its home/anchor | Multi-select of nodes, threshold in metres (default 300). Home is seeded from position-history inliers when available (else first live fix); while within half the threshold, home is gently averaged. Saved automations can **Reset homes from history** |
+| **A watched node's heartbeat is lost** | A hand-selected node stops being heard for longer than a per-node deadline | Multi-select of nodes; per-node timeout minutes (default 60); MeshCore parity |
+| **A watched node comes back after a heartbeat loss** | A watched node is heard again after its own lost-heartbeat alert fired | Pairs one-to-one with the loss trigger so a recovery automation only fires for nodes that had actually gone silent |
+| **A watched node rebooted** | An uptime reset is detected (uptime decreases without a matching graceful reboot) | Multi-select of nodes; suppresses matched self-triggered reboots so an automation-initiated `deviceReboot` doesn't re-fire the alert |
+| **A watched node's external power changed** | A node reports losing or restoring external power (voltage / power-source telemetry) | Multi-select of nodes; separate `lost` vs `restored` fires, both exposed as `{{ trigger.event }}` |
+| **A watched node's battery is trending down** | A node's battery drops through a threshold with a sustained negative slope over the window | Multi-select of nodes; threshold percent (default 25); window hours (default 24). Doubles as a solar underperformance proxy on nodes that normally recharge each day |
 
 ### Became mobile & left home (tamper / theft monitoring)
 
@@ -453,7 +458,7 @@ of prebuilt automations. Pick one, fill in a small wizard (which sources/channel
 it installs — **disabled**, for review, the same as any imported automation — ready to open in the
 visual builder, check over, and enable.
 
-The gallery ships with two templates today:
+The gallery ships with these templates today:
 
 - **Auto-Ack** — acknowledges direct, zero-hop text messages with a tapback or a reply, reproducing
   the common "answer range testers who hit me directly" pattern as an editable automation instead of
@@ -462,6 +467,11 @@ The gallery ships with two templates today:
   channel, tagged with its protocol of origin. See [Recipe — Meshtastic ↔ MeshCore
   bridge](#recipe-—-meshtastic-↔-meshcore-bridge) below for the full walkthrough, including the
   flood-safety guidance you should read before enabling it.
+- **Device Health** — a one-click starter for the device-health trigger family (heartbeat lost /
+  recovered, node rebooted, external power changed, battery trending down). Pick the nodes you want
+  to watch and the wizard installs one automation per event, each pre-wired to send an Apprise
+  notification. Automations land disabled for review, so you can tune thresholds and add channels
+  before flipping them on. Works for both Meshtastic and MeshCore nodes.
 
 Every template installs through the same [JSON import](#overview) path as a hand-exported automation
 (`POST /api/automations/import`), so it lands disabled, and a template that installs a **pair** of

--- a/docs/features/automation.md
+++ b/docs/features/automation.md
@@ -1218,6 +1218,10 @@ The `lorem` examples demonstrate the **multiple responses** feature where a scri
 
 See the [examples/auto-responder-scripts/README.md](https://github.com/MeshAddicts/meshmonitor/tree/main/examples/auto-responder-scripts) for detailed documentation.
 
+### Installed Scripts inventory
+
+**Global Settings → Scripts** lists every user script that MeshMonitor can see on disk, alongside which Auto Responder triggers reference it. A script that shows up here but has zero `usedBy` entries is a candidate to remove; a trigger that references a script name no longer present is easy to spot the other way. The `computeScriptUsage` helper does the same accounting that Auto Responder uses internally, so the inventory and the trigger picker stay in agreement.
+
 ### Managing Triggers
 
 **Adding Triggers**:

--- a/docs/features/device.md
+++ b/docs/features/device.md
@@ -1520,6 +1520,17 @@ owner: My Node Name
 owner_short: MNN
 ```
 
+### Restoring Configuration from Device Backup Management
+
+*New in 4.15.2.* Every backup listed under **Device → Backups** carries a **Restore** button. Restore is a local, per-source, verbatim replay of the saved YAML back onto whichever device this source is currently connected to. MeshMonitor sends each config chunk in the same order it exported them (device, module, channels), then asks the device to reboot to apply the changes; a banner in the panel surfaces the reboot notice directly from the "did-reboot" flag on the response, so the UI never claims a reboot happened that the device didn't do.
+
+Behavior:
+
+- **Local device only** — restore targets the device on the current source, not another node on the mesh. Cross-node config transfers still need the Meshtastic CLI recipe below.
+- **Verbatim replay** — every field in the backup is sent, including the encryption keys, WiFi passwords, and channel URLs. Restore does not merge or diff.
+- **Bluetooth is handled separately** — Bluetooth configuration has its own setter path, so the panel offers a Bluetooth restore too.
+- **`settings:write` required** — the button is hidden without it.
+
 ### Restoring Configuration with Meshtastic CLI
 
 You can restore a MeshMonitor backup to any Meshtastic device using the official Meshtastic CLI tools.

--- a/docs/features/map-analysis.md
+++ b/docs/features/map-analysis.md
@@ -32,6 +32,14 @@ The toolbar is now icon-based rather than text-labeled — every button carries 
 
 ## Toolbar
 
+::: tip Grouped toolbar menus (New in 4.15.2)
+The toolbar's per-category controls are now organised into **four labelled dropdown menus** — Filters, Layers, View, and Tools — instead of a long, wrap-happy row of buttons. Everything below is still there; open the matching menu to reach it. The Layer buttons live inside **Layers**, the 2D/3D/Follow controls under **View**, Measure and Link Profile under **Tools**, and every filter (source, node type, transport, node search, node multi-select) under **Filters**.
+:::
+
+::: tip Unified controls sidebar (New in 4.15.2)
+Layer-specific popovers now dock into the shared **map controls sidebar** on the right (the same sidebar the Dashboard, Nodes tab, and MeshCore maps use) instead of floating over the canvas. Click a layer's row in the sidebar to expand its options in place. Collapse the whole sidebar with the edge tab to work at full canvas width.
+:::
+
 The toolbar runs across the top of the canvas. From left to right:
 
 | Control | Purpose |
@@ -244,6 +252,17 @@ For a node seen by several sources (say, a Meshtastic radio *and* an MQTT bridge
 ### Limitations
 
 The terrain data (SRTM-derived, roughly 90 m per pixel) is a bare-earth elevation model — it does **not** account for buildings, trees, or other vegetation, so a "Clear" verdict is a first-pass estimate of geometric line-of-sight, not a guarantee of a working RF link. Node GPS altitude is not factored into antenna height; only the DEM terrain height plus your entered AGL value is used.
+
+## Site Planner
+
+The **Site Planner** panel projects a single node's terrain-aware coverage as a swept ring rather than a flat circle, using the same Fresnel and link-budget math as [Terrain Link Profile](#terrain-link-profile). Pick an origin node (or an arbitrary map point), and the panel draws the reachable envelope in every direction the DEM supports.
+
+When the result comes back as a **plain circle** rather than a terrain-shaped ring, the panel's banner explains why:
+
+- **Budget outran radius** — the link budget stayed clear beyond the search radius in every direction MeshMonitor tested, so the ring degenerates to a circle at the search radius itself. Raise the search radius to see the terrain-shaped envelope.
+- **DEM gap** — the elevation source didn't return a tile for part of the search area (usually a coastline, ocean, or a region outside your DEM's coverage). MeshMonitor falls back to a plain circle rather than half-drawing an envelope with a jagged missing edge.
+
+Both are user-actionable states, not failures — the banner tells you which one you're looking at instead of leaving the circle unexplained.
 
 ## 3D terrain view
 

--- a/docs/features/maps.md
+++ b/docs/features/maps.md
@@ -38,6 +38,9 @@ Each node is represented on the map with a marker that provides visual informati
   - Solid marker: Active node (heard recently)
   - Faded marker: Inactive node (not heard within configured time window)
 
+- **Per-node color** *(New in 4.15.2)*:
+  - Every node gets a deterministic color derived from its NodeNum using the same algorithm the official Meshtastic app uses. The color is applied to the map pin and to the matching node's row in the sidebar list, so a node is easy to pick out at a glance across the map and the list. Signal-quality color coding above still applies where the underlying color is used as a fill — the per-node color drives the pin's outline / accent so the two signals don't collide.
+
 #### Node Popups
 
 Click any node marker to view detailed information:
@@ -86,6 +89,11 @@ MeshMonitor remembers a **separate tileset preference for light and dark appeara
 - **Pan**: Click and drag to move the map
 - **Center on Node**: Click a node in the sidebar to center the map on that node. The map zooms in to a configurable target level (default 17, adjustable in **Settings → Map**) when the node is far away, but never zooms *out* below your current zoom level.
 - **Fit to Network**: Automatically adjusts zoom to show all active nodes
+- **Zoom to Fit**: A dedicated control in the map sidebar frames all currently-visible nodes in one click, honouring the active age and source filters (so a Zoom to Fit while you have "Only stationary" or "Last 24 h" on frames only that subset, not everything the mesh has ever heard).
+
+::: tip Unified map controls sidebar (New in 4.15.2)
+Every map surface, the Dashboard map, the Nodes tab map, MeshCore, and Map Analysis, now shares one **collapsible sidebar** on the right instead of individual floating panels stacked in the map corners. Layer toggles, filters, tileset controls, and per-surface controls all live in one place, in the same order, so muscle memory carries between views. Click the tab handle to collapse the sidebar back to a thin edge when you want the map full-width.
+:::
 
 ### Traceroute Visualization
 
@@ -166,6 +174,8 @@ last heard before the window it defines. Rather than one linear hour-per-tick
 narrowing to the last hour or reaching out to a month. The top stop always
 matches your **Max Node Age** setting, so the slider can never select an age
 the setting would filter out anyway.
+
+**Show all** (0) — the **Maximum Age of Active Nodes** setting in **Settings → Nodes** accepts `0` to mean "no age cap". At `0` the slider tops out at an unbounded "All" stop and MeshMonitor never hides a node for being stale. Useful for post-mortem review of a mesh you don't intend to prune.
 
 ### GNSS Satellite Overlay
 
@@ -248,6 +258,10 @@ MeshMonitor includes several pre-configured map styles:
 - **Use Cases**: Clean, minimal map display
 - **URL**: `https://cartodb-basemaps-a.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png`
 - **Attribution**: © OpenStreetMap contributors, © CartoDB
+
+::: tip Carto API key (New in 4.15.2)
+Both CartoDB tilesets accept a personal API key from a free [carto.com](https://carto.com/) account for higher rate limits than the anonymous public endpoint. Paste your **publishable** key into **Settings → Map → Carto API key**; MeshMonitor appends it as `?key=...` on every Carto tile request. The key is publishable by design (it lives in the browser), so treat it like any other public API token and rotate it if abused. Leave the field blank to keep using the anonymous endpoint.
+:::
 
 ### Custom Tile Servers
 

--- a/docs/features/mesh-issues-test-reference.md
+++ b/docs/features/mesh-issues-test-reference.md
@@ -344,6 +344,7 @@ Five thresholds are tunable in **Global Settings > Mesh Issues Analysis**:
 | Mobile span | 500 m | A4 |
 | Link SNR asymmetry | 6 dB | B3 |
 | Broadcast interval floor | 300 s | C2 |
+| Router cluster max link | 30 km | B1 (distance guard) |
 
 All other thresholds are fixed in code. See the
 [Mesh Issues Analysis](./mesh-issues#where-the-thresholds-come-from)

--- a/docs/features/mesh-issues.md
+++ b/docs/features/mesh-issues.md
@@ -140,6 +140,8 @@ settings](#settings); the rest stay fixed in code, listed here for reference:
 | Coverage-shadow range cap | 25 km | B7 |
 | Router-cluster warning size | 2 | B1 |
 | Router-cluster critical size | 4 | B1 |
+| Router-cluster client-overlap ratio | 90% | B1 (shared with B2) |
+| Router-cluster minimum non-cluster neighbours | 3 | B1 (shared with B2) |
 | Over-broadcast minimum samples | 6 | C2 |
 | Auto-close clean-run count | 3 | all rules |
 | Evidence list cap | 25 entries | all list-shaped evidence |
@@ -170,6 +172,17 @@ Each type section and node row carries a **bulk-actions menu**: dismiss or
 restore everything in that group at once, or mute the rule outright (see
 [Muting a rule](#muting-a-rule)). Bulk actions only ever touch findings your
 account can see.
+
+### Clickable node references
+
+Every place a node's name shows up in a finding, the By Node group headers,
+the member and "shared with" chips inside evidence, is a clickable link.
+Click one to jump straight to a DM thread with that node on its source's
+Messages tab. When the same node exists on more than one source, a small
+picker opens so you can choose which source to open the thread on. Cell
+contents that used to overflow the table into a horizontal scrollbar (the
+C1 Details column and the multi-source list, in particular) now wrap
+within their cell instead.
 
 ## Acting on findings
 
@@ -300,6 +313,7 @@ Issues Analysis**. The controls are global and require `settings:write`.
 | Mobile span | 500 m | 50–50,000 m | `[MeshMonitor]` |
 | Link SNR asymmetry | 6 dB | 1–30 dB | `[MeshMonitor]` |
 | Broadcast interval floor | 300 s | 30–3,600 s | `[MeshMonitor]` |
+| Router cluster max link | 30 km | 1–500 km | `[MeshMonitor]`, B1 distance guard |
 | Auto-close after | 3 clean runs | 1–20 | `[MeshMonitor]` |
 
 Every value is **clamped when read**, not rejected on save: an out-of-range

--- a/docs/features/meshcore.md
+++ b/docs/features/meshcore.md
@@ -263,7 +263,7 @@ There are three layers, resolved most-specific-first (**channel scope → source
 
 - **Per-channel Region / Scope** — each channel's settings has a **Region / Scope** field. Traffic on that channel is stamped with this scope.
 - **Per-source default scope** — the MeshCore **Settings** view has a default-scope section backed by the `meshcoreDefaultScope` setting. Channels without their own scope fall back to this, so you can scope a whole source with one value.
-- **Unscoped** — leave both blank and traffic goes out with no scope (the legacy behavior).
+- **Unscoped** — leave both blank and MeshMonitor asserts a **truly unscoped** flood (companion firmware v12+ accepts a raw `SetFloodScope` payload that clears the device's default), so the packet leaves your radio with no region tag regardless of any default the device itself has configured. On older firmware that lacks the raw form, MeshMonitor falls back to the node's default; upgrade the companion firmware if you rely on unscoped sends from a source whose device is set to a default region.
 
 Channel-settings and the per-message override both offer a region-picker **datalist** drawn from your saved + discovered regions (see below); free typing is still allowed. Region names are normalized (leading `#` stripped; letters, digits, and hyphens kept).
 
@@ -532,6 +532,20 @@ MeshMonitor enforces this in software; it cannot stop link-layer acknowledgement
 on-device advert schedule configured outside MeshMonitor. See
 [MeshCore Receive-Only Mode](/features/meshcore-receive-only) for the full picture, including
 Virtual Node behavior and the firmware limitation.
+
+## Per-Source Settings
+
+Alongside the receive-only toggle, MeshCore **Settings** exposes a small set of per-source controls that shape how MeshMonitor talks to the mesh through that specific source:
+
+- **Default Path Hash Size** — how many bytes of a route's next-hop identity to include when sending direct messages that carry a cached route. The default matches the companion firmware default; lower values shave a byte or two off each direct send, higher values reduce ambiguity on very dense networks. Leave it alone unless you have a specific reason to tune it.
+- **Maximum infrastructure node age (hours)** — a separate age window for repeaters and room servers. The main **Maximum Age of Active Nodes** setting applies to all MeshCore nodes; this second slider lets you keep infrastructure nodes on the map for longer than mobile companions. Two views honor it: the map's node-list, and the neighbours summary. Set it to `0` to inherit the main age window.
+- **Telemetry time window** — the telemetry panel in a MeshCore node's details view exposes a time-window selector so you can flip the charts between the last hour, day, or week without leaving the panel.
+
+## Autopoll Neighbours
+
+Beyond the periodic **Auto-Pathfinding** neighbours cycle (see above), MeshMonitor also runs a **per-node retrieval scheduler** that keeps a specific repeater's neighbour list fresh on its own schedule instead of waiting for the next global cycle. This is helpful when you care about one link's health more than the full mesh and want its neighbours refreshed every few minutes.
+
+The scheduler shares the global 60-second minimum spacing between mesh operations on the same source, so a per-node autopoll never overlaps a hand-triggered send or an Auto-Pathfinding cycle. Enable it per contact from the contact detail panel.
 
 ## Radio Configuration
 

--- a/docs/features/packet-monitor.md
+++ b/docs/features/packet-monitor.md
@@ -79,7 +79,9 @@ This is by design - the Packet Monitor shows mesh network traffic, not MeshMonit
 
 ## Filtering Packets
 
-Use the packet type dropdown to filter by specific packet types (portnums). Common filters include:
+Use the packet type dropdown to filter by specific packet types (portnums). The dropdown lists the **full set** of Meshtastic portnums, not just the common ones, so filters like `ADMIN`, `NEIGHBORINFO`, `WAYPOINT`, `ATAK_PLUGIN`, and every other named port are directly selectable.
+
+Common filters include:
 
 - **All Types** - Show all received packets
 - **TEXT_MESSAGE** - Show only text messages
@@ -87,6 +89,10 @@ Use the packet type dropdown to filter by specific packet types (portnums). Comm
 - **TELEMETRY** - Show only telemetry data
 - **TRACEROUTE** - Show only traceroute responses
 - **NODEINFO** - Show only node information packets
+
+Alongside the type dropdown, a **free-text search** field matches against decoded packet content and metadata (node names, node IDs, message text, evidence). The type filter and the search field combine with AND, so you can narrow a single portnum down to only rows that mention a specific node or word.
+
+Every packet monitor view, the main Meshtastic one, the per-source MQTT gateway monitor, and the MeshCore over-the-air monitor, exposes the same **Stop capturing** control at the top so a run does not need to be left open to sample a short window.
 
 ::: tip Traceroute Filter
 If you filter on TRACEROUTE and see no results, this likely means no traceroute operations have been performed on your mesh recently. Traceroute packets only appear when:

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -29,13 +29,13 @@ See [Multi-Source → Connection Types](/features/multi-source) for the full lis
 
 **Description**: Controls which nodes appear in the Node List based on their last activity.
 
-**Range**: 1-168 hours
+**Range**: 0-168 hours (`0` = show all, no age cap)
 
 **Default**: 24 hours
 
-**Effect**: Nodes that haven't been heard from in longer than this period will not appear in the Node List. This helps keep the list focused on currently active nodes in your mesh network.
+**Effect**: Nodes that haven't been heard from in longer than this period will not appear in the Node List. This helps keep the list focused on currently active nodes in your mesh network. Setting the value to `0` disables the cap entirely so every node stays visible, useful for post-mortem review of a mesh you don't intend to prune.
 
-**Side Effects**: Setting this too low may cause frequently-active nodes to disappear from the list temporarily. Setting it too high may clutter the list with offline nodes.
+**Side Effects**: Setting this too low may cause frequently-active nodes to disappear from the list temporarily. Setting it too high (or `0`) may clutter the list with offline nodes.
 
 ### Hide Incomplete Nodes
 

--- a/docs/features/translations.md
+++ b/docs/features/translations.md
@@ -12,6 +12,10 @@ MeshMonitor is currently available in:
 | German | `de` | Community contributed |
 | Spanish | `es` | Community contributed |
 | French | `fr` | Community contributed |
+| Indonesian | `id` | Community contributed |
+| Norwegian Bokmål | `nb_NO` | Community contributed |
+| Polish | `pl` | Community contributed |
+| Portuguese (Brazil) | `pt_BR` | Community contributed |
 | Russian | `ru` | Community contributed |
 
 ## How to Contribute Translations

--- a/docs/firmware-ota-prerequisites.md
+++ b/docs/firmware-ota-prerequisites.md
@@ -78,7 +78,7 @@ The node will reboot and return to normal Meshtastic operation. You can now disc
 
 Once the prerequisites are met, updating firmware through MeshMonitor follows these steps:
 
-1. **Select a version** — Choose a firmware version from the list in Configuration > Firmware Updates. Stable and alpha channels are available, or you can specify a custom URL.
+1. **Select a version** — Choose a firmware version from the list in Configuration > Firmware Updates. Stable, alpha, and **Nightly** channels are available, or you can specify a custom URL. The Nightly channel tracks the firmware `develop` branch (2.8.x pre-release builds) for testers who want early access to fixes before they land in an alpha or stable release. Nightly builds change quickly and can regress; use the Config backup step below and keep a known-good binary handy before flashing a Nightly onto an infrastructure node.
 
 2. **Preflight check** — MeshMonitor verifies your hardware is OTA-capable, identifies the correct firmware binary for your board, and checks version compatibility.
 


### PR DESCRIPTION
## Summary

Doc audit covering every user-visible change that shipped between v4.15.1 (2026-08-21) and v4.15.2-rc9. All updates land in existing pages; no new docs were created.

## Touched pages

- **docs/features/mesh-issues.md** — added clickable node references + source picker section; added router-cluster distance guard row and B1 client-overlap constants to threshold tables.
- **docs/features/mesh-issues-test-reference.md** — added routerClusterMaxLinkKm to the tunable settings table.
- **docs/features/automation-engine.md** — added five new device-health triggers (heartbeat lost / recovery, node rebooted, external power changed, battery trending down) and the Device Health quick-create template.
- **docs/features/automation.md** — added Installed Scripts inventory note under Auto Responder scripts.
- **docs/features/packet-monitor.md** — mentioned full portnum filter, free-text content search, and the shared Stop capturing control.
- **docs/features/meshcore.md** — added the Per-Source Settings section (Default Path Hash Size, infra age timeout, telemetry time window), documented per-node Autopoll Neighbours, clarified "Unscoped" as truly unscoped on firmware v12+.
- **docs/features/maps.md** — added unified controls sidebar tip, Zoom to Fit control, Carto API key setting, Maximum Age = 0 (show all) option, and per-node color algorithm.
- **docs/features/map-analysis.md** — added grouped toolbar menus tip, unified sidebar tip, and a Site Planner section explaining the "budget outran radius" / "DEM gap" banner cases.
- **docs/features/device.md** — added the in-app Device Backup Management Restore path.
- **docs/features/settings.md** — updated Maximum Age of Active Nodes range/description to cover the new 0 = show-all value.
- **docs/features/translations.md** — filled out the language table (added Indonesian, Norwegian Bokmål, Polish, Portuguese-BR).
- **docs/firmware-ota-prerequisites.md** — added the Nightly channel to the OTA channel list.

## Notable

- **B1 Router Cluster now requires client overlap** (not just mutual audibility) — a well-sited backbone that doesn't share clients will no longer flag. Existing findings will auto-close over the next few analysis runs. Documented in the B1 table row.
- **Migration 155** (key-security stale-flag cleanup) runs automatically on first boot after upgrade and clears any keyMismatchDetected flags left behind by the pre-4.15.2 source-blind read bug. Not surfaced as user-facing behavior in the docs (it's a one-shot fix, not something users configure), but flagged here for release-notes reference.

## Deliberately skipped

- Header UX polish (connection badge cycles status/battery/airtime, Disconnect/Reconnect moved to System Status popup, logo hidden on per-source pages) — intuitive on encounter, not something a user consults docs for.
- Internal dev-notes under docs/internal/ (out of scope per the audit brief).
- Refactors, dependency bumps, test-only changes.

## Test plan

- [x] Grep confirmed no page names moved (all edits use existing paths, no config.mts change needed).
- [ ] VitePress build succeeds (CI will verify).
- [ ] Manual re-read after CI (any typos or broken markdown surface there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G