### PR TITLE
chore: bump version to 4.16.0-rc1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.15.2",
+  "version": "4.16.0-rc1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.15.2",
+  "version": "4.16.0-rc1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.15.2
-appVersion: "4.15.2"
+version: 4.16.0-rc1
+appVersion: "4.16.0-rc1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.2",
+  "version": "4.16.0-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.15.2",
+      "version": "4.16.0-rc1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.15.2",
+  "version": "4.16.0-rc1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

First release candidate for **4.16.0**.

Minor rather than patch: two features landed since 4.15.2, and **migration 156** changes the shape of existing databases on upgrade. A version reading `4.15.3` would understate that — nobody would expect a schema change from a patch.

## Since v4.15.2 (`c1cf4770`) — 6 commits

**Features**
- #5010 — telemetry graphs grouped by category, with a Favorites section on top (#4930)
- #5009 — MeshCore repeater auto time-sync on a per-node cadence (#4916) — **adds migration 156**

**Bug fixes**
- #5019 — dark basemap defaults to a keyless tileset when no CARTO key is configured (#5015)
- #5017 — mobile header actions no longer overflow off-screen
- #5008 — airtime-cutoff counts relayed routers as neighbours (#4801)

**Docs**
- #5007 — Mesh Issues report announcement

## Changes

All five version files per CLAUDE.md — 7 lines total, the same shape as the 4.15.2 bump (#5006):

| File | |
|---|---|
| `package.json` | `version` |
| `package-lock.json` | root + `packages[""]`, regenerated with `npm install --package-lock-only` |
| `helm/meshmonitor/Chart.yaml` | `version` **and** `appVersion` |
| `desktop/package.json` | `version` |
| `desktop/src-tauri/tauri.conf.json` | `version` |

The RC suffix goes into the version string itself, not just the tag — matching `v4.15.2-rc2`..`rc9`, where `package.json` read the full `4.15.2-rcN`. `/create-release` validates that `package.json` matches the tag, so this has to land before the release is cut.

## Upgrade note

Migration 156 adds three columns to `meshcore_nodes` (`timeSyncEnabled` / `timeSyncIntervalMinutes` / `lastTimeSyncAt`). Idempotent on all three backends, no backfill — the feature is opt-in per node and defaults off, so no existing install starts transmitting on upgrade.

## Testing

- [x] Version-file diff verified as exactly 7 lines, no incidental reformatting
- [x] Lockfile regenerated rather than hand-edited
- [x] `system-test` label applied — release version-bump chores always run the hardware suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBktZBausKVUARXxqXV81u