### PR TITLE
feat(meshcore): auto time-sync remote repeaters on a per-node cadence (#4916)

### DIFF
--- a/docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md
+++ b/docs/internal/dev-notes/MESHCORE_REMOTE_ADMIN.md
@@ -86,6 +86,39 @@ The login replay-protection check is a timestamp in the request, so
 clocks must be roughly aligned. The companion firmware doesn't sync
 clocks automatically — that's what `clock sync` is for.
 
+### Scheduled clock pushes (#4916)
+
+`MeshCoreTimeSyncScheduler` (`src/server/services/meshcoreTimeSyncScheduler.ts`)
+does the above on a per-node cadence instead of waiting for someone to press
+the button. Points worth knowing before touching it:
+
+- **It needs a SAVED ADMIN password.** `time` is a mutating verb, so it goes
+  through `ensureSavedLogin()`, not `ensureGuestLogin()`. A node with time sync
+  enabled but no stored credential fails every cycle; the config panel warns
+  about this up front (`hasSavedCredential` on the GET) rather than leaving it
+  to the logs.
+- **One sync is FOUR packets, not one.** `ensureSavedLogin()` deliberately does
+  not cache the way `guestLoggedInNodes` does, so every sync is a login DM plus
+  its reply, then the CLI command plus its reply — and each floods when the
+  target's `out_path` is unknown. That is the whole reason the default cadence
+  is 12h with a 1h floor, versus the 15 minutes Meshtastic's equivalent uses.
+  Do not "harmonise" the two numbers; they are not measuring the same thing.
+- **`rewriteClockSync()` still does the real work.** The scheduler passes the
+  `clock sync` spelling into `sendCliCommand` rather than building
+  `time <epoch>` itself, so the epoch is stamped at the chokepoint — after the
+  login round-trip has already elapsed.
+- **Firmware refuses to move a clock BACKWARDS** (`secs > curr`). A repeater
+  whose RTC runs ahead of the server rejects every push until it is corrected
+  or reboots. `syncNodeTime` reports that as `rejected`, distinct from a
+  timeout, and the scheduler logs it at warn because it is persistent.
+- **Cadence lives in a third column set** (`timeSyncEnabled` /
+  `timeSyncIntervalMinutes` / `lastTimeSyncAt`, migration 156), separate from
+  the telemetry-060 and neighbours-153 trios, so none of the three schedulers
+  resets another's timer. The stamp is written BEFORE the send and to the
+  DATABASE — an in-memory stamp would be cleared by a restart, and a
+  success-only stamp would retry an offline or clock-ahead repeater on every
+  tick forever.
+
 Permission levels (from `setperm <pubkey-hex> <level>`):
 
 | Level | Name        | What it lets you do                                |

--- a/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
+++ b/src/components/MeshCore/MeshCoreDirectMessagesView.tsx
@@ -10,6 +10,7 @@ import { MeshCoreMessageStream } from './MeshCoreMessageStream';
 import { MeshCoreContactDetailPanel } from './MeshCoreContactDetailPanel';
 import { MeshCoreNodeTelemetryConfig } from './MeshCoreNodeTelemetryConfig';
 import { MeshCoreNodeNeighboursConfig } from './MeshCoreNodeNeighboursConfig';
+import { MeshCoreNodeTimeSyncConfig } from './MeshCoreNodeTimeSyncConfig';
 import TelemetryGraphs from '../TelemetryGraphs';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSettings } from '../../contexts/SettingsContext';
@@ -586,6 +587,12 @@ export const MeshCoreDirectMessagesView: React.FC<MeshCoreDirectMessagesViewProp
                     receiveOnly={receiveOnly}
                   />
                   <MeshCoreNodeNeighboursConfig
+                    baseUrl={baseUrl}
+                    sourceId={sourceId}
+                    publicKey={selected}
+                    receiveOnly={receiveOnly}
+                  />
+                  <MeshCoreNodeTimeSyncConfig
                     baseUrl={baseUrl}
                     sourceId={sourceId}
                     publicKey={selected}

--- a/src/components/MeshCore/MeshCoreNodeTimeSyncConfig.test.tsx
+++ b/src/components/MeshCore/MeshCoreNodeTimeSyncConfig.test.tsx
@@ -145,6 +145,32 @@ describe('MeshCoreNodeTimeSyncConfig', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent(/cannot go backwards/);
   });
 
+  it('names SESSION_SECRET rotation when a sync reports NO_SAVED_CREDENTIAL', async () => {
+    // The up-front banner cannot catch this: `hasSavedCredential` only proves
+    // the ciphertext blob exists, so a credential invalidated by a rotated
+    // SESSION_SECRET shows no warning yet fails every sync. The manual path is
+    // where the user finds out, so it must say something actionable.
+    csrfFetchMock.mockImplementation((_url: string, opts?: { method?: string }) => {
+      if (opts?.method === 'POST') {
+        return Promise.resolve(
+          errResponse(409, {
+            success: false,
+            code: 'NO_SAVED_CREDENTIAL',
+            error: 'No usable saved admin password for this node. Save one, then retry.',
+          }),
+        );
+      }
+      // Note hasSavedCredential: true — the blob is there, it just won't decrypt.
+      return Promise.resolve(okResponse(defaultGet({ hasSavedCredential: true })));
+    });
+    renderPanel();
+    // No up-front banner, because the blob exists.
+    expect(screen.queryByText(/No admin password is saved/)).toBeNull();
+
+    fireEvent.click(await screen.findByText('Sync Clock'));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/SESSION_SECRET/);
+  });
+
   it('warns when no admin password is saved — the schedule would silently no-op', async () => {
     csrfFetchMock.mockImplementation(() =>
       Promise.resolve(okResponse(defaultGet({ hasSavedCredential: false }))),

--- a/src/components/MeshCore/MeshCoreNodeTimeSyncConfig.test.tsx
+++ b/src/components/MeshCore/MeshCoreNodeTimeSyncConfig.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the per-node MeshCore time-sync config panel (#4916): the manual
+ * "Sync Clock" button, the enable toggle, the 1-hour interval floor, the
+ * missing-credential warning, and receive-only gating.
+ *
+ * The two behaviours worth guarding beyond the sibling panels' coverage are
+ * the interval floor (a sub-floor value must be rejected and the field
+ * reverted, not silently sent) and the no-credential warning (without a saved
+ * admin password the schedule would fail every cycle with nothing in the UI to
+ * explain it).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MeshCoreNodeTimeSyncConfig } from './MeshCoreNodeTimeSyncConfig';
+
+const { csrfFetchMock, hasPermissionMock, showToastMock } = vi.hoisted(() => ({
+  csrfFetchMock: vi.fn(),
+  hasPermissionMock: vi.fn(),
+  showToastMock: vi.fn(),
+}));
+
+// `t` and the returned object must be STABLE across renders. Real
+// react-i18next hands back a stable `t`, and the panel's load effect lists it
+// as a dependency — a fresh identity per render would re-fire that effect on
+// every render, clearing `error`/`syncMsg` the instant they were set and
+// making the assertions below flap.
+const stableT = (_key: string, fallback?: string | Record<string, unknown>) =>
+  typeof fallback === 'string' ? fallback : _key;
+const stableTranslation = { t: stableT };
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => stableTranslation,
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: hasPermissionMock }),
+}));
+
+vi.mock('../../hooks/useCsrfFetch', () => ({
+  useCsrfFetch: () => csrfFetchMock,
+}));
+
+vi.mock('../ToastContainer', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
+const PK = 'a'.repeat(64);
+
+const okResponse = (body: unknown) => ({ ok: true, json: async () => body });
+const errResponse = (status: number, body: unknown) => ({ ok: false, status, json: async () => body });
+
+const renderPanel = (receiveOnly = false) =>
+  render(
+    <MeshCoreNodeTimeSyncConfig
+      baseUrl=""
+      sourceId="test-source"
+      publicKey={PK}
+      receiveOnly={receiveOnly}
+    />,
+  );
+
+/** Default GET payload: enabled off, 12h interval, credential present. */
+function defaultGet(over: Record<string, unknown> = {}) {
+  return {
+    success: true,
+    data: {
+      enabled: false,
+      intervalMinutes: 720,
+      lastSyncAt: null,
+      minIntervalMinutes: 60,
+      hasSavedCredential: true,
+      ...over,
+    },
+  };
+}
+
+describe('MeshCoreNodeTimeSyncConfig', () => {
+  beforeEach(() => {
+    hasPermissionMock.mockReset().mockReturnValue(true);
+    showToastMock.mockReset();
+    csrfFetchMock.mockReset().mockImplementation((_url: string, opts?: { method?: string; body?: string }) => {
+      if (opts?.method === 'POST') {
+        return Promise.resolve(
+          okResponse({ success: true, data: { reply: 'OK', elapsedMs: 1200, syncedAt: 1_700_000_000_000 } }),
+        );
+      }
+      if (opts?.method === 'PATCH') {
+        const patch = JSON.parse(opts.body ?? '{}');
+        return Promise.resolve(
+          okResponse({
+            success: true,
+            data: {
+              enabled: patch.enabled ?? false,
+              intervalMinutes: patch.intervalMinutes ?? 720,
+              lastSyncAt: null,
+              minIntervalMinutes: 60,
+              hasSavedCredential: true,
+            },
+          }),
+        );
+      }
+      return Promise.resolve(okResponse(defaultGet()));
+    });
+  });
+
+  it('renders the sync button once loaded', async () => {
+    renderPanel();
+    expect(await screen.findByText('Sync Clock')).toBeInTheDocument();
+  });
+
+  it('shows the 12-hour default rendered as hours, not raw minutes', async () => {
+    renderPanel();
+    expect(await screen.findByText('12h')).toBeInTheDocument();
+  });
+
+  it('POSTs to the time-sync endpoint and confirms success', async () => {
+    renderPanel();
+    fireEvent.click(await screen.findByText('Sync Clock'));
+    await waitFor(() =>
+      expect(csrfFetchMock).toHaveBeenCalledWith(
+        `/api/sources/test-source/meshcore/nodes/${PK}/time-sync`,
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+    expect(await screen.findByText('Clock pushed to repeater.')).toBeInTheDocument();
+  });
+
+  it('surfaces a rejected push (repeater clock ahead) as an error, not a success', async () => {
+    csrfFetchMock.mockImplementation((_url: string, opts?: { method?: string }) => {
+      if (opts?.method === 'POST') {
+        return Promise.resolve(
+          errResponse(409, {
+            success: false,
+            code: 'CLOCK_PUSH_REJECTED',
+            error: 'Repeater refused the clock push (it may be running ahead of server time): ERR: clock cannot go backwards',
+          }),
+        );
+      }
+      return Promise.resolve(okResponse(defaultGet()));
+    });
+    renderPanel();
+    fireEvent.click(await screen.findByText('Sync Clock'));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/cannot go backwards/);
+  });
+
+  it('warns when no admin password is saved — the schedule would silently no-op', async () => {
+    csrfFetchMock.mockImplementation(() =>
+      Promise.resolve(okResponse(defaultGet({ hasSavedCredential: false }))),
+    );
+    renderPanel();
+    expect(
+      await screen.findByText(/No admin password is saved for this node/),
+    ).toBeInTheDocument();
+  });
+
+  it('does not warn about credentials when one is saved', async () => {
+    renderPanel();
+    await screen.findByText('Sync Clock');
+    expect(screen.queryByText(/No admin password is saved/)).toBeNull();
+  });
+
+  it('PATCHes enabled when the toggle is switched on', async () => {
+    renderPanel();
+    const toggle = await screen.findByLabelText('Auto time sync');
+    fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(csrfFetchMock).toHaveBeenCalledWith(
+        `/api/sources/test-source/meshcore/nodes/${PK}/time-sync-config`,
+        expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ enabled: true }) }),
+      ),
+    );
+  });
+
+  it('rejects a sub-floor interval, reverts the field, and never sends it', async () => {
+    renderPanel();
+    const input = await screen.findByLabelText('Interval (minutes)');
+    fireEvent.change(input, { target: { value: '5' } });
+    fireEvent.blur(input);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/between 60 and/);
+    // Reverted to the persisted value rather than left holding an invalid one.
+    expect((input as HTMLInputElement).value).toBe('720');
+    const patchCalls = csrfFetchMock.mock.calls.filter(
+      (c: unknown[]) => (c[1] as { method?: string } | undefined)?.method === 'PATCH',
+    );
+    expect(patchCalls).toHaveLength(0);
+  });
+
+  it('accepts an in-range interval and PATCHes it', async () => {
+    renderPanel();
+    const input = await screen.findByLabelText('Interval (minutes)');
+    fireEvent.change(input, { target: { value: '1440' } });
+    fireEvent.blur(input);
+
+    await waitFor(() =>
+      expect(csrfFetchMock).toHaveBeenCalledWith(
+        `/api/sources/test-source/meshcore/nodes/${PK}/time-sync-config`,
+        expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ intervalMinutes: 1440 }) }),
+      ),
+    );
+  });
+
+  it('disables the sync button in receive-only mode', async () => {
+    renderPanel(true);
+    expect(await screen.findByText('Sync Clock')).toBeDisabled();
+  });
+
+  it('disables editing without configuration:write', async () => {
+    hasPermissionMock.mockReturnValue(false);
+    renderPanel();
+    expect(await screen.findByLabelText('Auto time sync')).toBeDisabled();
+    // The manual sync mutates the remote clock, so it needs the same
+    // permission as an edit — unlike the telemetry/neighbours polls.
+    expect(screen.getByText('Sync Clock')).toBeDisabled();
+  });
+});

--- a/src/components/MeshCore/MeshCoreNodeTimeSyncConfig.tsx
+++ b/src/components/MeshCore/MeshCoreNodeTimeSyncConfig.tsx
@@ -16,6 +16,10 @@
  *    so unlike a telemetry or neighbours read it cannot fall back to a guest
  *    session. The GET reports `hasSavedCredential`; without one, enabling the
  *    schedule would quietly do nothing every cycle, so we warn up front.
+ *    That flag only proves a credential BLOB EXISTS, not that it still
+ *    decrypts — rotating SESSION_SECRET leaves it `true` while every sync
+ *    fails. The manual "Sync Now" path is what surfaces the real answer, so
+ *    its no-credential error names rotation as a possible cause.
  *  - The interval floor is 60 minutes, not 1. One sync costs four packets on
  *    the air (login + reply, then the CLI command + reply), so the cheap-looking
  *    small numbers the other panels accept would be genuinely harmful here.
@@ -207,6 +211,19 @@ export const MeshCoreNodeTimeSyncConfig: React.FC<MeshCoreNodeTimeSyncConfigProp
           ),
           'warning',
         );
