### PR TITLE
fix(header): stop mobile header actions from overflowing off-screen

### DIFF
--- a/src/components/AppHeader/AppHeader.css
+++ b/src/components/AppHeader/AppHeader.css
@@ -21,12 +21,20 @@
   display: flex;
   align-items: center;
   gap: 1rem;
+  /* Let this side shrink (and its badge truncate) before it pushes
+     header-right's action buttons off-screen on narrow viewports. */
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
 }
 
 .header-right {
   display: flex;
   align-items: center;
   gap: 16px;
+  /* Connection status + login/user menu are always-visible controls — never
+     let header-left's content shrink them off the right edge (#5016). */
+  flex-shrink: 0;
 }
 
 .header-title {
@@ -76,6 +84,10 @@
   font-size: 0.8rem;
   font-weight: 500;
   padding: 0.2rem 0.6rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 /* Node info */
@@ -271,10 +283,34 @@
 
 /* Mobile responsive */
 @media (max-width: 768px) {
+  .app-header {
+    /* Portrait phones are much narrower than the 2rem side padding assumes
+       (#5016) — the full desktop padding alone can eat ~15% of the viewport
+       width before any header content is laid out. */
+    padding: 1rem;
+    padding-top: max(1rem, env(safe-area-inset-top));
+  }
+
   .app-header .header-logo,
   .app-header .node-info,
   .app-header h1 {
     display: none;
+  }
+
+  .header-left {
+    gap: 0.5rem;
+  }
+
+  .header-right {
+    gap: 8px;
+  }
+
+  .back-to-sources-btn {
+    padding: 0.25rem 0.5rem;
+  }
+
+  .header-source-name {
+    max-width: 30vw;
   }
 
   .connection-status {


### PR DESCRIPTION
## Summary

- Fixes #5016 — on narrow portrait mobile viewports, the header row's action controls (in the reported case, the "Login" button) could be pushed entirely off the right edge of the screen with no way to reach them.
- Root cause: `.header-left` (back-to-sources button + source-name badge) and `.header-right` (connection status + login/user menu) never shrank or truncated, and `.app-header` kept its full desktop `2rem` side padding on portrait mobile — only the short-landscape media query reduced it. On a per-source page (back button + source badge both visible) while unauthenticated, the combined content width comfortably exceeds a ~400px phone viewport.
- Fix:
  - `header-left` can now shrink (`min-width: 0; flex: 1 1 auto;`) and its source-name badge truncates with an ellipsis instead of forcing overflow.
  - `header-right` is pinned to `flex-shrink: 0` so the connection status and login/user menu always stay fully visible and are prioritized over `header-left`'s content.
  - `.app-header`'s side padding is reduced on mobile portrait (`1rem`), matching the pattern already used for the short-landscape override.

## Test plan

- [x] `npx vitest run src/components/AppHeader/` — 13/13 passing
- [x] `npm run lint:ci` — clean (no new baseline violations)
- [ ] Manual verification on a narrow mobile viewport (reporter's device: Android 14, Chrome, ~410px CSS width, per-source view while unauthenticated) — could use a maintainer/reporter confirmation since I don't have live device access in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WV1eN9j3CvVgkx3VZTQumr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV1eN9j3CvVgkx3VZTQumr)_