+      } else if (data.code === 'NO_SAVED_CREDENTIAL') {
+        // This is the one case the up-front banner can miss: the blob exists
+        // (so hasSavedCredential was true and no warning showed) but no longer
+        // decrypts, which is what rotating SESSION_SECRET does. Say so, rather
+        // than leaving the user staring at a node they know they saved a
+        // password for.
+        setSyncMsg({
+          kind: 'err',
+          text: t(
+            'meshcore.time_sync_config.sync_no_credential',
+            'No usable admin password for this node. If you did save one, it may have been invalidated by a SESSION_SECRET change — log in again and re-save it.',
+          ),
+        });
       } else {
         setSyncMsg({
           kind: 'err',
@@ -248,6 +265,10 @@ export const MeshCoreNodeTimeSyncConfig: React.FC<MeshCoreNodeTimeSyncConfigProp
         </div>
       )}
 
+      {/*
+        Blob-existence check only — see the header doc. A saved-then-invalidated
+        credential still reports true here and is caught by "Sync Now" instead.
+      */}
       {!loading && !cfg.hasSavedCredential && (
         <div
           className="meshcore-empty-state"

--- a/src/components/MeshCore/MeshCoreNodeTimeSyncConfig.tsx
+++ b/src/components/MeshCore/MeshCoreNodeTimeSyncConfig.tsx
@@ -1,0 +1,387 @@
+/**
+ * Per-node time-sync config panel for the MeshCore per-node detail view
+ * (issue #4916).
+ *
+ * A sibling of `MeshCoreNodeTelemetryConfig` / `MeshCoreNodeNeighboursConfig`:
+ * mounts in the DM/contact detail pane of `MeshCoreDirectMessagesView` for a
+ * peer with a real 64-hex pubkey, reads/writes `(enabled, intervalMinutes)`
+ * for the (sourceId, publicKey) pair from
+ * `/api/sources/:id/meshcore/nodes/:publicKey/time-sync-config`, and offers a
+ * manual "Sync Now" that hits `/time-sync`.
+ *
+ * Two things make this panel different from its two siblings, and both are
+ * surfaced in the UI rather than left to the logs:
+ *
+ *  - It REQUIRES a saved admin password. `time` is a mutating firmware verb,
+ *    so unlike a telemetry or neighbours read it cannot fall back to a guest
+ *    session. The GET reports `hasSavedCredential`; without one, enabling the
+ *    schedule would quietly do nothing every cycle, so we warn up front.
+ *  - The interval floor is 60 minutes, not 1. One sync costs four packets on
+ *    the air (login + reply, then the CLI command + reply), so the cheap-looking
+ *    small numbers the other panels accept would be genuinely harmful here.
+ *    The server rejects sub-floor values too — this is not a UI-only guard.
+ *
+ * Edits are gated by `configuration:write`. So is the manual sync, unlike the
+ * telemetry/neighbours polls: it mutates the remote device's clock rather than
+ * reading from it.
+ */
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../contexts/AuthContext';
+import { useCsrfFetch } from '../../hooks/useCsrfFetch';
+import { useToast } from '../ToastContainer';
+import { isTxDisabledBody } from '../../utils/txDisabled';
+import { MeshCoreReceiveOnlyNote } from './MeshCoreReceiveOnlyNote';
+
+interface MeshCoreNodeTimeSyncConfigProps {
+  /** Frontend basename (e.g. '' or '/meshmonitor'). */
+  baseUrl: string;
+  /** Owning source id (UUID). */
+  sourceId: string;
+  /** 64-char hex pubkey of the remote MeshCore node. */
+  publicKey: string;
+  /** True when this MeshCore source is in strict receive-only mode (#4547). */
+  receiveOnly?: boolean;
+}
+
+interface TimeSyncConfigState {
+  enabled: boolean;
+  intervalMinutes: number;
+  lastSyncAt: number | null;
+  hasSavedCredential: boolean;
+}
+
+/** Mirrors MIN/MAX/DEFAULT_INTERVAL_MINUTES in meshcoreTimeSyncScheduler.ts. */
+const MIN_INTERVAL = 60;
+const MAX_INTERVAL = 7 * 24 * 60;
+const DEFAULT_INTERVAL = 720;
+
+const DEFAULT_CFG: TimeSyncConfigState = {
+  enabled: false,
+  intervalMinutes: DEFAULT_INTERVAL,
+  lastSyncAt: null,
+  hasSavedCredential: false,
+};
+
+/** "12h" / "90m" — intervals here are hours-scale, so raw minutes read poorly. */
+function formatInterval(minutes: number): string {
+  if (minutes % 60 === 0) return `${minutes / 60}h`;
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+}
+
+export const MeshCoreNodeTimeSyncConfig: React.FC<MeshCoreNodeTimeSyncConfigProps> = ({
+  baseUrl,
+  sourceId,
+  publicKey,
+  receiveOnly = false,
+}) => {
+  const { t } = useTranslation();
+  const csrfFetch = useCsrfFetch();
+  const { showToast } = useToast();
+  const { hasPermission } = useAuth();
+  const canWriteConfig = hasPermission('configuration', 'write');
+  // Unlike the telemetry/neighbours polls, a manual sync MUTATES the remote
+  // device, so it needs configuration:write to match the backend route.
+  const canSync = canWriteConfig;
+
+  const [cfg, setCfg] = useState<TimeSyncConfigState>(DEFAULT_CFG);
+  const [intervalDraft, setIntervalDraft] = useState<string>(String(DEFAULT_INTERVAL));
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [syncMsg, setSyncMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+
+  const endpoint = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/nodes/${encodeURIComponent(publicKey)}/time-sync-config`;
+  const syncEndpoint = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore/nodes/${encodeURIComponent(publicKey)}/time-sync`;
+
+  const applyResponse = (d: Record<string, unknown>): TimeSyncConfigState => ({
+    enabled: Boolean(d.enabled),
+    intervalMinutes: typeof d.intervalMinutes === 'number' ? d.intervalMinutes : DEFAULT_INTERVAL,
+    lastSyncAt: (d.lastSyncAt as number | null) ?? null,
+    hasSavedCredential: Boolean(d.hasSavedCredential),
+  });
+
+  // Refetch whenever the selected node or source changes.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setSaved(false);
+    setSyncMsg(null);
+    void (async () => {
+      try {
+        const response = await csrfFetch(endpoint);
+        const data = await response.json();
+        if (cancelled) return;
+        if (data.success && data.data) {
+          const next = applyResponse(data.data);
+          setCfg(next);
+          setIntervalDraft(String(next.intervalMinutes));
+        } else {
+          setError(data.error || t('meshcore.time_sync_config.load_error', 'Failed to load config'));
+        }
+      } catch (_err) {
+        if (!cancelled) {
+          setError(t('meshcore.time_sync_config.load_error', 'Failed to load config'));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [endpoint, csrfFetch, t]);
+
+  const save = async (patch: { enabled?: boolean; intervalMinutes?: number }) => {
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    try {
+      const response = await csrfFetch(endpoint, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+      const data = await response.json();
+      if (data.success && data.data) {
+        setCfg(applyResponse(data.data));
+        setSaved(true);
+        window.setTimeout(() => setSaved(false), 1800);
+      } else {
+        setError(data.error || t('meshcore.time_sync_config.save_error', 'Failed to save'));
+      }
+    } catch (_err) {
+      setError(t('meshcore.time_sync_config.save_error', 'Failed to save'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggle = (next: boolean) => {
+    setCfg((prev) => ({ ...prev, enabled: next }));
+    void save({ enabled: next });
+  };
+
+  const handleIntervalCommit = () => {
+    const n = parseInt(intervalDraft, 10);
+    if (!Number.isFinite(n) || n < MIN_INTERVAL || n > MAX_INTERVAL) {
+      setIntervalDraft(String(cfg.intervalMinutes));
+      setError(
+        t(
+          'meshcore.time_sync_config.interval_range',
+          `Interval must be between ${MIN_INTERVAL} and ${MAX_INTERVAL} minutes`,
+        ),
+      );
+      return;
+    }
+    if (n === cfg.intervalMinutes) return;
+    void save({ intervalMinutes: n });
+  };
+
+  const syncNow = async () => {
+    setSyncing(true);
+    setSyncMsg(null);
+    try {
+      const response = await csrfFetch(syncEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      const data = await response.json();
+      if (response.ok && data.success) {
+        setSyncMsg({
+          kind: 'ok',
+          text: t('meshcore.time_sync_config.sync_ok', 'Clock pushed to repeater.'),
+        });
+        // The server stamped lastTimeSyncAt; reflect it without a refetch.
+        setCfg((prev) => ({ ...prev, lastSyncAt: data.data?.syncedAt ?? Date.now() }));
+      } else if (isTxDisabledBody(response.status, data)) {
+        showToast(
+          t(
+            'meshcore.receive_only.blocked_toast',
+            'Receive-only mode is on for this MeshCore source — nothing was sent.',
+          ),
+          'warning',
+        );
+      } else {
+        setSyncMsg({
+          kind: 'err',
+          text: data.error || t('meshcore.time_sync_config.sync_error', 'Time sync failed'),
+        });
+      }
+    } catch (_err) {
+      setSyncMsg({ kind: 'err', text: t('meshcore.time_sync_config.sync_error', 'Time sync failed') });
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  return (
+    <div className="node-details-block">
+      <div className="node-details-header">
+        <h3 className="node-details-title">
+          {t('meshcore.time_sync_config.title', 'Time Sync')}
+        </h3>
+      </div>
+
+      <p className="hint" style={{ marginBottom: '0.75rem' }}>
+        {t(
+          'meshcore.time_sync_config.hint',
+          "Periodically push this server's clock to the repeater's RTC, which has no NTP or GPS of its own. Each sync costs four packets on the air (an admin login and its reply, then the time command and its reply), so the minimum interval is 1 hour and the default is 12. Spacing is shared with Telemetry and Neighbours Retrieval, and tracked separately from both.",
+        )}
+      </p>
+
+      {!canWriteConfig && (
+        <div
+          className="meshcore-empty-state"
+          style={{ marginBottom: '0.75rem', color: 'var(--color-warning)' }}
+          role="status"
+        >
+          {t(
+            'meshcore.config.permission_denied',
+            "You don't have permission to change configuration for this source.",
+          )}
+        </div>
+      )}
+
+      {!loading && !cfg.hasSavedCredential && (
+        <div
+          className="meshcore-empty-state"
+          style={{ marginBottom: '0.75rem', color: 'var(--color-warning)' }}
+          role="status"
+        >
+          {t(
+            'meshcore.time_sync_config.no_credential',
+            'No admin password is saved for this node. Setting the clock is an admin operation, so scheduled syncs will fail silently until you log in and save one.',
+          )}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="meshcore-empty-state">
+          {t('meshcore.time_sync_config.loading', 'Loading…')}
+        </div>
+      ) : (
+        <div className="node-details-grid">
+          <div className="node-detail-card">
+            <div className="node-detail-label">
+              {t('meshcore.time_sync_config.enabled_label', 'Auto time sync')}
+            </div>
+            <div className="node-detail-value">
+              <label style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem' }}>
+                <input
+                  type="checkbox"
+                  checked={cfg.enabled}
+                  onChange={(e) => handleToggle(e.target.checked)}
+                  disabled={!canWriteConfig || saving}
+                  aria-label={t('meshcore.time_sync_config.enabled_label', 'Auto time sync')}
+                />
+                <span>
+                  {cfg.enabled
+                    ? t('meshcore.time_sync_config.on', 'On')
+                    : t('meshcore.time_sync_config.off', 'Off')}
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <div className="node-detail-card">
+            <div className="node-detail-label">
+              {t('meshcore.time_sync_config.interval_label', 'Interval (minutes)')}
+            </div>
+            <div className="node-detail-value">
+              <input
+                type="number"
+                min={MIN_INTERVAL}
+                max={MAX_INTERVAL}
+                step={60}
+                value={intervalDraft}
+                onChange={(e) => setIntervalDraft(e.target.value)}
+                onBlur={handleIntervalCommit}
+                disabled={!canWriteConfig || saving}
+                aria-label={t('meshcore.time_sync_config.interval_label', 'Interval (minutes)')}
+                style={{ width: '6rem' }}
+              />
+              <span className="hint" style={{ marginLeft: '0.5rem' }}>
+                {formatInterval(cfg.intervalMinutes)}
+              </span>
+            </div>
+          </div>
+
+          {cfg.lastSyncAt && (
+            <div className="node-detail-card node-detail-card-2col">
+              <div className="node-detail-label">
+                {t('meshcore.time_sync_config.last_sync', 'Last sync')}
+              </div>
+              <div className="node-detail-value">
+                {new Date(cfg.lastSyncAt).toLocaleString()}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div style={{ marginTop: '1rem', borderTop: '1px solid var(--color-surface)', paddingTop: '0.75rem' }}>
+        <div className="node-details-header">
+          <h4 className="node-details-title" style={{ fontSize: '0.95rem' }}>
+            {t('meshcore.time_sync_config.sync_title', 'Sync Now')}
+          </h4>
+        </div>
+        <p className="hint" style={{ marginBottom: '0.5rem' }}>
+          {t(
+            'meshcore.time_sync_config.sync_hint',
+            "Push the clock immediately, outside the scheduled interval. Subject to the same 60-second mesh-TX spacing. The firmware refuses to move a clock backwards, so a repeater running ahead of this server will reject the push.",
+          )}
+        </p>
+        <MeshCoreReceiveOnlyNote receiveOnly={receiveOnly} />
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={() => void syncNow()}
+            disabled={!canSync || syncing || receiveOnly}
+            title={
+              receiveOnly
+                ? t(
+                    'meshcore.receive_only.control_tooltip',
+                    'Receive-only mode is on for this MeshCore source. Turn it off in MeshCore Settings to use this.',
+                  )
+                : undefined
+            }
+          >
+            {syncing
+              ? t('meshcore.time_sync_config.syncing', 'Syncing…')
+              : t('meshcore.time_sync_config.sync_button', 'Sync Clock')}
+          </button>
+        </div>
+        {syncMsg && (
+          <div
+            className="meshcore-empty-state"
+            style={{
+              marginTop: '0.5rem',
+              color: syncMsg.kind === 'ok' ? 'var(--color-success)' : 'var(--color-error)',
+            }}
+            role={syncMsg.kind === 'ok' ? 'status' : 'alert'}
+          >
+            {syncMsg.text}
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="meshcore-empty-state" style={{ marginTop: '0.5rem', color: 'var(--color-error)' }} role="alert">
+          {error}
+        </div>
+      )}
+      {saved && (
+        <div className="meshcore-empty-state" style={{ marginTop: '0.5rem', color: 'var(--color-success)' }} role="status">
+          {t('meshcore.time_sync_config.saved', 'Saved.')}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -170,6 +170,7 @@ import { migration as createMeshtasticHeardRepeatersMigration, runMigration152Po
 import { migration as meshcoreNodeNeighborsConfigMigration, runMigration153Postgres, runMigration153Mysql } from '../server/migrations/153_meshcore_node_neighbors_config.js';
 import { migration as createMeshIssuesMigration, runMigration154Postgres, runMigration154Mysql } from '../server/migrations/154_create_mesh_issues.js';
 import { migration as clearStaleKeyMismatchMigration, runMigration155Postgres, runMigration155Mysql } from '../server/migrations/155_clear_stale_key_mismatch.js';
+import { migration as meshcoreNodeTimeSyncConfigMigration, runMigration156Postgres, runMigration156Mysql } from '../server/migrations/156_meshcore_node_time_sync_config.js';
 
 // ============================================================================
 // Registry
@@ -2488,4 +2489,22 @@ registry.register({
   sqlite: (db) => clearStaleKeyMismatchMigration.up(db),
   postgres: (client) => runMigration155Postgres(client),
   mysql: (pool) => runMigration155Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 156: per-node time-sync config on `meshcore_nodes`, read by the
+// MeshCoreTimeSyncScheduler each tick (#4916). A THIRD separate column set,
+// independent of the migration-060 telemetry trio and the migration-153
+// neighbours trio, so none of the three schedulers resets another's cadence.
+// Default interval is 720 minutes (12h) because one repeater sync costs four
+// packets on the air. Idempotent across SQLite / PostgreSQL / MySQL.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 156,
+  name: 'meshcore_node_time_sync_config',
+  settingsKey: 'migration_156_meshcore_node_time_sync_config',
+  sqlite: (db) => meshcoreNodeTimeSyncConfigMigration.up(db),
+  postgres: (client) => runMigration156Postgres(client),
+  mysql: (pool) => runMigration156Mysql(pool),
 });

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -230,6 +230,9 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         neighborsEnabled INTEGER DEFAULT 0,
         neighborsIntervalMinutes INTEGER DEFAULT 60,
         lastNeighborsRequestAt INTEGER,
+        timeSyncEnabled INTEGER DEFAULT 0,
+        timeSyncIntervalMinutes INTEGER DEFAULT 720,
+        lastTimeSyncAt INTEGER,
         out_path TEXT,
         path_len INTEGER,
         adminCredential TEXT,
@@ -480,6 +483,9 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         neighborsEnabled INTEGER DEFAULT 0,
         neighborsIntervalMinutes INTEGER DEFAULT 60,
         lastNeighborsRequestAt INTEGER,
+        timeSyncEnabled INTEGER DEFAULT 0,
+        timeSyncIntervalMinutes INTEGER DEFAULT 720,
+        lastTimeSyncAt INTEGER,
         out_path TEXT,
         path_len INTEGER,
         adminCredential TEXT,
@@ -620,6 +626,92 @@ describe('MeshCoreRepository — sourceId stamping', () => {
     ).rejects.toThrow(/requires a sourceId/);
   });
 
+  // ============ Time-sync config (#4916) ============
+
+  it('getTimeSyncEnabledNodes only returns rows with timeSyncEnabled=true and matching sourceId', async () => {
+    await repo.upsertNode({ publicKey: 'pk-1' }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk-2' }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk-3' }, 'src-b');
+    await repo.setNodeTimeSyncConfig('src-a', 'pk-1', { enabled: true });
+    await repo.setNodeTimeSyncConfig('src-a', 'pk-2', { enabled: false });
+    await repo.setNodeTimeSyncConfig('src-b', 'pk-3', { enabled: true });
+
+    const aResult = await repo.getTimeSyncEnabledNodes('src-a');
+    expect(aResult.map((n) => n.publicKey)).toEqual(['pk-1']);
+
+    const bResult = await repo.getTimeSyncEnabledNodes('src-b');
+    expect(bResult.map((n) => n.publicKey)).toEqual(['pk-3']);
+  });
+
+  it('markTimeSyncRequested stamps lastTimeSyncAt WITHOUT touching the other two cadences', async () => {
+    await repo.upsertNode({ publicKey: 'pk-1' }, 'src-a');
+    await repo.setNodeTimeSyncConfig('src-a', 'pk-1', { enabled: true });
+    await repo.markTelemetryRequested('src-a', 'pk-1', 111_111);
+    await repo.markNeighborsRequested('src-a', 'pk-1', 222_222);
+    await repo.markTimeSyncRequested('src-a', 'pk-1', 999_999);
+
+    const row = db
+      .prepare(
+        `SELECT lastTimeSyncAt, lastNeighborsRequestAt, lastTelemetryRequestAt
+         FROM meshcore_nodes WHERE publicKey = 'pk-1'`,
+      )
+      .get() as {
+      lastTimeSyncAt: number;
+      lastNeighborsRequestAt: number;
+      lastTelemetryRequestAt: number;
+    };
+    // All three cadences must stay independent — a time-sync must never reset
+    // the telemetry or neighbours timer (#4916).
+    expect(row.lastTimeSyncAt).toBe(999_999);
+    expect(row.lastNeighborsRequestAt).toBe(222_222);
+    expect(row.lastTelemetryRequestAt).toBe(111_111);
+  });
+
+  it('setNodeTimeSyncConfig seeds a stub row with the 12-hour default interval', async () => {
+    await repo.setNodeTimeSyncConfig('src-a', 'pk-new', { enabled: true });
+    const row = db
+      .prepare(`SELECT timeSyncEnabled, timeSyncIntervalMinutes FROM meshcore_nodes WHERE publicKey = 'pk-new'`)
+      .get() as { timeSyncEnabled: number; timeSyncIntervalMinutes: number };
+    expect(row.timeSyncEnabled).toBe(1);
+    expect(row.timeSyncIntervalMinutes).toBe(720);
+  });
+
+  it('setNodeTimeSyncConfig is scoped by sourceId — same publicKey on two sources is independent', async () => {
+    await repo.upsertNode({ publicKey: 'pk-1' }, 'src-a');
+    await repo.upsertNode({ publicKey: 'pk-1' }, 'src-b');
+    await repo.setNodeTimeSyncConfig('src-a', 'pk-1', { enabled: true, intervalMinutes: 720 });
+    await repo.setNodeTimeSyncConfig('src-b', 'pk-1', { enabled: false, intervalMinutes: 1440 });
+
+    const a = await repo.getTimeSyncEnabledNodes('src-a');
+    expect(a.map((n) => n.publicKey)).toEqual(['pk-1']);
+    const b = await repo.getTimeSyncEnabledNodes('src-b');
+    expect(b).toHaveLength(0);
+  });
+
+  it('setNodeTimeSyncConfig leaves the unspecified field intact on update', async () => {
+    await repo.upsertNode({ publicKey: 'pk-1' }, 'src-a');
+    await repo.setNodeTimeSyncConfig('src-a', 'pk-1', { enabled: true, intervalMinutes: 1440 });
+    await repo.setNodeTimeSyncConfig('src-a', 'pk-1', { enabled: false });
+
+    const row = db
+      .prepare(`SELECT timeSyncEnabled, timeSyncIntervalMinutes FROM meshcore_nodes WHERE publicKey = 'pk-1'`)
+      .get() as { timeSyncEnabled: number; timeSyncIntervalMinutes: number };
+    expect(row.timeSyncEnabled).toBe(0);
+    expect(row.timeSyncIntervalMinutes).toBe(1440);
+  });
+
+  it('setNodeTimeSyncConfig throws without a sourceId', async () => {
+    await expect(
+      repo.setNodeTimeSyncConfig('', 'pk-1', { enabled: true }),
+    ).rejects.toThrow(/requires a sourceId/);
+  });
+
+  it('markTimeSyncRequested throws without a sourceId', async () => {
+    await expect(
+      repo.markTimeSyncRequested('', 'pk-1', 1),
+    ).rejects.toThrow(/requires a sourceId/);
+  });
+
   // ============ Composite-PK regression (issue: UNIQUE constraint failed) ============
 
   it('setNodeTelemetryConfig succeeds for the same publicKey under two sources on the composite-PK schema', async () => {
@@ -659,6 +751,9 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         neighborsEnabled INTEGER DEFAULT 0,
         neighborsIntervalMinutes INTEGER DEFAULT 60,
         lastNeighborsRequestAt INTEGER,
+        timeSyncEnabled INTEGER DEFAULT 0,
+        timeSyncIntervalMinutes INTEGER DEFAULT 720,
+        lastTimeSyncAt INTEGER,
         out_path TEXT,
         path_len INTEGER,
         adminCredential TEXT,
@@ -732,6 +827,9 @@ describe('MeshCoreRepository — sourceId stamping', () => {
         neighborsEnabled INTEGER DEFAULT 0,
         neighborsIntervalMinutes INTEGER DEFAULT 60,
         lastNeighborsRequestAt INTEGER,
+        timeSyncEnabled INTEGER DEFAULT 0,
+        timeSyncIntervalMinutes INTEGER DEFAULT 720,
+        lastTimeSyncAt INTEGER,
         out_path TEXT,
         path_len INTEGER,
         adminCredential TEXT,

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -78,6 +78,15 @@ export interface DbMeshCoreNode {
   neighborsIntervalMinutes?: number | null;
   lastNeighborsRequestAt?: number | null;
   /**
+   * Per-node time-sync config (migration 156, #4916). Controls whether the
+   * MeshCoreTimeSyncScheduler periodically pushes the server's wall clock to
+   * this repeater's RTC and at what cadence — independent of both trios above
+   * so none of the three schedulers resets another's timer.
+   */
+  timeSyncEnabled?: boolean | null;
+  timeSyncIntervalMinutes?: number | null;
+  lastTimeSyncAt?: number | null;
+  /**
    * MeshCore per-contact forwarding route (migration 068). `outPath` is a
    * comma-separated hex chain of hop hashes ("a3,7f,02"); `pathLen` is the
    * hop count. Both null means the firmware's OUT_PATH_UNKNOWN (0xFF)
@@ -490,6 +499,48 @@ export class MeshCoreRepository extends BaseRepository {
   }
 
   /**
+   * Persist the per-node time-sync config (migration 156, #4916). Direct
+   * mirror of `setNodeNeighborsConfig` — inserts a stub row when the node has
+   * only been seen in-memory, idempotent on (publicKey, sourceId). Passing
+   * `undefined` for either field leaves the existing value intact (on update)
+   * or applies the column default (on insert). Caller validates
+   * `intervalMinutes` against the scheduler's 1h floor.
+   */
+  async setNodeTimeSyncConfig(
+    sourceId: string,
+    publicKey: string,
+    cfg: { enabled?: boolean; intervalMinutes?: number },
+  ): Promise<void> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.setNodeTimeSyncConfig requires a sourceId');
+    }
+    const now = this.now();
+    const { meshcoreNodes } = this.tables;
+    const existing = await this.getNodeByPublicKeyAndSource(publicKey, sourceId);
+
+    if (existing) {
+      const patch: Record<string, unknown> = { updatedAt: now };
+      if (cfg.enabled !== undefined) patch.timeSyncEnabled = cfg.enabled;
+      if (cfg.intervalMinutes !== undefined) patch.timeSyncIntervalMinutes = cfg.intervalMinutes;
+      await this.db
+        .update(meshcoreNodes)
+        .set(patch)
+        .where(and(eq(meshcoreNodes.publicKey, publicKey), eq(meshcoreNodes.sourceId, sourceId)));
+      return;
+    }
+
+    const seed: Record<string, unknown> = {
+      publicKey,
+      sourceId,
+      createdAt: now,
+      updatedAt: now,
+    };
+    if (cfg.enabled !== undefined) seed.timeSyncEnabled = cfg.enabled;
+    if (cfg.intervalMinutes !== undefined) seed.timeSyncIntervalMinutes = cfg.intervalMinutes;
+    await this.db.insert(meshcoreNodes).values(seed);
+  }
+
+  /**
    * Set the local favorite flag for a (sourceId, publicKey) node
    * (migration 094). This repository method only writes local state; syncing
    * the firmware favourite bit to the device (#4838) is handled separately by
@@ -568,6 +619,35 @@ export class MeshCoreRepository extends BaseRepository {
     await this.db
       .update(meshcoreNodes)
       .set({ lastNeighborsRequestAt: when, updatedAt: when })
+      .where(and(eq(meshcoreNodes.publicKey, publicKey), eq(meshcoreNodes.sourceId, sourceId)));
+  }
+
+  /**
+   * Mark a node as having just had a time-sync push attempted. Stamps
+   * `lastTimeSyncAt` so the scheduler waits at least
+   * `timeSyncIntervalMinutes` before picking it again.
+   *
+   * Stamped in the DATABASE, not on the scheduler instance, and stamped
+   * BEFORE the send rather than after it succeeds. Both are deliberate: an
+   * in-memory stamp would be wiped by a restart (re-triggering a sync burst
+   * across the mesh), and stamping only on success would let a repeater that
+   * is offline or rejecting the push be retried every single tick.
+   *
+   * Separate from `markNeighborsRequested` / `markTelemetryRequested` so a
+   * time-sync never resets either of those cadences (#4916).
+   */
+  async markTimeSyncRequested(
+    sourceId: string,
+    publicKey: string,
+    when: number = this.now(),
+  ): Promise<void> {
+    if (!sourceId) {
+      throw new Error('MeshCoreRepository.markTimeSyncRequested requires a sourceId');
+    }
+    const { meshcoreNodes } = this.tables;
+    await this.db
+      .update(meshcoreNodes)
+      .set({ lastTimeSyncAt: when, updatedAt: when })
       .where(and(eq(meshcoreNodes.publicKey, publicKey), eq(meshcoreNodes.sourceId, sourceId)));
   }
 
@@ -789,6 +869,26 @@ export class MeshCoreRepository extends BaseRepository {
       .select()
       .from(meshcoreNodes)
       .where(and(eq(meshcoreNodes.sourceId, sourceId), eq(meshcoreNodes.neighborsEnabled, true)));
+    return this.normalizeBigInts(result) as unknown as DbMeshCoreNode[];
+  }
+
+  /**
+   * Return every node in a source that currently has time-sync enabled. Like
+   * `getNeighborsEnabledNodes`, per-node eligibility (interval vs
+   * `lastTimeSyncAt`) is decided in memory by the scheduler so the query
+   * stays engine-portable (#4916).
+   *
+   * Note this does NOT filter on `adminCredential` — a node can be enabled
+   * before its password is saved. The scheduler checks for a usable
+   * credential at send time via `ensureSavedLogin`, which is the only place
+   * that can tell a rotated or unreadable credential from a missing one.
+   */
+  async getTimeSyncEnabledNodes(sourceId: string): Promise<DbMeshCoreNode[]> {
+    const { meshcoreNodes } = this.tables;
+    const result = await this.db
+      .select()
+      .from(meshcoreNodes)
+      .where(and(eq(meshcoreNodes.sourceId, sourceId), eq(meshcoreNodes.timeSyncEnabled, true)));
     return this.normalizeBigInts(result) as unknown as DbMeshCoreNode[];
   }
 

--- a/src/db/schema/meshcoreNodes.ts
+++ b/src/db/schema/meshcoreNodes.ts
@@ -89,6 +89,16 @@ export const meshcoreNodesSqlite = sqliteTable('meshcore_nodes', {
   neighborsIntervalMinutes: integer('neighborsIntervalMinutes').default(60),
   lastNeighborsRequestAt: integer('lastNeighborsRequestAt'),
 
+  // Per-node time-sync config (migration 156, #4916). Read by the
+  // MeshCoreTimeSyncScheduler; a THIRD separate column set so time-sync,
+  // telemetry, and neighbours each keep an independent per-node cadence.
+  // Default 720 min (12h) — one sync costs four packets on the air (login +
+  // reply, then `time <epoch>` + reply), so this is far slower than the
+  // 15-min Meshtastic auto time-sync default.
+  timeSyncEnabled: integer('timeSyncEnabled', { mode: 'boolean' }).default(false),
+  timeSyncIntervalMinutes: integer('timeSyncIntervalMinutes').default(720),
+  lastTimeSyncAt: integer('lastTimeSyncAt'),
+
   // Per-room-server sync config (migration 072).
   roomSyncEnabled: integer('roomSyncEnabled', { mode: 'boolean' }).default(false),
   roomSyncIntervalMinutes: integer('roomSyncIntervalMinutes').default(60),
@@ -155,6 +165,16 @@ export const meshcoreNodesPostgres = pgTable('meshcore_nodes', {
   neighborsIntervalMinutes: pgInteger('neighborsIntervalMinutes').default(60),
   lastNeighborsRequestAt: pgBigint('lastNeighborsRequestAt', { mode: 'number' }),
 
+  // Per-node time-sync config (migration 156, #4916). Read by the
+  // MeshCoreTimeSyncScheduler; a THIRD separate column set so time-sync,
+  // telemetry, and neighbours each keep an independent per-node cadence.
+  // Default 720 min (12h) — one sync costs four packets on the air (login +
+  // reply, then `time <epoch>` + reply), so this is far slower than the
+  // 15-min Meshtastic auto time-sync default.
+  timeSyncEnabled: pgBoolean('timeSyncEnabled').default(false),
+  timeSyncIntervalMinutes: pgInteger('timeSyncIntervalMinutes').default(720),
+  lastTimeSyncAt: pgBigint('lastTimeSyncAt', { mode: 'number' }),
+
   roomSyncEnabled: pgBoolean('roomSyncEnabled').default(false),
   roomSyncIntervalMinutes: pgInteger('roomSyncIntervalMinutes').default(60),
   lastRoomSyncAt: pgBigint('lastRoomSyncAt', { mode: 'number' }),
@@ -214,6 +234,16 @@ export const meshcoreNodesMysql = mysqlTable('meshcore_nodes', {
   neighborsEnabled: myBoolean('neighborsEnabled').default(false),
   neighborsIntervalMinutes: myInt('neighborsIntervalMinutes').default(60),
   lastNeighborsRequestAt: myBigint('lastNeighborsRequestAt', { mode: 'number' }),
+
+  // Per-node time-sync config (migration 156, #4916). Read by the
+  // MeshCoreTimeSyncScheduler; a THIRD separate column set so time-sync,
+  // telemetry, and neighbours each keep an independent per-node cadence.
+  // Default 720 min (12h) — one sync costs four packets on the air (login +
+  // reply, then `time <epoch>` + reply), so this is far slower than the
+  // 15-min Meshtastic auto time-sync default.
+  timeSyncEnabled: myBoolean('timeSyncEnabled').default(false),
+  timeSyncIntervalMinutes: myInt('timeSyncIntervalMinutes').default(720),
+  lastTimeSyncAt: myBigint('lastTimeSyncAt', { mode: 'number' }),
 
   roomSyncEnabled: myBoolean('roomSyncEnabled').default(false),
   roomSyncIntervalMinutes: myInt('roomSyncIntervalMinutes').default(60),

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -5110,6 +5110,71 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
   }
 
   /**
+   * Push the server's wall clock to a remote repeater's RTC (#4916).
+   *
+   * Shared by the MeshCoreTimeSyncScheduler and the manual per-node
+   * time-sync route so both paths behave identically. Mirrors
+   * `pollNeighborsAndStore`'s division of labour: this does NOT own the
+   * per-source 60s TX gate or the `lastTimeSyncAt` stamp — callers enforce
+   * those.
+   *
+   * Two round-trips on the air, which is why the scheduler's default cadence
+   * is 12h rather than the 15 min Meshtastic uses:
+   *   1. `ensureSavedLogin()` — `time` is a mutating verb, so a guest session
+   *      is not enough. This deliberately does not cache, so it re-logs in on
+   *      every sync.
+   *   2. `sendCliCommand(publicKey, 'clock sync')` — rewritten at the
+   *      chokepoint by `rewriteClockSync()` into the absolute
+   *      `time <epoch>` verb (#3954). We pass the `clock sync` spelling
+   *      rather than building `time <epoch>` here so the epoch is stamped as
+   *      late as possible, after the login round-trip has already elapsed.
+   *
+   * Returns a discriminated result rather than a bare boolean because the
+   * failure modes need to be told apart in the UI:
+   *   - `no-credential` — nothing saved for this node, or it was rotated.
+   *     Retrying will never help until the user saves a password.
+   *   - `rejected` — firmware refused. Almost always its `secs > curr`
+   *     guard: MeshCore will not let a clock move BACKWARDS, so a repeater
+   *     whose RTC runs ahead of the server rejects every push until it is
+   *     manually corrected or reboots.
+   *   - `failed` — no reply (timeout / offline / lossy path). Worth retrying
+   *     on the next cadence.
+   */
+  async syncNodeTime(
+    publicKey: string,
+  ): Promise<
+    | { status: 'ok'; reply: string; elapsedMs: number }
+    | { status: 'rejected'; reply: string }
+    | { status: 'no-credential' }
+    | { status: 'failed'; error: string }
+  > {
+    if (this.deviceType !== MeshCoreDeviceType.COMPANION) {
+      return { status: 'failed', error: 'Remote time sync requires Companion firmware' };
+    }
+    if (!this.connected) {
+      return { status: 'failed', error: 'MeshCore source not connected' };
+    }
+
+    if (!(await this.ensureSavedLogin(publicKey))) {
+      return { status: 'no-credential' };
+    }
+
+    try {
+      // 'clock sync' is rewritten to `time <epoch>` inside sendCliCommand.
+      const { reply, elapsedMs } = await this.sendCliCommand(publicKey, 'clock sync');
+      // Firmware answers an accepted `time` with an OK/ack line and a refused
+      // one with an "ERR: ..." line — most commonly "clock cannot go
+      // backwards" when the target's RTC is ahead of ours.
+      if (/^\s*err\b/i.test(reply) || /cannot go backwards/i.test(reply)) {
+        return { status: 'rejected', reply: reply.trim() };
+      }
+      return { status: 'ok', reply: reply.trim(), elapsedMs };
+    } catch (error) {
+      return { status: 'failed', error: (error as Error).message };
+    }
+  }
+
+  /**
    * Reboot the locally connected device. Companion only. This is a
    * destructive operation — the device will disconnect and restart.
    */

--- a/src/server/migrations/156_meshcore_node_time_sync_config.pgmysql.test.ts
+++ b/src/server/migrations/156_meshcore_node_time_sync_config.pgmysql.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Migration 156 — PostgreSQL / MySQL container behaviour (#4916).
+ *
+ * `describe.skipIf(!postgresAvailable/!mysqlAvailable)` — seeds a minimal
+ * `meshcore_nodes` table against the live test containers (localhost:5433 /
+ * :3307), runs the ADD-COLUMN migration, asserts the three time-sync columns
+ * exist with their defaults, and asserts idempotency (running twice is a
+ * no-op). A silent skip here still reports `success: true` at the suite level
+ * — confirm via `numPendingTests` in the JSON reporter, not just the pass/fail
+ * summary (see CLAUDE.md Multi-Database section).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import mysql from 'mysql2/promise';
+import { runMigration156Postgres, runMigration156Mysql } from './156_meshcore_node_time_sync_config.js';
+import { postgresAvailable, mysqlAvailable } from '../../db/repositories/test-utils.js';
+
+const { Pool: PgPool } = pg;
+
+describe.skipIf(!postgresAvailable)('migration 156 — PostgreSQL (container)', () => {
+  let pool: InstanceType<typeof PgPool>;
+
+  beforeAll(async () => {
+    pool = new PgPool({
+      host: 'localhost',
+      port: 5433,
+      user: 'test',
+      password: 'test',
+      database: 'meshmonitor_test',
+    });
+    await pool.query('DROP TABLE IF EXISTS meshcore_nodes CASCADE');
+    await pool.query(`
+      CREATE TABLE meshcore_nodes (
+        "publicKey" TEXT NOT NULL,
+        name TEXT,
+        "sourceId" TEXT NOT NULL,
+        "createdAt" BIGINT NOT NULL,
+        "updatedAt" BIGINT NOT NULL,
+        PRIMARY KEY ("sourceId", "publicKey")
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query('DROP TABLE IF EXISTS meshcore_nodes CASCADE');
+      await pool.end();
+    }
+  });
+
+  it('adds the time-sync columns with defaults and is idempotent', async () => {
+    const client = await pool.connect();
+    try {
+      await runMigration156Postgres(client);
+      await expect(runMigration156Postgres(client)).resolves.toBeUndefined();
+    } finally {
+      client.release();
+    }
+
+    const now = Date.now();
+    await pool.query(
+      `INSERT INTO meshcore_nodes ("publicKey", name, "sourceId", "createdAt", "updatedAt")
+       VALUES ($1, $2, $3, $4, $4)`,
+      ['pk-1', 'node-1', 'src-a', now],
+    );
+
+    const { rows } = await pool.query(
+      `SELECT "timeSyncEnabled", "timeSyncIntervalMinutes", "lastTimeSyncAt"
+       FROM meshcore_nodes WHERE "publicKey" = 'pk-1'`,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].timeSyncEnabled).toBe(false);
+    expect(rows[0].timeSyncIntervalMinutes).toBe(720);
+    expect(rows[0].lastTimeSyncAt).toBeNull();
+  });
+});
+
+describe.skipIf(!mysqlAvailable)('migration 156 — MySQL (container)', () => {
+  let pool: mysql.Pool;
+
+  beforeAll(async () => {
+    pool = mysql.createPool({
+      host: 'localhost',
+      port: 3307,
+      user: 'test',
+      password: 'test',
+      database: 'meshmonitor_test',
+      connectionLimit: 5,
+    });
+    await pool.query('DROP TABLE IF EXISTS meshcore_nodes');
+    await pool.query(`
+      CREATE TABLE meshcore_nodes (
+        publicKey VARCHAR(64) NOT NULL,
+        name VARCHAR(255),
+        sourceId VARCHAR(64) NOT NULL,
+        createdAt BIGINT NOT NULL,
+        updatedAt BIGINT NOT NULL,
+        PRIMARY KEY (sourceId, publicKey)
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query('DROP TABLE IF EXISTS meshcore_nodes');
+      await pool.end();
+    }
+  });
+
+  it('adds the time-sync columns with defaults and is idempotent', async () => {
+    await runMigration156Mysql(pool);
+    await expect(runMigration156Mysql(pool)).resolves.toBeUndefined();
+
+    const now = Date.now();
+    await pool.query(
+      `INSERT INTO meshcore_nodes (publicKey, name, sourceId, createdAt, updatedAt)
+       VALUES (?, ?, ?, ?, ?)`,
+      ['pk-1', 'node-1', 'src-a', now, now],
+    );
+
+    const [rows] = await pool.query(
+      `SELECT timeSyncEnabled, timeSyncIntervalMinutes, lastTimeSyncAt
+       FROM meshcore_nodes WHERE publicKey = 'pk-1'`,
+    );
+    const result = rows as any[];
+    expect(result).toHaveLength(1);
+    expect(result[0].timeSyncEnabled).toBe(0);
+    expect(result[0].timeSyncIntervalMinutes).toBe(720);
+    expect(result[0].lastTimeSyncAt).toBeNull();
+  });
+});

--- a/src/server/migrations/156_meshcore_node_time_sync_config.test.ts
+++ b/src/server/migrations/156_meshcore_node_time_sync_config.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Migration 156 — Per-node time-sync columns on `meshcore_nodes` (#4916).
+ * SQLite-only test; the PostgreSQL / MySQL paths share the same shape and are
+ * exercised by the `.pgmysql` integration suite alongside this one.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migration } from './156_meshcore_node_time_sync_config.js';
+
+function createSchema(db: Database.Database) {
+  // Post-migration-057 shape: meshcore_nodes already has sourceId.
+  db.exec(`
+    CREATE TABLE meshcore_nodes (
+      publicKey TEXT PRIMARY KEY,
+      name TEXT,
+      sourceId TEXT,
+      createdAt INTEGER NOT NULL,
+      updatedAt INTEGER NOT NULL
+    );
+  `);
+}
+
+describe('Migration 156 — meshcore_nodes time-sync columns', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createSchema(db);
+  });
+
+  it('adds timeSyncEnabled, timeSyncIntervalMinutes, lastTimeSyncAt', () => {
+    migration.up(db);
+    const colNames = (db.prepare(`PRAGMA table_info(meshcore_nodes)`).all() as Array<{ name: string }>)
+      .map((c) => c.name);
+    expect(colNames).toContain('timeSyncEnabled');
+    expect(colNames).toContain('timeSyncIntervalMinutes');
+    expect(colNames).toContain('lastTimeSyncAt');
+  });
+
+  it('defaults to disabled with a 12-hour interval and no last-sync stamp', () => {
+    migration.up(db);
+    const ts = Date.now();
+    db.prepare(
+      `INSERT INTO meshcore_nodes (publicKey, name, sourceId, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)`,
+    ).run('pk-1', 'node-1', 'src-a', ts, ts);
+
+    const row = db
+      .prepare(
+        `SELECT timeSyncEnabled, timeSyncIntervalMinutes, lastTimeSyncAt
+         FROM meshcore_nodes WHERE publicKey = 'pk-1'`,
+      )
+      .get() as {
+      timeSyncEnabled: number;
+      timeSyncIntervalMinutes: number;
+      lastTimeSyncAt: number | null;
+    };
+    // Opt-in, never on by default: enabling this puts packets on the air.
+    expect(row.timeSyncEnabled).toBe(0);
+    // 720 minutes = 12h, NOT the 60 the other two trios default to — one sync
+    // is four packets, so the cadence is deliberately an order slower.
+    expect(row.timeSyncIntervalMinutes).toBe(720);
+    expect(row.lastTimeSyncAt).toBeNull();
+  });
+
+  it('is idempotent — running twice does not fail or duplicate columns', () => {
+    migration.up(db);
+    expect(() => migration.up(db)).not.toThrow();
+    const cols = db.prepare(`PRAGMA table_info(meshcore_nodes)`).all() as Array<{ name: string }>;
+    const timeSyncCols = cols.filter(
+      (c) => c.name.startsWith('timeSync') || c.name === 'lastTimeSyncAt',
+    );
+    expect(timeSyncCols).toHaveLength(3);
+  });
+
+  it('coexists with the telemetry and neighbours trios — all three stay independent', () => {
+    // Seed the migration-060 telemetry trio and the migration-153 neighbours
+    // trio first, then run 156. All three column sets must survive, because
+    // the whole point of a third set is that a time-sync never resets either
+    // of the other two schedulers' cadences.
+    db.exec(`ALTER TABLE meshcore_nodes ADD COLUMN telemetryEnabled INTEGER DEFAULT 0`);
+    db.exec(`ALTER TABLE meshcore_nodes ADD COLUMN lastTelemetryRequestAt INTEGER`);
+    db.exec(`ALTER TABLE meshcore_nodes ADD COLUMN neighborsEnabled INTEGER DEFAULT 0`);
+    db.exec(`ALTER TABLE meshcore_nodes ADD COLUMN lastNeighborsRequestAt INTEGER`);
+
+    migration.up(db);
+
+    const colNames = (db.prepare(`PRAGMA table_info(meshcore_nodes)`).all() as Array<{ name: string }>)
+      .map((c) => c.name);
+    for (const col of [
+      'telemetryEnabled',
+      'lastTelemetryRequestAt',
+      'neighborsEnabled',
+      'lastNeighborsRequestAt',
+      'timeSyncEnabled',
+      'lastTimeSyncAt',
+    ]) {
+      expect(colNames).toContain(col);
+    }
+  });
+
+  it('leaves existing rows untouched — no backfill enables anything', () => {
+    const ts = Date.now();
+    db.prepare(
+      `INSERT INTO meshcore_nodes (publicKey, name, sourceId, createdAt, updatedAt) VALUES (?, ?, ?, ?, ?)`,
+    ).run('pk-existing', 'pre-existing', 'src-a', ts, ts);
+
+    migration.up(db);
+
+    const row = db
+      .prepare(`SELECT timeSyncEnabled FROM meshcore_nodes WHERE publicKey = 'pk-existing'`)
+      .get() as { timeSyncEnabled: number };
+    // A node that existed before the feature must not start transmitting
+    // because someone upgraded.
+    expect(row.timeSyncEnabled).toBe(0);
+  });
+});

--- a/src/server/migrations/156_meshcore_node_time_sync_config.ts
+++ b/src/server/migrations/156_meshcore_node_time_sync_config.ts
@@ -1,0 +1,129 @@
+/**
+ * Migration 156: Per-node time-sync config on `meshcore_nodes`.
+ *
+ * Adds three nullable columns the new MeshCore time-sync scheduler
+ * (`MeshCoreTimeSyncScheduler`, issue #4916) reads on each tick. Deliberately
+ * a SEPARATE column set from the migration-060 telemetry trio and the
+ * migration-153 neighbours trio, for the same reason those two are separate
+ * from each other: a time-sync push must never reset the telemetry or
+ * neighbours cadence, and vice versa.
+ *
+ *   timeSyncEnabled          BOOLEAN  (false by default)
+ *   timeSyncIntervalMinutes  INTEGER  (720 = 12h default; 0 disables this row)
+ *   lastTimeSyncAt           BIGINT   (ms; null until first attempt)
+ *
+ * The 12h default is deliberately far slower than the Meshtastic auto
+ * time-sync default (15 min). One MeshCore repeater sync costs FOUR packets
+ * on the air, not one — `ensureSavedLogin()` does not cache, so every sync is
+ * a login DM plus its reply, then the `time <epoch>` CliData DM plus its
+ * reply — and each of those floods when the target's out_path is unknown.
+ * Repeater RTC drift is seconds-to-minutes per day, so 12h has ample margin.
+ *
+ * `lastTimeSyncAt` lives in the DATABASE rather than on the scheduler
+ * instance on purpose: an in-memory stamp would be cleared by every restart
+ * and by every settings save that re-arms the scheduler, so a user editing
+ * the config page would re-trigger a sync burst across their whole mesh
+ * (CLAUDE.md, "Does a save reset a safety timer?").
+ *
+ * Backfill is unnecessary — without `timeSyncEnabled=true` the scheduler
+ * never picks the row, so existing rows keep their current behaviour.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 156';
+
+interface ColumnSpec {
+  name: string;
+  sqliteType: string;
+  postgresType: string;
+  mysqlType: string;
+}
+
+const COLUMNS: ColumnSpec[] = [
+  {
+    name: 'timeSyncEnabled',
+    sqliteType: 'INTEGER DEFAULT 0',
+    postgresType: 'BOOLEAN DEFAULT FALSE',
+    mysqlType: 'TINYINT(1) DEFAULT 0',
+  },
+  {
+    name: 'timeSyncIntervalMinutes',
+    sqliteType: 'INTEGER DEFAULT 720',
+    postgresType: 'INTEGER DEFAULT 720',
+    mysqlType: 'INT DEFAULT 720',
+  },
+  {
+    name: 'lastTimeSyncAt',
+    sqliteType: 'INTEGER',
+    postgresType: 'BIGINT',
+    mysqlType: 'BIGINT',
+  },
+];
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding per-node time-sync columns to meshcore_nodes...`);
+
+    for (const col of COLUMNS) {
+      try {
+        db.exec(`ALTER TABLE meshcore_nodes ADD COLUMN ${col.name} ${col.sqliteType}`);
+        logger.debug(`${LABEL} (SQLite): added meshcore_nodes.${col.name}`);
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        if (message.includes('duplicate column')) {
+          logger.debug(`${LABEL} (SQLite): meshcore_nodes.${col.name} already exists, skipping`);
+        } else {
+          logger.error(`${LABEL} (SQLite): could not add meshcore_nodes.${col.name}:`, message);
+          throw e;
+        }
+      }
+    }
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration156Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding per-node time-sync columns...`);
+
+  for (const col of COLUMNS) {
+    await client.query(
+      `ALTER TABLE meshcore_nodes ADD COLUMN IF NOT EXISTS "${col.name}" ${col.postgresType}`,
+    );
+    logger.debug(`${LABEL} (PostgreSQL): ensured meshcore_nodes.${col.name}`);
+  }
+}
+
+// ============ MySQL ============
+
+export async function runMigration156Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding per-node time-sync columns...`);
+
+  const conn = await pool.getConnection();
+  try {
+    for (const col of COLUMNS) {
+      const [rows] = await conn.query(
+        `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'meshcore_nodes' AND COLUMN_NAME = ?`,
+        [col.name],
+      );
+      if (!Array.isArray(rows) || rows.length === 0) {
+        await conn.query(`ALTER TABLE meshcore_nodes ADD COLUMN ${col.name} ${col.mysqlType}`);
+        logger.debug(`${LABEL} (MySQL): added meshcore_nodes.${col.name}`);
+      } else {
+        logger.debug(`${LABEL} (MySQL): meshcore_nodes.${col.name} already exists, skipping`);
+      }
+    }
+  } finally {
+    conn.release();
+  }
+}

--- a/src/server/routes/meshcoreContactsRoutes.ts
+++ b/src/server/routes/meshcoreContactsRoutes.ts
@@ -21,6 +21,14 @@ import {
   MAX_INTERVAL_MINUTES as NEIGHBOURS_MAX_INTERVAL_MINUTES,
   MIN_INTERVAL_BETWEEN_REQUESTS_MS as NEIGHBOURS_MIN_INTERVAL_BETWEEN_REQUESTS_MS,
 } from '../services/meshcoreNeighboursScheduler.js';
+// Likewise the time-sync routes gate against the time-sync scheduler's own
+// constants, so the route floor and the scheduler floor can never drift (#4916).
+import {
+  DEFAULT_INTERVAL_MINUTES as TIME_SYNC_DEFAULT_INTERVAL_MINUTES,
+  MIN_INTERVAL_MINUTES as TIME_SYNC_MIN_INTERVAL_MINUTES,
+  MAX_INTERVAL_MINUTES as TIME_SYNC_MAX_INTERVAL_MINUTES,
+  MIN_INTERVAL_BETWEEN_REQUESTS_MS as TIME_SYNC_MIN_INTERVAL_BETWEEN_REQUESTS_MS,
+} from '../services/meshcoreTimeSyncScheduler.js';
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
@@ -1170,6 +1178,241 @@ router.patch(
     } catch (error) {
       logger.error('[API] Error setting per-node neighbours-config:', error);
       res.status(500).json({ success: false, error: 'Failed to update neighbours-config' });
+    }
+  },
+);
+
+/**
+ * GET /api/sources/:id/meshcore/nodes/:publicKey/time-sync-config
+ *
+ * Read the per-node time-sync config (issue #4916). Returns the persisted
+ * (timeSyncEnabled, timeSyncIntervalMinutes, lastTimeSyncAt) triple, or
+ * defaults if the node has never been written. Mirror of the
+ * neighbours-config GET.
+ *
+ * `hasSavedCredential` is included because time sync is the one per-node
+ * scheduler that CANNOT work without a saved admin password — `time` is a
+ * mutating verb, so a guest session is not enough. Surfacing it here lets the
+ * UI warn at configuration time instead of leaving the user to discover the
+ * failure in the logs 12 hours later.
+ */
+router.get(
+  '/nodes/:publicKey/time-sync-config',
+  optionalAuth(),
+  requirePermission('nodes', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id: string }).id;
+      const { publicKey } = req.params;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
+      }
+      const node = await databaseService.meshcore.getNodeByPublicKeyAndSource(publicKey, sourceId);
+      res.json({
+        success: true,
+        data: {
+          publicKey,
+          sourceId,
+          enabled: Boolean(node?.timeSyncEnabled),
+          intervalMinutes: node?.timeSyncIntervalMinutes ?? TIME_SYNC_DEFAULT_INTERVAL_MINUTES,
+          lastSyncAt: node?.lastTimeSyncAt ?? null,
+          minIntervalMinutes: TIME_SYNC_MIN_INTERVAL_MINUTES,
+          hasSavedCredential: Boolean(node?.adminCredential),
+        },
+      });
+    } catch (error) {
+      logger.error('[API] Error getting per-node time-sync-config:', error);
+      res.status(500).json({ success: false, error: 'Failed to read time-sync-config' });
+    }
+  },
+);
+
+/**
+ * PATCH /api/sources/:id/meshcore/nodes/:publicKey/time-sync-config
+ *
+ * Update the per-node time-sync config. Body:
+ *   { enabled?: boolean, intervalMinutes?: number }
+ *
+ * `intervalMinutes` is rejected below TIME_SYNC_MIN_INTERVAL_MINUTES (60)
+ * rather than silently clamped, so an API caller learns the floor exists.
+ * One sync is four packets on the air, so a mistyped small value would be
+ * genuinely harmful to the mesh.
+ *
+ * Gated by `configuration:write`, mirroring the neighbours-config PATCH.
+ */
+router.patch(
+  '/nodes/:publicKey/time-sync-config',
+  requireAuth(),
+  requirePermission('configuration', 'write', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id: string }).id;
+      const { publicKey } = req.params;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
+      }
+
+      const { enabled, intervalMinutes } = req.body ?? {};
+
+      const patch: { enabled?: boolean; intervalMinutes?: number } = {};
+      if (enabled !== undefined) {
+        if (typeof enabled !== 'boolean') {
+          return res.status(400).json({ success: false, error: 'enabled must be a boolean' });
+        }
+        patch.enabled = enabled;
+      }
+      if (intervalMinutes !== undefined) {
+        const n = Number(intervalMinutes);
+        if (
+          !Number.isInteger(n)
+          || n < TIME_SYNC_MIN_INTERVAL_MINUTES
+          || n > TIME_SYNC_MAX_INTERVAL_MINUTES
+        ) {
+          return res.status(400).json({
+            success: false,
+            error: `intervalMinutes must be an integer between ${TIME_SYNC_MIN_INTERVAL_MINUTES} and ${TIME_SYNC_MAX_INTERVAL_MINUTES}`,
+          });
+        }
+        patch.intervalMinutes = n;
+      }
+      if (patch.enabled === undefined && patch.intervalMinutes === undefined) {
+        return res.status(400).json({ success: false, error: 'No fields to update' });
+      }
+
+      // Backfill advType/advName/position from the in-memory contact before
+      // seeding the stub row, mirroring the neighbours-config PATCH.
+      const manager = managerFor(req, res);
+      const contact = manager.getContact(publicKey);
+      if (contact) {
+        try {
+          await databaseService.meshcore.upsertNode(
+            {
+              publicKey,
+              name: contact.advName ?? contact.name ?? null,
+              advType: contact.advType ?? null,
+              latitude: contact.latitude ?? null,
+              longitude: contact.longitude ?? null,
+              positionSource: (typeof contact.latitude === 'number'
+                && typeof contact.longitude === 'number'
+                && !isBogusPosition(contact.latitude, contact.longitude))
+                ? 'contact'
+                : undefined,
+              lastHeard: contact.lastSeen ?? null,
+            },
+            sourceId,
+          );
+        } catch (err) {
+          logger.warn(
+            `[API] time-sync-config: contact backfill for ${publicKey.substring(0, 16)}… failed: ${(err as Error).message}`,
+          );
+        }
+      }
+      await databaseService.meshcore.setNodeTimeSyncConfig(sourceId, publicKey, patch);
+      const node = await databaseService.meshcore.getNodeByPublicKeyAndSource(publicKey, sourceId);
+      res.json({
+        success: true,
+        data: {
+          publicKey,
+          sourceId,
+          enabled: Boolean(node?.timeSyncEnabled),
+          intervalMinutes: node?.timeSyncIntervalMinutes ?? TIME_SYNC_DEFAULT_INTERVAL_MINUTES,
+          lastSyncAt: node?.lastTimeSyncAt ?? null,
+          minIntervalMinutes: TIME_SYNC_MIN_INTERVAL_MINUTES,
+          hasSavedCredential: Boolean(node?.adminCredential),
+        },
+      });
+    } catch (error) {
+      logger.error('[API] Error setting per-node time-sync-config:', error);
+      res.status(500).json({ success: false, error: 'Failed to update time-sync-config' });
+    }
+  },
+);
+
+/**
+ * POST /api/sources/:id/meshcore/nodes/:publicKey/time-sync
+ *
+ * Push the server clock to this repeater immediately, outside the scheduler's
+ * cadence (#4916). Honours the same per-source 60s mesh-TX gate as the
+ * scheduler and the other manual polls, so the button can't be spammed onto
+ * the air.
+ *
+ * Gated by `configuration:write` rather than `nodes:read` — unlike the
+ * telemetry and neighbours polls, this MUTATES the remote device (it sets its
+ * RTC), so it is a configuration action that happens to transmit rather than
+ * a read that happens to transmit.
+ */
+router.post(
+  '/nodes/:publicKey/time-sync',
+  meshcoreDeviceLimiter,
+  requireAuth(),
+  requirePermission('configuration', 'write', { sourceIdFrom: 'params.id' }),
+  requireMeshcoreTx(),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id: string }).id;
+      const { publicKey } = req.params;
+      if (!isValidPublicKey(publicKey)) {
+        return res.status(400).json({ success: false, error: 'Invalid public key format (expected 64-character hex string)' });
+      }
+
+      const manager = managerFor(req, res);
+      if (!manager.isConnected()) {
+        return res.status(409).json({ success: false, error: 'MeshCore source is not connected' });
+      }
+
+      // Per-source 60s mesh-TX gate — the same primitive the scheduler uses.
+      const lastTx = manager.getLastMeshTxAt();
+      const sinceLastTx = Date.now() - lastTx;
+      if (lastTx > 0 && sinceLastTx < TIME_SYNC_MIN_INTERVAL_BETWEEN_REQUESTS_MS) {
+        const retryAfterSecs = Math.ceil((TIME_SYNC_MIN_INTERVAL_BETWEEN_REQUESTS_MS - sinceLastTx) / 1000);
+        res.set('Retry-After', String(retryAfterSecs));
+        return res.status(429).json({
+          success: false,
+          error: `Too soon since last mesh transmission; retry in ${retryAfterSecs}s`,
+          retryAfterSecs,
+        });
+      }
+
+      // Stamp before issuing so the gate applies regardless of result and the
+      // scheduler's fair-rotation clock advances too.
+      const now = Date.now();
+      manager.recordMeshTx(now);
+      await databaseService.meshcore.markTimeSyncRequested(sourceId, publicKey, now);
+
+      const result = await manager.syncNodeTime(publicKey);
+      if (result.status === 'no-credential') {
+        return res.status(409).json({
+          success: false,
+          error: 'No usable saved admin password for this node. Save one, then retry.',
+          code: 'NO_SAVED_CREDENTIAL',
+        });
+      }
+      if (result.status === 'rejected') {
+        // Not a server error — the firmware answered, and said no. Almost
+        // always its "clock cannot go backwards" guard.
+        return res.status(409).json({
+          success: false,
+          error: `Repeater refused the clock push (it may be running ahead of server time): ${result.reply}`,
+          code: 'CLOCK_PUSH_REJECTED',
+          reply: result.reply,
+        });
+      }
+      if (result.status === 'failed') {
+        return res.status(504).json({
+          success: false,
+          error: `No reply from repeater: ${result.error}`,
+          code: 'CLOCK_PUSH_NO_REPLY',
+        });
+      }
+
+      res.json({
+        success: true,
+        data: { reply: result.reply, elapsedMs: result.elapsedMs, syncedAt: now },
+      });
+    } catch (error) {
+      if (failIfTxDisabled(res, error)) return;
+      logger.error('[API] Error pushing node time sync:', error);
+      res.status(500).json({ success: false, error: 'Time sync failed' });
     }
   },
 );

--- a/src/server/routes/meshcoreContactsRoutes.ts
+++ b/src/server/routes/meshcoreContactsRoutes.ts
@@ -1195,6 +1195,16 @@ router.patch(
  * mutating verb, so a guest session is not enough. Surfacing it here lets the
  * UI warn at configuration time instead of leaving the user to discover the
  * failure in the logs 12 hours later.
+ *
+ * CAVEAT on what that flag actually means: it reports that a credential BLOB
+ * EXISTS, not that the blob still decrypts. `adminCredential` is AES-256-GCM
+ * ciphertext keyed on SESSION_SECRET, and only `ensureSavedLogin` — via the
+ * credential store's `load()` — can tell a usable credential from a rotated
+ * or corrupted one. So rotating SESSION_SECRET leaves this reporting `true`
+ * while every scheduled sync fails `no-credential`. Deliberately not
+ * decrypting here: this is a read-only display endpoint on a hot path, and a
+ * false positive in a warning is cheaper than doing crypto per request. The
+ * scheduler logs the real answer at warn level when it happens.
  */
 router.get(
   '/nodes/:publicKey/time-sync-config',

--- a/src/server/routes/meshcoreRoutes.test.ts
+++ b/src/server/routes/meshcoreRoutes.test.ts
@@ -81,6 +81,7 @@ const meshcoreManager = {
   recordMeshTx: vi.fn(),
   // Shared request→resolve→store used by the manual neighbours-poll route (#4618).
   pollNeighborsAndStore: vi.fn().mockResolvedValue({ total: 2, written: 2 }),
+  syncNodeTime: vi.fn().mockResolvedValue({ status: 'ok', reply: 'OK', elapsedMs: 1200 }),
   // Fire-and-forget scope-cache refresh invoked by the saved-regions routes (#3829).
   notifySavedRegionsChanged: vi.fn(),
   // Receive-only TX guard (#4547) — requireMeshcoreTx() calls this unconditionally
@@ -1895,6 +1896,216 @@ describe('MeshCore Routes', () => {
       expect(res.body.retryAfterSecs).toBeGreaterThan(0);
       expect(res.headers['retry-after']).toBeDefined();
       expect(meshcoreManager.pollNeighborsAndStore).not.toHaveBeenCalled();
+      expect(meshcoreManager.recordMeshTx).not.toHaveBeenCalled();
+    });
+  });
+
+  // ============ Time-sync config + manual sync (#4916) ============
+
+  describe('PATCH /api/sources/test-source/meshcore/nodes/:publicKey/time-sync-config', () => {
+    const TS_PUBKEY = 'f'.repeat(64);
+    const upsertNode = vi.fn().mockResolvedValue(undefined);
+    const setNodeTimeSyncConfig = vi.fn().mockResolvedValue(undefined);
+    const getNodeByPublicKeyAndSource = vi.fn().mockResolvedValue({
+      publicKey: TS_PUBKEY,
+      timeSyncEnabled: true,
+      timeSyncIntervalMinutes: 720,
+      lastTimeSyncAt: null,
+      adminCredential: 'cipher',
+    });
+
+    beforeEach(() => {
+      (DatabaseService as any).meshcore = {
+        upsertNode,
+        setNodeTimeSyncConfig,
+        getNodeByPublicKeyAndSource,
+      };
+      upsertNode.mockClear();
+      setNodeTimeSyncConfig.mockClear();
+      getNodeByPublicKeyAndSource.mockClear();
+      meshcoreManager.getContact.mockReset();
+    });
+
+    it('requires authentication', async () => {
+      const res = await request(app)
+        .patch(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync-config`)
+        .send({ enabled: true });
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects a sub-floor interval — the 1-hour floor is server-enforced', async () => {
+      // A time-sync costs four packets on the air, so a mistyped small value
+      // must not be accepted just because the UI happened to allow it.
+      const res = await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync-config`)
+        .send({ intervalMinutes: 5 });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/between 60 and/);
+      expect(setNodeTimeSyncConfig).not.toHaveBeenCalled();
+    });
+
+    it('rejects an interval above the 7-day ceiling', async () => {
+      const res = await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync-config`)
+        .send({ intervalMinutes: 999_999 });
+      expect(res.status).toBe(400);
+      expect(setNodeTimeSyncConfig).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-integer interval', async () => {
+      const res = await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync-config`)
+        .send({ intervalMinutes: 90.5 });
+      expect(res.status).toBe(400);
+      expect(setNodeTimeSyncConfig).not.toHaveBeenCalled();
+    });
+
+    it('accepts the 60-minute floor exactly', async () => {
+      meshcoreManager.getContact.mockReturnValueOnce(undefined);
+      const res = await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync-config`)
+        .send({ intervalMinutes: 60 });
+      expect(res.status).toBe(200);
+      expect(setNodeTimeSyncConfig).toHaveBeenCalledWith(
+        'test-source',
+        TS_PUBKEY,
+        { intervalMinutes: 60 },
+      );
+    });
+
+    it('persists enabled + interval and echoes the stored config', async () => {
+      meshcoreManager.getContact.mockReturnValueOnce(undefined);
+      const res = await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync-config`)
+        .send({ enabled: true, intervalMinutes: 1440 });
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(setNodeTimeSyncConfig).toHaveBeenCalledWith(
+        'test-source',
+        TS_PUBKEY,
+        { enabled: true, intervalMinutes: 1440 },
+      );
+      expect(res.body.data).toMatchObject({
+        enabled: true,
+        intervalMinutes: 720,
+        minIntervalMinutes: 60,
+        hasSavedCredential: true,
+      });
+    });
+
+    it('reports hasSavedCredential=false so the UI can warn before the schedule silently no-ops', async () => {
+      getNodeByPublicKeyAndSource.mockResolvedValueOnce({
+        publicKey: TS_PUBKEY,
+        timeSyncEnabled: true,
+        timeSyncIntervalMinutes: 720,
+        lastTimeSyncAt: null,
+        adminCredential: null,
+      });
+      meshcoreManager.getContact.mockReturnValueOnce(undefined);
+      const res = await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync-config`)
+        .send({ enabled: true });
+      expect(res.status).toBe(200);
+      expect(res.body.data.hasSavedCredential).toBe(false);
+    });
+
+    it('rejects a request with no updatable fields', async () => {
+      const res = await authenticatedAgent
+        .patch(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync-config`)
+        .send({});
+      expect(res.status).toBe(400);
+      expect(setNodeTimeSyncConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/sources/test-source/meshcore/nodes/:publicKey/time-sync', () => {
+    const TS_PUBKEY = 'b'.repeat(64);
+    const MALFORMED = 'abcd1234';
+    const markTimeSyncRequested = vi.fn();
+
+    beforeEach(() => {
+      (DatabaseService as any).meshcore = { markTimeSyncRequested };
+      markTimeSyncRequested.mockReset().mockResolvedValue(undefined);
+      meshcoreManager.isConnected.mockReturnValue(true);
+      meshcoreManager.getLastMeshTxAt.mockReturnValue(0);
+      meshcoreManager.recordMeshTx.mockReset();
+      meshcoreManager.syncNodeTime.mockReset().mockResolvedValue({
+        status: 'ok', reply: 'OK', elapsedMs: 1200,
+      });
+    });
+
+    afterEach(() => {
+      meshcoreManager.isConnected.mockReturnValue(false);
+      meshcoreManager.getLastMeshTxAt.mockReturnValue(0);
+    });
+
+    it('requires authentication', async () => {
+      const res = await request(app)
+        .post(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync`);
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects a malformed public key', async () => {
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${MALFORMED}/time-sync`);
+      expect(res.status).toBe(400);
+    });
+
+    it('syncs: stamps the gate before sending and returns the reply', async () => {
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync`);
+      expect(res.status).toBe(200);
+      expect(res.body.data).toMatchObject({ reply: 'OK', elapsedMs: 1200 });
+      expect(meshcoreManager.syncNodeTime).toHaveBeenCalledWith(TS_PUBKEY);
+      expect(meshcoreManager.recordMeshTx).toHaveBeenCalledTimes(1);
+      expect(markTimeSyncRequested).toHaveBeenCalledWith('test-source', TS_PUBKEY, expect.any(Number));
+    });
+
+    it('returns 409 NO_SAVED_CREDENTIAL when no admin password is stored', async () => {
+      meshcoreManager.syncNodeTime.mockResolvedValueOnce({ status: 'no-credential' });
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync`);
+      expect(res.status).toBe(409);
+      expect(res.body.code).toBe('NO_SAVED_CREDENTIAL');
+      // Still stamped — this failure is persistent, not transient.
+      expect(markTimeSyncRequested).toHaveBeenCalled();
+    });
+
+    it('returns 409 CLOCK_PUSH_REJECTED when the repeater refuses (clock ahead)', async () => {
+      meshcoreManager.syncNodeTime.mockResolvedValueOnce({
+        status: 'rejected', reply: 'ERR: clock cannot go backwards',
+      });
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync`);
+      expect(res.status).toBe(409);
+      expect(res.body.code).toBe('CLOCK_PUSH_REJECTED');
+      expect(res.body.reply).toMatch(/cannot go backwards/);
+    });
+
+    it('returns 504 CLOCK_PUSH_NO_REPLY on timeout', async () => {
+      meshcoreManager.syncNodeTime.mockResolvedValueOnce({ status: 'failed', error: 'timeout' });
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync`);
+      expect(res.status).toBe(504);
+      expect(res.body.code).toBe('CLOCK_PUSH_NO_REPLY');
+    });
+
+    it('returns 409 when the source is not connected', async () => {
+      meshcoreManager.isConnected.mockReturnValue(false);
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync`);
+      expect(res.status).toBe(409);
+      expect(meshcoreManager.syncNodeTime).not.toHaveBeenCalled();
+    });
+
+    it('enforces the shared 60s mesh-TX gate with 429 + Retry-After', async () => {
+      meshcoreManager.getLastMeshTxAt.mockReturnValue(Date.now() - 5_000);
+      const res = await authenticatedAgent
+        .post(`/api/sources/test-source/meshcore/nodes/${TS_PUBKEY}/time-sync`);
+      expect(res.status).toBe(429);
+      expect(res.body.retryAfterSecs).toBeGreaterThan(0);
+      expect(res.headers['retry-after']).toBeDefined();
+      expect(meshcoreManager.syncNodeTime).not.toHaveBeenCalled();
       expect(meshcoreManager.recordMeshTx).not.toHaveBeenCalled();
     });
   });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -580,6 +580,29 @@ setTimeout(async () => {
   }
 }, 9000); // After telemetry scheduler, before room-sync.
 
+// MeshCore Time-Sync Scheduler (#4916) — periodically pushes the server's wall
+// clock to each opt-in remote repeater's RTC via the absolute `time <epoch>`
+// verb. The most expensive of the MeshCore schedulers: one sync is FOUR
+// packets (login + reply, then the CLI command + reply), because
+// `ensureSavedLogin` deliberately does not cache. It therefore honours the
+// same per-source 60s minimum through the shared `MeshCoreManager.lastMeshTxAt`
+// primitive, and its per-node cadence defaults to 12h with a 1h floor. That
+// cadence lives in a THIRD separate column set (`lastTimeSyncAt`, migration
+// 156) so time-sync, telemetry, and neighbours never reset one another.
+const meshcoreTimeSyncScheduler = new MeshCoreTimeSyncScheduler({
+  registry: sourceManagerRegistry,
+  database: databaseService,
+});
+setMeshCoreTimeSyncScheduler(meshcoreTimeSyncScheduler);
+setTimeout(async () => {
+  try {
+    await databaseService.waitForReady();
+    meshcoreTimeSyncScheduler.start();
+  } catch (error) {
+    logger.error('Failed to start MeshCore time-sync scheduler:', error);
+  }
+}, 11000); // Last of the MeshCore schedulers — after room-sync.
+
 // ==========================================
 // Version Check (detection / notification only)
 // ==========================================
@@ -642,6 +665,10 @@ import {
   MeshCoreNeighboursScheduler,
   setMeshCoreNeighboursScheduler,
 } from './services/meshcoreNeighboursScheduler.js';
+import {
+  MeshCoreTimeSyncScheduler,
+  setMeshCoreTimeSyncScheduler,
+} from './services/meshcoreTimeSyncScheduler.js';
 import { getMeshCoreCredentialStore } from './services/meshcoreCredentialStore.js';
 import embedProfileRoutes from './routes/embedProfileRoutes.js';
 import embedPublicRoutes from './routes/embedPublicRoutes.js';

--- a/src/server/services/meshcoreTimeSyncScheduler.test.ts
+++ b/src/server/services/meshcoreTimeSyncScheduler.test.ts
@@ -1,0 +1,385 @@
+/**
+ * MeshCoreTimeSyncScheduler tests (#4916).
+ *
+ * Covers the pure helpers (`isNodeEligible`, `pickMostOverdue`,
+ * `clampIntervalMinutes`) and `tickOneManager`: the receive-only (#4547) skip,
+ * the SHARED per-source 60s mesh-TX floor (the guarantee that a time-sync
+ * never collides with a telemetry or neighbours poll — all three read
+ * `getLastMeshTxAt`), the pre-stamp ordering (`markTimeSyncRequested` +
+ * `recordMeshTx` BEFORE the RF round-trips), and the four `syncNodeTime`
+ * outcomes.
+ *
+ * The stamp-before-send ordering is the load-bearing one here. A time-sync is
+ * four packets, and its two most likely failure modes — an offline repeater
+ * and one whose RTC runs ahead (firmware refuses to move a clock backwards) —
+ * are both persistent. If the stamp only landed on success, either would be
+ * retried on every single tick forever.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  MeshCoreTimeSyncScheduler,
+  isNodeEligible,
+  pickMostOverdue,
+  clampIntervalMinutes,
+  DEFAULT_INTERVAL_MINUTES,
+  MIN_INTERVAL_MINUTES,
+  MAX_INTERVAL_MINUTES,
+  type TimeSyncSchedulerDatabase,
+} from './meshcoreTimeSyncScheduler.js';
+import type { DbMeshCoreNode } from '../../db/repositories/meshcore.js';
+import type { MeshCoreManager } from '../meshcoreManager.js';
+import type { SourceManagerRegistry } from '../sourceManagerRegistry.js';
+
+type SyncResult = Awaited<ReturnType<MeshCoreManager['syncNodeTime']>>;
+
+function node(over: Partial<DbMeshCoreNode>): DbMeshCoreNode {
+  return {
+    publicKey: 'pk-x',
+    timeSyncEnabled: true,
+    timeSyncIntervalMinutes: DEFAULT_INTERVAL_MINUTES,
+    lastTimeSyncAt: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...over,
+  } as unknown as DbMeshCoreNode;
+}
+
+const HOUR = 60 * 60_000;
+
+describe('constants', () => {
+  it('defaults to 12 hours — far slower than the 15-minute Meshtastic equivalent', () => {
+    // One MeshCore sync is four packets (login + reply, then the CLI command
+    // + reply) versus Meshtastic's one admin packet, so the cadence is not
+    // comparable and must not be "harmonised" with it.
+    expect(DEFAULT_INTERVAL_MINUTES).toBe(720);
+  });
+
+  it('floors at 1 hour and ceilings at 7 days', () => {
+    expect(MIN_INTERVAL_MINUTES).toBe(60);
+    expect(MAX_INTERVAL_MINUTES).toBe(7 * 24 * 60);
+  });
+});
+
+describe('clampIntervalMinutes', () => {
+  it('rejects non-numeric and non-positive values rather than substituting a default', () => {
+    expect(clampIntervalMinutes('nonsense')).toBeNull();
+    expect(clampIntervalMinutes(0)).toBeNull();
+    expect(clampIntervalMinutes(-5)).toBeNull();
+    expect(clampIntervalMinutes(undefined)).toBeNull();
+  });
+
+  it('raises a sub-floor value to the 1-hour floor', () => {
+    expect(clampIntervalMinutes(5)).toBe(MIN_INTERVAL_MINUTES);
+    expect(clampIntervalMinutes(59)).toBe(MIN_INTERVAL_MINUTES);
+  });
+
+  it('caps an over-ceiling value at 7 days', () => {
+    expect(clampIntervalMinutes(999_999)).toBe(MAX_INTERVAL_MINUTES);
+  });
+
+  it('passes an in-range value through, rounded', () => {
+    expect(clampIntervalMinutes(720)).toBe(720);
+    expect(clampIntervalMinutes(90.4)).toBe(90);
+  });
+});
+
+describe('isNodeEligible', () => {
+  it('rejects disabled nodes', () => {
+    expect(isNodeEligible(node({ timeSyncEnabled: false }), 0)).toBe(false);
+  });
+
+  it('rejects a non-positive interval', () => {
+    expect(isNodeEligible(node({ timeSyncIntervalMinutes: 0 }), 1_000_000_000)).toBe(false);
+  });
+
+  it('accepts a node never synced before', () => {
+    expect(isNodeEligible(node({ lastTimeSyncAt: null }), 1_000_000_000)).toBe(true);
+  });
+
+  it('rejects a node still inside its interval', () => {
+    const now = 1_000_000_000;
+    expect(
+      isNodeEligible(node({ timeSyncIntervalMinutes: 720, lastTimeSyncAt: now - 6 * HOUR }), now),
+    ).toBe(false);
+  });
+
+  it('accepts a node past its interval', () => {
+    const now = 1_000_000_000;
+    expect(
+      isNodeEligible(node({ timeSyncIntervalMinutes: 720, lastTimeSyncAt: now - 13 * HOUR }), now),
+    ).toBe(true);
+  });
+
+  it('applies the 1-hour floor at READ time to a sub-floor stored interval', () => {
+    // A row edited directly in the database (or written before the floor
+    // existed) must not be able to drive a faster cadence than the scheduler
+    // permits — the floor is not a UI-only guard.
+    const now = 1_000_000_000;
+    const rogue = node({ timeSyncIntervalMinutes: 5, lastTimeSyncAt: now - 10 * 60_000 });
+    // 10 minutes have passed, which would satisfy a stored 5-minute interval,
+    // but the floor holds it to an hour.
+    expect(isNodeEligible(rogue, now)).toBe(false);
+    expect(isNodeEligible(node({ timeSyncIntervalMinutes: 5, lastTimeSyncAt: now - 61 * 60_000 }), now)).toBe(true);
+  });
+});
+
+describe('pickMostOverdue', () => {
+  it('returns undefined when nothing is eligible', () => {
+    expect(pickMostOverdue([node({ timeSyncEnabled: false })], 1_000_000_000)).toBeUndefined();
+  });
+
+  it('picks the most overdue eligible node', () => {
+    const now = 1_000_000_000;
+    const a = node({ publicKey: 'aaa', lastTimeSyncAt: now - 13 * HOUR });
+    const b = node({ publicKey: 'bbb', lastTimeSyncAt: now - 40 * HOUR });
+    expect(pickMostOverdue([a, b], now)?.publicKey).toBe('bbb');
+  });
+
+  it('breaks a tie deterministically on publicKey so two nodes do not ping-pong', () => {
+    const now = 1_000_000_000;
+    const a = node({ publicKey: 'bbb', lastTimeSyncAt: null });
+    const b = node({ publicKey: 'aaa', lastTimeSyncAt: null });
+    expect(pickMostOverdue([a, b], now)?.publicKey).toBe('aaa');
+    expect(pickMostOverdue([b, a], now)?.publicKey).toBe('aaa');
+  });
+});
+
+// ============ tickOneManager ============
+
+interface FakeState {
+  sourceId: string;
+  connected: boolean;
+  receiveOnly: boolean;
+  lastMeshTxAt: number;
+  syncedFor: string[];
+  syncResult: SyncResult;
+  syncThrows: boolean;
+}
+
+function makeFakeManager(init: Partial<FakeState>): MeshCoreManager & { _state: FakeState } {
+  const state: FakeState = {
+    sourceId: 'src-a',
+    connected: true,
+    receiveOnly: false,
+    lastMeshTxAt: 0,
+    syncedFor: [],
+    syncResult: { status: 'ok', reply: 'OK', elapsedMs: 1200 },
+    syncThrows: false,
+    ...init,
+  };
+  const m: any = {
+    sourceId: state.sourceId,
+    sourceType: 'meshcore',
+    isConnected: () => state.connected,
+    isReceiveOnly: () => state.receiveOnly,
+    getLastMeshTxAt: () => state.lastMeshTxAt,
+    recordMeshTx: (when: number = Date.now()) => { state.lastMeshTxAt = when; },
+    syncNodeTime: async (publicKey: string) => {
+      state.syncedFor.push(publicKey);
+      if (state.syncThrows) throw new Error('boom');
+      return state.syncResult;
+    },
+    _state: state,
+  };
+  return m as MeshCoreManager & { _state: FakeState };
+}
+
+function makeRegistry(managers: MeshCoreManager[]): SourceManagerRegistry {
+  return { getAllManagers: () => managers } as unknown as SourceManagerRegistry;
+}
+
+function makeDb(nodes: DbMeshCoreNode[]): {
+  db: TimeSyncSchedulerDatabase;
+  getEnabled: ReturnType<typeof vi.fn>;
+  mark: ReturnType<typeof vi.fn>;
+} {
+  const getEnabled = vi.fn().mockResolvedValue(nodes);
+  const mark = vi.fn().mockResolvedValue(undefined);
+  return {
+    db: { meshcore: { getTimeSyncEnabledNodes: getEnabled, markTimeSyncRequested: mark } },
+    getEnabled,
+    mark,
+  };
+}
+
+function makeScheduler(
+  manager: MeshCoreManager,
+  db: TimeSyncSchedulerDatabase,
+  now: number,
+): MeshCoreTimeSyncScheduler {
+  return new MeshCoreTimeSyncScheduler({
+    registry: makeRegistry([manager]),
+    database: db,
+    now: () => now,
+  });
+}
+
+describe('MeshCoreTimeSyncScheduler.tickOneManager', () => {
+  const NOW = 1_000_000_000;
+
+  it('skips a receive-only manager before the enabled-nodes DB read', async () => {
+    // Must short-circuit ahead of any send primitive: syncNodeTime →
+    // ensureSavedLogin → requireTransmit would otherwise throw (#4547).
+    const manager = makeFakeManager({ receiveOnly: true });
+    const { db, getEnabled } = makeDb([node({ publicKey: 'pk-a' })]);
+
+    await makeScheduler(manager, db, NOW).tickOneManager(manager);
+
+    expect(getEnabled).not.toHaveBeenCalled();
+    expect(manager._state.syncedFor).toEqual([]);
+  });
+
+  it('skips a disconnected manager', async () => {
+    const manager = makeFakeManager({ connected: false });
+    const { db, getEnabled } = makeDb([node({ publicKey: 'pk-a' })]);
+
+    await makeScheduler(manager, db, NOW).tickOneManager(manager);
+
+    expect(getEnabled).not.toHaveBeenCalled();
+  });
+
+  it('syncs the most-overdue node and pre-stamps mark + recordMeshTx', async () => {
+    const manager = makeFakeManager({ lastMeshTxAt: 0 });
+    const { db, mark } = makeDb([node({ publicKey: 'pk-a', lastTimeSyncAt: null })]);
+
+    await makeScheduler(manager, db, NOW).tickOneManager(manager);
+
+    expect(mark).toHaveBeenCalledWith('src-a', 'pk-a', NOW);
+    expect(manager._state.lastMeshTxAt).toBe(NOW); // recordMeshTx pre-stamp
+    expect(manager._state.syncedFor).toEqual(['pk-a']);
+  });
+
+  it('honours the shared 60s floor — a recent neighbours TX blocks a time-sync', async () => {
+    // lastMeshTxAt was set 30s ago (e.g. by the neighbours scheduler on the
+    // same source). Time-sync must back off, so no two of the three MeshCore
+    // schedulers transmit within 60s of each other.
+    const manager = makeFakeManager({ lastMeshTxAt: NOW - 30_000 });
+    const { db, getEnabled } = makeDb([node({ publicKey: 'pk-a' })]);
+
+    await makeScheduler(manager, db, NOW).tickOneManager(manager);
+
+    expect(getEnabled).not.toHaveBeenCalled();
+    expect(manager._state.syncedFor).toEqual([]);
+  });
+
+  it('allows a sync once 60s has elapsed since the last mesh TX', async () => {
+    const manager = makeFakeManager({ lastMeshTxAt: NOW - 61_000 });
+    const { db } = makeDb([node({ publicKey: 'pk-a' })]);
+
+    await makeScheduler(manager, db, NOW).tickOneManager(manager);
+
+    expect(manager._state.syncedFor).toEqual(['pk-a']);
+  });
+
+  it('sends at most one sync per manager per tick', async () => {
+    const manager = makeFakeManager({});
+    const { db } = makeDb([
+      node({ publicKey: 'pk-a', lastTimeSyncAt: null }),
+      node({ publicKey: 'pk-b', lastTimeSyncAt: null }),
+      node({ publicKey: 'pk-c', lastTimeSyncAt: null }),
+    ]);
+
+    await makeScheduler(manager, db, NOW).tickOneManager(manager);
+
+    expect(manager._state.syncedFor).toHaveLength(1);
+  });
+
+  it('does nothing when no node is enabled', async () => {
+    const manager = makeFakeManager({});
+    const { db } = makeDb([]);
+
+    await makeScheduler(manager, db, NOW).tickOneManager(manager);
+
+    expect(manager._state.syncedFor).toEqual([]);
+  });
+
+  it('does nothing when every enabled node is still inside its interval', async () => {
+    const manager = makeFakeManager({});
+    const { db, mark } = makeDb([
+      node({ publicKey: 'pk-a', timeSyncIntervalMinutes: 720, lastTimeSyncAt: NOW - HOUR }),
+    ]);
+
+    await makeScheduler(manager, db, NOW).tickOneManager(manager);
+
+    expect(manager._state.syncedFor).toEqual([]);
+    expect(mark).not.toHaveBeenCalled();
+  });
+
+  // --- the four syncNodeTime outcomes, all of which must still be stamped ---
+
+  it('stamps even when the repeater REJECTS the push (clock running ahead)', async () => {
+    // Firmware refuses to move a clock backwards. That is persistent: without
+    // the pre-stamp this node would be retried on every single tick, four
+    // packets at a time, until someone fixed its RTC by hand.
+    const manager = makeFakeManager({
+      syncResult: { status: 'rejected', reply: 'ERR: clock cannot go backwards' },
+    });
+    const { db, mark } = makeDb([node({ publicKey: 'pk-a' })]);
+
+    await makeScheduler(manager, db, NOW).tickOneManager(manager);
+
+    expect(mark).toHaveBeenCalledWith('src-a', 'pk-a', NOW);
+    expect(manager._state.lastMeshTxAt).toBe(NOW);
+  });
+
+  it('stamps even when there is NO SAVED CREDENTIAL', async () => {
+    // Equally persistent — it will never succeed until the user saves a
+    // password, so it must not be retried every tick.
+    const manager = makeFakeManager({ syncResult: { status: 'no-credential' } });
+    const { db, mark } = makeDb([node({ publicKey: 'pk-a' })]);
+
+    await makeScheduler(manager, db, NOW).tickOneManager(manager);
+
+    expect(mark).toHaveBeenCalledWith('src-a', 'pk-a', NOW);
+  });
+
+  it('stamps even when the sync FAILS with no reply', async () => {
+    const manager = makeFakeManager({ syncResult: { status: 'failed', error: 'timeout' } });
+    const { db, mark } = makeDb([node({ publicKey: 'pk-a' })]);
+
+    await makeScheduler(manager, db, NOW).tickOneManager(manager);
+
+    expect(mark).toHaveBeenCalledWith('src-a', 'pk-a', NOW);
+  });
+
+  it('swallows a throwing syncNodeTime — one bad node cannot kill the tick', async () => {
+    const manager = makeFakeManager({ syncThrows: true });
+    const { db, mark } = makeDb([node({ publicKey: 'pk-a' })]);
+
+    await expect(makeScheduler(manager, db, NOW).tickOneManager(manager)).resolves.toBeUndefined();
+    expect(mark).toHaveBeenCalled();
+  });
+});
+
+describe('MeshCoreTimeSyncScheduler.tick', () => {
+  const NOW = 1_000_000_000;
+
+  it('ignores non-MeshCore managers in the registry', async () => {
+    const meshcore = makeFakeManager({ sourceId: 'src-a' });
+    const meshtastic: any = { sourceId: 'src-b', sourceType: 'meshtastic_tcp' };
+    const { db } = makeDb([node({ publicKey: 'pk-a' })]);
+    const scheduler = new MeshCoreTimeSyncScheduler({
+      registry: makeRegistry([meshcore, meshtastic]),
+      database: db,
+      now: () => NOW,
+    });
+
+    await expect(scheduler.tick()).resolves.toBeUndefined();
+    expect(meshcore._state.syncedFor).toEqual(['pk-a']);
+  });
+
+  it('keeps going when one manager throws', async () => {
+    const bad = makeFakeManager({ sourceId: 'src-bad' });
+    (bad as any).isConnected = () => { throw new Error('registry churn'); };
+    const good = makeFakeManager({ sourceId: 'src-good' });
+    const { db } = makeDb([node({ publicKey: 'pk-a' })]);
+    const scheduler = new MeshCoreTimeSyncScheduler({
+      registry: makeRegistry([bad, good]),
+      database: db,
+      now: () => NOW,
+    });
+
+    await expect(scheduler.tick()).resolves.toBeUndefined();
+    expect(good._state.syncedFor).toEqual(['pk-a']);
+  });
+});

--- a/src/server/services/meshcoreTimeSyncScheduler.ts
+++ b/src/server/services/meshcoreTimeSyncScheduler.ts
@@ -96,9 +96,25 @@ export function resolveTickMs(envValue: string | undefined): number {
 
 /**
  * Clamp a user-supplied interval to [MIN_INTERVAL_MINUTES, MAX_INTERVAL_MINUTES].
- * Exported so the route and the scheduler cannot disagree about the floor.
+ * Exported so the route and the scheduler cannot disagree about the bounds.
  * Returns null for values that aren't a positive finite number, letting the
  * caller reject rather than silently substitute something.
+ *
+ * NOTE — this CLAMPS a sub-floor value up to the floor, whereas the PATCH
+ * route REJECTS one with a 400. That difference is deliberate, not an
+ * oversight, because the two are answering different questions:
+ *
+ *   - The route is talking to a person. Someone who types `5` probably meant
+ *     seconds, or did not realise a sync is four packets; silently storing 60
+ *     would hide their mistake. So it refuses and names the floor.
+ *   - This helper is the last line of defence for a value that is ALREADY in
+ *     the database — written before the floor existed, or edited by hand. At
+ *     that point rejecting achieves nothing (there is no one to tell), so the
+ *     safe move is to clamp and carry on. `isNodeEligible` re-floors for the
+ *     same reason.
+ *
+ * So `clampIntervalMinutes(5) === 60` while `PATCH { intervalMinutes: 5 }`
+ * returns 400. Both protect the same bound, from different directions.
  */
 export function clampIntervalMinutes(value: unknown): number | null {
   const n = typeof value === 'number' ? value : Number(value);
@@ -211,6 +227,14 @@ export class MeshCoreTimeSyncScheduler {
       logger.debug(`[MeshCoreTimeSync:${manager.sourceId}] Skipping - receive-only mode`);
       return;
     }
+
+    // Companion-only is NOT checked here, unlike receive-only above. The two
+    // look similar but are not: receive-only must short-circuit before any
+    // send primitive, because `requireTransmit()` would throw and be caught
+    // only by tick()'s per-manager handler. A non-Companion device instead
+    // gets a clean `{ status: 'failed' }` out of `syncNodeTime`, which the
+    // switch below already handles — so the guard is deliberately delegated
+    // there rather than duplicated.
 
     const now = this.nowFn();
     const sinceLastTx = now - manager.getLastMeshTxAt();

--- a/src/server/services/meshcoreTimeSyncScheduler.ts
+++ b/src/server/services/meshcoreTimeSyncScheduler.ts
@@ -1,0 +1,293 @@
+/**
+ * MeshCore Time-Sync Scheduler — periodic clock push to each opt-in remote
+ * repeater across every connected source (issue #4916).
+ *
+ * Models the MeshCoreNeighboursScheduler exactly, but drives a `time <epoch>`
+ * push instead of a neighbour-table query. Like that scheduler it PUTS
+ * PACKETS ON THE AIR, and it is the most expensive of the three, so
+ * throttling is non-negotiable:
+ *
+ *   - Per-node cadence: `timeSyncIntervalMinutes` from `meshcore_nodes`,
+ *     defaulting to 12h and floored at 1h (`MIN_INTERVAL_MINUTES`).
+ *   - Per-source minimum: `MIN_INTERVAL_BETWEEN_REQUESTS_MS` (60s) between
+ *     any two scheduled mesh ops on the same manager — enforced via the
+ *     SHARED `MeshCoreManager.lastMeshTxAt` primitive. Because telemetry,
+ *     room-sync, neighbours, and now time-sync all coordinate against that
+ *     one field, no two of them transmit within 60s of each other on the
+ *     same source; they interleave rather than collide.
+ *   - Per-tick budget: at most one sync per manager per tick.
+ *
+ * WHY THE CADENCE IS SO MUCH SLOWER THAN MESHTASTIC'S. The Meshtastic auto
+ * time-sync defaults to 15 minutes and costs one admin packet. One MeshCore
+ * repeater sync costs FOUR packets: `ensureSavedLogin()` does not cache, so
+ * every sync is a login DM plus its reply, then the `time <epoch>` CliData DM
+ * plus its reply — and each of those floods when the target's `out_path` is
+ * unknown, which multiplies it again. At 12h across ten repeaters that is
+ * roughly 3 packets/hour; at 15 min it would be roughly 160/hour, which no
+ * LoRa mesh should be asked to carry. Repeater RTC drift is seconds-to-minutes
+ * per day, so 12h has ample margin. (The "~22 minutes behind" in #3954 was
+ * inherited drift from our own unsynced companion, since fixed — not the
+ * repeater's own RTC.)
+ *
+ * The per-node cadence and last-sync stamp live in a SEPARATE column set
+ * (`lastTimeSyncAt`, migration 156) from both the telemetry trio and the
+ * neighbours trio, so a time-sync never resets either of those timers. The
+ * stamp is written to the DATABASE, not to an instance field, so a restart or
+ * a settings save cannot re-arm it and trigger a mesh-wide burst.
+ *
+ * Tick cadence defaults to 30s. Configurable via `MESHCORE_TIME_SYNC_TICK_MS`.
+ */
+import { logger } from '../../utils/logger.js';
+import type { DbMeshCoreNode } from '../../db/repositories/meshcore.js';
+import type { MeshCoreManager } from '../meshcoreManager.js';
+import type { SourceManagerRegistry } from '../sourceManagerRegistry.js';
+import { isMeshCoreManager } from '../sourceManagerTypes.js';
+
+/** Database surface the scheduler depends on (kept thin for testability). */
+export interface TimeSyncSchedulerDatabase {
+  meshcore: {
+    getTimeSyncEnabledNodes: (sourceId: string) => Promise<DbMeshCoreNode[]>;
+    markTimeSyncRequested: (sourceId: string, publicKey: string, when?: number) => Promise<void>;
+  };
+}
+
+/** Minimum spacing between scheduled mesh requests on the same source (ms). */
+export const MIN_INTERVAL_BETWEEN_REQUESTS_MS = 60_000;
+
+/** Default scheduler tick (ms); always >= 1s, clamped on parse. */
+export const DEFAULT_TICK_MS = 30_000;
+const MIN_TICK_MS = 1_000;
+
+/**
+ * Default per-node cadence, in minutes (12h). Also the column default in
+ * migration 156 — kept in sync so a row written before the column existed and
+ * a row written by the UI agree.
+ */
+export const DEFAULT_INTERVAL_MINUTES = 720;
+
+/**
+ * Floor on the per-node interval, in minutes (1h). A sync is four packets, so
+ * a mistyped `5` would put a repeater's worth of traffic on the air every five
+ * minutes. Enforced here AND at the route, so neither the UI nor a direct API
+ * call can go below it.
+ */
+export const MIN_INTERVAL_MINUTES = 60;
+
+/** Sanity ceiling on the per-node interval the UI can set, in minutes (7d). */
+export const MAX_INTERVAL_MINUTES = 7 * 24 * 60;
+
+export interface MeshCoreTimeSyncSchedulerOptions {
+  registry: SourceManagerRegistry;
+  database: TimeSyncSchedulerDatabase;
+  /** Override the env-derived tick (tests). */
+  tickMs?: number;
+  /** Override the inter-request minimum (tests). */
+  minIntervalMs?: number;
+  /** Inject a clock for tests. */
+  now?: () => number;
+}
+
+export function resolveTickMs(envValue: string | undefined): number {
+  if (!envValue) return DEFAULT_TICK_MS;
+  const parsed = parseInt(envValue, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TICK_MS;
+  return Math.max(parsed, MIN_TICK_MS);
+}
+
+/**
+ * Clamp a user-supplied interval to [MIN_INTERVAL_MINUTES, MAX_INTERVAL_MINUTES].
+ * Exported so the route and the scheduler cannot disagree about the floor.
+ * Returns null for values that aren't a positive finite number, letting the
+ * caller reject rather than silently substitute something.
+ */
+export function clampIntervalMinutes(value: unknown): number | null {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.min(Math.max(Math.round(n), MIN_INTERVAL_MINUTES), MAX_INTERVAL_MINUTES);
+}
+
+/**
+ * Decide whether a node is currently eligible for a fresh time-sync push.
+ * Pure function, exported for the unit test.
+ *
+ * The stored interval is floored at read time as well as at write time: a row
+ * written before the floor existed, or edited directly in the database, must
+ * not be able to drive a faster cadence than the scheduler permits.
+ */
+export function isNodeEligible(node: DbMeshCoreNode, now: number): boolean {
+  if (!node.timeSyncEnabled) return false;
+  const raw = node.timeSyncIntervalMinutes;
+  if (raw === null || raw === undefined || raw <= 0) return false;
+  const interval = Math.max(raw, MIN_INTERVAL_MINUTES);
+  const last = node.lastTimeSyncAt ?? 0;
+  return (now - last) >= interval * 60_000;
+}
+
+/**
+ * Pick the most overdue eligible node, or undefined if none. Stable
+ * tiebreaker on publicKey so two nodes that came due in the same tick don't
+ * ping-pong on every cycle.
+ */
+export function pickMostOverdue(nodes: DbMeshCoreNode[], now: number): DbMeshCoreNode | undefined {
+  const eligible = nodes.filter((n) => isNodeEligible(n, now));
+  if (eligible.length === 0) return undefined;
+  eligible.sort((a, b) => {
+    const aOver = now - (a.lastTimeSyncAt ?? 0);
+    const bOver = now - (b.lastTimeSyncAt ?? 0);
+    if (aOver !== bOver) return bOver - aOver;
+    return a.publicKey.localeCompare(b.publicKey);
+  });
+  return eligible[0];
+}
+
+export class MeshCoreTimeSyncScheduler {
+  private readonly registry: SourceManagerRegistry;
+  private readonly database: TimeSyncSchedulerDatabase;
+  private readonly tickMs: number;
+  private readonly minIntervalMs: number;
+  private readonly nowFn: () => number;
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+
+  constructor(opts: MeshCoreTimeSyncSchedulerOptions) {
+    this.registry = opts.registry;
+    this.database = opts.database;
+    this.tickMs = opts.tickMs ?? resolveTickMs(process.env.MESHCORE_TIME_SYNC_TICK_MS);
+    this.minIntervalMs = opts.minIntervalMs ?? MIN_INTERVAL_BETWEEN_REQUESTS_MS;
+    this.nowFn = opts.now ?? Date.now;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    logger.info(
+      `[MeshCoreTimeSync] Scheduler starting (tick=${Math.round(this.tickMs / 1000)}s, ` +
+        `min-interval=${Math.round(this.minIntervalMs / 1000)}s)`,
+    );
+    this.timer = setInterval(() => {
+      this.tick().catch((err) => logger.error('[MeshCoreTimeSync] Unhandled tick error:', err));
+    }, this.tickMs);
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * One tick. Visible for tests. Walks every registered manager and issues
+   * at most one time-sync per source, gated by both the in-DB per-node
+   * cadence and the per-manager 60s minimum.
+   */
+  async tick(): Promise<void> {
+    if (this.running) {
+      logger.debug('[MeshCoreTimeSync] Previous tick still running, skipping');
+      return;
+    }
+    this.running = true;
+    try {
+      const managers = this.registry.getAllManagers().filter(isMeshCoreManager);
+      for (const manager of managers) {
+        try {
+          await this.tickOneManager(manager);
+        } catch (err) {
+          logger.warn(`[MeshCoreTimeSync:${manager.sourceId}] Tick failed:`, err);
+        }
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /** Process a single manager. Visible for tests. */
+  async tickOneManager(manager: MeshCoreManager): Promise<void> {
+    if (!manager.isConnected()) return;
+    // Receive-only (#4547): skip before any guarded send primitive —
+    // syncNodeTime → ensureSavedLogin → requireTransmit would otherwise throw
+    // and rely on tick()'s per-manager catch.
+    if (manager.isReceiveOnly()) {
+      logger.debug(`[MeshCoreTimeSync:${manager.sourceId}] Skipping - receive-only mode`);
+      return;
+    }
+
+    const now = this.nowFn();
+    const sinceLastTx = now - manager.getLastMeshTxAt();
+    if (manager.getLastMeshTxAt() > 0 && sinceLastTx < this.minIntervalMs) {
+      logger.debug(
+        `[MeshCoreTimeSync:${manager.sourceId}] Throttled — last mesh tx was ${Math.round(sinceLastTx / 1000)}s ago`,
+      );
+      return;
+    }
+
+    const nodes = await this.database.meshcore.getTimeSyncEnabledNodes(manager.sourceId);
+    if (nodes.length === 0) return;
+
+    const target = pickMostOverdue(nodes, now);
+    if (!target) return;
+
+    const keyShort = target.publicKey.substring(0, 16);
+    logger.debug(`[MeshCoreTimeSync:${manager.sourceId}] Pushing clock to ${keyShort}…`);
+
+    // Stamp BEFORE issuing — preserves fair rotation when several nodes share
+    // the same overdue-by, and applies the per-source cadence regardless of
+    // how long the two round-trips take or whether they succeed. A repeater
+    // that is offline or rejecting the push must not be retried every tick.
+    // Mirrors the telemetry and neighbours schedulers.
+    await this.database.meshcore.markTimeSyncRequested(manager.sourceId, target.publicKey, now);
+    manager.recordMeshTx(now);
+
+    try {
+      const result = await manager.syncNodeTime(target.publicKey);
+      switch (result.status) {
+        case 'ok':
+          logger.debug(
+            `[MeshCoreTimeSync:${manager.sourceId}] ${keyShort}… clock set in ${result.elapsedMs}ms`,
+          );
+          break;
+        case 'rejected':
+          // Firmware refused, virtually always its "clock cannot go backwards"
+          // guard. Retrying on the next cadence is harmless but will keep
+          // failing until the repeater's RTC is corrected, so say so once at
+          // warn level rather than burying it in debug.
+          logger.warn(
+            `[MeshCoreTimeSync:${manager.sourceId}] ${keyShort}… refused the clock push ` +
+              `(likely running ahead of server time): ${result.reply}`,
+          );
+          break;
+        case 'no-credential':
+          logger.warn(
+            `[MeshCoreTimeSync:${manager.sourceId}] ${keyShort}… has time sync enabled but no ` +
+              `usable saved admin password — save one, or disable time sync for this node`,
+          );
+          break;
+        case 'failed':
+          logger.debug(
+            `[MeshCoreTimeSync:${manager.sourceId}] ${keyShort}… sync failed: ${result.error}`,
+          );
+          break;
+      }
+    } catch (err) {
+      logger.warn(
+        `[MeshCoreTimeSync:${manager.sourceId}] syncNodeTime(${keyShort}…) threw:`,
+        err,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level singleton — mirrors the telemetry/neighbours/room-sync
+// schedulers so the manual-sync route can reach the same instance.
+// ---------------------------------------------------------------------------
+
+let _scheduler: MeshCoreTimeSyncScheduler | null = null;
+
+export function setMeshCoreTimeSyncScheduler(scheduler: MeshCoreTimeSyncScheduler | null): void {
+  _scheduler = scheduler;
+}
+
+export function getMeshCoreTimeSyncScheduler(): MeshCoreTimeSyncScheduler | null {
+  return _scheduler;
+}


### PR DESCRIPTION
## Summary

Fixes #4916. MeshMonitor already syncs the directly-connected Companion's clock (#3957) and auto-polls telemetry (#4884) and neighbours (#4618) from remote MeshCore repeaters. Remote repeaters have no NTP or GPS, so their RTCs drift, and correcting one meant a manual CLI command or a button press. This schedules it.

Modelled on `MeshCoreNeighboursScheduler`, with a **third** per-node column set (migration 156) so none of the three schedulers resets another's cadence.

## Mesh impact

Worked through the [checklist](../blob/main/CLAUDE.md#mesh-impact-checklist) before writing the code. The headline: **one MeshCore sync costs four packets, not one.** `ensureSavedLogin()` does not cache the way `guestLoggedInNodes` does, so every sync is a login DM plus its reply, then the `time <epoch>` CliData plus its reply — and each floods when the target's `out_path` is unknown (~16–32 tx).

| Cadence | 10 repeaters | |
|---|---|---|
| 15 min (Meshtastic auto time-sync default) | ~160 pkt/hr | unusable on LoRa |
| **12 h (this default)** | **~3 pkt/hr** | comfortable |

Repeater RTC drift is seconds-to-minutes per day, so 12h has ample margin. (The "~22 min behind" in #3954 was inherited drift from our own unsynced companion, since fixed — not the repeater's own RTC.) **Default 12h, floor 1h**, both chosen by the maintainer rather than picked here.

The floor is enforced in three places, not one: the PATCH route rejects sub-60 with a 400 rather than silently clamping, the UI reverts the field, and `isNodeEligible` re-floors at read time so a row edited straight in the database cannot beat it either. Shares the existing per-source 60s `lastMeshTxAt` primitive, so a time-sync never transmits within 60s of a telemetry or neighbours poll.

### Does a save reset a safety timer?

No. `lastTimeSyncAt` is written to the **database**, not an instance field, and stamped **before** the send on **every** outcome including failure:

- An in-memory stamp would be cleared by every restart and every re-arm, bursting the whole mesh whenever someone edited settings.
- A success-only stamp would retry an offline repeater — or one whose RTC runs *ahead*, which firmware refuses permanently via its `secs > curr` guard — four packets at a time, every 30-second tick, forever.

Both failure modes here are persistent rather than transient, which is what makes this the load-bearing decision.

## Changes

- **Migration 156** — `timeSyncEnabled` / `timeSyncIntervalMinutes` (720) / `lastTimeSyncAt` on `meshcore_nodes`, all three backends, idempotent, no backfill (an existing node cannot start transmitting because someone upgraded).
- **`syncNodeTime()`** — returns a discriminated result (`ok` / `rejected` / `no-credential` / `failed`) so the UI can tell "clock running ahead" from "no reply" from "you never saved a password". Passes the `clock sync` spelling into `sendCliCommand` so `rewriteClockSync()` stamps the epoch at the chokepoint, after the login round-trip has elapsed.
- **`MeshCoreTimeSyncScheduler`** — wired at 11s, last of the MeshCore schedulers.
- **Routes** — GET/PATCH `/time-sync-config`, POST `/time-sync`.
- **UI** — `MeshCoreNodeTimeSyncConfig` panel beside Telemetry and Neighbours Retrieval.

Two things differ from the sibling panels, and both are surfaced in the UI rather than left to the logs:

- **It requires a saved admin password.** `time` is a mutating verb, so unlike a telemetry or neighbours read it cannot fall back to a guest session. The GET reports `hasSavedCredential` and the panel warns up front, instead of the schedule failing silently every 12 hours.
- **Manual sync is gated on `configuration:write`**, not `nodes:read` like the telemetry/neighbours polls — it mutates the remote device's clock.

## Testing

- [x] Full Vitest suite: **18,245 passed / 0 failed**, 5,116 suites, 109 skipped — with PostgreSQL and MySQL containers up, so the multi-backend suites actually ran (migration 156's `.pgmysql` suite reports 2 passed, not skipped)
- [x] 66 new tests: 29 scheduler, 5 + 2 migration, 8 repo, 11 route, 11 component
- [x] Typecheck clean on both `tsconfig.json` and `tsconfig.server.json`
- [x] Lint ratchet clean (no in-repo `FAIL` lines)

**No screenshot attached**, by maintainer decision — capturing one meant rebuilding the dev container, which is currently up and may belong to another session.

## Issues Resolved

Closes #4916

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBktZBausKVUARXxqXV81u