### PR TITLE
feat(observer): multi-broker Analyzer Observer backend (#5014 Phase 1)

### DIFF
--- a/docs/internal/dev-notes/MESHMAPPER_OBSERVER_EPIC.md
+++ b/docs/internal/dev-notes/MESHMAPPER_OBSERVER_EPIC.md
@@ -1,0 +1,72 @@
+# MeshMapper Observer Epic — issue #5014
+
+**Goal:** let any MeshCore source contribute coverage data to MeshMapper and
+LetsMesh with no extra observer hardware, by extending the existing per-source
+Analyzer Observer from one broker to many.
+
+Plan comment on the issue:
+https://github.com/Yeraze/meshmonitor/issues/5014#issuecomment-5513926532
+
+## Research facts (verified 2026-09-02)
+
+- MeshMapper is **MeshCore-only**. Its observer ingestion path is MQTT, in the
+  exact wire contract our Analyzer Observer already speaks
+  (`src/server/services/meshcoreObserverPacket.ts`): topics
+  `meshcore/{IATA}/{PUBLIC_KEY}/packets` + `/status`, packet JSON per
+  `ObserverPacketPayload`, Ed25519 JWT auth (`v1_{PUBLIC_KEY}` username,
+  `aud` claim) minted by `meshcoreObserverToken.ts`.
+- Brokers: `wss://mqtt.meshmapper.net:443` (audience `mqtt.meshmapper.net`),
+  LetsMesh `mqtt-us-v1.letsmesh.net` / `mqtt-eu-v1.letsmesh.net` (port 443,
+  WebSockets + TLS). MeshMapper recommends dual-publish; it dedupes.
+- Reference implementation: `agessaman/meshcore-packet-capture` (N sequential
+  brokers, same topics/payload/JWT).
+- The issue's "Third-Party API" link is the reverse direction (MeshMapper app
+  → third-party endpoint); its CSV upload is admin-only legacy import. Neither
+  is our path.
+
+## Interview decisions (project owner, 2026-09-02)
+
+1. **Approach:** extend the Analyzer Observer to multi-broker (config
+   `brokers[]`, per-broker status); MeshMapper/LetsMesh become UI presets.
+   NOT a separate parallel bridge.
+2. **Filtering (packet type / node allow-block / bbox) and rate limiting:
+   deferred.** v1 forwards everything, matching `meshcore-packet-capture`.
+   Relay is passive — zero airtime cost.
+3. **Status UI: both** — compact indicator on the Dashboard source card AND
+   per-broker detail on `MeshCoreSourcePage.tsx`.
+4. Corrected plan posted to #5014 before building.
+
+Out of scope: Meshtastic data (MeshMapper has no ingestion for it), inbound
+wardrive ingestion via MeshMapper's third-party endpoint API.
+
+## Phases
+
+### Phase 1 — Multi-broker observer backend ✅ status: [ ] not started
+
+- `MeshCoreObserverConfig` gains `brokers[]` (url, authMode, tokenAudience,
+  label); legacy single `brokerUrl` block normalized transparently at read
+  time (config is a JSON blob in `sources.config` — no DB migration).
+- `meshcoreObserverPublisher` becomes a per-broker client pool: shared packet
+  stream + device identity; per-broker connect state, counters,
+  drop-when-disconnected, `lastError` redaction. Credential store keyed
+  per broker for password-mode brokers.
+- New `GET /api/sources/:id/observer/status` route (closes the existing
+  "getObserverStatus has no consumer" gap), envelope + `requirePermission`.
+- Exit criteria: full Vitest suite green; tests prove one source publishing to
+  2+ mock brokers concurrently, legacy config back-compat, per-broker
+  credential isolation.
+
+### Phase 2 — UI: broker list, presets, status ✅ status: [ ] not started
+
+- Observer fieldset on `DashboardPage.tsx` → broker-list editor with one-click
+  presets: MeshMapper, LetsMesh US, LetsMesh EU, custom. Form↔config mapping
+  in `DashboardPage.observerConfig.ts` extended (unit-tested).
+- Status: indicator on Dashboard source card + per-broker panel (connected,
+  publishes, dropped, last publish, last error) on `MeshCoreSourcePage.tsx`.
+- User docs: "contribute to MeshMapper" guide.
+- Exit criteria: browser-validated (configure MeshMapper + LetsMesh on a live
+  source, watch status update); screenshots on the PR; suite green.
+
+## Deviations / notes
+
+(record per phase)

--- a/docs/internal/dev-notes/MESHMAPPER_OBSERVER_EPIC.md
+++ b/docs/internal/dev-notes/MESHMAPPER_OBSERVER_EPIC.md
@@ -41,7 +41,7 @@ wardrive ingestion via MeshMapper's third-party endpoint API.
 
 ## Phases
 
-### Phase 1 — Multi-broker observer backend ✅ status: [ ] not started
+### Phase 1 — Multi-broker observer backend ✅ status: [x] implemented (PR pending)
 
 - `MeshCoreObserverConfig` gains `brokers[]` (url, authMode, tokenAudience,
   label); legacy single `brokerUrl` block normalized transparently at read
@@ -69,4 +69,21 @@ wardrive ingestion via MeshMapper's third-party endpoint API.
 
 ## Deviations / notes
 
-(record per phase)
+### Phase 1 (implemented 2026-09-02)
+
+- Spec: `MESHMAPPER_OBSERVER_PHASE1_SPEC.md`. Work packages WP1–WP4 as planned.
+- No whole-config size guard — a universal 4096-byte cap would have made
+  existing >4KB SQLite/PG configs uneditable. Instead: observer-block-only cap
+  (`MAX_OBSERVER_CONFIG_BYTES` = 1536, `OBSERVER_CONFIG_TOO_LARGE`) plus a
+  non-rejecting MySQL `logger.warn` when a whole blob exceeds 4096.
+- `MISSING_BROKER` fires only when `brokers` was explicitly provided but
+  yields no usable entry AND no legacy `brokerUrl` exists; a fully-absent
+  `brokers` runs the exact pre-#5014 path (`INVALID_PARAMETER`), preserving
+  every pre-existing assertion.
+- Review fix: token renewal now excludes hard-stopped connections
+  (`hardStoppedKeys`) — without it, the hourly renewal resurrected a
+  connection that hard-stopped on auth failure and disabled its latch forever.
+- `MAX_OBSERVER_BROKERS = 8` — above the three named brokers, keeps the blob
+  small. Flag to project owner at PR review.
+- Behaviour change (deliberate, in PR body): `MAX_AUTH_FAILURES` hard-stops
+  only the offending connection, not the whole observer.

--- a/docs/internal/dev-notes/MESHMAPPER_OBSERVER_PHASE1_SPEC.md
+++ b/docs/internal/dev-notes/MESHMAPPER_OBSERVER_PHASE1_SPEC.md
@@ -1,0 +1,1225 @@
+# MeshMapper Observer, Phase 1 Spec: multi-broker observer backend
+
+**Epic:** [#5014](https://github.com/Yeraze/meshmonitor/issues/5014)
+**Phase plan:** `docs/internal/dev-notes/MESHMAPPER_OBSERVER_EPIC.md` (Phase 1)
+**Prior art:** `MESHCORE_OBSERVER_PHASE1_SPEC.md` (key store, routes, validation),
+`MESHCORE_OBSERVER_PHASE2_SPEC.md` (publisher, wire contract, status)
+
+**Scope:** backend only. One MeshCore source publishes the same OTA packet
+stream to N Analyzer brokers concurrently, with per-broker connection state,
+counters, credentials and tokens. Config is a JSON blob in `sources.config`,
+so there is **no DB migration in this phase**. The Dashboard broker-list
+editor, the presets, and the status panels are Phase 2.
+
+**Non-goals (deferred, per the epic's interview decisions):** packet
+filtering, node allow/block lists, bbox limits, rate limiting. v1 forwards
+everything, matching `agessaman/meshcore-packet-capture`. The relay is
+passive, so there is zero airtime cost and the Mesh Impact Checklist has no
+new limits to set.
+
+---
+
+## 1. Reuse inventory (mandatory, read before writing code)
+
+Everything below already exists and MUST be used or extended. Anything not on
+this list needs a justification against the closest entry.
+
+### 1.1 Services and helpers that must be reused as-is
+
+| Thing | File | How Phase 1 uses it |
+|---|---|---|
+| `MqttBrokerClient` + `MqttBrokerClientOptions` | `src/server/transports/mqttBrokerClient.ts` | One instance per broker. Unchanged. The `will` / `keepalive` / `clientIdPrefix` wiring the publisher already builds is moved verbatim into the per-broker connection. |
+| `normalizeBrokerUrl` | `src/server/transports/mqttBrokerClient.ts` | Normalizes each `brokers[].url` exactly as it normalizes today's single `brokerUrl`. **Do not modify it** (shared with the MQTT bridge). |
+| `observerTopics(iataCode, publicKey)` | `src/server/services/meshcoreObserverPacket.ts` | Unchanged. Called once per distinct topic public key, not once per broker. |
+| `buildObserverPacketPayload` / `buildObserverStatusPayload` / `ObserverPacketIdentity` / `ObserverStatsInput` | `src/server/services/meshcoreObserverPacket.ts` | Unchanged. The wire contract is identical for every broker: that is exactly why one source can dual-publish. |
+| `mintObserverToken(privateKeyHex, audience, opts)` | `src/server/services/meshcoreObserverToken.ts` | Unchanged. Already takes an explicit audience, so per-broker audiences need no new signing code. |
+| `MeshCoreObserverKeyStore` | `src/server/services/meshcoreObserverKeyStore.ts` | Unchanged. One signing key per source, shared by every token-mode broker. |
+| `ok()` / `fail()` | `src/server/utils/apiResponse.ts` | The new `GET /observer/status` route uses these, like every other handler in `sourceObserverRoutes.ts`. |
+| `requirePermission(resource, action, { sourceIdFrom })` | `src/server/auth/authMiddleware.ts` | Same call shape as the sibling observer routes. |
+| `resolveMeshCoreSource(req, res)` | `src/server/routes/sourceObserverRoutes.ts` (module-local) | Reused verbatim by the new status route. |
+| `refreshObserverPublisher(source)` | `src/server/routes/sourceObserverRoutes.ts` (module-local) | Reused by the new per-broker credential writes, same hot-swap semantics. |
+| `auditMeshcoreEvent` | `src/server/routes/meshcoreRouteShared.ts` | New credential events audited the same way (event fired, values never recorded). |
+| `sourceManagerRegistry.reconfigureObserver(id, cfg)` | `src/server/sourceManagerRegistry.ts` | Unchanged duck-typed hot-swap seam. `brokers[]` rides through it as part of the raw observer block. |
+| `deepEqualIgnoring(a, b, ['observer'])` hot-swap branch | `src/server/routes/sourceRoutes.ts` (~line 1090) | **Unchanged.** It stringifies the whole `observer` block, so a `brokers[]` edit already routes to the hot-swap branch instead of a device restart. |
+| `MqttBridgePublisherPool` | `src/server/mqttBridgePublisherPool.ts` | **Structural precedent, not a dependency.** Copy its `PoolEntry` shape (client + publishes + lastPublishAt + lastError) and its lazy-entry / no-idle-eviction policy. Do not import it: it keys on Meshtastic gateway ids, shares one URL across entries, and has no LWT, all of which are wrong here. |
+
+### 1.2 Test harnesses that must be reused
+
+| Harness | Where | Used by |
+|---|---|---|
+| `createRouteTestApp()` / `RouteTestHarness` | `src/server/test-helpers/routeTestApp.ts` | Every route test in WP4. Mandatory per CLAUDE.md. See `sourceObserverRoutes.perSource.test.ts` for the "seed my own meshcore source, then grant against its id" recipe (the harness's built-in `sourceA`/`sourceB` are `meshtastic_tcp`). |
+| `vi.mock('mqtt')` + `makeFakeClient()` fake mqtt.js client | `src/server/services/meshcoreObserverPublisher.test.ts` (lines 1-70) | Every publisher test. Drives the **real** `MqttBrokerClient` underneath, so per-broker CONNECT options (LWT topic, username, password) are asserted for real. `mockConnect.mock.calls` gives one entry per broker, which is how multi-broker assertions read connections apart. |
+| `createClient` / `mintToken` / `loadCredentials` injection seams | `MeshCoreObserverPublisherOptions` | Kept, with widened signatures (see 3.3). Do not add a fourth seam. |
+| `setMeshCoreObserverCredentialStoreForTesting` / `setMeshCoreObserverKeyStoreForTesting` | the two stores | Credential-store tests keep using these. |
+| Deterministic clamped orlp private key recipe | `sourceObserverRoutes.perSource.test.ts` lines 19-26 | Reuse for any test needing a real signing key. |
+| `vi.useFakeTimers()` around `RENEWAL_CHECK_MS` / `STATUS_REFRESH_MS` | `meshcoreObserverPublisher.test.ts` | Reuse for the multi-broker renewal and status-refresh tests. |
+
+### 1.3 New things, and why the closest existing mechanism does not fit
+
+| New thing | Closest existing mechanism | Why it is not enough |
+|---|---|---|
+| `src/server/services/meshcoreObserverStatus.ts` (types only) | `MeshCoreObserverStatus` currently lives in `meshcoreObserverPublisher.ts` | The new `GET /observer/status` route needs the type without importing the publisher (which value-imports the credential store, the token minter and `package.json`). A types-only module also lets WP3 and WP4 run in parallel without touching the same file. The publisher re-exports both types, so every existing import path keeps working. |
+| `ObserverBrokerConnection` (module-private class inside `meshcoreObserverPublisher.ts`) | `MqttBridgePublisherPool`'s `PoolEntry` | Pool entries there share one URL, one credential and no LWT. Observer brokers differ in URL, auth mode, audience, credential and LWT topic. Same shape, different content: copy the shape, keep it local to the publisher rather than generalizing the pool (a shared abstraction over two pools with no common config would be a worse artifact than two small ones). |
+| Encrypted credential **document** (v2) inside the existing envelope | `meshcore_observer_credentials` one row per source | Per-broker credentials need per-broker keying. See §4 for the full trade-off against the rejected new-table migration. |
+| `observerBrokerKey(url)` | none | Two lines, but it is the identity function for credentials, status and dedupe. It must live in exactly one place. |
+
+---
+
+## 2. Config schema and normalization
+
+### 2.1 Persisted shape (`sources.config.observer`)
+
+`src/server/meshcoreConfig.ts`. Every legacy field is **kept and still
+honoured**; `brokers` is purely additive.
+
+```ts
+/** One Analyzer broker this source publishes to (#5014 Phase 1). */
+export interface MeshCoreObserverBrokerConfig {
+  /** ws/wss/mqtt/mqtts URL, or a bare host:port that normalizeBrokerUrl accepts. */
+  url: string;
+  /** Defaults to the block-level authMode, which itself defaults to 'token'. */
+  authMode?: 'token' | 'password';
+  /**
+   * Required in token mode. NOT inherited from the block-level tokenAudience:
+   * two brokers with different audiences are the normal case, and silently
+   * inheriting one would mint tokens the other broker rejects. The only
+   * exception is the legacy synthesized entry (see 2.3).
+   */
+  tokenAudience?: string;
+  /** Free-text display label, e.g. "MeshMapper". UI only, never on the wire. */
+  label?: string;
+}
+
+export interface MeshCoreObserverConfig {
+  enabled?: boolean;
+  /** Block-level default auth mode. LEGACY + default for brokers[] entries. */
+  authMode?: 'token' | 'password';
+  /** LEGACY single broker. See the precedence rule in 2.3. */
+  brokerUrl?: string;
+  /** Shared across every broker: it is the observer's REGION, not a broker property. */
+  iataCode?: string;
+  /** LEGACY single audience. Applies only to the legacy broker entry. */
+  tokenAudience?: string;
+  /** Multi-broker list (#5014). When present and non-empty it is authoritative. */
+  brokers?: MeshCoreObserverBrokerConfig[];
+}
+```
+
+**`iataCode` stays block-level on purpose.** It is the region segment of the
+topic (`meshcore/{IATA}/{PUBKEY}/packets`) and identifies *where the observer
+is*, not which broker it talks to. MeshMapper and LetsMesh both want the same
+region for the same physical node. Keeping it shared also keeps the blob
+small (see 2.5).
+
+### 2.2 Normalized runtime shape
+
+Returned by `observerConfigFromSource`, consumed by the publisher.
+
+```ts
+export interface NormalizedObserverBroker {
+  /** Stable identity: normalizeBrokerUrl(url).toLowerCase(). Non-secret. */
+  key: string;
+  /** normalizeBrokerUrl(url). */
+  url: string;
+  authMode: 'token' | 'password';
+  /** Present iff authMode === 'token' (normalization drops token brokers without one). */
+  tokenAudience?: string;
+  label?: string;
+  /**
+   * True iff this entry corresponds to the block-level legacy `brokerUrl`.
+   * The publisher uses it, and only it, to fall back to the pre-#5014
+   * single-credential row. See 2.3 and §4.3.
+   */
+  legacy: boolean;
+}
+
+/**
+ * Superset of the pre-#5014 runtime shape: the flat brokerUrl / authMode /
+ * tokenAudience fields are RETAINED as mirrors of brokers[0] so every
+ * existing reader (and every existing test) keeps compiling and keeps
+ * observing the same values for a single-broker source.
+ */
+export interface NormalizedObserverConfig {
+  enabled: true;
+  iataCode: string;
+  brokers: NormalizedObserverBroker[];
+  authMode: 'token' | 'password';
+  brokerUrl: string;
+  tokenAudience?: string;
+}
+```
+
+`MeshCoreConfig['observer']` (in `meshcoreManager.ts`) is retyped from
+`MeshCoreObserverConfig` to `NormalizedObserverConfig | undefined`. This is a
+narrowing, not a widening: the manager only ever assigns it from
+`observerConfigFromSource`.
+
+### 2.3 The normalization function
+
+```ts
+/** Stable, case-insensitive broker identity. The one place this is derived. */
+export function observerBrokerKey(url: string): string;   // throws only if normalizeBrokerUrl throws
+
+/**
+ * Pure: turns the persisted (legacy or multi) observer block into the ordered,
+ * deduped, validated broker list. Exported for direct unit testing.
+ * Never throws. Returns [] when nothing usable is configured.
+ */
+export function normalizeObserverBrokers(
+  o: MeshCoreObserverConfig | undefined | null,
+): NormalizedObserverBroker[];
+
+/** Unchanged signature. Now returns the richer NormalizedObserverConfig. */
+export function observerConfigFromSource(
+  cfg: MeshCoreSourceConfig,
+): MeshCoreConfig['observer'];
+```
+
+`normalizeObserverBrokers` semantics, in order:
+
+1. **Source list selection.** If `o.brokers` is a non-empty array, that array
+   is authoritative and `o.brokerUrl` is **not** added as an extra entry.
+   Otherwise, synthesize a single entry from `o.brokerUrl` (when present).
+
+   > This rule is safety-critical. The Phase 2 UI will migrate the legacy
+   > broker into `brokers[0]` and may well leave the stale top-level
+   > `brokerUrl` in the blob. Appending both would double-publish every packet
+   > to the same broker. The dedupe in step 5 would usually catch it, but only
+   > if the two spellings normalize identically; the precedence rule removes
+   > the whole class of bug.
+
+2. **Per-entry auth mode:** `entry.authMode ?? o.authMode ?? 'token'`.
+
+3. **Per-entry audience:** `entry.tokenAudience?.trim()`. For the *synthesized
+   legacy* entry only, fall back to `o.tokenAudience?.trim()`.
+
+4. **Per-entry URL:** `normalizeBrokerUrl(entry.url)`. On throw, `logger.warn`
+   naming the index and **skip that entry only**. One malformed broker must
+   not disable the others (this is a deliberate change from the pre-#5014
+   all-or-nothing rule, which had exactly one broker to lose).
+
+5. **Dedupe by `key`, first wins**, with a `logger.debug` on the discard.
+
+6. **Completeness:** drop a `token`-mode entry with no `tokenAudience`
+   (`logger.warn`). A `password`-mode entry needs no audience. This mirrors
+   `observerConfigFromSource`'s existing per-mode rule, applied per broker.
+
+7. **Legacy flag:** `legacy = true` when the entry was synthesized from
+   `o.brokerUrl`, **or** when `o.brokerUrl` is present and
+   `observerBrokerKey(o.brokerUrl) === entry.key`. The second clause is what
+   keeps the stored pre-#5014 credential reachable after the Phase 2 UI moves
+   that broker into `brokers[]`. At most one entry can carry it (dedupe
+   guarantees key uniqueness).
+
+`observerConfigFromSource` then:
+
+- returns `undefined` when `!o?.enabled`, when `iataCode` is missing, or when
+  `normalizeObserverBrokers` returns `[]` (preserving today's
+  "incomplete block disables the observer" contract);
+- otherwise returns `{ enabled: true, iataCode: o.iataCode.trim().toUpperCase(),
+  brokers, authMode: brokers[0].authMode, brokerUrl: brokers[0].url,
+  tokenAudience: brokers[0].tokenAudience }`.
+
+`observerAuthMode(o)` is unchanged and still exported (the publisher inlines
+its logic to dodge an import cycle; that stays true).
+
+### 2.4 Server-side validation
+
+`validateObserverConfig(type, config)` in `src/server/routes/sourceRoutes.ts`
+(exported, already unit-tested by `sourceRoutes.observerValidation.test.ts`).
+Additive changes only; every existing rule and error code is preserved.
+
+Refactor first: extract the existing broker-URL check (explicit-scheme
+rejection before normalization, then `new URL(normalizeBrokerUrl(...))`,
+then protocol + hostname assertions) into a module-local helper:
+
+```ts
+function validateBrokerUrlValue(
+  value: unknown,
+  field: string,   // 'observer.brokerUrl' | 'observer.brokers[2].url'
+): { status: number; error: string; code: string } | null;
+```
+
+Then apply it to both the legacy field and every `brokers[]` entry. **The
+explicit-scheme pre-check must not be lost in the extraction** (it is the
+guard against `http://host` laundering into `mqtt://http://host`).
+
+New rules, all inside the `enabled === true` branch except where noted:
+
+| Rule | Code | Status |
+|---|---|---|
+| `observer.brokers`, when present, must be an array (checked regardless of `enabled`) | `INVALID_PARAMETER_TYPE` | 400 |
+| `observer.brokers.length <= MAX_OBSERVER_BROKERS` (**8**) | `TOO_MANY_BROKERS` | 400 |
+| Each entry must be a non-null, non-array object | `INVALID_PARAMETER_TYPE` | 400 |
+| Each entry runs `observerConfigContainsKeyMaterial` (checked regardless of `enabled`, same as the block) | `OBSERVER_KEY_IN_CONFIG` | 400 |
+| Each `entry.url` runs `validateBrokerUrlValue` | `INVALID_PARAMETER` / `INVALID_BROKER_URL` | 400 |
+| `entry.authMode`, when present, is `'token'` or `'password'` | `INVALID_OBSERVER_AUTH_MODE` | 400 |
+| Token-mode entry needs a `tokenAudience`: non-empty string, no whitespace, <= 255 | `INVALID_PARAMETER` | 400 |
+| `entry.label`, when present, is a string <= 64 chars | `INVALID_PARAMETER` | 400 |
+| Normalized URLs must be unique across the array | `DUPLICATE_BROKER_URL` | 400 |
+| **Relaxed:** when `enabled === true`, require `brokerUrl` **or** a non-empty `brokers[]`, not `brokerUrl` alone | `MISSING_BROKER` | 400 |
+
+The `MISSING_BROKER` relaxation is what lets the Phase 2 UI stop writing the
+legacy field. Existing configs (legacy field, no `brokers`) still pass through
+the unchanged `brokerUrl` branch, so no currently-valid config becomes
+invalid.
+
+### 2.5 Observer block size guard (MySQL `sources.config` is `varchar(4096)`)
+
+**Decision: cap the serialized `observer` block only. There is deliberately NO
+whole-config size guard.**
+
+A universal `MAX_SOURCE_CONFIG_BYTES = 4096` check across every source type was
+considered and **rejected as a back-compat break**. SQLite `TEXT` and
+PostgreSQL `text` have no 4096 limit, so an existing deployment can legitimately
+be holding a larger config today. The plausible case is a big `mqtt_bridge`
+block with many subscriptions, filters and topic rewrites. A universal 400
+`CONFIG_TOO_LARGE` would make that source **uneditable after upgrade**: the
+operator could not even open the form and shrink it, because the save path
+would reject the blob it just loaded. Phase 1 must not be able to brick an
+existing source it has nothing to do with.
+
+Capping only the observer block is additive by construction: the constraint
+applies to a field this phase is introducing, so it cannot invalidate a config
+that is valid today. Add to `sourceRoutes.ts`, inside `validateObserverConfig`
+(not as a separate validator, and not on any other source type):
+
+```ts
+/**
+ * Serialized-byte ceiling for the `observer` block alone.
+ *
+ * `sources.config` is `varchar(4096)` on MySQL (TEXT on SQLite/PostgreSQL), so
+ * the blob as a whole has a hard limit on ONE backend. We deliberately do not
+ * police the whole blob (that would reject pre-existing oversized configs on
+ * the backends where they are legal), only the part #5014 adds. 1536 bytes is
+ * ~37% of the MySQL column, which keeps a fully-populated 8-broker observer
+ * comfortably clear of transport + virtualNode config in the same blob.
+ */
+export const MAX_OBSERVER_CONFIG_BYTES = 1536;
+```
+
+Checked once, after the per-broker rules pass and regardless of `enabled` (a
+disabled-but-huge block would still be persisted):
+
+```
+if (Buffer.byteLength(JSON.stringify(observerObj), 'utf8') > MAX_OBSERVER_CONFIG_BYTES)
+    -> { status: 400, code: 'OBSERVER_CONFIG_TOO_LARGE' }
+```
+
+Budget check: a broker entry costs ~150 bytes serialized (url ~40, tokenAudience
+~30, label ~20, authMode ~20, plus ~40 of JSON punctuation and key names). Eight
+of them is ~1200 bytes; `enabled` + `iataCode` + the retained legacy mirrors add
+~150. So `MAX_OBSERVER_BROKERS = 8` fits inside 1536 with headroom, and the two
+constants are chosen together: neither is arbitrary and neither should be raised
+without re-checking the other.
+
+**MySQL diagnostic (non-rejecting).** The pre-existing whole-blob risk on MySQL
+is not made worse by this phase, but it is worth surfacing. In the source
+create/update handlers (where `databaseService` is already imported), after
+validation passes:
+
+```
+if (databaseService.drizzleDbType === 'mysql'
+    && Buffer.byteLength(JSON.stringify(config), 'utf8') > 4096) {
+  logger.warn(`Source ${id} config exceeds the MySQL varchar(4096) column width; the write may fail or truncate`);
+}
+```
+
+This never rejects and never changes a status code. It exists so an operator
+hitting a driver-level truncation has a log line naming the cause instead of an
+opaque write failure.
+
+---
+
+## 3. Publisher: one instance, N clients
+
+### 3.1 Decision: one publisher owning N connections (not N publishers)
+
+**Chosen: one `MeshCoreObserverPublisher` owning an internal array of
+`ObserverBrokerConnection`.** Reasons, strongest first:
+
+1. **`stats()` costs a device round-trip.** Every publisher arms a
+   `STATUS_REFRESH_MS` (5 min) timer that calls `stats()`, which runs
+   `get_stats core` + `radio` over the local bridge. N publishers means N
+   times the device polling for identical data. One publisher reads stats once
+   per tick and publishes the resulting status to every broker.
+2. **Payload construction is on the packet hot path.** `handleOtaPacket` runs
+   at mesh packet rate. Building and `JSON.stringify`-ing the payload once and
+   publishing the same `Buffer` to every broker is the whole point; N
+   publishers would each rebuild it from the same event.
+3. **One lifecycle field in the manager.** `observerPublisher` stays a single
+   nullable field, and `startObserver` / `stopObserver` / `getObserverStatus`
+   / `reconfigureObserver` keep their exact shapes. N publishers would push
+   pool management into `meshcoreManager.ts`, which is the file we least want
+   to grow.
+4. **One `getStatus()` aggregate.** The manager's `getStatus()` conditional
+   spread (`...(observer ? { observer } : {})`) is preserved byte-for-byte for
+   single-broker sources.
+5. Token minting dedupes across brokers that share an audience (§3.4). N
+   publishers cannot see each other's tokens.
+
+### 3.2 `ObserverBrokerConnection` (module-private, in `meshcoreObserverPublisher.ts`)
+
+Owns everything that is per-broker. Never throws out of any method.
+
+```ts
+interface BrokerConnectionDeps {
+  sourceId: string;
+  iataCode: string;
+  device: MeshCoreObserverPublisherOptions['device'];
+  createClient: (opts: MqttBrokerClientOptions) => MqttBrokerClient;
+  /** Called when this connection hard-stops on repeated auth rejection. */
+  onAuthHardStop: (key: string) => void;
+}
+
+type ResolvedCredential =
+  | { kind: 'ok'; username: string; password: string; publicKey: string; tokenExpiresAt: number | null }
+  | { kind: 'error'; message: string; keyStored: boolean };
+
+class ObserverBrokerConnection {
+  constructor(broker: NormalizedObserverBroker, deps: BrokerConnectionDeps);
+
+  readonly key: string;
+  readonly broker: NormalizedObserverBroker;
+
+  /** Topic public key for this connection, or null before a successful start. */
+  get originId(): string | null;
+
+  /** Connect with a resolved credential. Records failures in lastError; never throws. */
+  async start(cred: ResolvedCredential): Promise<void>;
+
+  /** Publish offline status (best-effort) then disconnect({ flush: true }). Idempotent. */
+  async stop(): Promise<void>;
+
+  /**
+   * Sync. Drops (dropped++) when the socket is down. Takes a PRE-SERIALIZED
+   * buffer so the caller can share one across brokers with the same originId.
+   */
+  publishPacket(payload: Buffer): void;
+
+  /** Publish the retained online status with the caller's already-read stats. */
+  async publishOnlineStatus(stats: ObserverStatsInput | null): Promise<void>;
+
+  /** Tear down and reconnect with a fresh token (D-9: mqtt.js bakes creds into CONNECT). */
+  async rebuildWithToken(token: ObserverToken): Promise<void>;
+
+  getStatus(): MeshCoreObserverBrokerStatus;
+  isConnected(): boolean;
+}
+```
+
+Per-connection state, all moved off the publisher: `client`, `topics`,
+`tokenPublicKey`, `keyStored`, `publishes`, `dropped`, `lastPublishAt`,
+`lastError`, `tokenExpiresAt`, `authFailures`, `authStopping`.
+
+Behaviour that moves in **unchanged** (it is per-socket by nature):
+
+- `buildClientOptions`: LWT built from this broker's own status topic,
+  `clientIdPrefix: 'meshmonitor-observer'`, `keepalive: 60`.
+- `wireClientListeners`: the `error` listener still skips CONNACK codes 4/5 so
+  the `permission-denied` message wins; `permission-denied` still increments
+  `authFailures` and hard-stops at `MAX_AUTH_FAILURES`.
+- `redactToken()` applied to every `lastError` assignment. **The regex and the
+  helper stay module-level and shared**, not duplicated per connection.
+- The `publishOnlineStatus` re-read-after-await discipline (capture `client`
+  into a local after the await, then null-check that local).
+
+**Behaviour change, deliberate and worth calling out in the PR:**
+`MAX_AUTH_FAILURES` now hard-stops **only the offending connection**, not the
+whole observer. A LetsMesh credential typo must not silence MeshMapper. The
+publisher's timers stay armed while at least one connection is alive; when the
+last one hard-stops, `onAuthHardStop` lets the publisher clear its timers and
+set `running = false`.
+
+### 3.3 `MeshCoreObserverPublisher` public surface
+
+Unchanged method names and contracts. Only the option seams widen:
+
+```ts
+export interface MeshCoreObserverPublisherOptions {
+  sourceId: string;
+  config: NonNullable<MeshCoreConfig['observer']>;   // now NormalizedObserverConfig
+  device: () => { origin: string; model?: string; firmwareVersion?: string; radio?: string; publicKey?: string };
+  stats?: () => Promise<ObserverStatsInput | null>;
+
+  /** WIDENED: audience is now explicit, because brokers differ. */
+  mintToken?: (sourceId: string, audience: string) => Promise<ObserverTokenResult>;
+
+  /** WIDENED: per-broker key + the legacy-fallback flag. */
+  loadCredentials?: (
+    sourceId: string,
+    brokerKey: string,
+    legacy: boolean,
+  ) => Promise<ObserverCredentialLoadResult>;
+
+  createClient?: (opts: MqttBrokerClientOptions) => MqttBrokerClient;
+}
+```
+
+Defaults:
+
+- `mintToken` -> `(id, aud) => mintObserverTokenForSourceDetailed(id, aud)`
+- `loadCredentials` -> `(id, key, legacy) => resolveBrokerCredential(id, key, legacy)`
+  (§4.3, a small module-local function over the store)
+
+`start()` keeps its **never-throw** contract:
+
+1. Reset `authStopping` / `authFailures` on every connection.
+2. Build one `ObserverBrokerConnection` per `config.brokers` entry.
+3. **Resolve credentials.**
+   - Token mode: collect the distinct `tokenAudience` values, mint one token
+     per audience (`Promise.allSettled` over the distinct set), cache in
+     `tokensByAudience: Map<string, ObserverToken>`. A failed mint marks every
+     connection on that audience with the mapped `LAST_ERROR` message and
+     `keyStored = false`, exactly as today's `mintFailureMessage` does.
+   - Password mode: `loadCredentials(sourceId, key, legacy)` per connection,
+     plus the existing `device().publicKey` requirement (`LAST_ERROR.noPublicKey`).
+4. `await Promise.allSettled(connections.map(c => c.start(cred)))`. A rejected
+   settle is logged at `debug` and left as that connection's `lastError`; it
+   never propagates.
+5. Arm **one** renewal timer (only when at least one token-mode connection
+   exists) and **one** status-refresh timer.
+6. `this.running = true` when at least one connection was constructed.
+
+`stop()`: `await Promise.allSettled(connections.map(c => c.stop()))`, clear
+both timers, `running = false`, empty the connection list. Still idempotent,
+still best-effort per connection.
+
+`handleOtaPacket(event)`: sync, never throws.
+
+```
+group the connections by originId (skip connections with a null originId)
+for each group:
+    identity = { origin: device().origin, originId }
+    payload  = buildObserverPacketPayload(event, identity)
+    if (!payload) continue                       // blank/missing raw_hex, as today
+    buf = Buffer.from(JSON.stringify(payload))   // built ONCE per group
+    for each connection in group: connection.publishPacket(buf)
+```
+
+A connection with a null `originId` (never successfully started) counts a
+`dropped`, matching today's behaviour when `tokenPublicKey` is null. In
+practice there is exactly one group: token mode derives `originId` from the
+one signing key, password mode from the one node public key.
+
+`refreshStatus()` tick: keep the `refreshingStatus` latch, read `stats()`
+**once**, then `await Promise.allSettled(connected.map(c =>
+c.publishOnlineStatus(stats)))`. Skip entirely when no connection is
+connected (preserves the "never let a publish reach a disconnected client"
+invariant).
+
+`checkRenewal()` tick: keep the `renewing` latch. For each entry in
+`tokensByAudience` whose `expiresAt` is inside
+`RENEWAL_CHECK_MS / 1000 + RENEWAL_THRESHOLD_S`, re-mint for that audience;
+on success replace the cached token and `rebuildWithToken` every connection on
+that audience; on failure set those connections' `lastError` and leave their
+sockets untouched (a transient mint failure must never tear down a working
+connection). **Never hardcode the derived 3900s window.**
+
+### 3.4 Token minting per broker
+
+`src/server/services/meshcoreObserverToken.ts`:
+
+```ts
+export async function mintObserverTokenForSourceDetailed(
+  sourceId: string,
+  audienceOverride?: string,
+): Promise<ObserverTokenResult>;
+```
+
+- With no override: **behaviour is byte-identical to today** (reads
+  `observerConfigFromSource(cfg)?.tokenAudience`, which is now the
+  `brokers[0]` mirror, i.e. the same value for every pre-#5014 config).
+- With an override: still requires the source to exist and be `meshcore`, and
+  still requires an enabled observer block, but uses the override as the
+  audience and skips the `!observer.tokenAudience -> not_configured` gate.
+- `mintObserverTokenForSource(sourceId)` (the flat `| null` wrapper) is
+  unchanged and untouched.
+
+Minting is deduped **by audience**, not by broker: two brokers sharing an
+audience share one WASM signature and one token. Renewal follows the same
+grouping.
+
+### 3.5 `meshcoreManager.ts` changes
+
+Small and mechanical:
+
+- `MeshCoreConfig['observer']` retyped to `NormalizedObserverConfig | undefined`.
+- `startObserver()` / `stopObserver()` / `getObserverStatus()` /
+  `reconfigureObserver()`: **no logic changes.** The publisher constructor
+  call, the `device` closure, the `stats` closure, the `ota_packet`
+  subscribe/unsubscribe and the try/catch are all unchanged.
+- `MeshCoreSourceStatus.observer` picks up the new aggregate + `brokers` shape
+  through the type import. The conditional spread in `getStatus()` is unchanged.
+- The `!this.nativeBackend` companion-only guard is unchanged.
+
+---
+
+## 4. Credentials: per-broker, no migration
+
+### 4.1 Decision, and the rejected alternative
+
+**Chosen: keep `meshcore_observer_credentials` at one row per source, and make
+the AES-256-GCM *plaintext* a versioned JSON document holding every broker's
+credential.** No schema change, no migration, no repository change.
+
+**Rejected: a new `meshcore_observer_broker_credentials` table** with PK
+`(sourceId, brokerKey)`, created by a three-backend migration. It is a
+perfectly clean design and a reviewer may reasonably prefer it. It was not
+chosen because:
+
+- One AES envelope per source means **one `kid`, one rotation story**. N rows
+  means N envelopes and a set of partial-rotation states (`key_rotated` for
+  broker A but not B) that the UI and the publisher would both have to model.
+- Zero migration risk across SQLite / PostgreSQL / MySQL, and the epic's Phase
+  1 exit criteria explicitly assume no migration.
+- The write path is operator-driven through a single route, so the
+  read-modify-write is not a practical concurrency hazard. (It is a real one
+  in principle; see 4.4.)
+
+Modifying the existing table's primary key was rejected outright: SQLite
+cannot alter a PK without a full table rebuild, which is exactly the class of
+destructive migration that caused #4233.
+
+### 4.2 The credential document
+
+The **plaintext inside the existing envelope** becomes:
+
+```ts
+interface StoredCredentialDoc {
+  v: 2;
+  /** brokerKey -> credential. brokerKey = observerBrokerKey(url). */
+  brokers: Record<string, { username: string; password: string }>;
+  /**
+   * The pre-#5014 single credential, carried forward verbatim when a v1
+   * document is upgraded in place. Read by load() and by the legacy fallback.
+   */
+  legacy?: { username: string; password: string };
+}
+```
+
+Decode rule (`decodeDoc(plaintext, clearUsername)`):
+
+```
+try p = JSON.parse(plaintext)
+if (p && typeof p === 'object' && !Array.isArray(p) && p.v === 2 && p.brokers && typeof p.brokers === 'object')
+    -> v2 document
+else
+    -> v1: { v: 2, brokers: {}, legacy: { username: clearUsername, password: plaintext } }
+```
+
+A v1 password that happens to be exactly a `{"v":2,"brokers":{...}}` JSON
+object would be misread. This is accepted and must be commented: the
+probability is negligible and the alternative (a length-prefixed container)
+would break every existing row.
+
+The clear `username` column stays as-is and remains **display-only**: it holds
+the legacy username when a legacy entry exists, otherwise the username of the
+lexicographically-first broker entry. It is never used to authenticate a
+per-broker connection.
+
+### 4.3 `MeshCoreObserverCredentialStore` API
+
+Existing methods `store` / `load` / `clear` / `status` / `capability` /
+`currentFingerprint` keep their **exact signatures and semantics**:
+
+- `store(sourceId, username, password)` writes a v2 doc whose `legacy` is the
+  supplied pair, **preserving any existing `brokers` map**.
+- `load(sourceId)` returns the `legacy` entry: `{kind:'ok'}` when present,
+  `{kind:'none'}` when the doc has no legacy entry, `{kind:'key_rotated'}`
+  unchanged. For any pre-#5014 row this is bit-for-bit today's behaviour.
+- `clear(sourceId)` still deletes the whole row.
+- `status(sourceId)` unchanged, **plus** one additive optional field (§5.3).
+
+New methods:
+
+```ts
+/** Max distinct broker credentials per source. Matches MAX_OBSERVER_BROKERS. */
+export const OBSERVER_MAX_BROKER_CREDENTIALS = 8;
+
+/** Read-modify-write one broker's entry. Throws when capability.canStore is false
+ *  (same as store()) or when adding would exceed the cap. */
+async storeForBroker(sourceId: string, brokerKey: string, username: string, password: string): Promise<void>;
+
+/** This broker's credential only. Never falls back to `legacy`. */
+async loadForBroker(sourceId: string, brokerKey: string): Promise<ObserverCredentialLoadResult>;
+
+/** Remove one broker's entry. No-op when absent. Deletes the row when the doc
+ *  ends up completely empty (no brokers, no legacy). */
+async clearForBroker(sourceId: string, brokerKey: string): Promise<void>;
+
+/** Non-secret enumeration for the UI. NEVER returns passwords. Returns [] on
+ *  key_rotated / no row (the caller learns rotation from status()). */
+async listBrokers(sourceId: string): Promise<Array<{ brokerKey: string; username: string }>>;
+```
+
+The publisher's default resolver, module-local in
+`meshcoreObserverPublisher.ts`:
+
+```ts
+async function resolveBrokerCredential(
+  sourceId: string,
+  brokerKey: string,
+  legacy: boolean,
+): Promise<ObserverCredentialLoadResult> {
+  const store = getMeshCoreObserverCredentialStore();
+  const perBroker = await store.loadForBroker(sourceId, brokerKey);
+  if (perBroker.kind !== 'none' || !legacy) return perBroker;
+  // Legacy broker only: fall back to the pre-#5014 single credential.
+  return store.load(sourceId);
+}
+```
+
+Precedence is deliberate: a per-broker credential wins over the legacy one, so
+re-entering credentials through the new route always takes effect. A
+non-legacy broker **never** sees the legacy credential, which is the
+per-broker isolation guarantee.
+
+### 4.4 Concurrency note (must appear as a code comment)
+
+`storeForBroker` and `clearForBroker` are read-modify-write over one row. Two
+concurrent writes to *different* brokers can lose one update. Accepted for
+v1: both paths are operator-driven admin routes on a single source, and the
+loss is recoverable by re-entering the credential. If Phase 2's UI ever
+batch-saves N brokers, it must serialize the PUTs.
+
+---
+
+## 5. Status and route contract
+
+### 5.1 Types (`src/server/services/meshcoreObserverStatus.ts`, new, types only)
+
+```ts
+export interface MeshCoreObserverBrokerStatus {
+  /** Stable identity. Same value as NormalizedObserverBroker.key. */
+  key: string;
+  /** Normalized broker URL. Non-secret, but see 5.4. */
+  url: string;
+  label: string | null;
+  authMode: 'token' | 'password';
+  tokenAudience: string | null;
+  /** This broker has every field its auth mode requires. */
+  configured: boolean;
+  /** Its credential exists and decrypts under the current SESSION_SECRET. */
+  keyStored: boolean;
+  connected: boolean;
+  publishes: number;
+  /** Packets dropped because THIS broker's socket was down. */
+  dropped: number;
+  lastPublishAt: number | null;
+  /** Token-redacted. */
+  lastError: string | null;
+  /** Unix SECONDS. Null in password mode. */
+  tokenExpiresAt: number | null;
+}
+
+export interface MeshCoreObserverStatus {
+  // ---- aggregate; every field below existed pre-#5014 and keeps its meaning
+  //      for a single-broker source ----
+  /** ANY broker configured. */
+  configured: boolean;
+  /** brokers[0].authMode. Legacy field, kept for existing consumers. */
+  authMode: 'token' | 'password';
+  /** ANY broker's credential present and decryptable. */
+  keyStored: boolean;
+  /** ANY broker connected. */
+  connected: boolean;
+  /** SUM over brokers. */
+  publishes: number;
+  /** SUM over brokers. */
+  dropped: number;
+  /** MAX over brokers (most recent). */
+  lastPublishAt: number | null;
+  /** Most recently set non-null broker lastError. Token-redacted. */
+  lastError: string | null;
+  /** MIN over non-null broker values (earliest expiry). */
+  tokenExpiresAt: number | null;
+
+  // ---- new ----
+  brokers: MeshCoreObserverBrokerStatus[];
+}
+```
+
+`meshcoreObserverPublisher.ts` re-exports both types
+(`export type { MeshCoreObserverStatus, MeshCoreObserverBrokerStatus } from
+'./meshcoreObserverStatus.js';`) so every existing import site is unchanged.
+
+Aggregate rules are chosen so a **single-broker source produces exactly the
+values it produces today**. That is the back-compat test in §6.
+
+### 5.2 New route: `GET /api/sources/:id/observer/status`
+
+In `src/server/routes/sourceObserverRoutes.ts` (already mounted at
+`/:id/observer` from `sourceRoutes.ts` line 1807, `mergeParams: true`).
+
+```ts
+router.get(
+  '/status',
+  requirePermission('configuration', 'read', { sourceIdFrom: 'params.id' }),
+  async (req, res) => { ... },
+);
+```
+
+Permission rationale: `configuration:read` with source scoping, identical to
+`GET /observer/key` and `GET /observer/credentials`. The payload is observer
+configuration plus counters, which is the same trust class as those two, and
+using the same gate means the Phase 2 UI needs no extra grant.
+
+Handler:
+
+1. `const source = await resolveMeshCoreSource(req, res); if (!source) return;`
+   (404 `SOURCE_NOT_FOUND` / 400 `INVALID_PARAMETER` come for free).
+2. `const mgr = sourceManagerRegistry.getManager(source.id);`
+3. If `mgr && isMeshCoreManager(mgr)` and `mgr.getObserverStatus()` returns a
+   value: `ok(res, { running: true, ...status })`.
+4. Otherwise synthesize a not-running snapshot from the saved config, so the UI
+   gets a meaningful answer for a disabled / disconnected / never-started
+   source instead of a 404:
+   ```ts
+   const observer = observerConfigFromSource(source.config as MeshCoreSourceConfig);
+   // observer === undefined -> configured:false, brokers: []
+   ```
+   with every counter at 0, `connected: false`, `keyStored: false`,
+   `lastError: null`, `tokenExpiresAt: null`, and one `brokers[]` entry per
+   normalized broker carrying `key` / `url` / `label` / `authMode` /
+   `tokenAudience` / `configured: true`.
+5. `try/catch` -> `fail(res, 500, 'INTERNAL_ERROR', 'Failed to get Analyzer Observer status')`,
+   matching the sibling handlers.
+
+Response body (envelope, `{ success: true, data: ... }`):
+
+```json
+{
+  "success": true,
+  "data": {
+    "running": true,
+    "configured": true,
+    "authMode": "token",
+    "keyStored": true,
+    "connected": true,
+    "publishes": 412,
+    "dropped": 3,
+    "lastPublishAt": 1756800000000,
+    "lastError": null,
+    "tokenExpiresAt": 1756880000,
+    "brokers": [
+      {
+        "key": "wss://mqtt.meshmapper.net:443",
+        "url": "wss://mqtt.meshmapper.net:443",
+        "label": "MeshMapper",
+        "authMode": "token",
+        "tokenAudience": "mqtt.meshmapper.net",
+        "configured": true,
+        "keyStored": true,
+        "connected": true,
+        "publishes": 210,
+        "dropped": 0,
+        "lastPublishAt": 1756800000000,
+        "lastError": null,
+        "tokenExpiresAt": 1756880000
+      },
+      {
+        "key": "wss://mqtt-us-v1.letsmesh.net:443",
+        "url": "wss://mqtt-us-v1.letsmesh.net:443",
+        "label": "LetsMesh US",
+        "authMode": "token",
+        "tokenAudience": "mqtt-us-v1.letsmesh.net",
+        "configured": true,
+        "keyStored": true,
+        "connected": false,
+        "publishes": 202,
+        "dropped": 3,
+        "lastPublishAt": 1756799000000,
+        "lastError": "Broker rejected the observer auth token (check tokenAudience and the stored key).",
+        "tokenExpiresAt": 1756880000
+      }
+    ]
+  }
+}
+```
+
+**Secrets hygiene, same contract as the sibling routes:** no handler returns a
+private key, a minted token, or a password. `lastError` is `redactToken`-ed at
+the point it is set, inside the publisher, and never re-derived here.
+
+### 5.3 Additive changes to the existing credential routes
+
+Back-compat rule: **a request that omits the new fields behaves exactly as it
+does today.**
+
+| Route | Change |
+|---|---|
+| `GET /observer/credentials` | Response gains `brokers: Array<{ brokerKey, username }>` from `listBrokers()`. Every existing field is unchanged. |
+| `PUT /observer/credentials` | Body gains optional `brokerKey: string`. Absent -> `store()` (unchanged legacy path). Present -> validate, then `storeForBroker()`. |
+| `DELETE /observer/credentials` | Gains optional `?brokerKey=` query param. Absent -> `clear()` (unchanged, wipes everything). Present -> `clearForBroker()`. |
+
+`brokerKey` validation on PUT/DELETE, in that order:
+
+1. must be a non-empty string <= 255 chars -> 400 `INVALID_PARAMETER_TYPE` / `INVALID_PARAMETER`;
+2. must match a `key` in `observerConfigFromSource(source.config)?.brokers`
+   -> 400 `UNKNOWN_BROKER` otherwise. This is what bounds the document: an
+   operator cannot accumulate credentials for brokers that are not configured.
+
+Both write paths keep the existing `capability.canStore` gate on PUT, keep the
+deliberate absence of that gate on DELETE, call `auditMeshcoreEvent` with the
+existing event names plus `brokerKey` in the detail object (the key is a URL,
+not a secret), and call `refreshObserverPublisher(source)` so the running
+publisher picks the credential up without a source bounce.
+
+### 5.4 `GET /api/sources/:id/status` (no change needed, one thing to verify)
+
+The `!canReadNodes` branch in `sourceRoutes.ts` (~line 1269) already deletes
+the **entire** `observer` object for anonymous / non-`nodes:read` callers, so
+the new `brokers[].url` and `brokers[].lastError` are covered with no code
+change. **The implementer must verify this and add an assertion to
+`sourceRoutes.observerStatus.test.ts`**, because `brokers[].url` exposes the
+broker hostname outright, which is the very leak that strip exists to prevent.
+If the strip were ever narrowed to `lastError` alone, this becomes a bug.
+
+`stripObserverKeyMaterial` (~line 404) **does** need extending: it currently
+strips key-material fields from the `observer` block only, not from
+`observer.brokers[i]`. Map over the array and apply the same destructuring
+strip to each entry, preserving the "applies to admins too" rule.
+
+---
+
+## 6. Test plan
+
+Standard Vitest suite. Route tests use `createRouteTestApp()`. Publisher tests
+use the existing `vi.mock('mqtt')` + `createClient`/`mintToken`/`loadCredentials`
+seams. No new harness.
+
+### 6.1 `src/server/meshcoreConfig.observerBrokers.test.ts` (new, WP1)
+
+Pure unit tests on `normalizeObserverBrokers` / `observerBrokerKey` /
+`observerConfigFromSource`.
+
+1. **Legacy config normalizes to one broker.** `{enabled, brokerUrl, iataCode,
+   tokenAudience}` -> `brokers.length === 1`, `legacy === true`,
+   `key === observerBrokerKey(brokerUrl)`, and the flat mirrors
+   (`brokerUrl`/`authMode`/`tokenAudience`) equal today's values.
+2. **Legacy password-mode config** normalizes with `authMode: 'password'` and
+   no audience, and is still `enabled`.
+3. **`brokers[]` wins over `brokerUrl`.** Both present, different URLs -> the
+   result has exactly the `brokers[]` entries; the legacy URL does not appear.
+4. **Legacy flag survives the UI migration.** `brokerUrl: X` plus
+   `brokers: [{url: X, ...}, {url: Y, ...}]` -> one entry, `X` marked
+   `legacy: true`, `Y` marked `legacy: false`.
+5. **Dedupe:** two entries whose URLs normalize identically (e.g.
+   `broker.test:1883` and `mqtt://broker.test:1883`) collapse to one.
+6. **Per-entry auth mode + audience:** entry-level values win; block-level
+   `authMode` is the default; block-level `tokenAudience` does **not** leak
+   into a non-legacy `brokers[]` entry.
+7. **One bad broker does not kill the rest:** an entry with an unnormalizable
+   URL, and a token-mode entry with no audience, are each dropped while the
+   others survive.
+8. **Disabling rules:** `enabled: false`, missing `iataCode`, and
+   `brokers: []` with no `brokerUrl` each return `undefined`.
+9. **Order is preserved** (broker order in the config is broker order in the
+   normalized list), because Phase 2's UI list depends on it.
+
+### 6.2 `src/server/routes/sourceRoutes.observerValidation.test.ts` (extend, WP1)
+
+10. Accepts a valid two-broker config.
+11. Rejects: non-array `brokers`; 9 brokers (`TOO_MANY_BROKERS`); a non-object
+    entry; an `http://` entry URL (`INVALID_BROKER_URL`, proving the
+    scheme pre-check survived the `validateBrokerUrlValue` extraction); a
+    token-mode entry with no audience; a `label` over 64 chars; two entries
+    with the same normalized URL (`DUPLICATE_BROKER_URL`); an entry carrying
+    `password` (`OBSERVER_KEY_IN_CONFIG`, and it must fire even when
+    `enabled: false`).
+12. `enabled: true` with `brokers[]` and **no** `brokerUrl` is accepted
+    (the `MISSING_BROKER` relaxation); `enabled: true` with neither is
+    rejected with `MISSING_BROKER`.
+13. Every pre-existing assertion in this file still passes untouched.
+14. **Observer block size cap:** an `observer` block serializing to more than
+    `MAX_OBSERVER_CONFIG_BYTES` is rejected with `OBSERVER_CONFIG_TOO_LARGE`
+    (assert it fires for a disabled block too); a block at exactly the limit is
+    accepted; and a **non-observer** config well over 4096 bytes (e.g. a fat
+    `mqtt_bridge` block) is **accepted**, pinning the decision not to add a
+    whole-config guard. A valid 8-broker observer block fits under the cap.
+
+### 6.3 `src/server/routes/sourceRoutes.observerStrip.test.ts` (extend, WP1)
+
+15. A stored row with `observer.brokers[1].password` has it stripped for
+    admins and non-admins alike, alongside the existing block-level strip.
+
+### 6.4 `src/server/services/meshcoreObserverCredentialStore.test.ts` (extend, WP2)
+
+16. **v1 read path unchanged:** a row written by the old `store()` still loads
+    through `load()` as `{kind:'ok'}`, and `status()` reports the same shape
+    it does today.
+17. **v1 -> v2 upgrade is lossless:** `store()` a legacy credential, then
+    `storeForBroker('wss://b/')`; `load()` still returns the legacy pair and
+    `loadForBroker('wss://b/')` returns the new one.
+18. **Per-broker isolation:** credentials for broker A and broker B round-trip
+    independently; `loadForBroker(A)` never returns B's password, and
+    `loadForBroker('wss://never-configured/')` returns `{kind:'none'}`.
+19. **No legacy leak:** with only a legacy credential stored,
+    `loadForBroker(anyKey)` returns `{kind:'none'}` (the fallback lives in the
+    publisher, not the store).
+20. `clearForBroker` removes one entry and leaves the others; clearing the
+    last entry when no legacy exists deletes the row.
+21. `listBrokers` returns `{brokerKey, username}` pairs and **never** a
+    password field (assert on `Object.keys`).
+22. `key_rotated`: a doc encrypted under a different SESSION_SECRET returns
+    `key_rotated` from both `load()` and `loadForBroker()`, and `listBrokers`
+    returns `[]`.
+23. `storeForBroker` throws when `capability.canStore` is false, and rejects
+    the 9th distinct broker.
+24. A v1 password that is *not* valid JSON, and one that is valid JSON but not
+    the v2 shape (e.g. `"[1,2,3]"`), both decode as v1.
+
+### 6.5 `src/server/services/meshcoreObserverPublisher.multiBroker.test.ts` (new, WP3)
+
+The headline suite. Uses `vi.mock('mqtt')`; `mockConnect.mock.results` yields
+one fake client per broker, in config order.
+
+25. **Concurrent publish to 2 brokers:** two token-mode brokers with different
+    audiences. `start()` opens two sockets; `mintToken` is called twice, once
+    per audience. One `handleOtaPacket` -> **both** fake clients received a
+    publish, on their own `meshcore/{IATA}/{PUBKEY}/packets` topic, with
+    **byte-identical** payloads.
+26. **Payload built once:** spy on `buildObserverPacketPayload`; one
+    `handleOtaPacket` across 3 same-`originId` brokers calls it exactly once.
+27. **Per-broker audience:** `mintToken` receives each broker's own audience;
+    the CONNECT password for each socket is that broker's token.
+28. **Shared audience dedupes:** two brokers with the same audience ->
+    `mintToken` called once, both sockets get the same token.
+29. **Drop-when-disconnected is per broker:** disconnect broker B's fake
+    client, publish -> A's `publishes` increments, B's `dropped` increments,
+    A's `dropped` stays 0. Aggregate `publishes` is the sum.
+30. **Per-broker lastError isolation:** emit an `error` on B's client ->
+    `getStatus().brokers[1].lastError` set, `brokers[0].lastError` null,
+    aggregate `lastError` non-null.
+31. **Token redaction per broker:** an error message embedding a
+    JWT-shaped token comes back `[REDACTED]` in that broker's `lastError`.
+32. **Auth hard-stop is per broker:** `MAX_AUTH_FAILURES` `permission-denied`
+    events on B disconnect B only; A stays connected and keeps publishing;
+    `isRunning()` stays true.
+33. **Renewal rebuilds only the affected audience:** fake timers, token for
+    audience-A near expiry and audience-B fresh; one `RENEWAL_CHECK_MS` tick
+    re-mints A only and rebuilds only A's socket (assert
+    `mockConnect.mock.calls.length` grew by exactly 1). Window derived from
+    `RENEWAL_CHECK_MS`/`RENEWAL_THRESHOLD_S`, never hardcoded.
+34. **A failed renewal mint does not tear down the working socket.**
+35. **Status refresh reads stats once:** `STATUS_REFRESH_MS` tick with 3
+    brokers -> the `stats` seam is called exactly once, and 3 retained
+    `online` publishes go out.
+36. **Password-mode per-broker credentials:** two password brokers;
+    `loadCredentials` is called with each broker's `key` and its `legacy`
+    flag; each socket's CONNECT carries its own username/password.
+37. **Mixed modes on one source:** one token broker + one password broker
+    start together; the password broker's `tokenExpiresAt` is null.
+38. **`start()` never throws** when every mint fails, when every credential is
+    missing, and when `createClient` throws for one broker (the others still
+    come up).
+39. **`stop()`** publishes an offline status and disconnects on **every**
+    broker, and is idempotent.
+
+### 6.6 `meshcoreObserverPublisher.test.ts` / `.staticAuth.test.ts` / `.perSource.test.ts` (extend, WP3)
+
+40. **Single-broker back-compat:** every existing test passes with a legacy
+    config, and one new assertion confirms `getStatus()` reports
+    `brokers.length === 1` whose per-broker fields equal the aggregate fields.
+    This is the guarantee that Phase 2's UI and the existing
+    `GET /:id/status` consumer see no behavioural change.
+41. Type-only updates: `makeMintTokenAlwaysOk` / `makeMintToken` /
+    `loadCredentials` mock signatures widen to the new arities.
+
+### 6.7 `meshcoreObserverToken.test.ts` (extend, WP3)
+
+42. `mintObserverTokenForSourceDetailed(id)` with no override behaves exactly
+    as before (all existing cases).
+43. With an `audienceOverride`, the minted token's `aud` claim is the override,
+    not the config value, and a source whose config has no `tokenAudience` at
+    all still mints successfully.
+
+### 6.8 `src/server/routes/sourceObserverRoutes.status.test.ts` (new, WP4)
+
+`createRouteTestApp` harness, `sourceManagerRegistry` mocked with a fake
+MeshCore manager (same pattern as `sourceRoutes.observerStatus.test.ts`).
+
+44. 200 with the full aggregate + `brokers[]` for a `configuration:read`
+    grant on that source, wrapped in `{ success: true, data }`.
+45. 403 without the grant; 403 for a grant on a **different** source (per-source
+    isolation, mirroring `sourceObserverRoutes.perSource.test.ts`).
+46. 404 `SOURCE_NOT_FOUND` for an unknown id; 400 `INVALID_PARAMETER` for a
+    non-meshcore source.
+47. No registered manager -> 200 with `running: false`, zeroed counters and
+    `brokers[]` synthesized from the saved config.
+48. Observer disabled in config -> 200 with `running: false`,
+    `configured: false`, `brokers: []`.
+49. The response contains no `password`, no `privateKey` and no token-shaped
+    string (assert on the serialized body).
+
+### 6.9 `sourceObserverRoutes.credentials.test.ts` (extend, WP4)
+
+50. PUT with no `brokerKey` behaves exactly as today (legacy store path) and
+    still calls `reconfigureObserver`.
+51. PUT with a `brokerKey` matching a configured broker stores per-broker; a
+    subsequent `GET /credentials` lists it under `brokers[]` with its username
+    and no password.
+52. PUT with an unconfigured `brokerKey` -> 400 `UNKNOWN_BROKER`.
+53. DELETE `?brokerKey=` removes one entry, leaving the others and the legacy
+    entry; DELETE with no param still wipes everything.
+54. Both new paths audit and both call `refreshObserverPublisher`.
+
+### 6.10 Suite-wide
+
+55. `npm test` fully green, 0 failures (CLAUDE.md gate). No PostgreSQL /
+    MySQL containers are required: this phase adds no schema or migration.
+56. `npm run lint:ci 2>&1 | grep '^FAIL' | grep -v '.claude/worktrees'` is
+    empty. No new `any`, no raw `fetch`, no baseline growth.
+
+---
+
+## 7. Work packages
+
+Four packages. **WP1 and WP2 run in parallel. WP3 and WP4 run in parallel once
+both are merged.** No two packages touch the same file.
+
+### WP1: config schema, normalization and validation
+
+**Depends on:** nothing. **Parallel with:** WP2.
+
+Files:
+- `src/server/meshcoreConfig.ts` (modify)
+- `src/server/services/meshcoreObserverStatus.ts` (**new**, types only)
+- `src/server/routes/sourceRoutes.ts` (modify: `validateObserverConfig`
+  including the `MAX_OBSERVER_CONFIG_BYTES` check, `validateBrokerUrlValue`
+  extraction, `stripObserverKeyMaterial`, and the non-rejecting MySQL blob-size
+  `logger.warn` in the create/update handlers)
+- `src/server/meshcoreConfig.observerBrokers.test.ts` (**new**)
+- `src/server/routes/sourceRoutes.observerValidation.test.ts` (extend)
+- `src/server/routes/sourceRoutes.observerStrip.test.ts` (extend)
+
+Acceptance:
+- `MeshCoreObserverBrokerConfig`, `NormalizedObserverBroker`,
+  `NormalizedObserverConfig`, `observerBrokerKey`, `normalizeObserverBrokers`
+  exported exactly as specified in §2.
+- `observerConfigFromSource` keeps its signature and its "incomplete ->
+  undefined" contract, and its flat mirrors match §2.2.
+- `MeshCoreObserverStatus` / `MeshCoreObserverBrokerStatus` defined in the new
+  types module exactly as in §5.1 (nothing consumes them yet; WP3 wires them
+  in and re-exports from the publisher).
+- `MAX_OBSERVER_CONFIG_BYTES` caps the `observer` block only. **No
+  whole-config guard is added**, and no non-observer source type gains a new
+  rejection path: an existing >4KB `mqtt_bridge` config must still save
+  unchanged on SQLite and PostgreSQL. The MySQL oversize check is a
+  `logger.warn` and never a 400.
+- Tests 1-15 pass. Every pre-existing observer-validation and strip assertion
+  still passes.
+- `MeshCoreConfig['observer']` is **not** retyped here (that is WP3), so this
+  package compiles standalone.
+
+### WP2: per-broker credential store
+
+**Depends on:** nothing. **Parallel with:** WP1.
+
+Files:
+- `src/server/services/meshcoreObserverCredentialStore.ts` (modify)
+- `src/server/services/meshcoreObserverCredentialStore.test.ts` (extend)
+
+Acceptance:
+- `StoredCredentialDoc` v2, `decodeDoc` and the four new methods land exactly
+  as in §4.2/§4.3, with the v1-misparse caveat and the read-modify-write
+  concurrency caveat present as code comments.
+- `store` / `load` / `clear` / `status` / `capability` keep their signatures;
+  `status()` gains only the optional `brokers` field.
+- **No schema, repository or migration change.** `MeshCoreObserverCredentialsRepository`
+  and `src/db/schema/meshcoreObserverCredentials.ts` are untouched.
+- Tests 16-24 pass; every pre-existing credential-store assertion still passes.
+
+### WP3: publisher connection pool, token minting, manager wiring
+
+**Depends on:** WP1 (config + status types), WP2 (store API).
+**Parallel with:** WP4.
+
+Files:
+- `src/server/services/meshcoreObserverPublisher.ts` (modify, the bulk of the work)
+- `src/server/services/meshcoreObserverToken.ts` (modify: `audienceOverride`)
+- `src/server/meshcoreManager.ts` (modify: retype `MeshCoreConfig['observer']`
+  and the `MeshCoreSourceStatus` import; **no logic changes**)
+- `src/server/services/meshcoreObserverPublisher.multiBroker.test.ts` (**new**)
+- `src/server/services/meshcoreObserverPublisher.test.ts` (extend)
+- `src/server/services/meshcoreObserverPublisher.staticAuth.test.ts` (extend)
+- `src/server/services/meshcoreObserverPublisher.perSource.test.ts` (extend)
+- `src/server/services/meshcoreObserverToken.test.ts` (extend)
+
+Acceptance:
+- `start()` / `stop()` / `handleOtaPacket()` / `getStatus()` / `isRunning()`
+  keep their names and contracts; `start()` still never throws.
+- `ObserverBrokerConnection` owns all per-broker state; `redactToken`,
+  `LAST_ERROR`, `RENEWAL_CHECK_MS`, `RENEWAL_THRESHOLD_S`,
+  `MAX_AUTH_FAILURES` and `STATUS_REFRESH_MS` stay module-level exports with
+  their current values.
+- Exactly one renewal timer and one status-refresh timer per publisher, both
+  `unref()`-ed; `stats()` called at most once per refresh tick.
+- Payload serialized once per distinct `originId` per packet.
+- Auth hard-stop scoped to one connection.
+- Tests 25-43 pass. `sourceRoutes.observerStatus.test.ts` still passes
+  untouched.
+
+### WP4: status route and per-broker credential routes
+
+**Depends on:** WP1 (normalize + status types), WP2 (store API).
+**Parallel with:** WP3.
+
+Files:
+- `src/server/routes/sourceObserverRoutes.ts` (modify)
+- `src/server/routes/sourceObserverRoutes.status.test.ts` (**new**)
+- `src/server/routes/sourceObserverRoutes.credentials.test.ts` (extend)
+
+Acceptance:
+- `GET /api/sources/:id/observer/status` exists, uses `ok()`/`fail()`,
+  `requirePermission('configuration', 'read', { sourceIdFrom: 'params.id' })`
+  and `resolveMeshCoreSource`, and returns §5.2's shape including the
+  not-running synthesis.
+- The three credential routes accept the new optional `brokerKey` and are
+  byte-compatible when it is omitted.
+- No handler returns a password, a private key or a token.
+- Tests 44-54 pass; every pre-existing route assertion still passes.
+- The `!canReadNodes` strip on `GET /:id/status` is verified to drop the whole
+  `observer` object (§5.4), with an assertion added if one is missing.
+
+### Ordering summary
+
+```
+WP1 ─┐
+     ├─> WP3 (publisher + manager)   ─┐
+WP2 ─┘                                 ├─> PR / CI
+     └─> WP4 (routes)                ─┘
+```
+
+WP3 and WP4 share **zero** files. WP1's new types module is the seam that lets
+WP4 build the status response without importing the publisher.
+
+---
+
+## 8. Deviations and open questions for the reviewer
+
+1. **Per-broker auth hard-stop** (§3.2) is a behaviour change from Phase 2's
+   whole-publisher stop. It is the right call for dual-publish, but it is a
+   change, and it belongs in the PR body.
+2. **Encrypted credential document vs a new table** (§4.1). The trade-off is
+   recorded; flipping to a `meshcore_observer_broker_credentials` table with a
+   three-backend migration is a contained change confined to WP2 plus the
+   repository and schema files, if a reviewer prefers it.
+3. **`brokers[]` beats `brokerUrl`** (§2.3 rule 1). The alternative (union the
+   two) risks double-publishing and was rejected. Phase 2's form must write
+   the legacy broker into `brokers[0]`, and should clear the stale top-level
+   `brokerUrl` once it does, though the `legacy` flag means it does not have
+   to for credentials to keep working.
+4. **`MAX_OBSERVER_BROKERS = 8`** and **`MAX_OBSERVER_CONFIG_BYTES = 1536`**
+   are the two numbers this spec picks, and they are chosen together (see
+   2.5's budget arithmetic). 8 is well above the three brokers the epic names
+   (MeshMapper, LetsMesh US, LetsMesh EU). Confirm both with the project owner
+   before merge. Note the deliberate absence of a whole-config guard: a
+   universal 4096-byte cap would make a pre-existing oversized config on
+   SQLite/PostgreSQL uneditable after upgrade, so MySQL's column width is
+   surfaced as a log warning rather than enforced as a rejection.
+5. **Mesh impact:** none. The observer is a passive relay of packets the radio
+   already heard; no new transmissions, no new timers on the RF side. The only
+   new per-tick cost is N MQTT publishes on the existing 5-minute status
+   refresh, over IP.

--- a/src/server/meshcoreConfig.observer.test.ts
+++ b/src/server/meshcoreConfig.observer.test.ts
@@ -76,13 +76,29 @@ describe('observerConfigFromSource', () => {
     const observer = observerConfigFromSource({
       observer: { enabled: true, brokerUrl: 'mqtts://host:8883', iataCode: 'MCO', tokenAudience: 'my-aud' },
     });
+    // #5014 Phase 1: brokers[] now carries the (single, legacy-synthesized)
+    // broker, and the flat fields remain a mirror of brokers[0].
     expect(observer).toEqual({
       enabled: true,
+      iataCode: 'MCO',
+      brokers: [
+        {
+          key: 'mqtts://host:8883',
+          url: 'mqtts://host:8883',
+          authMode: 'token',
+          tokenAudience: 'my-aud',
+          legacy: true,
+        },
+      ],
       authMode: 'token',
       brokerUrl: 'mqtts://host:8883',
-      iataCode: 'MCO',
       tokenAudience: 'my-aud',
     });
+    // Flat mirrors equal brokers[0] exactly (#5014 §2.2 contract).
+    expect(observer?.brokers?.[0]).toBeDefined();
+    expect(observer?.brokerUrl).toBe(observer?.brokers?.[0]?.url);
+    expect(observer?.authMode).toBe(observer?.brokers?.[0]?.authMode);
+    expect(observer?.tokenAudience).toBe(observer?.brokers?.[0]?.tokenAudience);
   });
 
   it('normalizes a bare host:port brokerUrl using normalizeBrokerUrl (mqtts for 8883)', () => {
@@ -127,13 +143,20 @@ describe('meshcoreConfigFromSource — observer plumbing', () => {
       }),
     );
     expect(cfg?.connectionType).toBe(ConnectionType.SERIAL);
+    // #5014 Phase 1: brokers[] mirrors the flat legacy fields.
     expect(cfg?.observer).toEqual({
       enabled: true,
+      iataCode: 'MCO',
+      brokers: [
+        { key: 'mqtts://host:8883', url: 'mqtts://host:8883', authMode: 'token', tokenAudience: 'aud', legacy: true },
+      ],
       authMode: 'token',
       brokerUrl: 'mqtts://host:8883',
-      iataCode: 'MCO',
       tokenAudience: 'aud',
     });
+    expect(cfg?.observer?.brokerUrl).toBe(cfg?.observer?.brokers?.[0]?.url);
+    expect(cfg?.observer?.authMode).toBe(cfg?.observer?.brokers?.[0]?.authMode);
+    expect(cfg?.observer?.tokenAudience).toBe(cfg?.observer?.brokers?.[0]?.tokenAudience);
   });
 
   it('carries observer through the TCP branch', () => {
@@ -148,13 +171,20 @@ describe('meshcoreConfigFromSource — observer plumbing', () => {
       }),
     );
     expect(cfg?.connectionType).toBe(ConnectionType.TCP);
+    // #5014 Phase 1: brokers[] mirrors the flat legacy fields.
     expect(cfg?.observer).toEqual({
       enabled: true,
+      iataCode: 'MCO',
+      brokers: [
+        { key: 'mqtts://host:8883', url: 'mqtts://host:8883', authMode: 'token', tokenAudience: 'aud', legacy: true },
+      ],
       authMode: 'token',
       brokerUrl: 'mqtts://host:8883',
-      iataCode: 'MCO',
       tokenAudience: 'aud',
     });
+    expect(cfg?.observer?.brokerUrl).toBe(cfg?.observer?.brokers?.[0]?.url);
+    expect(cfg?.observer?.authMode).toBe(cfg?.observer?.brokers?.[0]?.authMode);
+    expect(cfg?.observer?.tokenAudience).toBe(cfg?.observer?.brokers?.[0]?.tokenAudience);
   });
 
   it('leaves observer undefined on both branches when not configured', () => {

--- a/src/server/meshcoreConfig.observerBrokers.test.ts
+++ b/src/server/meshcoreConfig.observerBrokers.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Pure unit tests for `normalizeObserverBrokers` / `observerBrokerKey` /
+ * `observerConfigFromSource` (#5014 Phase 1 WP1).
+ *
+ * Covers docs/internal/dev-notes/MESHMAPPER_OBSERVER_PHASE1_SPEC.md §6.1,
+ * tests 1-9. No DB, no mocks needed — these functions are pure.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeObserverBrokers,
+  observerBrokerKey,
+  observerConfigFromSource,
+  type MeshCoreObserverConfig,
+  type MeshCoreSourceConfig,
+} from './meshcoreConfig.js';
+
+describe('observerBrokerKey', () => {
+  it('normalizes and lowercases the URL', () => {
+    expect(observerBrokerKey('Broker.Test:8883')).toBe('mqtts://broker.test:8883');
+    expect(observerBrokerKey('MQTT://Broker.Test:1883')).toBe('mqtt://broker.test:1883');
+  });
+
+  it('is case-insensitive: two spellings of the same broker produce the same key', () => {
+    expect(observerBrokerKey('broker.test:8883')).toBe(observerBrokerKey('BROKER.TEST:8883'));
+  });
+});
+
+describe('normalizeObserverBrokers', () => {
+  // ── Test 1: legacy config normalizes to one broker ─────────────────────
+  it('normalizes a legacy config to one broker, flat mirrors intact', () => {
+    const o: MeshCoreObserverConfig = {
+      enabled: true,
+      brokerUrl: 'mqtts://broker.test:8883',
+      iataCode: 'MCO',
+      tokenAudience: 'my-aud',
+    };
+    const brokers = normalizeObserverBrokers(o);
+    expect(brokers).toHaveLength(1);
+    expect(brokers[0].legacy).toBe(true);
+    expect(brokers[0].key).toBe(observerBrokerKey(o.brokerUrl!));
+    expect(brokers[0].url).toBe('mqtts://broker.test:8883');
+    expect(brokers[0].authMode).toBe('token');
+    expect(brokers[0].tokenAudience).toBe('my-aud');
+
+    const runtime = observerConfigFromSource({ observer: o } as MeshCoreSourceConfig);
+    expect(runtime?.brokerUrl).toBe('mqtts://broker.test:8883');
+    expect(runtime?.authMode).toBe('token');
+    expect(runtime?.tokenAudience).toBe('my-aud');
+  });
+
+  // ── Test 2: legacy password-mode config ─────────────────────────────────
+  it('normalizes a legacy password-mode config with no audience, still enabled', () => {
+    const o: MeshCoreObserverConfig = {
+      enabled: true,
+      authMode: 'password',
+      brokerUrl: 'mqtt://broker.test:1883',
+      iataCode: 'ALA',
+    };
+    const brokers = normalizeObserverBrokers(o);
+    expect(brokers).toHaveLength(1);
+    expect(brokers[0].authMode).toBe('password');
+    expect(brokers[0].tokenAudience).toBeUndefined();
+
+    const runtime = observerConfigFromSource({ observer: o } as MeshCoreSourceConfig);
+    expect(runtime?.enabled).toBe(true);
+    expect(runtime?.authMode).toBe('password');
+    expect(runtime?.tokenAudience).toBeUndefined();
+  });
+
+  // ── Test 3: brokers[] wins over brokerUrl ────────────────────────────────
+  it('uses brokers[] exclusively when present and non-empty; the legacy URL does not appear', () => {
+    const o: MeshCoreObserverConfig = {
+      enabled: true,
+      brokerUrl: 'mqtt://legacy.test:1883',
+      tokenAudience: 'legacy-aud',
+      iataCode: 'MCO',
+      brokers: [{ url: 'mqtt://multi.test:1883', tokenAudience: 'multi-aud' }],
+    };
+    const brokers = normalizeObserverBrokers(o);
+    expect(brokers).toHaveLength(1);
+    expect(brokers[0].url).toBe('mqtt://multi.test:1883');
+    expect(brokers.some((b) => b.key === observerBrokerKey('mqtt://legacy.test:1883'))).toBe(false);
+  });
+
+  // ── Test 4: legacy flag survives the UI migration ───────────────────────
+  it('flags the entry matching the legacy brokerUrl as legacy, others not', () => {
+    const o: MeshCoreObserverConfig = {
+      enabled: true,
+      brokerUrl: 'mqtt://x.test:1883',
+      iataCode: 'MCO',
+      brokers: [
+        { url: 'mqtt://x.test:1883', tokenAudience: 'aud-x' },
+        { url: 'mqtt://y.test:1883', tokenAudience: 'aud-y' },
+      ],
+    };
+    const brokers = normalizeObserverBrokers(o);
+    expect(brokers).toHaveLength(2);
+    const x = brokers.find((b) => b.url === 'mqtt://x.test:1883');
+    const y = brokers.find((b) => b.url === 'mqtt://y.test:1883');
+    expect(x?.legacy).toBe(true);
+    expect(y?.legacy).toBe(false);
+  });
+
+  // ── Test 5: dedupe ────────────────────────────────────────────────────────
+  it('dedupes two entries whose URLs normalize identically, first wins', () => {
+    const o: MeshCoreObserverConfig = {
+      enabled: true,
+      iataCode: 'MCO',
+      brokers: [
+        { url: 'broker.test:1883', tokenAudience: 'first' },
+        { url: 'mqtt://broker.test:1883', tokenAudience: 'second' },
+      ],
+    };
+    const brokers = normalizeObserverBrokers(o);
+    expect(brokers).toHaveLength(1);
+    expect(brokers[0].tokenAudience).toBe('first');
+  });
+
+  // ── Test 6: per-entry auth mode + audience ──────────────────────────────
+  describe('per-entry auth mode and audience', () => {
+    it('entry-level authMode wins over the block-level default', () => {
+      const o: MeshCoreObserverConfig = {
+        enabled: true,
+        authMode: 'token',
+        iataCode: 'MCO',
+        brokers: [{ url: 'mqtt://a.test:1883', authMode: 'password' }],
+      };
+      const brokers = normalizeObserverBrokers(o);
+      expect(brokers).toHaveLength(1);
+      expect(brokers[0].authMode).toBe('password');
+    });
+
+    it('block-level authMode is the default for an entry that omits its own', () => {
+      const o: MeshCoreObserverConfig = {
+        enabled: true,
+        authMode: 'password',
+        iataCode: 'MCO',
+        brokers: [{ url: 'mqtt://a.test:1883' }],
+      };
+      const brokers = normalizeObserverBrokers(o);
+      expect(brokers).toHaveLength(1);
+      expect(brokers[0].authMode).toBe('password');
+    });
+
+    it('block-level tokenAudience does NOT leak into a non-legacy brokers[] entry (password mode proves no value crosses over)', () => {
+      const o: MeshCoreObserverConfig = {
+        enabled: true,
+        tokenAudience: 'BLOCK-LEVEL-AUD',
+        iataCode: 'MCO',
+        brokers: [{ url: 'mqtt://a.test:1883', authMode: 'password' }],
+      };
+      const brokers = normalizeObserverBrokers(o);
+      expect(brokers).toHaveLength(1);
+      expect(brokers[0].tokenAudience).toBeUndefined();
+    });
+
+    it('block-level tokenAudience does NOT leak into a token-mode non-legacy entry — it is dropped instead of inheriting', () => {
+      const o: MeshCoreObserverConfig = {
+        enabled: true,
+        tokenAudience: 'BLOCK-LEVEL-AUD',
+        iataCode: 'MCO',
+        brokers: [{ url: 'mqtt://a.test:1883' }], // token mode (default), no own audience
+      };
+      const brokers = normalizeObserverBrokers(o);
+      expect(brokers).toHaveLength(0);
+    });
+  });
+
+  // ── Test 7: one bad broker does not kill the rest ───────────────────────
+  it('drops an unnormalizable URL and a token-mode entry with no audience, keeping the rest', () => {
+    const o: MeshCoreObserverConfig = {
+      enabled: true,
+      iataCode: 'MCO',
+      brokers: [
+        { url: '', tokenAudience: 'unused' }, // no usable url -> skipped
+        { url: 'mqtt://no-audience.test:1883' }, // token mode, no audience -> skipped
+        { url: 'mqtt://good.test:1883', tokenAudience: 'good-aud' },
+      ],
+    };
+    const brokers = normalizeObserverBrokers(o);
+    expect(brokers).toHaveLength(1);
+    expect(brokers[0].url).toBe('mqtt://good.test:1883');
+  });
+
+  // ── Test 8: disabling rules ──────────────────────────────────────────────
+  describe('observerConfigFromSource disabling rules', () => {
+    it('returns undefined when enabled is false', () => {
+      expect(
+        observerConfigFromSource({
+          observer: { enabled: false, brokerUrl: 'mqtt://a.test:1883', iataCode: 'MCO', tokenAudience: 'aud' },
+        } as MeshCoreSourceConfig),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when iataCode is missing', () => {
+      expect(
+        observerConfigFromSource({
+          observer: { enabled: true, brokerUrl: 'mqtt://a.test:1883', tokenAudience: 'aud' },
+        } as MeshCoreSourceConfig),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when brokers is [] and there is no brokerUrl', () => {
+      expect(
+        observerConfigFromSource({
+          observer: { enabled: true, iataCode: 'MCO', brokers: [] },
+        } as MeshCoreSourceConfig),
+      ).toBeUndefined();
+    });
+  });
+
+  // ── Test 9: order is preserved ───────────────────────────────────────────
+  it('preserves broker order in the normalized list', () => {
+    const o: MeshCoreObserverConfig = {
+      enabled: true,
+      iataCode: 'MCO',
+      brokers: [
+        { url: 'mqtt://c.test:1883', tokenAudience: 'c' },
+        { url: 'mqtt://a.test:1883', tokenAudience: 'a' },
+        { url: 'mqtt://b.test:1883', tokenAudience: 'b' },
+      ],
+    };
+    const brokers = normalizeObserverBrokers(o);
+    expect(brokers.map((b) => b.url)).toEqual([
+      'mqtt://c.test:1883',
+      'mqtt://a.test:1883',
+      'mqtt://b.test:1883',
+    ]);
+  });
+
+  it('returns [] for a null/undefined observer block', () => {
+    expect(normalizeObserverBrokers(undefined)).toEqual([]);
+    expect(normalizeObserverBrokers(null)).toEqual([]);
+  });
+});

--- a/src/server/meshcoreConfig.ts
+++ b/src/server/meshcoreConfig.ts
@@ -69,23 +69,213 @@ export interface MeshCoreObserverConfig {
    *   brokers (e.g. meshcoretel.ru) that don't verify the signature. The
    *   password is NEVER in this block — it lives encrypted in
    *   `meshcore_observer_credentials` (see meshcoreObserverCredentialStore).
+   *
+   * When `brokers[]` is present and non-empty, this is only the DEFAULT
+   * auth mode for an entry that omits its own `authMode` — see
+   * `MeshCoreObserverBrokerConfig.authMode`.
    */
   authMode?: 'token' | 'password';
-  /** Broker URL. ws/wss/mqtt/mqtts; bare host:port is normalized by normalizeBrokerUrl. */
+  /**
+   * LEGACY single broker (pre-#5014). Kept and still honoured: when
+   * `brokers` is absent or empty, this (plus `authMode` / `tokenAudience`)
+   * is synthesized into a single-entry broker list — see the precedence
+   * rule in `normalizeObserverBrokers`.
+   */
   brokerUrl?: string;
-  /** 3-letter IATA region code, or the literal 'test' for local validation. */
+  /**
+   * 3-letter IATA region code, or the literal 'test' for local validation.
+   * Shared across every broker on purpose (#5014): it is the REGION segment
+   * of the topic (`meshcore/{IATA}/{PUBKEY}/packets`), not a broker property.
+   */
   iataCode?: string;
   /**
    * Must equal the broker's AUTH_EXPECTED_AUDIENCE, or auth is rejected.
    * Only meaningful in `token` mode — a static-credential broker signs
    * nothing, so there is no audience to match.
+   *
+   * LEGACY: applies only to the synthesized legacy broker entry. A
+   * `brokers[]` entry needs its own `tokenAudience` — this value is
+   * deliberately NOT inherited by other entries, since two brokers with
+   * different audiences is the normal multi-broker case (#5014).
    */
+  tokenAudience?: string;
+  /**
+   * Multi-broker list (#5014 Phase 1). When present and non-empty this is
+   * authoritative: the legacy `brokerUrl` above is NOT unioned in as an
+   * extra entry (see `normalizeObserverBrokers` rule 1 — unioning risks
+   * double-publishing the same broker under two spellings).
+   */
+  brokers?: MeshCoreObserverBrokerConfig[];
+}
+
+/** One Analyzer broker this source publishes to (#5014 Phase 1). */
+export interface MeshCoreObserverBrokerConfig {
+  /** ws/wss/mqtt/mqtts URL, or a bare host:port that normalizeBrokerUrl accepts. */
+  url: string;
+  /** Defaults to the block-level `authMode`, which itself defaults to 'token'. */
+  authMode?: 'token' | 'password';
+  /**
+   * Required in token mode. NOT inherited from the block-level
+   * `tokenAudience`: two brokers with different audiences are the normal
+   * case, and silently inheriting one would mint tokens the other broker
+   * rejects. The only exception is the legacy synthesized entry — see the
+   * precedence rule in `normalizeObserverBrokers`.
+   */
+  tokenAudience?: string;
+  /** Free-text display label, e.g. "MeshMapper". UI only, never on the wire. */
+  label?: string;
+}
+
+/**
+ * One normalized, validated broker entry, as produced by
+ * `normalizeObserverBrokers` and consumed by the publisher (#5014 Phase 1).
+ */
+export interface NormalizedObserverBroker {
+  /** Stable identity: normalizeBrokerUrl(url).toLowerCase(). Non-secret. */
+  key: string;
+  /** normalizeBrokerUrl(url). */
+  url: string;
+  authMode: 'token' | 'password';
+  /** Present iff authMode === 'token' (normalization drops token brokers without one). */
+  tokenAudience?: string;
+  label?: string;
+  /**
+   * True iff this entry corresponds to the block-level legacy `brokerUrl`.
+   * The publisher uses it, and only it, to fall back to the pre-#5014
+   * single-credential row. At most one entry can carry it (dedupe
+   * guarantees key uniqueness).
+   */
+  legacy: boolean;
+}
+
+/**
+ * Superset of the pre-#5014 runtime shape: the flat brokerUrl / authMode /
+ * tokenAudience fields are RETAINED as mirrors of brokers[0] so every
+ * existing reader (and every existing test) keeps compiling and keeps
+ * observing the same values for a single-broker source (#5014 Phase 1).
+ */
+export interface NormalizedObserverConfig {
+  enabled: true;
+  iataCode: string;
+  brokers: NormalizedObserverBroker[];
+  authMode: 'token' | 'password';
+  brokerUrl: string;
   tokenAudience?: string;
 }
 
 /** Normalize the (optional, back-compatible) observer auth mode. */
 export function observerAuthMode(o: MeshCoreObserverConfig | undefined | null): 'token' | 'password' {
   return o?.authMode === 'password' ? 'password' : 'token';
+}
+
+/**
+ * Stable, case-insensitive broker identity. The one place this is derived —
+ * credentials, status and dedupe all key off this value (#5014 Phase 1).
+ * Throws only if `normalizeBrokerUrl` throws (unnormalizable input).
+ */
+export function observerBrokerKey(url: string): string {
+  return normalizeBrokerUrl(url).toLowerCase();
+}
+
+/**
+ * Pure: turns the persisted (legacy or multi) observer block into the
+ * ordered, deduped, validated broker list the publisher consumes. Never
+ * throws. Returns `[]` when nothing usable is configured (#5014 Phase 1).
+ *
+ * Semantics, in order (see MESHMAPPER_OBSERVER_PHASE1_SPEC.md §2.3 for the
+ * full rationale on each rule):
+ *  1. Source list selection: `o.brokers` wins outright when it is a
+ *     non-empty array — `o.brokerUrl` is NOT unioned in as an extra entry,
+ *     which would risk double-publishing the same broker under two
+ *     spellings once the Phase 2 UI migrates it into `brokers[0]`.
+ *     Otherwise, synthesize a single entry from `o.brokerUrl` (when present).
+ *  2. Per-entry auth mode: `entry.authMode ?? o.authMode ?? 'token'`.
+ *  3. Per-entry audience: `entry.tokenAudience?.trim()`. Only the
+ *     synthesized legacy entry falls back to `o.tokenAudience?.trim()`.
+ *  4. Per-entry URL: `normalizeBrokerUrl(entry.url)`. On throw, warn naming
+ *     the index and skip that entry only — one malformed broker must not
+ *     disable the others.
+ *  5. Dedupe by `key`, first wins.
+ *  6. Completeness: drop a token-mode entry with no `tokenAudience`. A
+ *     password-mode entry needs no audience.
+ *  7. Legacy flag: true when the entry was synthesized from `o.brokerUrl`,
+ *     OR when `o.brokerUrl` is present and its key matches this entry's key
+ *     (keeps the pre-#5014 stored credential reachable after the Phase 2 UI
+ *     moves that broker into `brokers[]`).
+ */
+export function normalizeObserverBrokers(
+  o: MeshCoreObserverConfig | undefined | null,
+): NormalizedObserverBroker[] {
+  if (!o) return [];
+  const blockAuthMode = observerAuthMode(o);
+  const brokersProvided = Array.isArray(o.brokers) && o.brokers.length > 0;
+  const rawList: MeshCoreObserverBrokerConfig[] = brokersProvided
+    ? (o.brokers as MeshCoreObserverBrokerConfig[])
+    : o.brokerUrl
+      ? [{ url: o.brokerUrl, authMode: o.authMode, tokenAudience: o.tokenAudience }]
+      : [];
+  // True only for the single entry synthesized from the legacy field above —
+  // NOT for a real brokers[] entry that merely happens to match it (rule 7's
+  // second clause handles that case, without the audience fallback).
+  const synthesizedFromLegacy = !brokersProvided && !!o.brokerUrl;
+
+  const seen = new Map<string, NormalizedObserverBroker>();
+  const order: string[] = [];
+
+  for (let i = 0; i < rawList.length; i++) {
+    const raw = rawList[i];
+    if (!raw || typeof raw.url !== 'string' || raw.url.length === 0) {
+      logger.warn(`[MeshCoreConfig] observer.brokers[${i}] has no url; skipping`);
+      continue;
+    }
+    let url: string;
+    try {
+      url = normalizeBrokerUrl(raw.url);
+    } catch {
+      logger.warn(`[MeshCoreConfig] observer.brokers[${i}].url failed to normalize; skipping`);
+      continue;
+    }
+    const key = url.toLowerCase();
+    const isSynthesizedLegacyEntry = synthesizedFromLegacy && i === 0;
+    const authMode: 'token' | 'password' =
+      raw.authMode === 'password' ? 'password' : raw.authMode === 'token' ? 'token' : blockAuthMode;
+    const tokenAudience = isSynthesizedLegacyEntry
+      ? raw.tokenAudience?.trim() || o.tokenAudience?.trim() || undefined
+      : raw.tokenAudience?.trim() || undefined;
+
+    if (authMode === 'token' && !tokenAudience) {
+      logger.warn(`[MeshCoreConfig] observer.brokers[${i}] (${key}) is token-mode with no tokenAudience; skipping`);
+      continue;
+    }
+
+    if (seen.has(key)) {
+      logger.debug(`[MeshCoreConfig] observer.brokers[${i}] (${key}) duplicates an earlier broker; discarding`);
+      continue;
+    }
+
+    // At most one entry can carry legacy: true (dedupe guarantees key
+    // uniqueness, and o.brokerUrl can match at most one normalized key).
+    let legacy = isSynthesizedLegacyEntry;
+    if (!legacy && o.brokerUrl) {
+      try {
+        legacy = observerBrokerKey(o.brokerUrl) === key;
+      } catch {
+        // o.brokerUrl itself fails to normalize — can't match; leave legacy false.
+      }
+    }
+
+    seen.set(key, {
+      key,
+      url,
+      authMode,
+      ...(tokenAudience ? { tokenAudience } : {}),
+      ...(raw.label ? { label: raw.label } : {}),
+      legacy,
+    });
+    order.push(key);
+  }
+
+  return order.map((k) => seen.get(k)!);
 }
 
 /** Default TCP port the Virtual Node server listens on when none is given. */
@@ -109,39 +299,37 @@ export function virtualNodeConfigFromSource(cfg: MeshCoreSourceConfig): MeshCore
 
 /**
  * Build the runtime Analyzer Observer config from a source's saved config, or
- * undefined when disabled/absent or missing a required field.
+ * undefined when disabled/absent or missing a required field (#5014 Phase 1:
+ * now multi-broker aware via `normalizeObserverBrokers`).
  *
- * Required fields depend on the auth mode (#4595): `token` mode needs
- * brokerUrl + iataCode + tokenAudience; `password` mode needs only brokerUrl
- * + iataCode, because the broker verifies no signature and therefore has no
- * audience. The username/password themselves are NOT config — they live
- * encrypted in `meshcore_observer_credentials`.
+ * "Incomplete block disables the observer" contract, preserved: returns
+ * `undefined` when `!o.enabled`, when `iataCode` is missing, or when
+ * `normalizeObserverBrokers` yields no usable broker at all (a bad
+ * `brokerUrl`, or a token-mode broker with no `tokenAudience`, are each
+ * warned-and-skipped there rather than throwing).
+ *
+ * The flat `authMode` / `brokerUrl` / `tokenAudience` fields on the returned
+ * value are mirrors of `brokers[0]` — kept so every pre-#5014 reader (and
+ * every pre-#5014 test) keeps observing the same values for a single-broker
+ * source. `NormalizedObserverConfig` (the richer, multi-broker-aware type)
+ * documents the full shape; `MeshCoreConfig['observer']` itself is not
+ * retyped to it here — that is #5014 Phase 1 WP3.
  */
 export function observerConfigFromSource(cfg: MeshCoreSourceConfig): MeshCoreConfig['observer'] {
   const o = cfg.observer;
-  if (!o?.enabled) return undefined;
-  const authMode = observerAuthMode(o);
-  if (!o.brokerUrl || !o.iataCode) return undefined;
-  if (authMode === 'token' && !o.tokenAudience) return undefined;
-  // The stored URL was validated at write time, but normalize can still throw
-  // on a row written by an older version or edited out-of-band. Silently
-  // returning undefined here would disable the observer with no trace — warn
-  // so the operator can see why it never started.
-  let brokerUrl: string;
-  try {
-    brokerUrl = normalizeBrokerUrl(o.brokerUrl);
-  } catch {
-    logger.warn('[MeshCoreConfig] observer.brokerUrl failed to normalize; observer disabled for this source');
-    return undefined;
-  }
+  if (!o?.enabled || !o.iataCode) return undefined;
+  const brokers = normalizeObserverBrokers(o);
+  if (brokers.length === 0) return undefined;
+  const primary = brokers[0];
   return {
     enabled: true,
-    authMode,
-    brokerUrl,
     iataCode: o.iataCode.trim().toUpperCase(),
+    brokers,
+    authMode: primary.authMode,
+    brokerUrl: primary.url,
     // Carried through in password mode only when the operator happened to
     // leave a value behind; the publisher ignores it in that mode.
-    tokenAudience: o.tokenAudience?.trim(),
+    ...(primary.tokenAudience ? { tokenAudience: primary.tokenAudience } : {}),
   };
 }
 

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -49,7 +49,7 @@ import {
 // a static value import of it here would make the cycle real (meshcoreConfig.ts
 // already imports the MeshCoreManager class by value), so it is resolved with a
 // dynamic import() at call time instead — see reconfigureObserver() below.
-import type { MeshCoreObserverConfig, MeshCoreSourceConfig } from './meshcoreConfig.js';
+import type { MeshCoreObserverConfig, MeshCoreSourceConfig, NormalizedObserverConfig } from './meshcoreConfig.js';
 import meshcorePacketLogService from './services/meshcorePacketLogService.js';
 import { notificationService } from './services/notificationService.js';
 import { DistanceDeleteScheduler } from './services/distanceDeleteScheduler.js';
@@ -409,8 +409,14 @@ export interface MeshCoreConfig {
   // See docs/internal/dev-notes/MESHCORE_VIRTUAL_NODE_DESIGN.md.
   virtualNode?: MeshCoreVirtualNodeConfig;
 
-  /** Analyzer Observer MQTT output (#4457). Consumed by the Phase 2 publisher. */
-  observer?: MeshCoreObserverConfig;
+  /**
+   * Analyzer Observer MQTT output (#4457), normalized and multi-broker-aware
+   * (#5014 Phase 1 WP3). Consumed by the publisher. This is a NARROWING of
+   * the field's pre-#5014 type (`MeshCoreObserverConfig`) — the manager only
+   * ever assigns it from `observerConfigFromSource`, which now returns the
+   * richer `NormalizedObserverConfig` shape.
+   */
+  observer?: NormalizedObserverConfig;
 }
 
 /**

--- a/src/server/routes/sourceObserverRoutes.credentials.test.ts
+++ b/src/server/routes/sourceObserverRoutes.credentials.test.ts
@@ -285,3 +285,211 @@ describe('sourceObserverRoutes — /credentials (#4595)', () => {
     await harness.db.sources.deleteSource('obs-creds-b').catch(() => {});
   });
 });
+
+/**
+ * Per-broker `brokerKey` support (#5014 Phase 1 WP4, spec §5.3, tests 50-54).
+ * A dedicated source carrying a real `brokers[]` config, so `brokerKey`
+ * validation has something to bound against (`UNKNOWN_BROKER`).
+ */
+describe('sourceObserverRoutes — /credentials brokerKey (#5014 Phase 1)', () => {
+  let harness: RouteTestHarness;
+
+  const MULTI_SOURCE_ID = 'obs-creds-multi';
+  const LEGACY_BROKER_KEY = 'wss://legacy.example:443';
+  const SECOND_BROKER_KEY = 'wss://second.example:443';
+  const UNKNOWN_KEY = 'wss://never-configured.example:443';
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/api/sources', sourceRoutes),
+    });
+    await harness.db.sources.deleteSource(MULTI_SOURCE_ID).catch(() => {});
+    await harness.db.sources.createSource({
+      id: MULTI_SOURCE_ID,
+      name: 'Obs Creds Multi',
+      type: 'meshcore',
+      config: {
+        observer: {
+          enabled: true,
+          iataCode: 'TST',
+          brokerUrl: LEGACY_BROKER_KEY,
+          tokenAudience: 'legacy-aud',
+          brokers: [
+            { url: LEGACY_BROKER_KEY, authMode: 'token', tokenAudience: 'legacy-aud', label: 'Legacy' },
+            { url: SECOND_BROKER_KEY, authMode: 'password', label: 'Second' },
+          ],
+        },
+      },
+      enabled: true,
+    });
+    await grantReadWrite(harness, harness.limited.id, MULTI_SOURCE_ID);
+    // Credentials are keyed by sourceId in a table independent of `sources`,
+    // so re-creating the source above does NOT clear a prior test's row for
+    // the same id — clear it explicitly for test isolation.
+    await new MeshCoreObserverCredentialStore('test-secret', true).clear(MULTI_SOURCE_ID);
+
+    mockSourceRegistry.getManager.mockReset();
+    mockSourceRegistry.getManager.mockReturnValue(undefined);
+    mockSourceRegistry.reconfigureObserver.mockReset();
+    mockSourceRegistry.reconfigureObserver.mockResolvedValue(true);
+    setMeshCoreObserverCredentialStoreForTesting(new MeshCoreObserverCredentialStore('test-secret', true));
+  });
+
+  afterEach(async () => {
+    setMeshCoreObserverCredentialStoreForTesting(null);
+    await new MeshCoreObserverCredentialStore('test-secret', true).clear(MULTI_SOURCE_ID);
+    await harness.db.sources.deleteSource(MULTI_SOURCE_ID).catch(() => {});
+    await harness.cleanup();
+  });
+
+  function multiAgent() {
+    return harness.loginAs(harness.limited);
+  }
+
+  it('PUT with no brokerKey behaves exactly as today (legacy path) even when brokers[] is configured', async () => {
+    const agent = await multiAgent();
+    const res = await agent
+      .put(`/api/sources/${MULTI_SOURCE_ID}/observer/credentials`)
+      .send({ username: 'meshcore', password: PASSWORD });
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({ stored: true, username: 'meshcore' });
+    expect(mockSourceRegistry.reconfigureObserver).toHaveBeenCalled();
+
+    const loaded = await new MeshCoreObserverCredentialStore('test-secret', true).load(MULTI_SOURCE_ID);
+    expect(loaded).toEqual({ kind: 'ok', username: 'meshcore', password: PASSWORD });
+  });
+
+  it('PUT with a brokerKey matching a configured broker stores per-broker; GET lists it under brokers[]', async () => {
+    const agent = await multiAgent();
+    const putRes = await agent
+      .put(`/api/sources/${MULTI_SOURCE_ID}/observer/credentials`)
+      .send({ username: 'second-user', password: PASSWORD, brokerKey: SECOND_BROKER_KEY });
+    expect(putRes.status).toBe(200);
+    expect(putRes.body.data.brokers).toEqual([{ brokerKey: SECOND_BROKER_KEY, username: 'second-user' }]);
+    // `stored`/`username` reflect "a row exists at all" (computeClearUsername
+    // falls back to the lexicographically-first broker when there is no
+    // legacy entry) — NOT the legacy single-credential slot specifically.
+    expect(putRes.body.data.stored).toBe(true);
+    expect(putRes.body.data.username).toBe('second-user');
+
+    const getRes = await agent.get(`/api/sources/${MULTI_SOURCE_ID}/observer/credentials`);
+    expect(getRes.body.data.brokers).toEqual([{ brokerKey: SECOND_BROKER_KEY, username: 'second-user' }]);
+    // Never a password anywhere in the response.
+    expect(JSON.stringify(getRes.body)).not.toContain(PASSWORD);
+
+    const loaded = await new MeshCoreObserverCredentialStore('test-secret', true).loadForBroker(
+      MULTI_SOURCE_ID,
+      SECOND_BROKER_KEY,
+    );
+    expect(loaded).toEqual({ kind: 'ok', username: 'second-user', password: PASSWORD });
+  });
+
+  it('PUT with an unconfigured brokerKey -> 400 UNKNOWN_BROKER', async () => {
+    const agent = await multiAgent();
+    const res = await agent
+      .put(`/api/sources/${MULTI_SOURCE_ID}/observer/credentials`)
+      .send({ username: 'x', password: PASSWORD, brokerKey: UNKNOWN_KEY });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('UNKNOWN_BROKER');
+  });
+
+  it('PUT rejects a non-string / over-long brokerKey before checking it is configured', async () => {
+    const agent = await multiAgent();
+    const nonString = await agent
+      .put(`/api/sources/${MULTI_SOURCE_ID}/observer/credentials`)
+      .send({ username: 'x', password: PASSWORD, brokerKey: 12345 });
+    expect(nonString.status).toBe(400);
+    expect(nonString.body.code).toBe('INVALID_PARAMETER_TYPE');
+
+    const tooLong = await agent
+      .put(`/api/sources/${MULTI_SOURCE_ID}/observer/credentials`)
+      .send({ username: 'x', password: PASSWORD, brokerKey: 'k'.repeat(256) });
+    expect(tooLong.status).toBe(400);
+    expect(tooLong.body.code).toBe('INVALID_PARAMETER');
+  });
+
+  it('DELETE ?brokerKey= removes one entry, leaving the others and the legacy entry', async () => {
+    const agent = await multiAgent();
+    await agent
+      .put(`/api/sources/${MULTI_SOURCE_ID}/observer/credentials`)
+      .send({ username: 'legacy-user', password: PASSWORD });
+    await agent
+      .put(`/api/sources/${MULTI_SOURCE_ID}/observer/credentials`)
+      .send({ username: 'legacy-broker-user', password: PASSWORD, brokerKey: LEGACY_BROKER_KEY });
+    await agent
+      .put(`/api/sources/${MULTI_SOURCE_ID}/observer/credentials`)
+      .send({ username: 'second-user', password: PASSWORD, brokerKey: SECOND_BROKER_KEY });
+
+    const delRes = await agent.delete(
+      `/api/sources/${MULTI_SOURCE_ID}/observer/credentials?brokerKey=${encodeURIComponent(SECOND_BROKER_KEY)}`,
+    );
+    expect(delRes.status).toBe(200);
+    expect(delRes.body.data.brokers).toEqual([{ brokerKey: LEGACY_BROKER_KEY, username: 'legacy-broker-user' }]);
+    // The legacy credential (store()) survives a per-broker delete.
+    expect(delRes.body.data.stored).toBe(true);
+    expect(delRes.body.data.username).toBe('legacy-user');
+
+    const store = new MeshCoreObserverCredentialStore('test-secret', true);
+    expect(await store.loadForBroker(MULTI_SOURCE_ID, SECOND_BROKER_KEY)).toEqual({ kind: 'none' });
+    expect(await store.load(MULTI_SOURCE_ID)).toEqual({ kind: 'ok', username: 'legacy-user', password: PASSWORD });
+  });
+
+  it('DELETE with no param still wipes everything (legacy + all brokers)', async () => {
+    const agent = await multiAgent();
+    await agent
+      .put(`/api/sources/${MULTI_SOURCE_ID}/observer/credentials`)
+      .send({ username: 'legacy-user', password: PASSWORD });
+    await agent
+      .put(`/api/sources/${MULTI_SOURCE_ID}/observer/credentials`)
+      .send({ username: 'second-user', password: PASSWORD, brokerKey: SECOND_BROKER_KEY });
+
+    const delRes = await agent.delete(`/api/sources/${MULTI_SOURCE_ID}/observer/credentials`);
+    expect(delRes.status).toBe(200);
+    expect(delRes.body.data.stored).toBe(false);
+    expect(delRes.body.data.brokers).toEqual([]);
+  });
+
+  it('DELETE with an unconfigured brokerKey -> 400 UNKNOWN_BROKER', async () => {
+    const agent = await multiAgent();
+    const res = await agent.delete(
+      `/api/sources/${MULTI_SOURCE_ID}/observer/credentials?brokerKey=${encodeURIComponent(UNKNOWN_KEY)}`,
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('UNKNOWN_BROKER');
+  });
+
+  it('both the PUT and DELETE per-broker paths audit with brokerKey in the detail, and hot-swap the publisher', async () => {
+    const agent = await multiAgent();
+
+    mockSourceRegistry.reconfigureObserver.mockClear();
+    await agent
+      .put(`/api/sources/${MULTI_SOURCE_ID}/observer/credentials`)
+      .send({ username: 'second-user', password: PASSWORD, brokerKey: SECOND_BROKER_KEY });
+    expect(mockSourceRegistry.reconfigureObserver).toHaveBeenCalled();
+
+    mockSourceRegistry.reconfigureObserver.mockClear();
+    await agent.delete(
+      `/api/sources/${MULTI_SOURCE_ID}/observer/credentials?brokerKey=${encodeURIComponent(SECOND_BROKER_KEY)}`,
+    );
+    expect(mockSourceRegistry.reconfigureObserver).toHaveBeenCalled();
+
+    const entries = await harness.db.auth.getAuditLogEntries(20, 0);
+    const setEntry = entries.find(
+      (e) => e.action === 'meshcore_observer_credentials_set' && e.details?.includes(SECOND_BROKER_KEY),
+    );
+    const clearEntry = entries.find(
+      (e) => e.action === 'meshcore_observer_credentials_clear' && e.details?.includes(SECOND_BROKER_KEY),
+    );
+    expect(setEntry).toBeDefined();
+    expect(clearEntry).toBeDefined();
+    expect(JSON.parse(setEntry!.details!)).toMatchObject({ sourceId: MULTI_SOURCE_ID, brokerKey: SECOND_BROKER_KEY });
+    expect(JSON.parse(clearEntry!.details!)).toMatchObject({
+      sourceId: MULTI_SOURCE_ID,
+      brokerKey: SECOND_BROKER_KEY,
+    });
+    // Never a secret in the audit trail.
+    for (const e of entries) {
+      expect(e.details ?? '').not.toContain(PASSWORD);
+    }
+  });
+});

--- a/src/server/routes/sourceObserverRoutes.status.test.ts
+++ b/src/server/routes/sourceObserverRoutes.status.test.ts
@@ -1,0 +1,239 @@
+/**
+ * GET /api/sources/:id/observer/status route tests (#5014 Phase 1 WP4,
+ * spec §5.2, §6.8, tests 44-49).
+ *
+ * Harness-based (createRouteTestApp): mounts the real `sourceRoutes` router
+ * so permission middleware runs for real against real SQL. Only
+ * `sourceManagerRegistry` is mocked, with a fake MeshCore manager exposing
+ * `getObserverStatus()` — the exact duck-type the route depends on (it never
+ * imports the publisher, so WP3 and WP4 can land independently).
+ * `databaseService` itself is never mocked.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import sourceRoutes from './sourceRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+const mockSourceRegistry = vi.hoisted(() => ({
+  getManager: vi.fn(),
+}));
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: mockSourceRegistry,
+}));
+
+const RUNNING_SOURCE_ID = 'obs-status-running';
+const NOT_RUNNING_SOURCE_ID = 'obs-status-not-running'; // no manager registered
+const DISABLED_SOURCE_ID = 'obs-status-disabled'; // observer disabled in config
+const NO_GRANT_SOURCE_ID = 'obs-status-no-grant';
+const ALL_SOURCE_IDS = [RUNNING_SOURCE_ID, NOT_RUNNING_SOURCE_ID, DISABLED_SOURCE_ID, NO_GRANT_SOURCE_ID];
+
+const FULL_STATUS = {
+  configured: true,
+  authMode: 'token' as const,
+  keyStored: true,
+  connected: true,
+  publishes: 412,
+  dropped: 3,
+  lastPublishAt: 1756800000000,
+  lastError: null,
+  tokenExpiresAt: 1756880000,
+  brokers: [
+    {
+      key: 'wss://mqtt.meshmapper.net:443',
+      url: 'wss://mqtt.meshmapper.net:443',
+      label: 'MeshMapper',
+      authMode: 'token' as const,
+      tokenAudience: 'mqtt.meshmapper.net',
+      configured: true,
+      keyStored: true,
+      connected: true,
+      publishes: 412,
+      dropped: 3,
+      lastPublishAt: 1756800000000,
+      lastError: null,
+      tokenExpiresAt: 1756880000,
+    },
+  ],
+};
+
+const MULTI_BROKER_CONFIG = {
+  observer: {
+    enabled: true,
+    iataCode: 'TST',
+    brokerUrl: 'wss://legacy.example:443',
+    tokenAudience: 'legacy-aud',
+    brokers: [
+      { url: 'wss://legacy.example:443', authMode: 'token', tokenAudience: 'legacy-aud', label: 'Legacy' },
+      { url: 'wss://second.example:443', authMode: 'password', label: 'Second' },
+    ],
+  },
+};
+
+describe('GET /api/sources/:id/observer/status (#5014 Phase 1)', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/api/sources', sourceRoutes),
+    });
+
+    for (const id of ALL_SOURCE_IDS) {
+      await harness.db.sources.deleteSource(id).catch(() => {});
+    }
+
+    await harness.db.sources.createSource({
+      id: RUNNING_SOURCE_ID,
+      name: 'Running',
+      type: 'meshcore',
+      config: MULTI_BROKER_CONFIG,
+      enabled: true,
+    });
+    await harness.db.sources.createSource({
+      id: NOT_RUNNING_SOURCE_ID,
+      name: 'Not running',
+      type: 'meshcore',
+      config: MULTI_BROKER_CONFIG,
+      enabled: true,
+    });
+    await harness.db.sources.createSource({
+      id: DISABLED_SOURCE_ID,
+      name: 'Disabled',
+      type: 'meshcore',
+      config: { observer: { enabled: false } },
+      enabled: true,
+    });
+    await harness.db.sources.createSource({
+      id: NO_GRANT_SOURCE_ID,
+      name: 'No grant',
+      type: 'meshcore',
+      config: MULTI_BROKER_CONFIG,
+      enabled: true,
+    });
+
+    await harness.grant(harness.limited.id, 'configuration', 'read', RUNNING_SOURCE_ID);
+    await harness.grant(harness.limited.id, 'configuration', 'read', NOT_RUNNING_SOURCE_ID);
+    await harness.grant(harness.limited.id, 'configuration', 'read', DISABLED_SOURCE_ID);
+    // Deliberately NO grant on NO_GRANT_SOURCE_ID — proves per-source isolation.
+
+    mockSourceRegistry.getManager.mockReset();
+    mockSourceRegistry.getManager.mockImplementation((id: string) => {
+      if (id === RUNNING_SOURCE_ID) {
+        return { sourceType: 'meshcore', getObserverStatus: vi.fn().mockReturnValue(FULL_STATUS) };
+      }
+      if (id === NOT_RUNNING_SOURCE_ID) {
+        return { sourceType: 'meshcore', getObserverStatus: vi.fn().mockReturnValue(undefined) };
+      }
+      return undefined;
+    });
+  });
+
+  afterEach(async () => {
+    for (const id of ALL_SOURCE_IDS) {
+      await harness.db.sources.deleteSource(id).catch(() => {});
+    }
+    await harness.cleanup();
+  });
+
+  it('[44] 200 with the full aggregate + brokers[] for a configuration:read grant, wrapped in the envelope', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get(`/api/sources/${RUNNING_SOURCE_ID}/observer/status`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual({ running: true, ...FULL_STATUS });
+  });
+
+  it('[45] 403 without the grant, and per-source isolation from a grant on a different source', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    // `harness.limited` IS granted on RUNNING_SOURCE_ID (beforeEach) but NOT
+    // on NO_GRANT_SOURCE_ID — the grant on the other source must not leak.
+    const res = await agent.get(`/api/sources/${NO_GRANT_SOURCE_ID}/observer/status`);
+    expect(res.status).toBe(403);
+  });
+
+  it('[46] 404 SOURCE_NOT_FOUND for an unknown id; 400 INVALID_PARAMETER for a non-meshcore source', async () => {
+    // Admin agent: requirePermission runs before the source lookup, so a
+    // limited user would get 403 on an unknown source, not 404.
+    const admin = await harness.loginAs(harness.admin);
+    const missing = await admin.get('/api/sources/does-not-exist/observer/status');
+    expect(missing.status).toBe(404);
+    expect(missing.body.code).toBe('SOURCE_NOT_FOUND');
+
+    await harness.db.sources.createSource({
+      id: 'tcp-src-status',
+      name: 'TCP',
+      type: 'meshtastic_tcp',
+      config: {},
+      enabled: true,
+    });
+    const wrongType = await admin.get('/api/sources/tcp-src-status/observer/status');
+    expect(wrongType.status).toBe(400);
+    expect(wrongType.body.code).toBe('INVALID_PARAMETER');
+    await harness.db.sources.deleteSource('tcp-src-status').catch(() => {});
+  });
+
+  it('[47] no registered manager -> 200 running:false, zeroed counters, brokers[] synthesized from config', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get(`/api/sources/${NOT_RUNNING_SOURCE_ID}/observer/status`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      running: false,
+      configured: true,
+      authMode: 'token',
+      keyStored: false,
+      connected: false,
+      publishes: 0,
+      dropped: 0,
+      lastPublishAt: null,
+      lastError: null,
+      tokenExpiresAt: null,
+      brokers: [
+        {
+          key: 'wss://legacy.example:443',
+          url: 'wss://legacy.example:443',
+          label: 'Legacy',
+          authMode: 'token',
+          tokenAudience: 'legacy-aud',
+          configured: true,
+          keyStored: false,
+          connected: false,
+          publishes: 0,
+          dropped: 0,
+          lastPublishAt: null,
+          lastError: null,
+          tokenExpiresAt: null,
+        },
+        {
+          key: 'wss://second.example:443',
+          url: 'wss://second.example:443',
+          label: 'Second',
+          authMode: 'password',
+          tokenAudience: null,
+          configured: true,
+          keyStored: false,
+          connected: false,
+          publishes: 0,
+          dropped: 0,
+          lastPublishAt: null,
+          lastError: null,
+          tokenExpiresAt: null,
+        },
+      ],
+    });
+  });
+
+  it('[48] observer disabled in config -> 200 running:false, configured:false, brokers: []', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get(`/api/sources/${DISABLED_SOURCE_ID}/observer/status`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({ running: false, configured: false, brokers: [] });
+  });
+
+  it('[49] the response never contains a password, private key or token-shaped string', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get(`/api/sources/${RUNNING_SOURCE_ID}/observer/status`);
+    const body = JSON.stringify(res.body);
+    expect(body).not.toMatch(/password/i);
+    expect(body).not.toMatch(/privateKey/i);
+    // A JWT-shaped token has two dots joining base64url segments.
+    expect(body).not.toMatch(/[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/);
+  });
+});

--- a/src/server/routes/sourceObserverRoutes.ts
+++ b/src/server/routes/sourceObserverRoutes.ts
@@ -41,6 +41,8 @@ import {
   OBSERVER_USERNAME_MAX_LENGTH,
 } from '../services/meshcoreObserverCredentialStore.js';
 import { deriveObserverPublicKey, isValidObserverPrivateKey } from '../services/meshcoreObserverToken.js';
+import { observerConfigFromSource, type MeshCoreSourceConfig, type NormalizedObserverConfig } from '../meshcoreConfig.js';
+import type { MeshCoreObserverStatus, MeshCoreObserverBrokerStatus } from '../services/meshcoreObserverStatus.js';
 import type { Source } from '../../db/repositories/sources.js';
 
 const router = Router({ mergeParams: true });
@@ -91,6 +93,123 @@ async function resolveMeshCoreSource(req: Request, res: Response): Promise<Sourc
   }
   return source;
 }
+
+/**
+ * Re-derive the normalized, multi-broker-aware observer config from a
+ * source's saved `config` blob (#5014 Phase 1). `observerConfigFromSource`'s
+ * declared return type (`MeshCoreConfig['observer']`) is not yet retyped to
+ * `NormalizedObserverConfig` here (that retyping is WP3, in
+ * `meshcoreManager.ts`, and runs in parallel) — but the object it actually
+ * constructs, when the observer is enabled and has at least one usable
+ * broker, always has the richer shape (see `normalizeObserverBrokers`). This
+ * cast is the one place that gap is bridged for the route layer; it never
+ * imports the publisher.
+ */
+function resolveNormalizedObserverConfig(source: Source): NormalizedObserverConfig | undefined {
+  return observerConfigFromSource(source.config as MeshCoreSourceConfig) as NormalizedObserverConfig | undefined;
+}
+
+/**
+ * Validate the optional `brokerKey` accepted by the credential PUT/DELETE
+ * routes (#5014 Phase 1, spec §5.3). Absent -> `{}` (legacy single-credential
+ * path, byte-compatible with pre-#5014 behaviour). Present -> type/length
+ * checked, then bounded against the source's currently CONFIGURED brokers —
+ * this is what stops an operator (or a stale client) from accumulating
+ * credentials for a broker that was removed from the config, or that was
+ * never configured at all.
+ */
+function validateBrokerKeyParam(
+  raw: unknown,
+  observer: NormalizedObserverConfig | undefined,
+): { brokerKey?: string; error?: { status: number; code: string; message: string } } {
+  if (raw === undefined) return {};
+  if (typeof raw !== 'string') {
+    return { error: { status: 400, code: 'INVALID_PARAMETER_TYPE', message: 'brokerKey must be a string' } };
+  }
+  if (raw.length === 0 || raw.length > 255) {
+    return {
+      error: {
+        status: 400,
+        code: 'INVALID_PARAMETER',
+        message: 'brokerKey must be a non-empty string of at most 255 characters',
+      },
+    };
+  }
+  const known = observer?.brokers.some((broker) => broker.key === raw) ?? false;
+  if (!known) {
+    return { error: { status: 400, code: 'UNKNOWN_BROKER', message: `Unknown or unconfigured broker: ${raw}` } };
+  }
+  return { brokerKey: raw };
+}
+
+/**
+ * Build the "not running" Analyzer Observer status snapshot from a source's
+ * saved config (#5014 Phase 1, spec §5.2 step 4) — used when no manager is
+ * registered for the source, or a registered manager reports no running
+ * publisher (`getObserverStatus()` returns `undefined`). Every counter is
+ * zeroed and every broker is `configured: true, keyStored: false,
+ * connected: false` so the UI gets a meaningful, config-derived answer
+ * instead of a 404.
+ */
+function synthesizeNotRunningStatus(source: Source): MeshCoreObserverStatus {
+  const observer = resolveNormalizedObserverConfig(source);
+  const brokers: MeshCoreObserverBrokerStatus[] = (observer?.brokers ?? []).map((broker) => ({
+    key: broker.key,
+    url: broker.url,
+    label: broker.label ?? null,
+    authMode: broker.authMode,
+    tokenAudience: broker.tokenAudience ?? null,
+    configured: true,
+    keyStored: false,
+    connected: false,
+    publishes: 0,
+    dropped: 0,
+    lastPublishAt: null,
+    lastError: null,
+    tokenExpiresAt: null,
+  }));
+  return {
+    configured: !!observer,
+    authMode: observer?.authMode ?? 'token',
+    keyStored: false,
+    connected: false,
+    publishes: 0,
+    dropped: 0,
+    lastPublishAt: null,
+    lastError: null,
+    tokenExpiresAt: null,
+    brokers,
+  };
+}
+
+// GET /api/sources/:id/observer/status — running publisher status (from the
+// registered manager) or a config-derived "not running" snapshot (#5014
+// Phase 1, spec §5.2). Depends only on the manager's `getObserverStatus()`
+// duck-type and the types-only `meshcoreObserverStatus.js` module — never
+// imports the publisher, so this route can be built in parallel with WP3.
+router.get(
+  '/status',
+  requirePermission('configuration', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const source = await resolveMeshCoreSource(req, res);
+      if (!source) return;
+
+      const mgr = sourceManagerRegistry.getManager(source.id);
+      const status = mgr && isMeshCoreManager(mgr) ? mgr.getObserverStatus() : undefined;
+
+      if (status) {
+        ok(res, { running: true, ...status });
+        return;
+      }
+
+      ok(res, { running: false, ...synthesizeNotRunningStatus(source) });
+    } catch (error) {
+      logger.error(`[API] Observer status error for ${req.params.id}:`, error);
+      fail(res, 500, 'INTERNAL_ERROR', 'Failed to get Analyzer Observer status');
+    }
+  },
+);
 
 // GET /api/sources/:id/observer/key — status only, never the key.
 router.get(
@@ -264,8 +383,14 @@ router.get(
     try {
       const source = await resolveMeshCoreSource(req, res);
       if (!source) return;
-      const status = await getMeshCoreObserverCredentialStore().status(source.id);
-      ok(res, status);
+      const store = getMeshCoreObserverCredentialStore();
+      const [status, brokers] = await Promise.all([store.status(source.id), store.listBrokers(source.id)]);
+      // `brokers` is always present here (even `[]`), sourced from
+      // `listBrokers()` directly — unlike `status()`'s own conditional
+      // `brokers` field (kept omitted-when-empty there for its pre-#5014
+      // `Object.keys` back-compat contract), the route response always
+      // carries the array so the UI never has to special-case its absence.
+      ok(res, { ...status, brokers });
     } catch (error) {
       logger.error(`[API] Observer credential status error for ${req.params.id}:`, error);
       fail(res, 500, 'INTERNAL_ERROR', 'Failed to get Analyzer Observer credential status');
@@ -292,6 +417,15 @@ router.put(
         );
         return;
       }
+
+      // Optional per-broker targeting (#5014 Phase 1). Absent -> the
+      // pre-#5014 legacy single-credential path below, byte-compatible.
+      const brokerKeyResult = validateBrokerKeyParam(req.body?.brokerKey, resolveNormalizedObserverConfig(source));
+      if (brokerKeyResult.error) {
+        fail(res, brokerKeyResult.error.status, brokerKeyResult.error.code, brokerKeyResult.error.message);
+        return;
+      }
+      const brokerKey = brokerKeyResult.brokerKey;
 
       const rawUsername = req.body?.username;
       const rawPassword = req.body?.password;
@@ -322,12 +456,20 @@ router.put(
         return;
       }
 
-      await store.store(source.id, username, rawPassword);
-      // Audit records THAT credentials changed, never the values.
-      auditMeshcoreEvent(req, 'meshcore_observer_credentials_set', 'configuration', { sourceId: source.id });
+      if (brokerKey) {
+        await store.storeForBroker(source.id, brokerKey, username, rawPassword);
+      } else {
+        await store.store(source.id, username, rawPassword);
+      }
+      // Audit records THAT credentials changed, never the values. `brokerKey`
+      // is a URL identity, not a secret, so it is safe to include verbatim.
+      auditMeshcoreEvent(req, 'meshcore_observer_credentials_set', 'configuration', {
+        sourceId: source.id,
+        ...(brokerKey ? { brokerKey } : {}),
+      });
       await refreshObserverPublisher(source);
-      const status = await store.status(source.id);
-      ok(res, status);
+      const [status, brokers] = await Promise.all([store.status(source.id), store.listBrokers(source.id)]);
+      ok(res, { ...status, brokers });
     } catch (error) {
       logger.error(`[API] Observer credential set error for ${req.params.id}:`, error);
       fail(res, 500, 'INTERNAL_ERROR', 'Failed to set Analyzer Observer broker credentials');
@@ -346,12 +488,31 @@ router.delete(
       const source = await resolveMeshCoreSource(req, res);
       if (!source) return;
 
+      // Optional per-broker targeting (#5014 Phase 1). Absent -> the
+      // pre-#5014 "wipe everything" path below, byte-compatible. Deliberately
+      // NOT gated on `capability.canStore`, for the same reason as the
+      // single-credential path: forgetting an unrecoverable secret must
+      // always be possible.
+      const brokerKeyResult = validateBrokerKeyParam(req.query.brokerKey, resolveNormalizedObserverConfig(source));
+      if (brokerKeyResult.error) {
+        fail(res, brokerKeyResult.error.status, brokerKeyResult.error.code, brokerKeyResult.error.message);
+        return;
+      }
+      const brokerKey = brokerKeyResult.brokerKey;
+
       const store = getMeshCoreObserverCredentialStore();
-      await store.clear(source.id);
-      auditMeshcoreEvent(req, 'meshcore_observer_credentials_clear', 'configuration', { sourceId: source.id });
+      if (brokerKey) {
+        await store.clearForBroker(source.id, brokerKey);
+      } else {
+        await store.clear(source.id);
+      }
+      auditMeshcoreEvent(req, 'meshcore_observer_credentials_clear', 'configuration', {
+        sourceId: source.id,
+        ...(brokerKey ? { brokerKey } : {}),
+      });
       await refreshObserverPublisher(source);
-      const status = await store.status(source.id);
-      ok(res, status);
+      const [status, brokers] = await Promise.all([store.status(source.id), store.listBrokers(source.id)]);
+      ok(res, { ...status, brokers });
     } catch (error) {
       logger.error(`[API] Observer credential clear error for ${req.params.id}:`, error);
       fail(res, 500, 'INTERNAL_ERROR', 'Failed to clear Analyzer Observer broker credentials');

--- a/src/server/routes/sourceRoutes.observerStatus.test.ts
+++ b/src/server/routes/sourceRoutes.observerStatus.test.ts
@@ -27,6 +27,7 @@ vi.mock('../sourceManagerRegistry.js', () => ({
 
 const SOURCE_ID = 'obs-status-source';
 const NO_OBSERVER_SOURCE_ID = 'obs-status-source-none';
+const BROKERS_SOURCE_ID = 'obs-status-source-brokers';
 
 const FULL_OBSERVER_STATUS = {
   configured: true,
@@ -37,6 +38,31 @@ const FULL_OBSERVER_STATUS = {
   lastPublishAt: 1700000000000,
   lastError: 'Broker rejected the observer auth token (mqtt://internal-broker.example:8883)',
   tokenExpiresAt: 1700086400,
+};
+
+// #5014 Phase 1: a status shaped with `brokers[]`, whose `url` is the exact
+// leak this strip must prevent (spec §5.4 — the implementer must verify the
+// `!canReadNodes` branch drops the WHOLE `observer` object, brokers included,
+// and pin it with an assertion if one is missing).
+const MULTI_BROKER_OBSERVER_STATUS = {
+  ...FULL_OBSERVER_STATUS,
+  brokers: [
+    {
+      key: 'wss://mqtt.meshmapper.net:443',
+      url: 'wss://mqtt.meshmapper.net:443',
+      label: 'MeshMapper',
+      authMode: 'token',
+      tokenAudience: 'mqtt.meshmapper.net',
+      configured: true,
+      keyStored: true,
+      connected: true,
+      publishes: 210,
+      dropped: 0,
+      lastPublishAt: 1756800000000,
+      lastError: null,
+      tokenExpiresAt: 1756880000,
+    },
+  ],
 };
 
 function fakeMeshCoreManager(observer: typeof FULL_OBSERVER_STATUS | undefined) {
@@ -80,10 +106,20 @@ describe('GET /:id/status — Analyzer Observer visibility (#4457 Phase 2)', () 
       enabled: true,
     });
 
+    await harness.db.sources.deleteSource(BROKERS_SOURCE_ID).catch(() => {});
+    await harness.db.sources.createSource({
+      id: BROKERS_SOURCE_ID,
+      name: 'Brokers Source',
+      type: 'meshcore',
+      config: { transport: 'usb', port: '/dev/ttyACM2', deviceType: 'companion' },
+      enabled: true,
+    });
+
     mockSourceRegistry.getManager.mockReset();
     mockSourceRegistry.getManager.mockImplementation((id: string) => {
       if (id === SOURCE_ID) return fakeMeshCoreManager(FULL_OBSERVER_STATUS);
       if (id === NO_OBSERVER_SOURCE_ID) return fakeMeshCoreManager(undefined);
+      if (id === BROKERS_SOURCE_ID) return fakeMeshCoreManager(MULTI_BROKER_OBSERVER_STATUS);
       return undefined;
     });
   });
@@ -91,6 +127,7 @@ describe('GET /:id/status — Analyzer Observer visibility (#4457 Phase 2)', () 
   afterEach(async () => {
     await harness.db.sources.deleteSource(SOURCE_ID).catch(() => {});
     await harness.db.sources.deleteSource(NO_OBSERVER_SOURCE_ID).catch(() => {});
+    await harness.db.sources.deleteSource(BROKERS_SOURCE_ID).catch(() => {});
     await harness.cleanup();
   });
 
@@ -131,6 +168,27 @@ describe('GET /:id/status — Analyzer Observer visibility (#4457 Phase 2)', () 
     const res = await agent.get(`/${SOURCE_ID}/status`);
     expect(res.status).toBe(200);
     expect(JSON.stringify(res.body)).not.toContain('internal-broker.example');
+  });
+
+  // #5014 Phase 1, spec §5.4: the implementer must verify the `!canReadNodes`
+  // strip drops the WHOLE `observer` object — brokers[] included — because
+  // `brokers[].url` exposes the broker hostname outright, the very leak this
+  // strip exists to prevent. If the strip were ever narrowed to `lastError`
+  // alone, this test pins the regression.
+  it('strips the entire observer object, including brokers[].url, for a non-privileged caller', async () => {
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get(`/${BROKERS_SOURCE_ID}/status`);
+    expect(res.status).toBe(200);
+    expect(res.body).not.toHaveProperty('observer');
+    expect(JSON.stringify(res.body)).not.toContain('mqtt.meshmapper.net');
+  });
+
+  it('includes the full observer shape with brokers[] for a user granted nodes:read', async () => {
+    await harness.grant(harness.limited.id, 'nodes', 'read', BROKERS_SOURCE_ID);
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.get(`/${BROKERS_SOURCE_ID}/status`);
+    expect(res.status).toBe(200);
+    expect(res.body.observer).toEqual(MULTI_BROKER_OBSERVER_STATUS);
   });
 
   describe('a source with no observer configured', () => {

--- a/src/server/routes/sourceRoutes.observerStrip.test.ts
+++ b/src/server/routes/sourceRoutes.observerStrip.test.ts
@@ -123,3 +123,74 @@ describe('sourceRoutes — stripSourceSecrets omits observer key material (#4457
     });
   });
 });
+
+// Test 15 (#5014 Phase 1 WP1): the same strip must also reach into
+// observer.brokers[] entries, not just the block itself.
+describe('sourceRoutes — stripSourceSecrets omits observer.brokers[] key material (#5014)', () => {
+  let harness: RouteTestHarness;
+
+  const BROKERS_SOURCE_ID = 'obs-strip-brokers-source';
+  // Distinct "leaked" password so we can assert it never survives, for a
+  // second broker entry (index 1) specifically — the pattern the spec test
+  // calls out.
+  const LEAKED_BROKER_PASSWORD = 'super-secret-broker-password';
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/', sourceRoutes),
+    });
+
+    await harness.db.sources.deleteSource(BROKERS_SOURCE_ID).catch(() => {});
+    await harness.db.sources.createSource({
+      id: BROKERS_SOURCE_ID,
+      name: 'Observer Brokers Strip Source',
+      type: 'meshcore',
+      config: {
+        transport: 'usb',
+        port: '/dev/ttyACM0',
+        deviceType: 'companion',
+        observer: {
+          enabled: true,
+          iataCode: 'MCO',
+          brokers: [
+            { url: 'wss://mqtt.meshmapper.net:443', tokenAudience: 'mqtt.meshmapper.net' },
+            { url: 'wss://mqtt-us-v1.letsmesh.net:443', password: LEAKED_BROKER_PASSWORD },
+          ],
+        },
+      },
+      enabled: true,
+    });
+
+    await harness.grant(harness.limited.id, 'sources', 'read');
+  });
+
+  afterEach(async () => {
+    await harness.db.sources.deleteSource(BROKERS_SOURCE_ID).catch(() => {});
+    await harness.cleanup();
+  });
+
+  it('strips observer.brokers[1].password for admins and non-admins alike, keeping the non-secret broker fields', async () => {
+    for (const user of ['admin', 'limited'] as const) {
+      const agent = await harness.loginAs(harness[user]);
+      const res = await agent.get(`/${BROKERS_SOURCE_ID}`);
+      expect(res.status).toBe(200);
+      const brokers = res.body.config.observer.brokers;
+      expect(brokers).toHaveLength(2);
+      expect(brokers[1].password).toBeUndefined();
+      expect(JSON.stringify(res.body)).not.toContain(LEAKED_BROKER_PASSWORD);
+      // Non-secret fields still round-trip.
+      expect(brokers[0].url).toBe('wss://mqtt.meshmapper.net:443');
+      expect(brokers[1].url).toBe('wss://mqtt-us-v1.letsmesh.net:443');
+    }
+  });
+
+  it('strips observer.brokers[1].password from the sources list too', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get('/');
+    expect(res.status).toBe(200);
+    const row = res.body.find((s: any) => s.id === BROKERS_SOURCE_ID);
+    expect(row).toBeDefined();
+    expect(row.config.observer.brokers[1].password).toBeUndefined();
+    expect(JSON.stringify(row)).not.toContain(LEAKED_BROKER_PASSWORD);
+  });
+});

--- a/src/server/routes/sourceRoutes.observerValidation.test.ts
+++ b/src/server/routes/sourceRoutes.observerValidation.test.ts
@@ -466,4 +466,173 @@ describe('validateObserverConfig', () => {
       validateObserverConfig('meshcore', { deviceType: 'companion', observer: VALID_OBSERVER }),
     ).toBeNull();
   });
+
+  // ── Multi-broker (#5014 Phase 1) ───────────────────────────────────────────
+  describe('brokers[] (#5014 Phase 1)', () => {
+    const TWO_BROKERS = {
+      enabled: true,
+      iataCode: 'MCO',
+      brokers: [
+        { url: 'wss://mqtt.meshmapper.net:443', tokenAudience: 'mqtt.meshmapper.net', label: 'MeshMapper' },
+        { url: 'wss://mqtt-us-v1.letsmesh.net:443', tokenAudience: 'mqtt-us-v1.letsmesh.net', label: 'LetsMesh US' },
+      ],
+    };
+
+    // ── Test 10 ───────────────────────────────────────────────────────────
+    it('accepts a valid two-broker config', () => {
+      expect(validateObserverConfig('meshcore', { observer: TWO_BROKERS })).toBeNull();
+    });
+
+    // ── Test 11 ───────────────────────────────────────────────────────────
+    it('rejects a non-array brokers value', () => {
+      const err = validateObserverConfig('meshcore', {
+        observer: { ...TWO_BROKERS, brokers: 'nope' },
+      });
+      expect(err).toEqual({ status: 400, error: 'observer.brokers must be an array', code: 'INVALID_PARAMETER_TYPE' });
+    });
+
+    it('rejects 9 brokers with TOO_MANY_BROKERS', () => {
+      const nine = Array.from({ length: 9 }, () => ({}));
+      const err = validateObserverConfig('meshcore', {
+        observer: { enabled: true, iataCode: 'MCO', brokers: nine },
+      });
+      expect(err?.code).toBe('TOO_MANY_BROKERS');
+    });
+
+    it('rejects a non-object entry', () => {
+      const err = validateObserverConfig('meshcore', {
+        observer: { ...TWO_BROKERS, brokers: [TWO_BROKERS.brokers[0], 'nope'] },
+      });
+      expect(err?.code).toBe('INVALID_PARAMETER_TYPE');
+    });
+
+    it('rejects an http:// entry URL with INVALID_BROKER_URL, proving the scheme pre-check survived the extraction', () => {
+      const err = validateObserverConfig('meshcore', {
+        observer: {
+          enabled: true,
+          iataCode: 'MCO',
+          brokers: [{ url: 'http://broker.example', tokenAudience: 'aud' }],
+        },
+      });
+      expect(err).toEqual({
+        status: 400,
+        error: 'observer.brokers[0].url must be a ws/wss/mqtt/mqtts URL',
+        code: 'INVALID_BROKER_URL',
+      });
+    });
+
+    it('rejects a token-mode entry with no audience', () => {
+      const err = validateObserverConfig('meshcore', {
+        observer: { enabled: true, iataCode: 'MCO', brokers: [{ url: 'mqtt://broker.test:1883' }] },
+      });
+      expect(err?.code).toBe('INVALID_PARAMETER');
+    });
+
+    it('rejects a label over 64 chars', () => {
+      const err = validateObserverConfig('meshcore', {
+        observer: {
+          enabled: true,
+          iataCode: 'MCO',
+          brokers: [{ url: 'mqtt://broker.test:1883', tokenAudience: 'aud', label: 'x'.repeat(65) }],
+        },
+      });
+      expect(err?.code).toBe('INVALID_PARAMETER');
+    });
+
+    it('rejects two entries with the same normalized URL', () => {
+      const err = validateObserverConfig('meshcore', {
+        observer: {
+          enabled: true,
+          iataCode: 'MCO',
+          brokers: [
+            { url: 'broker.test:1883', tokenAudience: 'a' },
+            { url: 'mqtt://broker.test:1883', tokenAudience: 'b' },
+          ],
+        },
+      });
+      expect(err?.code).toBe('DUPLICATE_BROKER_URL');
+    });
+
+    it('rejects an entry carrying a password, and fires even when enabled is false', () => {
+      const err = validateObserverConfig('meshcore', {
+        observer: {
+          enabled: false,
+          iataCode: 'MCO',
+          brokers: [{ url: 'mqtt://broker.test:1883', password: 'meshcore' }],
+        },
+      });
+      expect(err?.code).toBe('OBSERVER_KEY_IN_CONFIG');
+    });
+
+    // ── Test 12 ───────────────────────────────────────────────────────────
+    it('accepts enabled:true with brokers[] and no brokerUrl (the MISSING_BROKER relaxation)', () => {
+      expect(validateObserverConfig('meshcore', { observer: TWO_BROKERS })).toBeNull();
+    });
+
+    it('rejects enabled:true with neither a usable brokerUrl nor a non-empty brokers[] (MISSING_BROKER)', () => {
+      const err = validateObserverConfig('meshcore', {
+        observer: { enabled: true, iataCode: 'MCO', brokers: [] },
+      });
+      expect(err).toEqual({
+        status: 400,
+        error: 'observer requires either brokerUrl or a non-empty brokers array',
+        code: 'MISSING_BROKER',
+      });
+    });
+
+    // ── Test 13: every pre-existing assertion in this file still passes ────
+    // (asserted implicitly — this whole file is that regression suite; see
+    // the rows above this describe block, all unmodified.)
+
+    // ── Test 14: observer block size cap ────────────────────────────────────
+    describe('observer block size cap (MAX_OBSERVER_CONFIG_BYTES)', () => {
+      it('rejects an observer block over the byte cap, including when disabled', () => {
+        const err = validateObserverConfig('meshcore', {
+          observer: { enabled: false, padding: 'x'.repeat(2000) },
+        });
+        expect(err?.code).toBe('OBSERVER_CONFIG_TOO_LARGE');
+      });
+
+      it('rejects an observer block over the byte cap when enabled', () => {
+        const err = validateObserverConfig('meshcore', {
+          observer: { ...TWO_BROKERS, padding: 'x'.repeat(2000) },
+        });
+        expect(err?.code).toBe('OBSERVER_CONFIG_TOO_LARGE');
+      });
+
+      it('accepts an observer block at exactly the byte limit', () => {
+        const base = { enabled: false } as Record<string, unknown>;
+        const baseBytes = Buffer.byteLength(JSON.stringify(base), 'utf8');
+        // Account for the extra `"padding":"..."`, key/quote/comma overhead.
+        const overhead = Buffer.byteLength(JSON.stringify({ ...base, padding: '' }), 'utf8') - baseBytes;
+        const paddingLen = 1536 - baseBytes - overhead;
+        const withPadding = { ...base, padding: 'x'.repeat(paddingLen) };
+        expect(Buffer.byteLength(JSON.stringify(withPadding), 'utf8')).toBe(1536);
+        expect(validateObserverConfig('meshcore', { observer: withPadding })).toBeNull();
+      });
+
+      it('accepts a valid 8-broker observer block, which fits comfortably under the cap', () => {
+        const eight = Array.from({ length: 8 }, (_, i) => ({
+          url: `mqtt://b${i}.example:1883`,
+          tokenAudience: `aud${i}`,
+          label: `B${i}`,
+        }));
+        const observer = { enabled: true, iataCode: 'MCO', brokers: eight };
+        expect(Buffer.byteLength(JSON.stringify(observer), 'utf8')).toBeLessThanOrEqual(1536);
+        expect(validateObserverConfig('meshcore', { observer })).toBeNull();
+      });
+
+      it('pins the decision NOT to guard the whole config: a non-observer config well over 4096 bytes is accepted', () => {
+        const fatMqttBridgeConfig = {
+          upstream: { url: 'mqtt://broker.test:1883' },
+          topicRewrites: Array.from({ length: 50 }, (_, i) => ({
+            from: `from/topic/${i}/${'x'.repeat(50)}`,
+            to: `to/topic/${i}/${'y'.repeat(50)}`,
+          })),
+        };
+        expect(Buffer.byteLength(JSON.stringify(fatMqttBridgeConfig), 'utf8')).toBeGreaterThan(4096);
+        expect(validateObserverConfig('mqtt_bridge', fatMqttBridgeConfig)).toBeNull();
+      });
+    });
+  });
 });

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -27,6 +27,7 @@ import { mqttGeoSweepService, type GeoSweepStatsSink } from '../services/mqttGeo
 import type { MqttFilterConfig } from '../mqttPacketFilter.js';
 import { ok, fail } from '../utils/apiResponse.js';
 import { normalizeBrokerUrl } from '../transports/mqttBrokerClient.js';
+import { observerBrokerKey } from '../meshcoreConfig.js';
 
 const router = Router();
 
@@ -90,6 +91,65 @@ function observerConfigContainsKeyMaterial(observer: Record<string, unknown>): b
   return OBSERVER_KEY_MATERIAL_FIELDS.some((f) => Object.prototype.hasOwnProperty.call(observer, f));
 }
 
+// Multi-broker limits (#5014 Phase 1). Chosen together — see the budget
+// arithmetic in MESHMAPPER_OBSERVER_PHASE1_SPEC.md §2.5: a fully-populated
+// 8-broker block sits comfortably under the byte cap, and neither constant
+// should be raised without re-checking the other.
+export const MAX_OBSERVER_BROKERS = 8;
+
+/**
+ * Serialized-byte ceiling for the `observer` block alone.
+ *
+ * `sources.config` is `varchar(4096)` on MySQL (TEXT on SQLite/PostgreSQL), so
+ * the blob as a whole has a hard limit on ONE backend. We deliberately do not
+ * police the whole blob (that would reject pre-existing oversized configs on
+ * the backends where they are legal — e.g. a big `mqtt_bridge` block with many
+ * subscriptions/filters/rewrites — making that source uneditable after
+ * upgrade), only the part #5014 adds. 1536 bytes is ~37% of the MySQL column,
+ * which keeps a fully-populated 8-broker observer comfortably clear of
+ * transport + virtualNode config in the same blob.
+ */
+export const MAX_OBSERVER_CONFIG_BYTES = 1536;
+
+// Broker-URL shape check, shared by the legacy `observer.brokerUrl` field and
+// every `observer.brokers[i].url` entry (#5014 Phase 1). `field` names the
+// JSON path in the error message (e.g. 'observer.brokerUrl' or
+// 'observer.brokers[2].url'). Handles the "not even a string" case too, so
+// every call site can just forward the raw value.
+function validateBrokerUrlValue(
+  value: unknown,
+  field: string,
+): { status: number; error: string; code: string } | null {
+  if (typeof value !== 'string' || value.length === 0) {
+    return { status: 400, error: `${field} must be a non-empty string`, code: 'INVALID_PARAMETER' };
+  }
+  // Reject an explicit disallowed scheme BEFORE normalization. normalizeBrokerUrl
+  // (shared with the Phase 2 MQTT client — must not be modified here) only
+  // recognizes mqtt/mqtts/ws/wss/tcp/tls as an explicit passthrough scheme; any
+  // other explicit scheme (http://, https://, ftp://, ...) falls through its
+  // "bare host" branch and gets silently prefixed with mqtt://, laundering a bad
+  // scheme into an apparently-valid URL (e.g. "http://broker.example" would
+  // otherwise normalize to a parseable "mqtt://http://broker.example" whose
+  // hostname is "http"). Catch it here on the raw input instead.
+  const schemeSepIdx = value.indexOf('://');
+  if (schemeSepIdx !== -1) {
+    const scheme = value.slice(0, schemeSepIdx).toLowerCase();
+    if (!['ws', 'wss', 'mqtt', 'mqtts'].includes(scheme)) {
+      return { status: 400, error: `${field} must be a ws/wss/mqtt/mqtts URL`, code: 'INVALID_BROKER_URL' };
+    }
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(normalizeBrokerUrl(value));
+  } catch {
+    return { status: 400, error: `${field} must be a ws/wss/mqtt/mqtts URL`, code: 'INVALID_BROKER_URL' };
+  }
+  if (!['ws:', 'wss:', 'mqtt:', 'mqtts:'].includes(parsed.protocol) || parsed.hostname.length === 0) {
+    return { status: 400, error: `${field} must be a ws/wss/mqtt/mqtts URL`, code: 'INVALID_BROKER_URL' };
+  }
+  return null;
+}
+
 // Validate the `observer` (Analyzer Observer, #4457) config block nested
 // inside a source config blob. Returns null on success/absent, or
 // { status, error, code } on failure. Synchronous — unlike
@@ -118,6 +178,45 @@ export function validateObserverConfig(
       code: 'OBSERVER_KEY_IN_CONFIG',
     };
   }
+
+  // brokers[] structural shape + per-entry key-material scan (#5014 Phase 1).
+  // Regardless of `enabled`/`type`, mirroring the block-level key-material
+  // check above — a hostile client must not be able to smuggle a password
+  // into a brokers[] entry via a disabled block or an unrelated source type
+  // either. Full per-broker semantic validation (URL shape, auth mode,
+  // audience, label, dedupe) happens later, only once `enabled === true` on a
+  // meshcore source — see the `hasBrokersList` branch below.
+  const brokersRaw = observerObj.brokers;
+  let brokersArr: Record<string, unknown>[] | undefined;
+  if (brokersRaw !== undefined) {
+    if (!Array.isArray(brokersRaw)) {
+      return { status: 400, error: 'observer.brokers must be an array', code: 'INVALID_PARAMETER_TYPE' };
+    }
+    if (brokersRaw.length > MAX_OBSERVER_BROKERS) {
+      return {
+        status: 400,
+        error: `observer.brokers must contain at most ${MAX_OBSERVER_BROKERS} entries`,
+        code: 'TOO_MANY_BROKERS',
+      };
+    }
+    for (let i = 0; i < brokersRaw.length; i++) {
+      const entry = brokersRaw[i];
+      if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+        return { status: 400, error: `observer.brokers[${i}] must be an object`, code: 'INVALID_PARAMETER_TYPE' };
+      }
+      if (observerConfigContainsKeyMaterial(entry as Record<string, unknown>)) {
+        return {
+          status: 400,
+          error:
+            'observer config must not contain key material or a broker password; use ' +
+            'PUT /api/sources/:id/observer/key or PUT /api/sources/:id/observer/credentials',
+          code: 'OBSERVER_KEY_IN_CONFIG',
+        };
+      }
+    }
+    brokersArr = brokersRaw as Record<string, unknown>[];
+  }
+
   if (type !== 'meshcore') {
     return { status: 400, error: 'observer config is only supported on meshcore sources', code: 'INVALID_PARAMETER' };
   }
@@ -131,6 +230,21 @@ export function validateObserverConfig(
     };
   }
   const authMode: 'token' | 'password' = authModeRaw === 'password' ? 'password' : 'token';
+
+  // Observer block size guard (#5014 Phase 1 §2.5), regardless of `enabled`
+  // (a disabled-but-huge block would still be persisted). Deliberately scoped
+  // to the observer block alone — see MAX_OBSERVER_CONFIG_BYTES above. There
+  // is NO whole-config guard, and no non-observer source type gains a
+  // rejection path from this check.
+  const observerBytes = Buffer.byteLength(JSON.stringify(observerObj), 'utf8');
+  if (observerBytes > MAX_OBSERVER_CONFIG_BYTES) {
+    return {
+      status: 400,
+      error: `observer config must not exceed ${MAX_OBSERVER_CONFIG_BYTES} serialized bytes`,
+      code: 'OBSERVER_CONFIG_TOO_LARGE',
+    };
+  }
+
   if (observerObj.enabled !== true) return null;
   // Companion-only in BOTH modes. In password mode the reason is no longer
   // "a repeater can't export a signing key" but the harder one: the
@@ -144,34 +258,97 @@ export function validateObserverConfig(
       code: 'OBSERVER_REQUIRES_COMPANION',
     };
   }
-  const brokerUrl = observerObj.brokerUrl;
-  if (typeof brokerUrl !== 'string' || brokerUrl.length === 0) {
-    return { status: 400, error: 'observer.brokerUrl must be a non-empty string', code: 'INVALID_PARAMETER' };
-  }
-  // Reject an explicit disallowed scheme BEFORE normalization. normalizeBrokerUrl
-  // (shared with the Phase 2 MQTT client — must not be modified here) only
-  // recognizes mqtt/mqtts/ws/wss/tcp/tls as an explicit passthrough scheme; any
-  // other explicit scheme (http://, https://, ftp://, ...) falls through its
-  // "bare host" branch and gets silently prefixed with mqtt://, laundering a bad
-  // scheme into an apparently-valid URL (e.g. "http://broker.example" would
-  // otherwise normalize to a parseable "mqtt://http://broker.example" whose
-  // hostname is "http"). Catch it here on the raw input instead.
-  const schemeSepIdx = brokerUrl.indexOf('://');
-  if (schemeSepIdx !== -1) {
-    const scheme = brokerUrl.slice(0, schemeSepIdx).toLowerCase();
-    if (!['ws', 'wss', 'mqtt', 'mqtts'].includes(scheme)) {
-      return { status: 400, error: 'observer.brokerUrl must be a ws/wss/mqtt/mqtts URL', code: 'INVALID_BROKER_URL' };
+
+  // Broker requirement + validation (#5014 Phase 1). `brokers[]`, when a
+  // non-empty array, is authoritative: it is validated in full here and the
+  // legacy `brokerUrl` — if also present — is still shape-checked (existing
+  // rule preserved) but not required. When `brokers[]` is absent entirely,
+  // this is the EXACT pre-#5014 code path (brokerUrl required), so an
+  // existing config's error codes/messages are unchanged. Only when `brokers`
+  // was explicitly given but has no usable entry, and there is no legacy
+  // brokerUrl either, is the relaxed MISSING_BROKER case reached.
+  const hasBrokersList = brokersArr !== undefined && brokersArr.length > 0;
+  const legacyBrokerUrlRaw = observerObj.brokerUrl;
+  const legacyBrokerUrlProvided = legacyBrokerUrlRaw !== undefined;
+
+  if (!hasBrokersList) {
+    if (brokersArr !== undefined && !legacyBrokerUrlProvided) {
+      return {
+        status: 400,
+        error: 'observer requires either brokerUrl or a non-empty brokers array',
+        code: 'MISSING_BROKER',
+      };
+    }
+    const urlErr = validateBrokerUrlValue(legacyBrokerUrlRaw, 'observer.brokerUrl');
+    if (urlErr) return urlErr;
+  } else {
+    if (legacyBrokerUrlProvided) {
+      const urlErr = validateBrokerUrlValue(legacyBrokerUrlRaw, 'observer.brokerUrl');
+      if (urlErr) return urlErr;
+    }
+    const seenKeys = new Set<string>();
+    for (let i = 0; i < brokersArr!.length; i++) {
+      const entry = brokersArr![i];
+      const urlErr = validateBrokerUrlValue(entry.url, `observer.brokers[${i}].url`);
+      if (urlErr) return urlErr;
+
+      const entryAuthModeRaw = entry.authMode;
+      if (entryAuthModeRaw !== undefined && entryAuthModeRaw !== 'token' && entryAuthModeRaw !== 'password') {
+        return {
+          status: 400,
+          error: `observer.brokers[${i}].authMode must be 'token' or 'password'`,
+          code: 'INVALID_OBSERVER_AUTH_MODE',
+        };
+      }
+      // Defaults to the block-level authMode, matching normalizeObserverBrokers.
+      const entryAuthMode: 'token' | 'password' =
+        entryAuthModeRaw === 'password' ? 'password' : entryAuthModeRaw === 'token' ? 'token' : authMode;
+
+      if (entryAuthMode === 'token') {
+        const aud = entry.tokenAudience;
+        const isValidAud =
+          typeof aud === 'string' && aud.length > 0 && aud.length <= 255 && !/\s/.test(aud);
+        if (!isValidAud) {
+          return {
+            status: 400,
+            error: `observer.brokers[${i}].tokenAudience must be a non-empty string with no whitespace`,
+            code: 'INVALID_PARAMETER',
+          };
+        }
+      }
+
+      const label = entry.label;
+      if (label !== undefined && (typeof label !== 'string' || label.length > 64)) {
+        return {
+          status: 400,
+          error: `observer.brokers[${i}].label must be a string of at most 64 characters`,
+          code: 'INVALID_PARAMETER',
+        };
+      }
+
+      // validateBrokerUrlValue above already proved entry.url normalizes, so
+      // this cannot throw in practice; the catch is defence-in-depth only.
+      let key: string;
+      try {
+        key = observerBrokerKey(entry.url as string);
+      } catch {
+        return {
+          status: 400,
+          error: `observer.brokers[${i}].url must be a ws/wss/mqtt/mqtts URL`,
+          code: 'INVALID_BROKER_URL',
+        };
+      }
+      if (seenKeys.has(key)) {
+        return {
+          status: 400,
+          error: `observer.brokers[${i}].url duplicates another broker's normalized URL`,
+          code: 'DUPLICATE_BROKER_URL',
+        };
+      }
+      seenKeys.add(key);
     }
   }
-  let parsed: URL;
-  try {
-    parsed = new URL(normalizeBrokerUrl(brokerUrl));
-  } catch {
-    return { status: 400, error: 'observer.brokerUrl must be a ws/wss/mqtt/mqtts URL', code: 'INVALID_BROKER_URL' };
-  }
-  if (!['ws:', 'wss:', 'mqtt:', 'mqtts:'].includes(parsed.protocol) || parsed.hostname.length === 0) {
-    return { status: 400, error: 'observer.brokerUrl must be a ws/wss/mqtt/mqtts URL', code: 'INVALID_BROKER_URL' };
-  }
+
   const iataCode = observerObj.iataCode;
   const isValidIata = typeof iataCode === 'string' && (/^[A-Za-z]{3}$/.test(iataCode) || iataCode.toLowerCase() === 'test');
   if (!isValidIata) {
@@ -181,27 +358,35 @@ export function validateObserverConfig(
       code: 'INVALID_IATA_CODE',
     };
   }
-  const tokenAudience = observerObj.tokenAudience;
-  // Password mode signs nothing, so the broker has no audience to match.
-  // An empty/absent audience is fine there; a present one is still shape-
-  // checked so a later switch back to token mode can't inherit garbage.
-  if (
-    authMode === 'password' &&
-    (tokenAudience === undefined || tokenAudience === null || tokenAudience === '')
-  ) {
-    return null;
-  }
-  const isValidAudience =
-    typeof tokenAudience === 'string' &&
-    tokenAudience.length > 0 &&
-    tokenAudience.length <= 255 &&
-    !/\s/.test(tokenAudience);
-  if (!isValidAudience) {
-    return {
-      status: 400,
-      error: 'observer.tokenAudience must be a non-empty string with no whitespace',
-      code: 'INVALID_PARAMETER',
-    };
+
+  // Legacy tokenAudience requirement — meaningful only for the single/legacy
+  // broker path. When brokers[] is authoritative each entry validates its own
+  // audience above (with no block-level fallback, by design); the top-level
+  // field becomes a vestigial mirror once brokers[] wins, and must not be
+  // require-checked here (#5014).
+  if (!hasBrokersList) {
+    const tokenAudience = observerObj.tokenAudience;
+    // Password mode signs nothing, so the broker has no audience to match.
+    // An empty/absent audience is fine there; a present one is still shape-
+    // checked so a later switch back to token mode can't inherit garbage.
+    if (
+      authMode === 'password' &&
+      (tokenAudience === undefined || tokenAudience === null || tokenAudience === '')
+    ) {
+      return null;
+    }
+    const isValidAudience =
+      typeof tokenAudience === 'string' &&
+      tokenAudience.length > 0 &&
+      tokenAudience.length <= 255 &&
+      !/\s/.test(tokenAudience);
+    if (!isValidAudience) {
+      return {
+        status: 400,
+        error: 'observer.tokenAudience must be a non-empty string with no whitespace',
+        code: 'INVALID_PARAMETER',
+      };
+    }
   }
   return null;
 }
@@ -394,6 +579,15 @@ function preserveSourceCredentials(
   return merged;
 }
 
+// Shared by stripObserverKeyMaterial for both the block itself and every
+// brokers[] entry (#5014 Phase 1) — same field list as
+// observerConfigContainsKeyMaterial above.
+function stripKeyMaterialFields(obj: Record<string, unknown>): Record<string, unknown> {
+  const result = { ...obj };
+  for (const field of OBSERVER_KEY_MATERIAL_FIELDS) delete result[field];
+  return result;
+}
+
 // Analyzer Observer (#4457) defence-in-depth: the observer block itself
 // carries no secrets by design (brokerUrl/iataCode/tokenAudience are all
 // public-by-nature, and the signing key is never in `config` because
@@ -404,14 +598,18 @@ function preserveSourceCredentials(
 function stripObserverKeyMaterial<T extends Record<string, unknown>>(cfg: T): T {
   const obs = cfg?.observer;
   if (!obs || typeof obs !== 'object' || Array.isArray(obs)) return cfg;
-  const { privateKey, privateKeyHex, signingKey, key, secret, password, ...safeObserver } =
-    obs as Record<string, unknown>;
-  void privateKey;
-  void privateKeyHex;
-  void signingKey;
-  void key;
-  void secret;
-  void password; // #4595 static-credential password — same rule as key material.
+  const observerObj = obs as Record<string, unknown>;
+  const safeObserver = stripKeyMaterialFields(observerObj);
+  // #5014 Phase 1: the same key-material fields (in particular the #4595
+  // static-credential `password`) must never survive inside a brokers[]
+  // entry either.
+  if (Array.isArray(observerObj.brokers)) {
+    safeObserver.brokers = observerObj.brokers.map((entry) =>
+      entry && typeof entry === 'object' && !Array.isArray(entry)
+        ? stripKeyMaterialFields(entry as Record<string, unknown>)
+        : entry,
+    );
+  }
   return { ...cfg, observer: safeObserver } as T;
 }
 
@@ -695,6 +893,14 @@ router.post('/', requirePermission('sources', 'write'), async (req: Request, res
       createdBy: req.user?.id,
     });
 
+    // MySQL diagnostic only (#5014 Phase 1 §2.5) — never rejects, never
+    // changes the status code. `sources.config` is varchar(4096) on MySQL
+    // (unbounded TEXT on SQLite/PostgreSQL); this just names the cause when a
+    // write silently fails or truncates on that one backend.
+    if (databaseService.drizzleDbType === 'mysql' && Buffer.byteLength(JSON.stringify(config), 'utf8') > 4096) {
+      logger.warn(`Source ${source.id} config exceeds the MySQL varchar(4096) column width; the write may fail or truncate`);
+    }
+
     // Start manager if source is enabled and autoConnect is not explicitly false.
     // autoConnect=false means the source is registered but won't start monitoring
     // until a user explicitly clicks Connect (issue #2773).
@@ -840,6 +1046,18 @@ router.put('/:id', requirePermission('sources', 'write'), async (req: Request, r
     const source = await databaseService.sources.updateSource(req.params.id, updates);
     if (!source) {
       return res.status(404).json({ error: 'Source not found' });
+    }
+
+    // MySQL diagnostic only (#5014 Phase 1 §2.5) — never rejects, never
+    // changes the status code. `sources.config` is varchar(4096) on MySQL
+    // (unbounded TEXT on SQLite/PostgreSQL); this just names the cause when a
+    // write silently fails or truncates on that one backend.
+    if (
+      updates.config !== undefined &&
+      databaseService.drizzleDbType === 'mysql' &&
+      Buffer.byteLength(JSON.stringify(updates.config), 'utf8') > 4096
+    ) {
+      logger.warn(`Source ${source.id} config exceeds the MySQL varchar(4096) column width; the write may fail or truncate`);
     }
 
     // Propagate name change to the live MeshCore/Reticulum manager so

--- a/src/server/services/meshcoreObserverCredentialStore.test.ts
+++ b/src/server/services/meshcoreObserverCredentialStore.test.ts
@@ -4,11 +4,18 @@
  * status()", and key separation from the sibling observer *signing key* store
  * (a leaked SESSION_SECRET plus one table must not decrypt the other).
  *
+ * Also covers the #5014 Phase 1 multi-broker extension: the v1->v2 credential
+ * document upgrade, per-broker isolation, and the four new per-broker methods
+ * (tests 16-24 in `MESHMAPPER_OBSERVER_PHASE1_SPEC.md` §6.4).
+ *
  * The DB layer is mocked with an in-memory map keyed by sourceId, mirroring
  * `meshcore_observer_credentials`.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { MeshCoreObserverCredentialStore } from './meshcoreObserverCredentialStore.js';
+import {
+  MeshCoreObserverCredentialStore,
+  OBSERVER_MAX_BROKER_CREDENTIALS,
+} from './meshcoreObserverCredentialStore.js';
 import { MeshCoreObserverKeyStore } from './meshcoreObserverKeyStore.js';
 
 interface CredRow {
@@ -188,5 +195,170 @@ describe('MeshCoreObserverCredentialStore', () => {
       updatedAt: 1,
     });
     expect((await keys.load(SOURCE)).kind).toBe('key_rotated');
+  });
+
+  // ---------------------------------------------------------------------
+  // #5014 Phase 1 WP2: per-broker credential store (spec §6.4, tests 16-24)
+  // ---------------------------------------------------------------------
+
+  const BROKER_A = 'wss://mqtt.meshmapper.net:443';
+  const BROKER_B = 'wss://mqtt-us-v1.letsmesh.net:443';
+
+  it('[16] v1 read path unchanged: a legacy row still loads via load() and status() keeps its shape', async () => {
+    const store = new MeshCoreObserverCredentialStore(SECRET_A, true);
+    await store.store(SOURCE, 'meshcore', 'meshcore-pw');
+
+    expect(await store.load(SOURCE)).toEqual({ kind: 'ok', username: 'meshcore', password: 'meshcore-pw' });
+
+    const status = await store.status(SOURCE);
+    expect(Object.keys(status).sort()).toEqual(
+      ['canStore', 'keyRotated', 'reason', 'stored', 'updatedAt', 'username'].sort(),
+    );
+    expect(status).toMatchObject({ stored: true, username: 'meshcore', keyRotated: false });
+    expect(status).not.toHaveProperty('brokers');
+  });
+
+  it('[17] v1 -> v2 upgrade is lossless: legacy stays intact after storeForBroker() adds a broker', async () => {
+    const store = new MeshCoreObserverCredentialStore(SECRET_A, true);
+    await store.store(SOURCE, 'legacy-user', 'legacy-pw');
+    await store.storeForBroker(SOURCE, BROKER_A, 'broker-a-user', 'broker-a-pw');
+
+    expect(await store.load(SOURCE)).toEqual({ kind: 'ok', username: 'legacy-user', password: 'legacy-pw' });
+    expect(await store.loadForBroker(SOURCE, BROKER_A)).toEqual({
+      kind: 'ok',
+      username: 'broker-a-user',
+      password: 'broker-a-pw',
+    });
+  });
+
+  it('[18] per-broker isolation: A and B round-trip independently; an unconfigured broker returns none', async () => {
+    const store = new MeshCoreObserverCredentialStore(SECRET_A, true);
+    await store.storeForBroker(SOURCE, BROKER_A, 'user-a', 'pw-a');
+    await store.storeForBroker(SOURCE, BROKER_B, 'user-b', 'pw-b');
+
+    expect(await store.loadForBroker(SOURCE, BROKER_A)).toEqual({ kind: 'ok', username: 'user-a', password: 'pw-a' });
+    expect(await store.loadForBroker(SOURCE, BROKER_B)).toEqual({ kind: 'ok', username: 'user-b', password: 'pw-b' });
+
+    const loadedA = await store.loadForBroker(SOURCE, BROKER_A);
+    if (loadedA.kind === 'ok') {
+      expect(loadedA.password).not.toBe('pw-b');
+    }
+
+    expect(await store.loadForBroker(SOURCE, 'wss://never-configured/')).toEqual({ kind: 'none' });
+  });
+
+  it('[19] no legacy leak: with only a legacy credential stored, loadForBroker never falls back to it', async () => {
+    const store = new MeshCoreObserverCredentialStore(SECRET_A, true);
+    await store.store(SOURCE, 'legacy-user', 'legacy-pw');
+
+    expect(await store.loadForBroker(SOURCE, BROKER_A)).toEqual({ kind: 'none' });
+    expect(await store.loadForBroker(SOURCE, 'anything-at-all')).toEqual({ kind: 'none' });
+  });
+
+  it('[20] clearForBroker removes one entry and leaves the others; clearing the last entry with no legacy deletes the row', async () => {
+    const store = new MeshCoreObserverCredentialStore(SECRET_A, true);
+    await store.storeForBroker(SOURCE, BROKER_A, 'user-a', 'pw-a');
+    await store.storeForBroker(SOURCE, BROKER_B, 'user-b', 'pw-b');
+
+    await store.clearForBroker(SOURCE, BROKER_A);
+    expect(await store.loadForBroker(SOURCE, BROKER_A)).toEqual({ kind: 'none' });
+    expect(await store.loadForBroker(SOURCE, BROKER_B)).toEqual({ kind: 'ok', username: 'user-b', password: 'pw-b' });
+    expect(credRows.has(SOURCE)).toBe(true);
+
+    await store.clearForBroker(SOURCE, BROKER_B);
+    expect(credRows.has(SOURCE)).toBe(false);
+    expect(await store.loadForBroker(SOURCE, BROKER_B)).toEqual({ kind: 'none' });
+
+    // No-op on an already-absent broker / a row that no longer exists.
+    await expect(store.clearForBroker(SOURCE, BROKER_A)).resolves.toBeUndefined();
+  });
+
+  it('[20b] clearForBroker preserves a legacy entry when brokers become empty', async () => {
+    const store = new MeshCoreObserverCredentialStore(SECRET_A, true);
+    await store.store(SOURCE, 'legacy-user', 'legacy-pw');
+    await store.storeForBroker(SOURCE, BROKER_A, 'user-a', 'pw-a');
+
+    await store.clearForBroker(SOURCE, BROKER_A);
+
+    expect(credRows.has(SOURCE)).toBe(true);
+    expect(await store.load(SOURCE)).toEqual({ kind: 'ok', username: 'legacy-user', password: 'legacy-pw' });
+  });
+
+  it('[21] listBrokers returns {brokerKey, username} pairs and never a password field', async () => {
+    const store = new MeshCoreObserverCredentialStore(SECRET_A, true);
+    await store.storeForBroker(SOURCE, BROKER_A, 'user-a', 'pw-a');
+    await store.storeForBroker(SOURCE, BROKER_B, 'user-b', 'pw-b');
+
+    const listed = await store.listBrokers(SOURCE);
+    expect(listed).toHaveLength(2);
+    for (const entry of listed) {
+      expect(Object.keys(entry).sort()).toEqual(['brokerKey', 'username']);
+    }
+    expect(listed).toEqual(
+      expect.arrayContaining([
+        { brokerKey: BROKER_A, username: 'user-a' },
+        { brokerKey: BROKER_B, username: 'user-b' },
+      ]),
+    );
+    expect(JSON.stringify(listed)).not.toContain('pw-a');
+    expect(JSON.stringify(listed)).not.toContain('pw-b');
+  });
+
+  it('[21b] listBrokers returns [] when there is no row', async () => {
+    const store = new MeshCoreObserverCredentialStore(SECRET_A, true);
+    expect(await store.listBrokers('nope')).toEqual([]);
+  });
+
+  it('[22] key_rotated: a doc encrypted under a different SESSION_SECRET reports rotated everywhere, and listBrokers is []', async () => {
+    const original = new MeshCoreObserverCredentialStore(SECRET_A, true);
+    await original.storeForBroker(SOURCE, BROKER_A, 'user-a', 'pw-a');
+
+    const rotated = new MeshCoreObserverCredentialStore(SECRET_B, true);
+    expect((await rotated.load(SOURCE)).kind).toBe('key_rotated');
+    expect((await rotated.loadForBroker(SOURCE, BROKER_A)).kind).toBe('key_rotated');
+    expect(await rotated.listBrokers(SOURCE)).toEqual([]);
+    expect((await rotated.status(SOURCE)).keyRotated).toBe(true);
+  });
+
+  it('[23] storeForBroker throws when capability.canStore is false, and rejects the 9th distinct broker', async () => {
+    const noStore = new MeshCoreObserverCredentialStore(SECRET_A, false);
+    await expect(noStore.storeForBroker(SOURCE, BROKER_A, 'u', 'p')).rejects.toThrow(/auto-generated/);
+    expect(credRows.size).toBe(0);
+
+    const store = new MeshCoreObserverCredentialStore(SECRET_A, true);
+    for (let i = 0; i < OBSERVER_MAX_BROKER_CREDENTIALS; i++) {
+      await store.storeForBroker(SOURCE, `wss://broker-${i}.test/`, `user-${i}`, `pw-${i}`);
+    }
+    expect(await store.listBrokers(SOURCE)).toHaveLength(OBSERVER_MAX_BROKER_CREDENTIALS);
+
+    await expect(
+      store.storeForBroker(SOURCE, 'wss://one-too-many.test/', 'user-x', 'pw-x'),
+    ).rejects.toThrow(/maximum/i);
+    expect(await store.listBrokers(SOURCE)).toHaveLength(OBSERVER_MAX_BROKER_CREDENTIALS);
+
+    // Updating an already-stored broker's credential is not a NEW broker and
+    // must not be blocked by the cap.
+    await expect(store.storeForBroker(SOURCE, 'wss://broker-0.test/', 'user-0b', 'pw-0b')).resolves.toBeUndefined();
+    expect(await store.loadForBroker(SOURCE, 'wss://broker-0.test/')).toEqual({
+      kind: 'ok',
+      username: 'user-0b',
+      password: 'pw-0b',
+    });
+  });
+
+  it('[24] a v1 password that is not valid JSON, and one that is valid JSON but not the v2 shape, both decode as v1', async () => {
+    const store = new MeshCoreObserverCredentialStore(SECRET_A, true);
+
+    // Not JSON at all — a typical real-world legacy password.
+    await store.store(SOURCE, 'u1', 'not-json-at-all!!');
+    expect(await store.load(SOURCE)).toEqual({ kind: 'ok', username: 'u1', password: 'not-json-at-all!!' });
+
+    // Valid JSON, but not the v2 {v:2, brokers:{...}} shape (an array).
+    await store.store(SOURCE, 'u2', '[1,2,3]');
+    expect(await store.load(SOURCE)).toEqual({ kind: 'ok', username: 'u2', password: '[1,2,3]' });
+
+    // Valid JSON object, but missing the v2 discriminator.
+    await store.store(SOURCE, 'u3', '{"hello":"world"}');
+    expect(await store.load(SOURCE)).toEqual({ kind: 'ok', username: 'u3', password: '{"hello":"world"}' });
   });
 });

--- a/src/server/services/meshcoreObserverCredentialStore.test.ts
+++ b/src/server/services/meshcoreObserverCredentialStore.test.ts
@@ -361,4 +361,50 @@ describe('MeshCoreObserverCredentialStore', () => {
     await store.store(SOURCE, 'u3', '{"hello":"world"}');
     expect(await store.load(SOURCE)).toEqual({ kind: 'ok', username: 'u3', password: '{"hello":"world"}' });
   });
+
+  // ---------------------------------------------------------------------
+  // CodeQL "remote property injection" hardening (PR #5022 follow-up):
+  // brokerKey is request-body-derived. The route layer already bounds it
+  // against configured broker keys, but the store defends independently.
+  // ---------------------------------------------------------------------
+
+  const POLLUTION_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+  for (const key of POLLUTION_KEYS) {
+    it(`storeForBroker('${key}', ...) is rejected and pollutes nothing`, async () => {
+      const store = new MeshCoreObserverCredentialStore(SECRET_A, true);
+
+      await expect(store.storeForBroker(SOURCE, key, 'evil-user', 'evil-pw')).rejects.toThrow(/reserved/i);
+
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      expect(Object.prototype).not.toHaveProperty('polluted');
+      expect(Object.prototype.hasOwnProperty.call(Object.prototype, 'username')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(Object.prototype, 'password')).toBe(false);
+    });
+
+    it(`loadForBroker('${key}') is a safe no-op`, async () => {
+      const store = new MeshCoreObserverCredentialStore(SECRET_A, true);
+      await store.storeForBroker(SOURCE, BROKER_A, 'user-a', 'pw-a');
+
+      await expect(store.loadForBroker(SOURCE, key)).resolves.toEqual({ kind: 'none' });
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+
+      // The real, non-malicious data is untouched.
+      expect(await store.loadForBroker(SOURCE, BROKER_A)).toEqual({ kind: 'ok', username: 'user-a', password: 'pw-a' });
+    });
+
+    it(`clearForBroker('${key}') is a safe no-op`, async () => {
+      const store = new MeshCoreObserverCredentialStore(SECRET_A, true);
+      await store.storeForBroker(SOURCE, BROKER_A, 'user-a', 'pw-a');
+
+      await expect(store.clearForBroker(SOURCE, key)).resolves.toBeUndefined();
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      expect(Object.prototype).not.toHaveProperty('polluted');
+
+      // A stored doc round-trips unchanged afterward.
+      expect(await store.loadForBroker(SOURCE, BROKER_A)).toEqual({ kind: 'ok', username: 'user-a', password: 'pw-a' });
+      expect(await store.listBrokers(SOURCE)).toEqual([{ brokerKey: BROKER_A, username: 'user-a' }]);
+    });
+  }
+
 });

--- a/src/server/services/meshcoreObserverCredentialStore.ts
+++ b/src/server/services/meshcoreObserverCredentialStore.ts
@@ -19,15 +19,30 @@
  * distinct info strings key-separate the stores even though they share one
  * secret.
  *
+ * MULTI-BROKER (#5014 Phase 1): the schema is untouched — still one row per
+ * source, `meshcore_observer_credentials(sourceId, username, encryptedPassword)`.
+ * What changed is the shape of the AEAD *plaintext*: it is now a versioned
+ * JSON document (`StoredCredentialDoc`) holding every broker's credential
+ * plus the pre-#5014 "legacy" single credential, instead of a bare password
+ * string. One envelope, one `kid`, one rotation story, regardless of how many
+ * brokers a source publishes to. See `decodeDoc` for the v1/v2 discriminator
+ * and §4 of `docs/internal/dev-notes/MESHMAPPER_OBSERVER_PHASE1_SPEC.md` for
+ * the full trade-off against a per-broker table + migration (rejected).
+ *
  * WHERE THE SECRET LIVES (security summary):
  *   - `meshcore_observer_credentials.encryptedPassword` — AES-256-GCM
  *     envelope JSON. Nothing else in the process, the DB, or `sources.config`
- *     ever holds the password.
+ *     ever holds a password (legacy or per-broker).
  *   - It is decrypted in exactly ONE place: `MeshCoreObserverPublisher`, to
  *     build the MQTT CONNECT packet. No route ever reads it.
  *   - `username` is stored in the CLEAR alongside it. It is not a secret (a
  *     non-TLS broker receives it in plaintext regardless) and the UI needs it
- *     to show which account is configured.
+ *     to show which account is configured. It holds the legacy username when
+ *     a legacy entry exists, otherwise the username of the
+ *     lexicographically-first broker entry (see `computeClearUsername`). It
+ *     is display-only and is never used to authenticate a per-broker
+ *     connection — `loadForBroker` reads the real per-broker username out of
+ *     the decrypted document.
  *
  * Threat model (same as the sibling stores):
  *   - Defends against a DB-file-only exfil (someone grabs `meshmonitor.db`
@@ -54,6 +69,13 @@ const KDF_INFO_FINGERPRINT = 'meshcore-observer-cred-fingerprint-v1';
 export const OBSERVER_PASSWORD_MAX_LENGTH = 512;
 /** Hard cap on a stored username; matches the MySQL column width. */
 export const OBSERVER_USERNAME_MAX_LENGTH = 255;
+/**
+ * Max distinct broker credentials per source (#5014). Matches
+ * `MAX_OBSERVER_BROKERS` in `sourceRoutes.ts` validation — the two are chosen
+ * together (see spec §2.5): a source can never be *configured* with more
+ * brokers than it can have credentials for.
+ */
+export const OBSERVER_MAX_BROKER_CREDENTIALS = 8;
 
 interface StoredEnvelope {
   v: number;
@@ -61,6 +83,27 @@ interface StoredEnvelope {
   iv: string;
   ct: string;
   tag: string;
+}
+
+/**
+ * The AEAD plaintext shape (#5014). `brokerKey` is `observerBrokerKey(url)`
+ * (case-insensitive normalized URL) — see `meshcoreConfig.ts`. This module
+ * never derives or validates a `brokerKey`; it is an opaque string handed in
+ * by the caller (route or publisher), by design (this store must not import
+ * `meshcoreConfig.ts`).
+ */
+interface StoredCredentialDoc {
+  v: 2;
+  /** brokerKey -> credential. */
+  brokers: Record<string, { username: string; password: string }>;
+  /**
+   * The pre-#5014 single credential, carried forward verbatim when a v1
+   * document is upgraded in place (see `decodeDoc`). Read by `load()` and by
+   * the publisher's legacy-broker fallback (`resolveBrokerCredential`, which
+   * lives in `meshcoreObserverPublisher.ts`, NOT in this store — this store
+   * has no notion of which broker "is" the legacy one).
+   */
+  legacy?: { username: string; password: string };
 }
 
 export interface ObserverCredentialCapability {
@@ -83,7 +126,23 @@ export interface ObserverCredentialStatus {
   keyRotated: boolean;
   canStore: boolean;
   reason: string | null;
+  /**
+   * Non-secret per-broker enumeration (#5014) — same pairs as `listBrokers()`.
+   * Present only when the decrypted document actually has at least one
+   * broker entry; a pre-#5014 legacy-only row (or a not-found / key-rotated
+   * row) omits this field entirely rather than sending `brokers: []`, so
+   * `Object.keys(status)` is unchanged for every caller that predates
+   * multi-broker credentials.
+   */
+  brokers?: Array<{ brokerKey: string; username: string }>;
 }
+
+/** Result of decrypting and decoding a source's stored document. Internal —
+ *  every public method is a thin projection over this. */
+type DecodedDocResult =
+  | { kind: 'none' }
+  | { kind: 'key_rotated'; storedKid: string; row: { username: string; updatedAt: number } }
+  | { kind: 'ok'; doc: StoredCredentialDoc; row: { username: string; updatedAt: number } };
 
 export class MeshCoreObserverCredentialStore {
   private readonly aeadKey: Buffer;
@@ -115,65 +174,132 @@ export class MeshCoreObserverCredentialStore {
   }
 
   /**
-   * Encrypt and persist the broker password for a source, alongside the clear
-   * `username`. Throws when SESSION_SECRET is auto-generated — callers must
-   * check `capability` first.
+   * Encrypt and persist the LEGACY broker password for a source, alongside
+   * the clear `username`. Writes a v2 document whose `legacy` is the
+   * supplied pair, PRESERVING any existing `brokers` map (read-modify-write —
+   * see the concurrency note on `storeForBroker`). Throws when SESSION_SECRET
+   * is auto-generated — callers must check `capability` first.
    */
   async store(sourceId: string, username: string, password: string): Promise<void> {
     if (!this._capability.canStore) {
       throw new Error('Cannot persist Analyzer Observer broker password: SESSION_SECRET is auto-generated');
     }
-    const iv = crypto.randomBytes(12);
-    const cipher = crypto.createCipheriv('aes-256-gcm', this.aeadKey, iv);
-    const ct = Buffer.concat([cipher.update(Buffer.from(password, 'utf8')), cipher.final()]);
-    const tag = cipher.getAuthTag();
-    const envelope: StoredEnvelope = {
-      v: KDF_VERSION,
-      kid: this.currentKid,
-      iv: iv.toString('hex'),
-      ct: ct.toString('hex'),
-      tag: tag.toString('hex'),
-    };
-    await databaseService.meshcoreObserverCredentials.upsert(sourceId, username, JSON.stringify(envelope));
+    const existing = await this.readDoc(sourceId);
+    // A row we cannot decrypt (key_rotated) has an unrecoverable brokers map
+    // regardless of what we do here, so there is nothing to preserve; start
+    // fresh rather than blocking the operator's write.
+    const brokers = existing.kind === 'ok' ? existing.doc.brokers : {};
+    const doc: StoredCredentialDoc = { v: 2, brokers, legacy: { username, password } };
+    await this.persistDoc(sourceId, doc);
   }
 
   /**
-   * Load + decrypt the stored credentials for a source. Returns one of:
-   *   - `{ kind: 'none' }` when nothing is saved.
+   * Load + decrypt the stored LEGACY credential for a source. Returns one of:
+   *   - `{ kind: 'none' }` when nothing is saved, or a document exists but
+   *     has no `legacy` entry (e.g. only per-broker credentials).
    *   - `{ kind: 'ok', username, password }` on success.
    *   - `{ kind: 'key_rotated', storedKid }` when the envelope was encrypted
    *     with a different SESSION_SECRET.
+   *
+   * For any row written before #5014 this is bit-for-bit today's behaviour:
+   * such a row decodes to a document whose `legacy` is exactly that row's
+   * username/password (see `decodeDoc`).
    */
   async load(sourceId: string): Promise<ObserverCredentialLoadResult> {
-    const row = await databaseService.meshcoreObserverCredentials.getBySourceId(sourceId);
-    if (!row) return { kind: 'none' };
+    const result = await this.readDoc(sourceId);
+    if (result.kind === 'none') return { kind: 'none' };
+    if (result.kind === 'key_rotated') return { kind: 'key_rotated', storedKid: result.storedKid };
+    if (!result.doc.legacy) return { kind: 'none' };
+    return { kind: 'ok', username: result.doc.legacy.username, password: result.doc.legacy.password };
+  }
 
-    let env: StoredEnvelope;
-    try {
-      env = JSON.parse(row.encryptedPassword) as StoredEnvelope;
-    } catch {
-      logger.warn(
-        `[MeshCoreObserverCredentialStore] Malformed envelope for ${sourceId}; treating as rotated`,
+  /**
+   * Read-modify-write one broker's entry (#5014). Throws when
+   * `capability.canStore` is false (same condition as `store()`), or when
+   * adding a *new* distinct broker would exceed `OBSERVER_MAX_BROKER_CREDENTIALS`
+   * (updating an already-present `brokerKey` never counts against the cap).
+   *
+   * CONCURRENCY (must stay a comment — see spec §4.4): this is a
+   * read-decrypt-modify-encrypt-write cycle over ONE row. Two concurrent
+   * writes to *different* brokers on the same source can race and lose one
+   * update (last write wins on the whole document, not just the touched
+   * broker). Accepted for v1: both `storeForBroker` and `clearForBroker` are
+   * operator-driven admin-route calls against a single source, and the loss
+   * is recoverable by re-entering the credential. If a future UI ever
+   * batch-saves N brokers in one gesture, it MUST serialize those PUTs.
+   */
+  async storeForBroker(sourceId: string, brokerKey: string, username: string, password: string): Promise<void> {
+    if (!this._capability.canStore) {
+      throw new Error('Cannot persist Analyzer Observer broker password: SESSION_SECRET is auto-generated');
+    }
+    const existing = await this.readDoc(sourceId);
+    // See store()'s comment: a key-rotated row's brokers map is already
+    // unrecoverable, so we start fresh rather than blocking the write.
+    const doc: StoredCredentialDoc =
+      existing.kind === 'ok'
+        ? { v: 2, brokers: { ...existing.doc.brokers }, legacy: existing.doc.legacy }
+        : { v: 2, brokers: {} };
+
+    if (!(brokerKey in doc.brokers) && Object.keys(doc.brokers).length >= OBSERVER_MAX_BROKER_CREDENTIALS) {
+      throw new Error(
+        `Cannot store credentials for broker "${brokerKey}": the maximum of ` +
+          `${OBSERVER_MAX_BROKER_CREDENTIALS} distinct broker credentials has been reached`,
       );
-      return { kind: 'key_rotated', storedKid: '?' };
     }
-    if (env.v !== KDF_VERSION || env.kid !== this.currentKid) {
-      return { kind: 'key_rotated', storedKid: env.kid ?? '?' };
+
+    doc.brokers[brokerKey] = { username, password };
+    await this.persistDoc(sourceId, doc);
+  }
+
+  /**
+   * This broker's credential only. NEVER falls back to `legacy` — that
+   * fallback is a publisher-level policy decision (`resolveBrokerCredential`
+   * in `meshcoreObserverPublisher.ts`), not a store-level one, so that a
+   * non-legacy broker can never observe the legacy credential.
+   */
+  async loadForBroker(sourceId: string, brokerKey: string): Promise<ObserverCredentialLoadResult> {
+    const result = await this.readDoc(sourceId);
+    if (result.kind === 'none') return { kind: 'none' };
+    if (result.kind === 'key_rotated') return { kind: 'key_rotated', storedKid: result.storedKid };
+    const entry = result.doc.brokers[brokerKey];
+    if (!entry) return { kind: 'none' };
+    return { kind: 'ok', username: entry.username, password: entry.password };
+  }
+
+  /**
+   * Remove one broker's entry (#5014). No-op when absent — including when no
+   * row exists at all, or when the row exists but cannot be decrypted
+   * (key_rotated: see the concurrency/read-modify-write comment on
+   * `storeForBroker`; we refuse to blindly rewrite a document we cannot
+   * read). Deletes the whole row once the resulting document has neither
+   * broker entries nor a legacy entry, matching `clear()`'s row-deletion
+   * behaviour instead of leaving an empty husk envelope behind.
+   */
+  async clearForBroker(sourceId: string, brokerKey: string): Promise<void> {
+    const existing = await this.readDoc(sourceId);
+    if (existing.kind !== 'ok' || !(brokerKey in existing.doc.brokers)) {
+      return;
     }
-    try {
-      const decipher = crypto.createDecipheriv('aes-256-gcm', this.aeadKey, Buffer.from(env.iv, 'hex'));
-      decipher.setAuthTag(Buffer.from(env.tag, 'hex'));
-      const pt = Buffer.concat([decipher.update(Buffer.from(env.ct, 'hex')), decipher.final()]);
-      return { kind: 'ok', username: row.username, password: pt.toString('utf8') };
-    } catch (err) {
-      // kid matched but decrypt failed — upgrade hazard or row corruption.
-      // Treat as rotated so the operator re-enters rather than the publisher
-      // silently proceeding with a broken credential.
-      logger.warn(
-        `[MeshCoreObserverCredentialStore] Decrypt failed for ${sourceId} despite matching kid: ${(err as Error).message}`,
-      );
-      return { kind: 'key_rotated', storedKid: env.kid };
+    const brokers = { ...existing.doc.brokers };
+    delete brokers[brokerKey];
+    const doc: StoredCredentialDoc = { v: 2, brokers, legacy: existing.doc.legacy };
+    if (Object.keys(doc.brokers).length === 0 && !doc.legacy) {
+      await databaseService.meshcoreObserverCredentials.deleteBySourceId(sourceId);
+      return;
     }
+    await this.persistDoc(sourceId, doc);
+  }
+
+  /**
+   * Non-secret enumeration for the UI (#5014). NEVER returns a password —
+   * only `{ brokerKey, username }` pairs. Returns `[]` when there is no row,
+   * or the row cannot be decrypted (key_rotated): the caller learns about
+   * rotation from `status()`, not from an empty broker list.
+   */
+  async listBrokers(sourceId: string): Promise<Array<{ brokerKey: string; username: string }>> {
+    const result = await this.readDoc(sourceId);
+    if (result.kind !== 'ok') return [];
+    return Object.entries(result.doc.brokers).map(([brokerKey, cred]) => ({ brokerKey, username: cred.username }));
   }
 
   /** Clear any stored credentials for a source. No-op if none exists. */
@@ -182,14 +308,17 @@ export class MeshCoreObserverCredentialStore {
   }
 
   /**
-   * Report status without attempting decryption: compares the envelope's
-   * `v`/`kid` against the current fingerprint only. Never returns `storedKid`
-   * — exposing it would let a hostile script fingerprint SESSION_SECRET
-   * rotations across requests — and NEVER returns the password.
+   * Report status. Compares the envelope's `v`/`kid` against the current
+   * fingerprint and, when it matches, decrypts to populate the additive
+   * `brokers` field (#5014) — see that field's doc comment for the exact
+   * omission rule that keeps this back-compatible. Never returns
+   * `storedKid` — exposing it would let a hostile script fingerprint
+   * SESSION_SECRET rotations across requests — and NEVER returns a password.
    */
   async status(sourceId: string): Promise<ObserverCredentialStatus> {
-    const row = await databaseService.meshcoreObserverCredentials.getBySourceId(sourceId);
-    if (!row) {
+    const result = await this.readDoc(sourceId);
+
+    if (result.kind === 'none') {
       return {
         stored: false,
         username: null,
@@ -200,22 +329,95 @@ export class MeshCoreObserverCredentialStore {
       };
     }
 
-    let keyRotated: boolean;
-    try {
-      const env = JSON.parse(row.encryptedPassword) as StoredEnvelope;
-      keyRotated = env.v !== KDF_VERSION || env.kid !== this.currentKid;
-    } catch {
-      keyRotated = true;
+    if (result.kind === 'key_rotated') {
+      return {
+        stored: true,
+        username: result.row.username,
+        updatedAt: result.row.updatedAt,
+        keyRotated: true,
+        canStore: this._capability.canStore,
+        reason: this._capability.reason ?? null,
+      };
     }
+
+    const brokerEntries = Object.entries(result.doc.brokers).map(([brokerKey, cred]) => ({
+      brokerKey,
+      username: cred.username,
+    }));
 
     return {
       stored: true,
-      username: row.username,
-      updatedAt: row.updatedAt,
-      keyRotated,
+      username: result.row.username,
+      updatedAt: result.row.updatedAt,
+      keyRotated: false,
       canStore: this._capability.canStore,
       reason: this._capability.reason ?? null,
+      ...(brokerEntries.length > 0 ? { brokers: brokerEntries } : {}),
     };
+  }
+
+  /**
+   * Fetch, decrypt and decode the stored document for a source. The single
+   * place every public read/write path goes through, so the envelope
+   * parsing / kid-matching / decrypt-failure handling exists exactly once.
+   * Never throws.
+   */
+  private async readDoc(sourceId: string): Promise<DecodedDocResult> {
+    const row = await databaseService.meshcoreObserverCredentials.getBySourceId(sourceId);
+    if (!row) return { kind: 'none' };
+
+    let env: StoredEnvelope;
+    try {
+      env = JSON.parse(row.encryptedPassword) as StoredEnvelope;
+    } catch {
+      logger.warn(
+        `[MeshCoreObserverCredentialStore] Malformed envelope for ${sourceId}; treating as rotated`,
+      );
+      return { kind: 'key_rotated', storedKid: '?', row: { username: row.username, updatedAt: row.updatedAt } };
+    }
+    if (env.v !== KDF_VERSION || env.kid !== this.currentKid) {
+      return {
+        kind: 'key_rotated',
+        storedKid: env.kid ?? '?',
+        row: { username: row.username, updatedAt: row.updatedAt },
+      };
+    }
+    try {
+      const decipher = crypto.createDecipheriv('aes-256-gcm', this.aeadKey, Buffer.from(env.iv, 'hex'));
+      decipher.setAuthTag(Buffer.from(env.tag, 'hex'));
+      const pt = Buffer.concat([decipher.update(Buffer.from(env.ct, 'hex')), decipher.final()]).toString('utf8');
+      const doc = decodeDoc(pt, row.username);
+      return { kind: 'ok', doc, row: { username: row.username, updatedAt: row.updatedAt } };
+    } catch (err) {
+      // kid matched but decrypt failed — upgrade hazard or row corruption.
+      // Treat as rotated so the operator re-enters rather than the publisher
+      // silently proceeding with a broken credential.
+      logger.warn(
+        `[MeshCoreObserverCredentialStore] Decrypt failed for ${sourceId} despite matching kid: ${(err as Error).message}`,
+      );
+      return { kind: 'key_rotated', storedKid: env.kid, row: { username: row.username, updatedAt: row.updatedAt } };
+    }
+  }
+
+  /** Encrypt `doc` and upsert it, deriving the clear `username` column via
+   *  `computeClearUsername`. The one write path every mutator funnels through. */
+  private async persistDoc(sourceId: string, doc: StoredCredentialDoc): Promise<void> {
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv('aes-256-gcm', this.aeadKey, iv);
+    const ct = Buffer.concat([cipher.update(Buffer.from(JSON.stringify(doc), 'utf8')), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    const envelope: StoredEnvelope = {
+      v: KDF_VERSION,
+      kid: this.currentKid,
+      iv: iv.toString('hex'),
+      ct: ct.toString('hex'),
+      tag: tag.toString('hex'),
+    };
+    await databaseService.meshcoreObserverCredentials.upsert(
+      sourceId,
+      computeClearUsername(doc),
+      JSON.stringify(envelope),
+    );
   }
 }
 
@@ -228,6 +430,69 @@ export class MeshCoreObserverCredentialStore {
 function hkdfBytes(ikm: Buffer, info: string, length: number): Buffer {
   const salt = Buffer.alloc(32);
   return Buffer.from(crypto.hkdfSync('sha256', ikm, salt, info, length));
+}
+
+/**
+ * Decode the AEAD plaintext into a `StoredCredentialDoc` (#5014).
+ *
+ * ```
+ * try p = JSON.parse(plaintext)
+ * if (p && typeof p === 'object' && !Array.isArray(p) && p.v === 2
+ *     && p.brokers && typeof p.brokers === 'object')
+ *     -> v2 document, used as-is
+ * else
+ *     -> v1: wrap the plaintext (the bare legacy password) as
+ *        { v: 2, brokers: {}, legacy: { username: clearUsername, password: plaintext } }
+ * ```
+ *
+ * `clearUsername` is the row's clear `username` column, which — for a v1 row
+ * — IS the legacy username (that column has held exactly the legacy username
+ * since before #5014).
+ *
+ * MISPARSE CAVEAT (accepted, documented per spec §4.2): a v1 password that
+ * happens to be *exactly* a JSON object shaped like `{"v":2,"brokers":{...}}`
+ * would be misread as a v2 document instead of a literal password. This is
+ * accepted as negligible-probability: the alternative (a length-prefixed or
+ * otherwise self-describing container) would require rewriting every
+ * existing row to migrate, which is exactly the migration this design set
+ * out to avoid.
+ */
+function decodeDoc(plaintext: string, clearUsername: string): StoredCredentialDoc {
+  try {
+    const parsed: unknown = JSON.parse(plaintext);
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed) &&
+      (parsed as Record<string, unknown>).v === 2 &&
+      typeof (parsed as Record<string, unknown>).brokers === 'object' &&
+      (parsed as Record<string, unknown>).brokers !== null
+    ) {
+      return parsed as StoredCredentialDoc;
+    }
+  } catch {
+    // Not JSON at all — definitely a v1 plaintext password. Fall through.
+  }
+  return { v: 2, brokers: {}, legacy: { username: clearUsername, password: plaintext } };
+}
+
+/**
+ * Derive the clear `username` column value for a document (#5014). That
+ * column is display-only (see the file-header security summary) and holds:
+ *   - the legacy username, when a `legacy` entry exists (this is also what
+ *     keeps every pre-#5014 row's clear username byte-for-byte unchanged,
+ *     since `store()` always sets `legacy`);
+ *   - otherwise, the username of the lexicographically-first broker entry,
+ *     so a source with only per-broker credentials still shows *something*
+ *     recognizable in the UI;
+ *   - otherwise (a document with neither) the empty string — this path is
+ *     unreachable from any public method today, since `clearForBroker`
+ *     deletes the row instead of persisting a fully-empty document.
+ */
+function computeClearUsername(doc: StoredCredentialDoc): string {
+  if (doc.legacy) return doc.legacy.username;
+  const keys = Object.keys(doc.brokers).sort();
+  return keys.length > 0 ? doc.brokers[keys[0]].username : '';
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/services/meshcoreObserverCredentialStore.ts
+++ b/src/server/services/meshcoreObserverCredentialStore.ts
@@ -29,6 +29,22 @@
  * and §4 of `docs/internal/dev-notes/MESHMAPPER_OBSERVER_PHASE1_SPEC.md` for
  * the full trade-off against a per-broker table + migration (rejected).
  *
+ * IN-MEMORY REPRESENTATION (PR #5022 CodeQL follow-up): although the on-disk
+ * JSON shape keys brokers by a plain object (`StoredCredentialDoc.brokers:
+ * Record<string, ...>`), every in-memory read/mutation path holds brokers as
+ * a `DecodedDoc.brokers: Map<string, ...>` instead. `brokerKey` is
+ * request-body-derived (the credential PUT/DELETE routes), and CodeQL's
+ * "remote property injection" query flags ANY dynamic property
+ * read/write/delete keyed by tainted input — `obj[brokerKey]` — regardless of
+ * null-prototype objects or reserved-key guards layered on top. `Map.get` /
+ * `.set` / `.has` / `.delete` are method calls, not property accesses, so the
+ * query has nothing to flag. `decodeDoc` converts the on-disk object into a
+ * Map on read; `persistDoc` converts the Map back to a plain object
+ * (`Object.fromEntries`) on write, so the stored JSON shape — and therefore
+ * every existing row — is unchanged. `FORBIDDEN_BROKER_KEYS` filtering is
+ * kept as belt-and-braces even though a `Map` has no `Object.prototype` chain
+ * to pollute in the first place.
+ *
  * WHERE THE SECRET LIVES (security summary):
  *   - `meshcore_observer_credentials.encryptedPassword` — AES-256-GCM
  *     envelope JSON. Nothing else in the process, the DB, or `sources.config`
@@ -86,11 +102,15 @@ interface StoredEnvelope {
 }
 
 /**
- * The AEAD plaintext shape (#5014). `brokerKey` is `observerBrokerKey(url)`
- * (case-insensitive normalized URL) — see `meshcoreConfig.ts`. This module
- * never derives or validates a `brokerKey`; it is an opaque string handed in
- * by the caller (route or publisher), by design (this store must not import
- * `meshcoreConfig.ts`).
+ * The ON-DISK (AEAD plaintext) JSON shape (#5014). `brokerKey` is
+ * `observerBrokerKey(url)` (case-insensitive normalized URL) — see
+ * `meshcoreConfig.ts`. This module never derives or validates a `brokerKey`;
+ * it is an opaque string handed in by the caller (route or publisher), by
+ * design (this store must not import `meshcoreConfig.ts`).
+ *
+ * This interface describes ONLY the serialized form. See the file-header
+ * "IN-MEMORY REPRESENTATION" note — every live read/write path uses
+ * `DecodedDoc` instead, whose `brokers` is a `Map`.
  */
 interface StoredCredentialDoc {
   v: 2;
@@ -103,6 +123,19 @@ interface StoredCredentialDoc {
    * lives in `meshcoreObserverPublisher.ts`, NOT in this store — this store
    * has no notion of which broker "is" the legacy one).
    */
+  legacy?: { username: string; password: string };
+}
+
+/**
+ * The IN-MEMORY decoded document. Same information as `StoredCredentialDoc`,
+ * but `brokers` is a `Map` rather than a plain object, specifically so that
+ * `brokerKey`-keyed reads/writes/deletes are `Map` method calls rather than
+ * dynamic property accesses — see the file-header "IN-MEMORY REPRESENTATION"
+ * note.
+ */
+interface DecodedDoc {
+  v: 2;
+  brokers: Map<string, { username: string; password: string }>;
   legacy?: { username: string; password: string };
 }
 
@@ -142,7 +175,7 @@ export interface ObserverCredentialStatus {
 type DecodedDocResult =
   | { kind: 'none' }
   | { kind: 'key_rotated'; storedKid: string; row: { username: string; updatedAt: number } }
-  | { kind: 'ok'; doc: StoredCredentialDoc; row: { username: string; updatedAt: number } };
+  | { kind: 'ok'; doc: DecodedDoc; row: { username: string; updatedAt: number } };
 
 export class MeshCoreObserverCredentialStore {
   private readonly aeadKey: Buffer;
@@ -188,8 +221,8 @@ export class MeshCoreObserverCredentialStore {
     // A row we cannot decrypt (key_rotated) has an unrecoverable brokers map
     // regardless of what we do here, so there is nothing to preserve; start
     // fresh rather than blocking the operator's write.
-    const brokers = toNullProtoBrokers(existing.kind === 'ok' ? existing.doc.brokers : undefined);
-    const doc: StoredCredentialDoc = { v: 2, brokers, legacy: { username, password } };
+    const brokers = existing.kind === 'ok' ? new Map(existing.doc.brokers) : new Map<string, { username: string; password: string }>();
+    const doc: DecodedDoc = { v: 2, brokers, legacy: { username, password } };
     await this.persistDoc(sourceId, doc);
   }
 
@@ -228,11 +261,13 @@ export class MeshCoreObserverCredentialStore {
    * is recoverable by re-entering the credential. If a future UI ever
    * batch-saves N brokers in one gesture, it MUST serialize those PUTs.
    *
-   * PROTOTYPE-POLLUTION GUARD (CodeQL): `brokerKey` is attacker-influenced
-   * (request body). Reject `FORBIDDEN_BROKER_KEYS` outright, and build the
-   * broker map as a null-prototype object (`toNullProtoBrokers`) before the
-   * keyed write below, so even an unexpected key can never reach
-   * `Object.prototype`.
+   * PROTOTYPE-POLLUTION / INJECTION GUARD (CodeQL, PR #5022): `brokerKey` is
+   * attacker-influenced (request body). `FORBIDDEN_BROKER_KEYS` is still
+   * rejected outright as belt-and-braces, but the load-bearing defense is
+   * that `brokers` is a `Map` (see the file-header "IN-MEMORY REPRESENTATION"
+   * note) — `Map.set`/`.get`/`.has`/`.delete` are method calls, not dynamic
+   * property accesses, so there is no `obj[brokerKey]` for a "remote property
+   * injection" query to flag, and no `Object.prototype` chain to pollute.
    */
   async storeForBroker(sourceId: string, brokerKey: string, username: string, password: string): Promise<void> {
     if (!this._capability.canStore) {
@@ -244,21 +279,20 @@ export class MeshCoreObserverCredentialStore {
     const existing = await this.readDoc(sourceId);
     // See store()'s comment: a key-rotated row's brokers map is already
     // unrecoverable, so we start fresh rather than blocking the write.
-    const doc: StoredCredentialDoc =
-      existing.kind === 'ok'
-        ? { v: 2, brokers: toNullProtoBrokers(existing.doc.brokers), legacy: existing.doc.legacy }
-        : { v: 2, brokers: toNullProtoBrokers() };
+    const brokers =
+      existing.kind === 'ok' ? new Map(existing.doc.brokers) : new Map<string, { username: string; password: string }>();
+    const legacy = existing.kind === 'ok' ? existing.doc.legacy : undefined;
 
-    const alreadyPresent = Object.prototype.hasOwnProperty.call(doc.brokers, brokerKey);
-    if (!alreadyPresent && Object.keys(doc.brokers).length >= OBSERVER_MAX_BROKER_CREDENTIALS) {
+    const alreadyPresent = brokers.has(brokerKey);
+    if (!alreadyPresent && brokers.size >= OBSERVER_MAX_BROKER_CREDENTIALS) {
       throw new Error(
         `Cannot store credentials for broker "${brokerKey}": the maximum of ` +
           `${OBSERVER_MAX_BROKER_CREDENTIALS} distinct broker credentials has been reached`,
       );
     }
 
-    doc.brokers[brokerKey] = { username, password };
-    await this.persistDoc(sourceId, doc);
+    brokers.set(brokerKey, { username, password });
+    await this.persistDoc(sourceId, { v: 2, brokers, legacy });
   }
 
   /**
@@ -268,15 +302,16 @@ export class MeshCoreObserverCredentialStore {
    * non-legacy broker can never observe the legacy credential.
    *
    * `brokerKey` is attacker-influenced; a reserved key (`FORBIDDEN_BROKER_KEYS`)
-   * is treated as simply absent rather than looked up.
+   * is treated as simply absent rather than looked up. The lookup itself
+   * (`Map.get`) is not a dynamic property access — see the file-header note.
    */
   async loadForBroker(sourceId: string, brokerKey: string): Promise<ObserverCredentialLoadResult> {
     if (isForbiddenBrokerKey(brokerKey)) return { kind: 'none' };
     const result = await this.readDoc(sourceId);
     if (result.kind === 'none') return { kind: 'none' };
     if (result.kind === 'key_rotated') return { kind: 'key_rotated', storedKid: result.storedKid };
-    if (!Object.prototype.hasOwnProperty.call(result.doc.brokers, brokerKey)) return { kind: 'none' };
-    const entry = result.doc.brokers[brokerKey];
+    const entry = result.doc.brokers.get(brokerKey);
+    if (!entry) return { kind: 'none' };
     return { kind: 'ok', username: entry.username, password: entry.password };
   }
 
@@ -290,22 +325,22 @@ export class MeshCoreObserverCredentialStore {
    * behaviour instead of leaving an empty husk envelope behind.
    *
    * `brokerKey` is attacker-influenced; a reserved key (`FORBIDDEN_BROKER_KEYS`)
-   * is a safe no-op rather than being looked up or deleted.
+   * is a safe no-op rather than being looked up or deleted. The delete itself
+   * (`Map.delete`) is not a dynamic property access — see the file-header note.
    */
   async clearForBroker(sourceId: string, brokerKey: string): Promise<void> {
     if (isForbiddenBrokerKey(brokerKey)) return;
     const existing = await this.readDoc(sourceId);
-    if (existing.kind !== 'ok' || !Object.prototype.hasOwnProperty.call(existing.doc.brokers, brokerKey)) {
+    if (existing.kind !== 'ok' || !existing.doc.brokers.has(brokerKey)) {
       return;
     }
-    const brokers = toNullProtoBrokers(existing.doc.brokers);
-    delete brokers[brokerKey];
-    const doc: StoredCredentialDoc = { v: 2, brokers, legacy: existing.doc.legacy };
-    if (Object.keys(doc.brokers).length === 0 && !doc.legacy) {
+    const brokers = new Map(existing.doc.brokers);
+    brokers.delete(brokerKey);
+    if (brokers.size === 0 && !existing.doc.legacy) {
       await databaseService.meshcoreObserverCredentials.deleteBySourceId(sourceId);
       return;
     }
-    await this.persistDoc(sourceId, doc);
+    await this.persistDoc(sourceId, { v: 2, brokers, legacy: existing.doc.legacy });
   }
 
   /**
@@ -317,7 +352,10 @@ export class MeshCoreObserverCredentialStore {
   async listBrokers(sourceId: string): Promise<Array<{ brokerKey: string; username: string }>> {
     const result = await this.readDoc(sourceId);
     if (result.kind !== 'ok') return [];
-    return Object.entries(result.doc.brokers).map(([brokerKey, cred]) => ({ brokerKey, username: cred.username }));
+    return Array.from(result.doc.brokers.entries()).map(([brokerKey, cred]) => ({
+      brokerKey,
+      username: cred.username,
+    }));
   }
 
   /** Clear any stored credentials for a source. No-op if none exists. */
@@ -358,7 +396,7 @@ export class MeshCoreObserverCredentialStore {
       };
     }
 
-    const brokerEntries = Object.entries(result.doc.brokers).map(([brokerKey, cred]) => ({
+    const brokerEntries = Array.from(result.doc.brokers.entries()).map(([brokerKey, cred]) => ({
       brokerKey,
       username: cred.username,
     }));
@@ -417,12 +455,23 @@ export class MeshCoreObserverCredentialStore {
     }
   }
 
-  /** Encrypt `doc` and upsert it, deriving the clear `username` column via
-   *  `computeClearUsername`. The one write path every mutator funnels through. */
-  private async persistDoc(sourceId: string, doc: StoredCredentialDoc): Promise<void> {
+  /**
+   * Encrypt `doc` and upsert it, deriving the clear `username` column via
+   * `computeClearUsername`. The one write path every mutator funnels through.
+   * Converts the in-memory `Map` back to the on-disk `Record` shape
+   * (`Object.fromEntries`) so the stored JSON is byte-for-byte what
+   * `StoredCredentialDoc` describes, regardless of the in-memory
+   * representation — see the file-header "IN-MEMORY REPRESENTATION" note.
+   */
+  private async persistDoc(sourceId: string, doc: DecodedDoc): Promise<void> {
+    const serializable: StoredCredentialDoc = {
+      v: 2,
+      brokers: Object.fromEntries(doc.brokers),
+      legacy: doc.legacy,
+    };
     const iv = crypto.randomBytes(12);
     const cipher = crypto.createCipheriv('aes-256-gcm', this.aeadKey, iv);
-    const ct = Buffer.concat([cipher.update(Buffer.from(JSON.stringify(doc), 'utf8')), cipher.final()]);
+    const ct = Buffer.concat([cipher.update(Buffer.from(JSON.stringify(serializable), 'utf8')), cipher.final()]);
     const tag = cipher.getAuthTag();
     const envelope: StoredEnvelope = {
       v: KDF_VERSION,
@@ -451,12 +500,15 @@ function hkdfBytes(ikm: Buffer, info: string, length: number): Buffer {
 }
 
 /**
- * Prototype-pollution guard (CodeQL "remote property injection"): `brokerKey`
- * ultimately originates from a request body (the credential PUT/DELETE
- * routes), even though the route layer already bounds it against the
- * source's *configured* broker keys (normalized URLs — `__proto__` etc.
- * cannot match one). This store hardens itself independently rather than
- * relying solely on that upstream check.
+ * Injection guard (CodeQL "remote property injection" / prototype-pollution
+ * belt-and-braces): `brokerKey` ultimately originates from a request body
+ * (the credential PUT/DELETE routes), even though the route layer already
+ * bounds it against the source's *configured* broker keys (normalized URLs —
+ * `__proto__` etc. cannot match one), and even though `brokers` is a `Map`
+ * with no `Object.prototype` chain to pollute in the first place (see the
+ * file-header "IN-MEMORY REPRESENTATION" note, which is the load-bearing
+ * defense). This filter is kept anyway so these three names can never appear
+ * as a broker identity at all.
  */
 const FORBIDDEN_BROKER_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
@@ -465,47 +517,28 @@ function isForbiddenBrokerKey(key: string): boolean {
 }
 
 /**
- * Build a null-prototype copy of a broker map (dropping any of
- * `FORBIDDEN_BROKER_KEYS`), so every keyed write (`doc.brokers[brokerKey] =
- * ...`) or delete lands on a plain data map that has no `Object.prototype`
- * chain to pollute — belt-and-braces alongside the `isForbiddenBrokerKey`
- * checks at each call site. Called with no argument, it just returns a fresh
- * empty null-prototype map.
- */
-function toNullProtoBrokers(
-  src?: Record<string, { username: string; password: string }>,
-): Record<string, { username: string; password: string }> {
-  const out: Record<string, { username: string; password: string }> = Object.create(null);
-  if (!src) return out;
-  for (const key of Object.keys(src)) {
-    if (isForbiddenBrokerKey(key)) continue;
-    out[key] = src[key];
-  }
-  return out;
-}
-
-/**
- * Decode the AEAD plaintext into a `StoredCredentialDoc` (#5014).
+ * Decode the AEAD plaintext into a `DecodedDoc` (#5014).
  *
  * ```
  * try p = JSON.parse(plaintext)
  * if (p && typeof p === 'object' && !Array.isArray(p) && p.v === 2
  *     && p.brokers && typeof p.brokers === 'object')
- *     -> v2 document, used as-is
+ *     -> v2 document: brokers = new Map(Object.entries(p.brokers)
+ *                                          .filter(([k]) => !isForbiddenBrokerKey(k)))
  * else
  *     -> v1: wrap the plaintext (the bare legacy password) as
- *        { v: 2, brokers: {}, legacy: { username: clearUsername, password: plaintext } }
+ *        { v: 2, brokers: new Map(), legacy: { username: clearUsername, password: plaintext } }
  * ```
  *
  * `clearUsername` is the row's clear `username` column, which — for a v1 row
  * — IS the legacy username (that column has held exactly the legacy username
  * since before #5014).
  *
- * The `brokers` map on the returned document is always a sanitized,
- * null-prototype copy (`toNullProtoBrokers`) — even in the v2-as-is path —
- * so a maliciously-crafted stored envelope (or one written by a future bug)
- * can never carry a `__proto__`/`constructor`/`prototype` key back into a
- * live object that later gets a keyed write.
+ * The `brokers` Map built here always excludes `FORBIDDEN_BROKER_KEYS`, even
+ * on the v2-as-is path, so a maliciously-crafted or otherwise unexpected
+ * stored envelope can never reintroduce one of those names as a broker
+ * identity (belt-and-braces — see `FORBIDDEN_BROKER_KEYS`'s comment for why
+ * a `Map` already closes the underlying injection class).
  *
  * MISPARSE CAVEAT (accepted, documented per spec §4.2): a v1 password that
  * happens to be *exactly* a JSON object shaped like `{"v":2,"brokers":{...}}`
@@ -515,7 +548,7 @@ function toNullProtoBrokers(
  * existing row to migrate, which is exactly the migration this design set
  * out to avoid.
  */
-function decodeDoc(plaintext: string, clearUsername: string): StoredCredentialDoc {
+function decodeDoc(plaintext: string, clearUsername: string): DecodedDoc {
   try {
     const parsed: unknown = JSON.parse(plaintext);
     if (
@@ -531,12 +564,16 @@ function decodeDoc(plaintext: string, clearUsername: string): StoredCredentialDo
         brokers: Record<string, { username: string; password: string }>;
         legacy?: { username: string; password: string };
       };
-      return { v: 2, brokers: toNullProtoBrokers(p.brokers), legacy: p.legacy };
+      return {
+        v: 2,
+        brokers: new Map(Object.entries(p.brokers).filter(([key]) => !isForbiddenBrokerKey(key))),
+        legacy: p.legacy,
+      };
     }
   } catch {
     // Not JSON at all — definitely a v1 plaintext password. Fall through.
   }
-  return { v: 2, brokers: toNullProtoBrokers(), legacy: { username: clearUsername, password: plaintext } };
+  return { v: 2, brokers: new Map(), legacy: { username: clearUsername, password: plaintext } };
 }
 
 /**
@@ -552,10 +589,12 @@ function decodeDoc(plaintext: string, clearUsername: string): StoredCredentialDo
  *     unreachable from any public method today, since `clearForBroker`
  *     deletes the row instead of persisting a fully-empty document.
  */
-function computeClearUsername(doc: StoredCredentialDoc): string {
+function computeClearUsername(doc: DecodedDoc): string {
   if (doc.legacy) return doc.legacy.username;
-  const keys = Object.keys(doc.brokers).sort();
-  return keys.length > 0 ? doc.brokers[keys[0]].username : '';
+  const keys = Array.from(doc.brokers.keys()).sort();
+  if (keys.length === 0) return '';
+  const first = doc.brokers.get(keys[0]);
+  return first ? first.username : '';
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/services/meshcoreObserverCredentialStore.ts
+++ b/src/server/services/meshcoreObserverCredentialStore.ts
@@ -188,7 +188,7 @@ export class MeshCoreObserverCredentialStore {
     // A row we cannot decrypt (key_rotated) has an unrecoverable brokers map
     // regardless of what we do here, so there is nothing to preserve; start
     // fresh rather than blocking the operator's write.
-    const brokers = existing.kind === 'ok' ? existing.doc.brokers : {};
+    const brokers = toNullProtoBrokers(existing.kind === 'ok' ? existing.doc.brokers : undefined);
     const doc: StoredCredentialDoc = { v: 2, brokers, legacy: { username, password } };
     await this.persistDoc(sourceId, doc);
   }
@@ -227,20 +227,30 @@ export class MeshCoreObserverCredentialStore {
    * operator-driven admin-route calls against a single source, and the loss
    * is recoverable by re-entering the credential. If a future UI ever
    * batch-saves N brokers in one gesture, it MUST serialize those PUTs.
+   *
+   * PROTOTYPE-POLLUTION GUARD (CodeQL): `brokerKey` is attacker-influenced
+   * (request body). Reject `FORBIDDEN_BROKER_KEYS` outright, and build the
+   * broker map as a null-prototype object (`toNullProtoBrokers`) before the
+   * keyed write below, so even an unexpected key can never reach
+   * `Object.prototype`.
    */
   async storeForBroker(sourceId: string, brokerKey: string, username: string, password: string): Promise<void> {
     if (!this._capability.canStore) {
       throw new Error('Cannot persist Analyzer Observer broker password: SESSION_SECRET is auto-generated');
+    }
+    if (isForbiddenBrokerKey(brokerKey)) {
+      throw new Error(`Cannot store credentials for broker "${brokerKey}": reserved broker key`);
     }
     const existing = await this.readDoc(sourceId);
     // See store()'s comment: a key-rotated row's brokers map is already
     // unrecoverable, so we start fresh rather than blocking the write.
     const doc: StoredCredentialDoc =
       existing.kind === 'ok'
-        ? { v: 2, brokers: { ...existing.doc.brokers }, legacy: existing.doc.legacy }
-        : { v: 2, brokers: {} };
+        ? { v: 2, brokers: toNullProtoBrokers(existing.doc.brokers), legacy: existing.doc.legacy }
+        : { v: 2, brokers: toNullProtoBrokers() };
 
-    if (!(brokerKey in doc.brokers) && Object.keys(doc.brokers).length >= OBSERVER_MAX_BROKER_CREDENTIALS) {
+    const alreadyPresent = Object.prototype.hasOwnProperty.call(doc.brokers, brokerKey);
+    if (!alreadyPresent && Object.keys(doc.brokers).length >= OBSERVER_MAX_BROKER_CREDENTIALS) {
       throw new Error(
         `Cannot store credentials for broker "${brokerKey}": the maximum of ` +
           `${OBSERVER_MAX_BROKER_CREDENTIALS} distinct broker credentials has been reached`,
@@ -256,13 +266,17 @@ export class MeshCoreObserverCredentialStore {
    * fallback is a publisher-level policy decision (`resolveBrokerCredential`
    * in `meshcoreObserverPublisher.ts`), not a store-level one, so that a
    * non-legacy broker can never observe the legacy credential.
+   *
+   * `brokerKey` is attacker-influenced; a reserved key (`FORBIDDEN_BROKER_KEYS`)
+   * is treated as simply absent rather than looked up.
    */
   async loadForBroker(sourceId: string, brokerKey: string): Promise<ObserverCredentialLoadResult> {
+    if (isForbiddenBrokerKey(brokerKey)) return { kind: 'none' };
     const result = await this.readDoc(sourceId);
     if (result.kind === 'none') return { kind: 'none' };
     if (result.kind === 'key_rotated') return { kind: 'key_rotated', storedKid: result.storedKid };
+    if (!Object.prototype.hasOwnProperty.call(result.doc.brokers, brokerKey)) return { kind: 'none' };
     const entry = result.doc.brokers[brokerKey];
-    if (!entry) return { kind: 'none' };
     return { kind: 'ok', username: entry.username, password: entry.password };
   }
 
@@ -274,13 +288,17 @@ export class MeshCoreObserverCredentialStore {
    * read). Deletes the whole row once the resulting document has neither
    * broker entries nor a legacy entry, matching `clear()`'s row-deletion
    * behaviour instead of leaving an empty husk envelope behind.
+   *
+   * `brokerKey` is attacker-influenced; a reserved key (`FORBIDDEN_BROKER_KEYS`)
+   * is a safe no-op rather than being looked up or deleted.
    */
   async clearForBroker(sourceId: string, brokerKey: string): Promise<void> {
+    if (isForbiddenBrokerKey(brokerKey)) return;
     const existing = await this.readDoc(sourceId);
-    if (existing.kind !== 'ok' || !(brokerKey in existing.doc.brokers)) {
+    if (existing.kind !== 'ok' || !Object.prototype.hasOwnProperty.call(existing.doc.brokers, brokerKey)) {
       return;
     }
-    const brokers = { ...existing.doc.brokers };
+    const brokers = toNullProtoBrokers(existing.doc.brokers);
     delete brokers[brokerKey];
     const doc: StoredCredentialDoc = { v: 2, brokers, legacy: existing.doc.legacy };
     if (Object.keys(doc.brokers).length === 0 && !doc.legacy) {
@@ -433,6 +451,40 @@ function hkdfBytes(ikm: Buffer, info: string, length: number): Buffer {
 }
 
 /**
+ * Prototype-pollution guard (CodeQL "remote property injection"): `brokerKey`
+ * ultimately originates from a request body (the credential PUT/DELETE
+ * routes), even though the route layer already bounds it against the
+ * source's *configured* broker keys (normalized URLs — `__proto__` etc.
+ * cannot match one). This store hardens itself independently rather than
+ * relying solely on that upstream check.
+ */
+const FORBIDDEN_BROKER_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isForbiddenBrokerKey(key: string): boolean {
+  return FORBIDDEN_BROKER_KEYS.has(key);
+}
+
+/**
+ * Build a null-prototype copy of a broker map (dropping any of
+ * `FORBIDDEN_BROKER_KEYS`), so every keyed write (`doc.brokers[brokerKey] =
+ * ...`) or delete lands on a plain data map that has no `Object.prototype`
+ * chain to pollute — belt-and-braces alongside the `isForbiddenBrokerKey`
+ * checks at each call site. Called with no argument, it just returns a fresh
+ * empty null-prototype map.
+ */
+function toNullProtoBrokers(
+  src?: Record<string, { username: string; password: string }>,
+): Record<string, { username: string; password: string }> {
+  const out: Record<string, { username: string; password: string }> = Object.create(null);
+  if (!src) return out;
+  for (const key of Object.keys(src)) {
+    if (isForbiddenBrokerKey(key)) continue;
+    out[key] = src[key];
+  }
+  return out;
+}
+
+/**
  * Decode the AEAD plaintext into a `StoredCredentialDoc` (#5014).
  *
  * ```
@@ -448,6 +500,12 @@ function hkdfBytes(ikm: Buffer, info: string, length: number): Buffer {
  * `clearUsername` is the row's clear `username` column, which — for a v1 row
  * — IS the legacy username (that column has held exactly the legacy username
  * since before #5014).
+ *
+ * The `brokers` map on the returned document is always a sanitized,
+ * null-prototype copy (`toNullProtoBrokers`) — even in the v2-as-is path —
+ * so a maliciously-crafted stored envelope (or one written by a future bug)
+ * can never carry a `__proto__`/`constructor`/`prototype` key back into a
+ * live object that later gets a keyed write.
  *
  * MISPARSE CAVEAT (accepted, documented per spec §4.2): a v1 password that
  * happens to be *exactly* a JSON object shaped like `{"v":2,"brokers":{...}}`
@@ -468,12 +526,17 @@ function decodeDoc(plaintext: string, clearUsername: string): StoredCredentialDo
       typeof (parsed as Record<string, unknown>).brokers === 'object' &&
       (parsed as Record<string, unknown>).brokers !== null
     ) {
-      return parsed as StoredCredentialDoc;
+      const p = parsed as {
+        v: 2;
+        brokers: Record<string, { username: string; password: string }>;
+        legacy?: { username: string; password: string };
+      };
+      return { v: 2, brokers: toNullProtoBrokers(p.brokers), legacy: p.legacy };
     }
   } catch {
     // Not JSON at all — definitely a v1 plaintext password. Fall through.
   }
-  return { v: 2, brokers: {}, legacy: { username: clearUsername, password: plaintext } };
+  return { v: 2, brokers: toNullProtoBrokers(), legacy: { username: clearUsername, password: plaintext } };
 }
 
 /**

--- a/src/server/services/meshcoreObserverPublisher.multiBroker.test.ts
+++ b/src/server/services/meshcoreObserverPublisher.multiBroker.test.ts
@@ -436,6 +436,83 @@ describe('MeshCoreObserverPublisher — multi-broker (#5014 Phase 1 WP3)', () =>
     expect(newestOpts.password).toBe(renewedA.token);
   });
 
+  it('test 33b: a hard-stopped connection is excluded from renewal and never resurrected (review fix)', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });
+    const brokerB = broker({ url: 'wss://mqtt-b.test:443', tokenAudience: 'aud-b' });
+    // Both tokens are near expiry, so BOTH audiences would normally be due
+    // for renewal on the next tick.
+    const tokenA = makeToken({ publicKey: pubkeyFor('AA'), expiresAt: nowSeconds + 120 });
+    const tokenB = makeToken({ publicKey: pubkeyFor('BB'), expiresAt: nowSeconds + 120 });
+    const renewedA = makeToken({
+      publicKey: pubkeyFor('AA'),
+      token: 'renewedA.payload.' + 'a'.repeat(128),
+      expiresAt: nowSeconds + 86_400 + 120,
+    });
+
+    let mintCallsForA = 0;
+    let mintCallsForB = 0;
+    const mintToken = vi.fn(async (_sourceId: string, audience: string): Promise<ObserverTokenResult> => {
+      if (audience === 'aud-a') {
+        mintCallsForA++;
+        return { kind: 'ok', token: mintCallsForA === 1 ? tokenA : renewedA };
+      }
+      mintCallsForB++;
+      return { kind: 'ok', token: tokenB };
+    });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([brokerA, brokerB]),
+      device: makeDevice(),
+      mintToken,
+    });
+    const [, clientB] = await startAndConnectAll(publisher, 2);
+    expect(mintCallsForA).toBe(1);
+    expect(mintCallsForB).toBe(1);
+    const connectCountBeforeHardStop = mockConnect.mock.calls.length;
+
+    // Drive B to hard-stop via MAX_AUTH_FAILURES permission-denied events —
+    // same mechanism as test 32.
+    for (let i = 0; i < MAX_AUTH_FAILURES; i++) {
+      clientB!.emit('error', Object.assign(new Error('bad creds'), { code: 4 }));
+    }
+    await flushMicrotasks();
+    expect(publisher.getStatus().brokers[1]!.connected).toBe(false);
+    // Hard-stopping disconnects the existing socket; it does not open a new one.
+    expect(mockConnect.mock.calls.length).toBe(connectCountBeforeHardStop);
+
+    // Advance past the renewal window. Both audiences are "due", but B's
+    // connection is hard-stopped.
+    vi.advanceTimersByTime(RENEWAL_CHECK_MS);
+    await flushMicrotasks();
+
+    // A renews normally...
+    expect(mintCallsForA).toBe(2);
+    // ...but B's audience is never even re-minted (no live connection to use it).
+    expect(mintCallsForB).toBe(1);
+    // Exactly one NEW socket total — A's rebuild. B's socket count is unchanged.
+    expect(mockConnect.mock.calls.length).toBe(connectCountBeforeHardStop + 1);
+    // Bring A's rebuilt socket up so its `connected` status reflects reality.
+    fakeClientAt(connectCountBeforeHardStop).emit('connect');
+    await flushMicrotasks();
+
+    const status = publisher.getStatus();
+    expect(status.brokers[1]!.connected).toBe(false);
+    expect(status.brokers[0]!.connected).toBe(true);
+    // B stays down permanently — isRunning() reflects A only.
+    expect(publisher.isRunning()).toBe(true);
+
+    // A's token is now fresh (just renewed to a 24h expiry), so a further
+    // tick renews nothing at all — confirming B's exclusion isn't a one-tick
+    // fluke and no connect is attempted for either broker.
+    vi.advanceTimersByTime(RENEWAL_CHECK_MS);
+    await flushMicrotasks();
+    expect(mockConnect.mock.calls.length).toBe(connectCountBeforeHardStop + 1);
+    expect(mintCallsForB).toBe(1);
+    expect(publisher.getStatus().brokers[1]!.connected).toBe(false);
+  });
+
   it('test 34: a failed renewal mint does not tear down the working socket', async () => {
     const nowSeconds = Math.floor(Date.now() / 1000);
     const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });

--- a/src/server/services/meshcoreObserverPublisher.multiBroker.test.ts
+++ b/src/server/services/meshcoreObserverPublisher.multiBroker.test.ts
@@ -1,0 +1,659 @@
+/**
+ * meshcoreObserverPublisher multi-broker tests (#5014 Phase 1 WP3 — spec
+ * §6.5, tests 25-39). One MeshCore source publishing the same OTA packet
+ * stream to N Analyzer brokers concurrently, with per-broker connection
+ * state, counters, credentials and tokens.
+ *
+ * Same harness shape as the sibling publisher test files: mock the 'mqtt'
+ * module, drive the REAL `MqttBrokerClient` underneath (so per-broker CONNECT
+ * options — LWT topic, username, password — are asserted for real), and
+ * inject only `mintToken` / `loadCredentials` / `createClient`.
+ * `mockConnect.mock.results` yields one fake client per broker, in config
+ * order.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type MockedFunction } from 'vitest';
+import { EventEmitter } from 'events';
+
+type SubscribeCallback = (
+  err: Error | null,
+  granted: Array<{ topic: string; qos: number }>,
+  packet: unknown,
+) => void;
+type PublishCallback = (err?: Error) => void;
+type EndCallback = () => void;
+type PublishOpts = { qos: number; retain: boolean };
+type SubscribeOpts = { qos: number };
+type EndOpts = Record<string, never>;
+
+interface FakeMqttClient extends EventEmitter {
+  subscribe: MockedFunction<(topics: string[], opts: SubscribeOpts, cb?: SubscribeCallback) => void>;
+  publish: MockedFunction<(topic: string, payload: Buffer, opts: PublishOpts, cb?: PublishCallback) => void>;
+  end: MockedFunction<(force: boolean, opts: EndOpts, cb?: EndCallback) => void>;
+  reconnect: MockedFunction<() => void>;
+}
+
+function makeFakeClient(): FakeMqttClient {
+  const c = new EventEmitter() as FakeMqttClient;
+  c.subscribe = vi.fn((_topics: string[], _opts: SubscribeOpts, cb?: SubscribeCallback) => {
+    cb?.(null, [], {});
+  }) as FakeMqttClient['subscribe'];
+  c.publish = vi.fn((_topic: string, _payload: Buffer, _opts: PublishOpts, cb?: PublishCallback) => {
+    cb?.();
+  }) as FakeMqttClient['publish'];
+  c.end = vi.fn((_force: boolean, _opts: EndOpts, cb?: EndCallback) => {
+    cb?.();
+  }) as FakeMqttClient['end'];
+  c.reconnect = vi.fn() as FakeMqttClient['reconnect'];
+  return c;
+}
+
+vi.mock('mqtt', () => ({
+  connect: vi.fn(() => makeFakeClient()),
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { connect } from 'mqtt';
+import {
+  MeshCoreObserverPublisher,
+  RENEWAL_CHECK_MS,
+  MAX_AUTH_FAILURES,
+  STATUS_REFRESH_MS,
+  type MeshCoreObserverPublisherOptions,
+} from './meshcoreObserverPublisher.js';
+import * as observerPacket from './meshcoreObserverPacket.js';
+import { MqttBrokerClient } from '../transports/mqttBrokerClient.js';
+import type { ObserverCredentialLoadResult } from './meshcoreObserverCredentialStore.js';
+import type { ObserverToken, ObserverTokenResult } from './meshcoreObserverToken.js';
+import type { NormalizedObserverBroker } from '../meshcoreConfig.js';
+
+const mockConnect = connect as MockedFunction<typeof connect>;
+const fakeClientAt = (i: number): FakeMqttClient => mockConnect.mock.results[i]!.value as FakeMqttClient;
+const connectOptionsAt = (i: number) => mockConnect.mock.calls[i]![1]!;
+
+const SOURCE_ID = 'src-observer-multi';
+const IATA = 'TEST';
+
+function pubkeyFor(label: string): string {
+  return label.repeat(64).slice(0, 64).toUpperCase();
+}
+const PUBKEY = pubkeyFor('AB');
+
+function makeToken(overrides: Partial<ObserverToken> = {}): ObserverToken {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  return {
+    token: 'headerpart1234567890abcdef.payloadpart1234567890abcdef.' + 'a'.repeat(128),
+    publicKey: PUBKEY,
+    issuedAt: nowSeconds,
+    expiresAt: nowSeconds + 86_400,
+    ...overrides,
+  };
+}
+
+function broker(overrides: Partial<NormalizedObserverBroker> & { url: string }): NormalizedObserverBroker {
+  return {
+    key: overrides.url.toLowerCase(),
+    authMode: 'token',
+    legacy: false,
+    ...overrides,
+  };
+}
+
+function makeConfig(brokers: NormalizedObserverBroker[]): MeshCoreObserverPublisherOptions['config'] {
+  return {
+    enabled: true,
+    iataCode: IATA,
+    brokers,
+    authMode: brokers[0]?.authMode ?? 'token',
+    brokerUrl: brokers[0]?.url ?? 'mqtt://unused.test:1883',
+    ...(brokers[0]?.tokenAudience ? { tokenAudience: brokers[0].tokenAudience } : {}),
+  };
+}
+
+function makeDevice(publicKey?: string): MeshCoreObserverPublisherOptions['device'] {
+  return () => ({ origin: 'MyNode', model: 'ModelX', firmwareVersion: 'v1.16.1', radio: '915,250,7,5', publicKey });
+}
+
+/** mintToken mock that resolves 'ok' with a distinct token per audience, keyed by an optional map. */
+function makeMintTokenByAudience(
+  tokensByAudience: Record<string, ObserverToken>,
+): MockedFunction<(sourceId: string, audience: string) => Promise<ObserverTokenResult>> {
+  return vi.fn(async (_sourceId: string, audience: string): Promise<ObserverTokenResult> => {
+    const token = tokensByAudience[audience];
+    return token ? { kind: 'ok', token } : { kind: 'mint_failed', message: 'no token for audience' };
+  });
+}
+
+function loaderByBrokerKey(
+  credsByKey: Record<string, { username: string; password: string }>,
+): MockedFunction<(sourceId: string, brokerKey: string, legacy: boolean) => Promise<ObserverCredentialLoadResult>> {
+  return vi.fn(async (_sourceId: string, brokerKey: string, _legacy: boolean): Promise<ObserverCredentialLoadResult> => {
+    const cred = credsByKey[brokerKey];
+    return cred ? { kind: 'ok', ...cred } : { kind: 'none' };
+  });
+}
+
+async function flushMicrotasks(times = 30): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+/** Starts the publisher, flushes until every expected client is created, then connects all of them. */
+async function startAndConnectAll(
+  publisher: MeshCoreObserverPublisher,
+  expectedClientCount: number,
+): Promise<FakeMqttClient[]> {
+  const startPromise = publisher.start();
+  await flushMicrotasks();
+  const clients: FakeMqttClient[] = [];
+  for (let i = 0; i < expectedClientCount; i++) clients.push(fakeClientAt(i));
+  for (const c of clients) c.emit('connect');
+  await startPromise;
+  await flushMicrotasks();
+  return clients;
+}
+
+describe('MeshCoreObserverPublisher — multi-broker (#5014 Phase 1 WP3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('test 25: concurrent publish to 2 token-mode brokers with different audiences', async () => {
+    const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });
+    const brokerB = broker({ url: 'wss://mqtt-b.test:443', tokenAudience: 'aud-b' });
+    const tokenA = makeToken({ publicKey: pubkeyFor('AA'), token: 'tokA.payload.' + 'a'.repeat(128) });
+    const tokenB = makeToken({ publicKey: pubkeyFor('BB'), token: 'tokB.payload.' + 'b'.repeat(128) });
+    const mintToken = makeMintTokenByAudience({ 'aud-a': tokenA, 'aud-b': tokenB });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([brokerA, brokerB]),
+      device: makeDevice(),
+      mintToken,
+    });
+
+    const [clientA, clientB] = await startAndConnectAll(publisher, 2);
+    expect(mintToken).toHaveBeenCalledTimes(2);
+    expect(mintToken).toHaveBeenCalledWith(SOURCE_ID, 'aud-a');
+    expect(mintToken).toHaveBeenCalledWith(SOURCE_ID, 'aud-b');
+
+    clientA!.publish.mockClear();
+    clientB!.publish.mockClear();
+
+    publisher.handleOtaPacket({ snr: 5, rssi: -70, raw_hex: '0900aa' });
+    await flushMicrotasks();
+
+    // Each broker uses ITS OWN topic (derived from its own token's public key).
+    expect(clientA!.publish).toHaveBeenCalledTimes(1);
+    expect(clientB!.publish).toHaveBeenCalledTimes(1);
+    const [topicA, payloadA] = clientA!.publish.mock.calls[0]!;
+    const [topicB, payloadB] = clientB!.publish.mock.calls[0]!;
+    expect(topicA).toBe(`meshcore/test/${tokenA.publicKey}/packets`);
+    expect(topicB).toBe(`meshcore/test/${tokenB.publicKey}/packets`);
+    // Different origin ids -> different payloads (this is NOT the "shared
+    // audience" case), but each is internally well-formed.
+    expect(JSON.parse(payloadA.toString()).origin_id).toBe(tokenA.publicKey);
+    expect(JSON.parse(payloadB.toString()).origin_id).toBe(tokenB.publicKey);
+  });
+
+  it('test 26: payload is built exactly once per distinct originId, even across 3 same-origin brokers', async () => {
+    const spy = vi.spyOn(observerPacket, 'buildObserverPacketPayload');
+    const brokers = [
+      broker({ url: 'wss://mqtt-1.test:443', tokenAudience: 'shared-aud' }),
+      broker({ url: 'wss://mqtt-2.test:443', tokenAudience: 'shared-aud' }),
+      broker({ url: 'wss://mqtt-3.test:443', tokenAudience: 'shared-aud' }),
+    ];
+    const token = makeToken();
+    const mintToken = makeMintTokenByAudience({ 'shared-aud': token });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig(brokers),
+      device: makeDevice(),
+      mintToken,
+    });
+    await startAndConnectAll(publisher, 3);
+    spy.mockClear();
+
+    publisher.handleOtaPacket({ snr: 1, rssi: -1, raw_hex: '0900aa' });
+    await flushMicrotasks();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  it('test 27: mintToken receives each broker\'s own audience; CONNECT password is that broker\'s token', async () => {
+    const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });
+    const brokerB = broker({ url: 'wss://mqtt-b.test:443', tokenAudience: 'aud-b' });
+    const tokenA = makeToken({ publicKey: pubkeyFor('AA'), token: 'tokA.payload.' + 'a'.repeat(128) });
+    const tokenB = makeToken({ publicKey: pubkeyFor('BB'), token: 'tokB.payload.' + 'b'.repeat(128) });
+    const mintToken = makeMintTokenByAudience({ 'aud-a': tokenA, 'aud-b': tokenB });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([brokerA, brokerB]),
+      device: makeDevice(),
+      mintToken,
+    });
+    await startAndConnectAll(publisher, 2);
+
+    expect(connectOptionsAt(0).password).toBe(tokenA.token);
+    expect(connectOptionsAt(0).username).toBe(`v1_${tokenA.publicKey}`);
+    expect(connectOptionsAt(1).password).toBe(tokenB.token);
+    expect(connectOptionsAt(1).username).toBe(`v1_${tokenB.publicKey}`);
+  });
+
+  it('test 28: two brokers sharing an audience dedupe minting — one mint call, same token on both sockets', async () => {
+    const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'shared-aud' });
+    const brokerB = broker({ url: 'wss://mqtt-b.test:443', tokenAudience: 'shared-aud' });
+    const token = makeToken();
+    const mintToken = makeMintTokenByAudience({ 'shared-aud': token });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([brokerA, brokerB]),
+      device: makeDevice(),
+      mintToken,
+    });
+    await startAndConnectAll(publisher, 2);
+
+    expect(mintToken).toHaveBeenCalledTimes(1);
+    expect(connectOptionsAt(0).password).toBe(token.token);
+    expect(connectOptionsAt(1).password).toBe(token.token);
+  });
+
+  it('test 29: drop-when-disconnected is per broker; aggregate publishes is the sum', async () => {
+    const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });
+    const brokerB = broker({ url: 'wss://mqtt-b.test:443', tokenAudience: 'aud-b' });
+    const tokenA = makeToken({ publicKey: pubkeyFor('AA') });
+    const tokenB = makeToken({ publicKey: pubkeyFor('BB') });
+    const mintToken = makeMintTokenByAudience({ 'aud-a': tokenA, 'aud-b': tokenB });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([brokerA, brokerB]),
+      device: makeDevice(),
+      mintToken,
+    });
+    const [clientA, clientB] = await startAndConnectAll(publisher, 2);
+    clientA!.publish.mockClear();
+    clientB!.publish.mockClear();
+
+    // Disconnect B only.
+    clientB!.emit('close');
+    await flushMicrotasks();
+
+    publisher.handleOtaPacket({ snr: 1, rssi: -1, raw_hex: '0900aa' });
+    await flushMicrotasks();
+
+    const status = publisher.getStatus();
+    expect(status.brokers[0]!.publishes).toBe(1);
+    expect(status.brokers[0]!.dropped).toBe(0);
+    expect(status.brokers[1]!.publishes).toBe(0);
+    expect(status.brokers[1]!.dropped).toBe(1);
+    expect(status.publishes).toBe(1);
+    expect(status.dropped).toBe(1);
+  });
+
+  it('test 30: per-broker lastError isolation', async () => {
+    const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });
+    const brokerB = broker({ url: 'wss://mqtt-b.test:443', tokenAudience: 'aud-b' });
+    const tokenA = makeToken({ publicKey: pubkeyFor('AA') });
+    const tokenB = makeToken({ publicKey: pubkeyFor('BB') });
+    const mintToken = makeMintTokenByAudience({ 'aud-a': tokenA, 'aud-b': tokenB });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([brokerA, brokerB]),
+      device: makeDevice(),
+      mintToken,
+    });
+    const [, clientB] = await startAndConnectAll(publisher, 2);
+
+    clientB!.emit('error', new Error('broker B exploded'));
+    await flushMicrotasks();
+
+    const status = publisher.getStatus();
+    expect(status.brokers[1]!.lastError).toContain('broker B exploded');
+    expect(status.brokers[0]!.lastError).toBeNull();
+    expect(status.lastError).toContain('broker B exploded');
+  });
+
+  it('test 31: token-shaped substrings are redacted per broker', async () => {
+    const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });
+    const mintToken = makeMintTokenByAudience({ 'aud-a': makeToken() });
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([brokerA]),
+      device: makeDevice(),
+      mintToken,
+    });
+    const [client] = await startAndConnectAll(publisher, 1);
+
+    const embeddedToken = 'headerpart1234567890abcdef.payloadpart1234567890abcdef.' + 'c'.repeat(128);
+    client!.emit('error', new Error(`token rejected: ${embeddedToken}`));
+
+    const lastError = publisher.getStatus().brokers[0]!.lastError;
+    expect(lastError).not.toContain(embeddedToken);
+    expect(lastError).toContain('[REDACTED]');
+  });
+
+  it('test 32: auth hard-stop is per broker — B disconnects, A keeps publishing, isRunning() stays true', async () => {
+    const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });
+    const brokerB = broker({ url: 'wss://mqtt-b.test:443', tokenAudience: 'aud-b' });
+    const tokenA = makeToken({ publicKey: pubkeyFor('AA') });
+    const tokenB = makeToken({ publicKey: pubkeyFor('BB') });
+    const mintToken = makeMintTokenByAudience({ 'aud-a': tokenA, 'aud-b': tokenB });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([brokerA, brokerB]),
+      device: makeDevice(),
+      mintToken,
+    });
+    const [clientA, clientB] = await startAndConnectAll(publisher, 2);
+
+    for (let i = 0; i < MAX_AUTH_FAILURES; i++) {
+      clientB!.emit('error', Object.assign(new Error('bad creds'), { code: 4 }));
+    }
+    await flushMicrotasks();
+
+    expect(publisher.isRunning()).toBe(true);
+    const status = publisher.getStatus();
+    expect(status.brokers[1]!.connected).toBe(false);
+    expect(status.brokers[0]!.connected).toBe(true);
+
+    clientA!.publish.mockClear();
+    publisher.handleOtaPacket({ snr: 1, rssi: -1, raw_hex: '0900aa' });
+    await flushMicrotasks();
+    expect(clientA!.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('test 32b: when the LAST live connection hard-stops, timers clear and isRunning() goes false', async () => {
+    const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });
+    const tokenA = makeToken();
+    const mintToken = makeMintTokenByAudience({ 'aud-a': tokenA });
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([brokerA]),
+      device: makeDevice(),
+      mintToken,
+    });
+    const [client] = await startAndConnectAll(publisher, 1);
+
+    for (let i = 0; i < MAX_AUTH_FAILURES; i++) {
+      client!.emit('error', Object.assign(new Error('bad creds'), { code: 4 }));
+    }
+    await flushMicrotasks();
+
+    expect(publisher.isRunning()).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('test 33: renewal rebuilds only the affected audience', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });
+    const brokerB = broker({ url: 'wss://mqtt-b.test:443', tokenAudience: 'aud-b' });
+    const tokenA = makeToken({ publicKey: pubkeyFor('AA'), expiresAt: nowSeconds + 120 }); // near expiry
+    const tokenB = makeToken({ publicKey: pubkeyFor('BB'), expiresAt: nowSeconds + 86_400 + 120 }); // fresh
+    const renewedA = makeToken({
+      publicKey: pubkeyFor('AA'),
+      token: 'renewedA.payload.' + 'a'.repeat(128),
+      expiresAt: nowSeconds + 86_400 + 120,
+    });
+
+    let mintCallsForA = 0;
+    const mintToken = vi.fn(async (_sourceId: string, audience: string): Promise<ObserverTokenResult> => {
+      if (audience === 'aud-a') {
+        mintCallsForA++;
+        return { kind: 'ok', token: mintCallsForA === 1 ? tokenA : renewedA };
+      }
+      return { kind: 'ok', token: tokenB };
+    });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([brokerA, brokerB]),
+      device: makeDevice(),
+      mintToken,
+    });
+    await startAndConnectAll(publisher, 2);
+    const connectCountBefore = mockConnect.mock.calls.length;
+
+    vi.advanceTimersByTime(RENEWAL_CHECK_MS);
+    await flushMicrotasks();
+
+    expect(mintCallsForA).toBe(2); // initial + renewal
+    // Exactly one NEW socket (A's rebuild) — B untouched.
+    expect(mockConnect.mock.calls.length).toBe(connectCountBefore + 1);
+    const newestOpts = connectOptionsAt(mockConnect.mock.calls.length - 1);
+    expect(newestOpts.password).toBe(renewedA.token);
+  });
+
+  it('test 34: a failed renewal mint does not tear down the working socket', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });
+    const tokenA = makeToken({ expiresAt: nowSeconds + 120 });
+    let calls = 0;
+    const mintToken = vi.fn(async (): Promise<ObserverTokenResult> => {
+      calls++;
+      return calls === 1 ? { kind: 'ok', token: tokenA } : { kind: 'mint_failed', message: 'renewal boom' };
+    });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([brokerA]),
+      device: makeDevice(),
+      mintToken,
+    });
+    const [client] = await startAndConnectAll(publisher, 1);
+    const connectCountBefore = mockConnect.mock.calls.length;
+
+    vi.advanceTimersByTime(RENEWAL_CHECK_MS);
+    await flushMicrotasks();
+
+    expect(calls).toBe(2);
+    expect(mockConnect.mock.calls.length).toBe(connectCountBefore); // no rebuild
+    expect(client!.end).not.toHaveBeenCalled();
+    expect(publisher.getStatus().brokers[0]!.lastError).toBe('Failed to mint observer auth token.');
+  });
+
+  it('test 35: status refresh reads stats exactly once per tick across 3 brokers, and publishes to all 3', async () => {
+    const brokers = [
+      broker({ url: 'wss://mqtt-1.test:443', tokenAudience: 'aud-1' }),
+      broker({ url: 'wss://mqtt-2.test:443', tokenAudience: 'aud-2' }),
+      broker({ url: 'wss://mqtt-3.test:443', tokenAudience: 'aud-3' }),
+    ];
+    const tokens = {
+      'aud-1': makeToken({ publicKey: pubkeyFor('11') }),
+      'aud-2': makeToken({ publicKey: pubkeyFor('22') }),
+      'aud-3': makeToken({ publicKey: pubkeyFor('33') }),
+    };
+    const mintToken = makeMintTokenByAudience(tokens);
+    const stats = vi.fn().mockResolvedValue({ batteryMv: 4021 });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig(brokers),
+      device: makeDevice(),
+      mintToken,
+      stats,
+    });
+    const clients = await startAndConnectAll(publisher, 3);
+    stats.mockClear();
+    for (const c of clients) c.publish.mockClear();
+
+    await vi.advanceTimersByTimeAsync(STATUS_REFRESH_MS);
+    await flushMicrotasks();
+
+    expect(stats).toHaveBeenCalledTimes(1);
+    for (const c of clients) {
+      const statusCalls = c.publish.mock.calls.filter((call) => call[0].endsWith('/status'));
+      expect(statusCalls).toHaveLength(1);
+      expect(JSON.parse(statusCalls[0]![1]!.toString()).stats).toEqual({ battery_mv: 4021 });
+    }
+  });
+
+  it('test 36: password-mode per-broker credentials — each socket gets its own username/password', async () => {
+    const brokerA = broker({ url: 'wss://mqtt-a.test:443', authMode: 'password', legacy: false });
+    const brokerB = broker({ url: 'wss://mqtt-b.test:443', authMode: 'password', legacy: true });
+    const loadCredentials = loaderByBrokerKey({
+      'wss://mqtt-a.test:443': { username: 'user-a', password: 'pass-a' },
+      'wss://mqtt-b.test:443': { username: 'user-b', password: 'pass-b' },
+    });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([brokerA, brokerB]),
+      device: makeDevice(PUBKEY),
+      mintToken: vi.fn(),
+      loadCredentials,
+    });
+    await startAndConnectAll(publisher, 2);
+
+    expect(loadCredentials).toHaveBeenCalledWith(SOURCE_ID, 'wss://mqtt-a.test:443', false);
+    expect(loadCredentials).toHaveBeenCalledWith(SOURCE_ID, 'wss://mqtt-b.test:443', true);
+    expect(connectOptionsAt(0).username).toBe('user-a');
+    expect(connectOptionsAt(0).password).toBe('pass-a');
+    expect(connectOptionsAt(1).username).toBe('user-b');
+    expect(connectOptionsAt(1).password).toBe('pass-b');
+  });
+
+  it('test 37: mixed modes on one source — password broker has null tokenExpiresAt', async () => {
+    const tokenBroker = broker({ url: 'wss://mqtt-tok.test:443', tokenAudience: 'aud-tok' });
+    const passwordBroker = broker({ url: 'wss://mqtt-pass.test:443', authMode: 'password', legacy: false });
+    const token = makeToken();
+    const mintToken = makeMintTokenByAudience({ 'aud-tok': token });
+    const loadCredentials = loaderByBrokerKey({
+      'wss://mqtt-pass.test:443': { username: 'user', password: 'pass' },
+    });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([tokenBroker, passwordBroker]),
+      device: makeDevice(PUBKEY),
+      mintToken,
+      loadCredentials,
+    });
+    await startAndConnectAll(publisher, 2);
+
+    const status = publisher.getStatus();
+    expect(status.brokers[0]!.authMode).toBe('token');
+    expect(status.brokers[0]!.tokenExpiresAt).toBeGreaterThan(0);
+    expect(status.brokers[1]!.authMode).toBe('password');
+    expect(status.brokers[1]!.tokenExpiresAt).toBeNull();
+  });
+
+  describe('test 38: start() never throws', () => {
+    it('when every mint fails', async () => {
+      const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });
+      const brokerB = broker({ url: 'wss://mqtt-b.test:443', tokenAudience: 'aud-b' });
+      const mintToken = vi.fn(async (): Promise<ObserverTokenResult> => ({ kind: 'mint_failed', message: 'boom' }));
+      const publisher = new MeshCoreObserverPublisher({
+        sourceId: SOURCE_ID,
+        config: makeConfig([brokerA, brokerB]),
+        device: makeDevice(),
+        mintToken,
+      });
+
+      await expect(publisher.start()).resolves.toBeUndefined();
+      expect(publisher.isRunning()).toBe(false);
+      expect(mockConnect).not.toHaveBeenCalled();
+    });
+
+    it('when every credential is missing', async () => {
+      const brokerA = broker({ url: 'wss://mqtt-a.test:443', authMode: 'password' });
+      const brokerB = broker({ url: 'wss://mqtt-b.test:443', authMode: 'password' });
+      const loadCredentials = loaderByBrokerKey({});
+      const publisher = new MeshCoreObserverPublisher({
+        sourceId: SOURCE_ID,
+        config: makeConfig([brokerA, brokerB]),
+        device: makeDevice(PUBKEY),
+        mintToken: vi.fn(),
+        loadCredentials,
+      });
+
+      await expect(publisher.start()).resolves.toBeUndefined();
+      expect(publisher.isRunning()).toBe(false);
+      expect(mockConnect).not.toHaveBeenCalled();
+    });
+
+    it('when createClient throws for one broker — the others still come up', async () => {
+      const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });
+      const brokerB = broker({ url: 'wss://mqtt-b.test:443', tokenAudience: 'aud-b' });
+      const tokenA = makeToken({ publicKey: pubkeyFor('AA') });
+      const tokenB = makeToken({ publicKey: pubkeyFor('BB') });
+      const mintToken = makeMintTokenByAudience({ 'aud-a': tokenA, 'aud-b': tokenB });
+
+      let call = 0;
+      const createClient = vi.fn((opts) => {
+        call++;
+        if (call === 1) throw new Error('createClient boom');
+        // Fall through to a REAL MqttBrokerClient around the mocked 'mqtt'
+        // module for the surviving broker.
+        return new MqttBrokerClient(opts);
+      });
+
+      const publisher = new MeshCoreObserverPublisher({
+        sourceId: SOURCE_ID,
+        config: makeConfig([brokerA, brokerB]),
+        device: makeDevice(),
+        mintToken,
+        createClient,
+      });
+
+      const startPromise = publisher.start();
+      await flushMicrotasks();
+      // Only brokerB's createClient call actually built a socket — brokerA's
+      // threw before ever reaching `mqtt.connect`.
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+      fakeClientAt(0).emit('connect');
+      await expect(startPromise).resolves.toBeUndefined();
+      await flushMicrotasks();
+
+      expect(publisher.isRunning()).toBe(true);
+      const status = publisher.getStatus();
+      expect(status.brokers[0]!.keyStored).toBe(false);
+      expect(status.brokers[0]!.lastError).toContain('createClient boom');
+      expect(status.brokers[1]!.connected).toBe(true);
+    });
+  });
+
+  it('test 39: stop() publishes offline + disconnects on every broker, and is idempotent', async () => {
+    const brokerA = broker({ url: 'wss://mqtt-a.test:443', tokenAudience: 'aud-a' });
+    const brokerB = broker({ url: 'wss://mqtt-b.test:443', tokenAudience: 'aud-b' });
+    const tokenA = makeToken({ publicKey: pubkeyFor('AA') });
+    const tokenB = makeToken({ publicKey: pubkeyFor('BB') });
+    const mintToken = makeMintTokenByAudience({ 'aud-a': tokenA, 'aud-b': tokenB });
+
+    const publisher = new MeshCoreObserverPublisher({
+      sourceId: SOURCE_ID,
+      config: makeConfig([brokerA, brokerB]),
+      device: makeDevice(),
+      mintToken,
+    });
+    const [clientA, clientB] = await startAndConnectAll(publisher, 2);
+    clientA!.publish.mockClear();
+    clientB!.publish.mockClear();
+
+    await publisher.stop();
+
+    for (const c of [clientA!, clientB!]) {
+      expect(c.publish).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(c.publish.mock.calls[0]![1]!.toString()).status).toBe('offline');
+      expect(c.end).toHaveBeenCalledTimes(1);
+    }
+    expect(vi.getTimerCount()).toBe(0);
+
+    // Idempotent: no additional publishes/disconnects.
+    await publisher.stop();
+    expect(clientA!.publish).toHaveBeenCalledTimes(1);
+    expect(clientB!.publish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/meshcoreObserverPublisher.perSource.test.ts
+++ b/src/server/services/meshcoreObserverPublisher.perSource.test.ts
@@ -89,20 +89,23 @@ function makeToken(fixture: SourceFixture): ObserverToken {
 
 function makeMintToken(
   fixture: SourceFixture,
-): MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>> {
-  const fn = vi.fn() as MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>>;
+): MockedFunction<(sourceId: string, audience: string) => Promise<ObserverTokenResult>> {
+  const fn = vi.fn() as MockedFunction<(sourceId: string, audience: string) => Promise<ObserverTokenResult>>;
   fn.mockResolvedValue({ kind: 'ok', token: makeToken(fixture) });
   return fn;
 }
 
 function makePublisher(
   fixture: SourceFixture,
-  mintToken: MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>>,
+  mintToken: MockedFunction<(sourceId: string, audience: string) => Promise<ObserverTokenResult>>,
 ): MeshCoreObserverPublisher {
+  const url = 'mqtt://broker.test:1883';
   const config: MeshCoreObserverPublisherOptions['config'] = {
     enabled: true,
-    brokerUrl: 'mqtt://broker.test:1883',
     iataCode: fixture.iataCode,
+    brokers: [{ key: url.toLowerCase(), url, authMode: 'token', tokenAudience: 'aud.test', legacy: true }],
+    authMode: 'token',
+    brokerUrl: url,
     tokenAudience: 'aud.test',
   };
   return new MeshCoreObserverPublisher({
@@ -119,7 +122,7 @@ async function flushMicrotasks(times = 10): Promise<void> {
 
 async function startAndConnect(publisher: MeshCoreObserverPublisher): Promise<FakeMqttClient> {
   const startPromise = publisher.start();
-  await flushMicrotasks(3);
+  await flushMicrotasks(30);
   const client = lastFakeClient();
   client.emit('connect');
   await startPromise;
@@ -163,10 +166,10 @@ describe('MeshCoreObserverPublisher — per-source isolation (#4457 §7.4)', () 
     await startAndConnect(pubA);
     await startAndConnect(pubB);
 
-    expect(mintA).toHaveBeenCalledWith(SOURCE_A.sourceId);
-    expect(mintB).toHaveBeenCalledWith(SOURCE_B.sourceId);
-    expect(mintA).not.toHaveBeenCalledWith(SOURCE_B.sourceId);
-    expect(mintB).not.toHaveBeenCalledWith(SOURCE_A.sourceId);
+    expect(mintA).toHaveBeenCalledWith(SOURCE_A.sourceId, 'aud.test');
+    expect(mintB).toHaveBeenCalledWith(SOURCE_B.sourceId, 'aud.test');
+    expect(mintA).not.toHaveBeenCalledWith(SOURCE_B.sourceId, 'aud.test');
+    expect(mintB).not.toHaveBeenCalledWith(SOURCE_A.sourceId, 'aud.test');
   });
 
   it('never cross-delivers a packet handed to A onto B\'s client, and keeps counters independent', async () => {
@@ -216,7 +219,7 @@ describe('MeshCoreObserverPublisher — per-source isolation (#4457 §7.4)', () 
     // B started but never connected — its socket stays down.
     const pubB = makePublisher(SOURCE_B, mintB);
     const startPromiseB = pubB.start();
-    await flushMicrotasks(3);
+    await flushMicrotasks(30);
     const clientB = lastFakeClient();
 
     pubB.handleOtaPacket({ snr: 1, rssi: -1, raw_hex: '0900aa' });

--- a/src/server/services/meshcoreObserverPublisher.staticAuth.test.ts
+++ b/src/server/services/meshcoreObserverPublisher.staticAuth.test.ts
@@ -75,16 +75,39 @@ const PUBKEY = 'AB'.repeat(32);
 const TOKEN_STRING = 'headerpart1234567890abcdef.payloadpart1234567890abcdef.' + 'a'.repeat(128);
 const BROKER_USER = 'meshcore';
 const BROKER_PASS = 'meshcore';
+const BROKER_URL = 'mqtt://meshcoretel.test:1883';
+const BROKER_KEY = BROKER_URL.toLowerCase();
 
+/** Legacy single (password-mode) broker, expressed as `NormalizedObserverConfig` (#5014 Phase 1 WP3). */
 function makeConfig(
   overrides: Partial<MeshCoreObserverPublisherOptions['config']> = {},
 ): MeshCoreObserverPublisherOptions['config'] {
   return {
     enabled: true,
-    authMode: 'password',
-    brokerUrl: 'mqtt://meshcoretel.test:1883',
     iataCode: 'ALA',
+    brokers: [{ key: BROKER_KEY, url: BROKER_URL, authMode: 'password', legacy: true }],
+    authMode: 'password',
+    brokerUrl: BROKER_URL,
     ...overrides,
+  };
+}
+
+/** Legacy single token-mode broker config, matching `meshcoreObserverPublisher.test.ts`'s shape. */
+function makeTokenConfig(
+  overrides: { tokenAudience?: string } = { tokenAudience: 'aud.test' },
+): MeshCoreObserverPublisherOptions['config'] {
+  const url = 'mqtt://broker.test:1883';
+  const key = url.toLowerCase();
+  const tokenAudience = overrides.tokenAudience;
+  return {
+    enabled: true,
+    iataCode: 'TEST',
+    brokers: tokenAudience
+      ? [{ key, url, authMode: 'token', tokenAudience, legacy: true }]
+      : [], // token-mode entry with no audience is dropped by normalizeObserverBrokers
+    authMode: 'token',
+    brokerUrl: url,
+    ...(tokenAudience ? { tokenAudience } : {}),
   };
 }
 
@@ -107,14 +130,16 @@ function makeToken(): ObserverToken {
 
 function loader(
   result: ObserverCredentialLoadResult,
-): MockedFunction<(sourceId: string) => Promise<ObserverCredentialLoadResult>> {
-  const fn = vi.fn() as MockedFunction<(sourceId: string) => Promise<ObserverCredentialLoadResult>>;
+): MockedFunction<(sourceId: string, brokerKey: string, legacy: boolean) => Promise<ObserverCredentialLoadResult>> {
+  const fn = vi.fn() as MockedFunction<
+    (sourceId: string, brokerKey: string, legacy: boolean) => Promise<ObserverCredentialLoadResult>
+  >;
   fn.mockResolvedValue(result);
   return fn;
 }
 
-function minter(): MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>> {
-  const fn = vi.fn() as MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>>;
+function minter(): MockedFunction<(sourceId: string, audience: string) => Promise<ObserverTokenResult>> {
+  const fn = vi.fn() as MockedFunction<(sourceId: string, audience: string) => Promise<ObserverTokenResult>>;
   fn.mockResolvedValue({ kind: 'ok', token: makeToken() });
   return fn;
 }
@@ -125,7 +150,7 @@ async function flushMicrotasks(times = 10): Promise<void> {
 
 async function startAndConnect(publisher: MeshCoreObserverPublisher): Promise<FakeMqttClient> {
   const startPromise = publisher.start();
-  await flushMicrotasks(3);
+  await flushMicrotasks(30);
   const client = lastFakeClient();
   client.emit('connect');
   await startPromise;
@@ -160,7 +185,7 @@ describe('MeshCoreObserverPublisher — static credentials (#4595)', () => {
     expect(opts.password).toBe(BROKER_PASS);
     expect(opts.username).not.toMatch(/^v1_/);
     expect(mintToken).not.toHaveBeenCalled();
-    expect(loadCredentials).toHaveBeenCalledWith(SOURCE_ID);
+    expect(loadCredentials).toHaveBeenCalledWith(SOURCE_ID, BROKER_KEY, true);
 
     const status = publisher.getStatus();
     expect(status).toMatchObject({
@@ -318,7 +343,7 @@ describe('MeshCoreObserverPublisher — static credentials (#4595)', () => {
       const loadCredentials = loader({ kind: 'ok', username: BROKER_USER, password: BROKER_PASS });
       const publisher = new MeshCoreObserverPublisher({
         sourceId: SOURCE_ID,
-        config: { enabled: true, brokerUrl: 'mqtt://broker.test:1883', iataCode: 'TEST', tokenAudience: 'aud.test' },
+        config: makeTokenConfig(),
         device: makeDevice(PUBKEY),
         mintToken,
         loadCredentials,
@@ -330,7 +355,7 @@ describe('MeshCoreObserverPublisher — static credentials (#4595)', () => {
       expect(opts.username).toBe(`v1_${PUBKEY}`);
       expect(opts.password).toBe(TOKEN_STRING);
       expect(loadCredentials).not.toHaveBeenCalled();
-      expect(mintToken).toHaveBeenCalledWith(SOURCE_ID);
+      expect(mintToken).toHaveBeenCalledWith(SOURCE_ID, 'aud.test');
 
       const status = publisher.getStatus();
       expect(status.authMode).toBe('token');
@@ -340,13 +365,7 @@ describe('MeshCoreObserverPublisher — static credentials (#4595)', () => {
     it('an explicit authMode:token behaves identically to an absent one', async () => {
       const publisher = new MeshCoreObserverPublisher({
         sourceId: SOURCE_ID,
-        config: {
-          enabled: true,
-          authMode: 'token',
-          brokerUrl: 'mqtt://broker.test:1883',
-          iataCode: 'TEST',
-          tokenAudience: 'aud.test',
-        },
+        config: makeTokenConfig(),
         device: makeDevice(PUBKEY),
         mintToken: minter(),
         loadCredentials: loader({ kind: 'none' }),
@@ -358,9 +377,13 @@ describe('MeshCoreObserverPublisher — static credentials (#4595)', () => {
     });
 
     it('still requires a tokenAudience to count as configured', async () => {
+      // No audience -> normalizeObserverBrokers drops the (only) broker
+      // entirely, leaving `brokers: []` — exactly what a hand-built
+      // NormalizedObserverConfig looks like for "nothing usable configured"
+      // (§2.3 rule 6 / §5.1's `configured: ANY broker configured`).
       const publisher = new MeshCoreObserverPublisher({
         sourceId: SOURCE_ID,
-        config: { enabled: true, authMode: 'token', brokerUrl: 'mqtt://broker.test:1883', iataCode: 'TEST' },
+        config: makeTokenConfig({ tokenAudience: undefined }),
         device: makeDevice(PUBKEY),
         mintToken: minter(),
         loadCredentials: loader({ kind: 'none' }),

--- a/src/server/services/meshcoreObserverPublisher.test.ts
+++ b/src/server/services/meshcoreObserverPublisher.test.ts
@@ -84,11 +84,22 @@ function makeToken(overrides: Partial<ObserverToken> = {}): ObserverToken {
   };
 }
 
+const BROKER_URL = 'mqtt://broker.test:1883';
+const BROKER_KEY = BROKER_URL.toLowerCase();
+
+/**
+ * Legacy single-broker config, expressed in the new `NormalizedObserverConfig`
+ * shape (#5014 Phase 1 WP3) — this is exactly what `observerConfigFromSource`
+ * produces for the pre-#5014 `{enabled, brokerUrl, iataCode, tokenAudience}`
+ * block, i.e. one `legacy: true` broker plus the retained flat mirrors.
+ */
 function makeConfig(): MeshCoreObserverPublisherOptions['config'] {
   return {
     enabled: true,
-    brokerUrl: 'mqtt://broker.test:1883',
     iataCode: 'TEST',
+    brokers: [{ key: BROKER_KEY, url: BROKER_URL, authMode: 'token', tokenAudience: 'aud.test', legacy: true }],
+    authMode: 'token',
+    brokerUrl: BROKER_URL,
     tokenAudience: 'aud.test',
   };
 }
@@ -104,22 +115,22 @@ function makeDevice(): MeshCoreObserverPublisherOptions['device'] {
 
 function makeMintToken(
   ...results: ObserverTokenResult[]
-): MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>> {
-  const fn = vi.fn() as MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>>;
+): MockedFunction<(sourceId: string, audience: string) => Promise<ObserverTokenResult>> {
+  const fn = vi.fn() as MockedFunction<(sourceId: string, audience: string) => Promise<ObserverTokenResult>>;
   for (const r of results) fn.mockResolvedValueOnce(r);
   return fn;
 }
 
 function makeMintTokenAlwaysOk(
   token: ObserverToken = makeToken(),
-): MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>> {
-  const fn = vi.fn() as MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>>;
+): MockedFunction<(sourceId: string, audience: string) => Promise<ObserverTokenResult>> {
+  const fn = vi.fn() as MockedFunction<(sourceId: string, audience: string) => Promise<ObserverTokenResult>>;
   fn.mockResolvedValue({ kind: 'ok', token });
   return fn;
 }
 
 function makePublisher(
-  mintToken: MockedFunction<(sourceId: string) => Promise<ObserverTokenResult>> = makeMintTokenAlwaysOk(),
+  mintToken: MockedFunction<(sourceId: string, audience: string) => Promise<ObserverTokenResult>> = makeMintTokenAlwaysOk(),
   sourceId: string = SOURCE_ID,
   extra: Partial<MeshCoreObserverPublisherOptions> = {},
 ): { publisher: MeshCoreObserverPublisher; mintToken: typeof mintToken } {
@@ -144,7 +155,7 @@ async function flushMicrotasks(times = 10): Promise<void> {
  */
 async function startAndConnect(publisher: MeshCoreObserverPublisher): Promise<FakeMqttClient> {
   const startPromise = publisher.start();
-  await flushMicrotasks(3);
+  await flushMicrotasks(30);
   const client = lastFakeClient();
   client.emit('connect');
   await startPromise;
@@ -228,7 +239,7 @@ describe('MeshCoreObserverPublisher', () => {
   it('drops packets and counts them when the socket is down (never queues via mqtt.js)', async () => {
     const { publisher } = makePublisher();
     const startPromise = publisher.start();
-    await flushMicrotasks(3);
+    await flushMicrotasks(30);
     const client = lastFakeClient();
     // Deliberately do NOT emit 'connect' — the socket stays down.
 
@@ -539,5 +550,31 @@ describe('MeshCoreObserverPublisher', () => {
     expect(lastError).not.toBeNull();
     expect(lastError).not.toContain(embeddedToken);
     expect(lastError).toContain('[REDACTED]');
+  });
+
+  describe('single-broker back-compat (#5014 Phase 1 WP3 — spec test 40)', () => {
+    it('getStatus() reports brokers.length === 1 whose per-broker fields equal the aggregate fields', async () => {
+      const { publisher } = makePublisher();
+      const client = await startAndConnect(publisher);
+      client.publish.mockClear();
+
+      publisher.handleOtaPacket({ snr: 1, rssi: -1, raw_hex: '0900aa' });
+      await flushMicrotasks();
+
+      const status = publisher.getStatus();
+      expect(status.brokers).toHaveLength(1);
+      const broker = status.brokers[0]!;
+      expect(broker.key).toBe(BROKER_KEY);
+      expect(broker.url).toBe(BROKER_URL);
+      expect(broker.authMode).toBe(status.authMode);
+      expect(broker.configured).toBe(status.configured);
+      expect(broker.keyStored).toBe(status.keyStored);
+      expect(broker.connected).toBe(status.connected);
+      expect(broker.publishes).toBe(status.publishes);
+      expect(broker.dropped).toBe(status.dropped);
+      expect(broker.lastPublishAt).toBe(status.lastPublishAt);
+      expect(broker.lastError).toBe(status.lastError);
+      expect(broker.tokenExpiresAt).toBe(status.tokenExpiresAt);
+    });
   });
 });

--- a/src/server/services/meshcoreObserverPublisher.ts
+++ b/src/server/services/meshcoreObserverPublisher.ts
@@ -1,19 +1,23 @@
 /**
  * meshcoreObserverPublisher
  *
- * MeshCore Analyzer Observer publisher (#4457 Phase 2, WP4). One instance
- * per MeshCore Companion source: mints an auth token (Phase 1 WP3 seam),
- * opens one authenticated, publish-only MQTT socket to a
+ * MeshCore Analyzer Observer publisher (#4457 Phase 2, WP4; multi-broker
+ * #5014 Phase 1 WP3). One instance per MeshCore Companion source, owning N
+ * `ObserverBrokerConnection`s — one per configured Analyzer broker. Mints
+ * per-audience auth tokens (deduped across brokers that share an audience),
+ * opens one authenticated, publish-only MQTT socket per broker to a
  * `michaelhart/meshcore-mqtt-broker`-compatible broker, relays every OTA
- * packet the radio hears (WP1's encoder), and publishes online/offline
- * status. **Never subscribes to anything** — that is this phase's headline
- * invariant (see `docs/internal/dev-notes/MESHCORE_OBSERVER_PHASE2_SPEC.md`
- * §2.2, §9 WP4, §10).
+ * packet the radio hears (WP1's encoder) to every broker, and publishes
+ * online/offline status to each. **Never subscribes to anything** — that is
+ * this phase's headline invariant (see
+ * `docs/internal/dev-notes/MESHCORE_OBSERVER_PHASE2_SPEC.md` §2.2, §9 WP4,
+ * §10).
  *
- * Two auth modes (#4595):
+ * Two auth modes (#4595), now per-broker (#5014):
  * - `token` (default): the original scheme — mint an Ed25519-signed token
  *   from the companion's signing key, username `v1_{PUBLIC_KEY}`, renewed on
- *   a timer.
+ *   a timer. Minting is deduped BY AUDIENCE, not by broker: two brokers that
+ *   share a `tokenAudience` share one WASM signature and one token.
  * - `password`: a STATIC MQTT username/password loaded from the encrypted
  *   credential store, for regional brokers (e.g. meshcoretel.ru) that verify
  *   no signature. Nothing expires, so there is NO renewal timer, and the
@@ -21,35 +25,41 @@
  *   from a signing key. The password is decrypted HERE and nowhere else —
  *   it is never returned by a route and never written to `sources.config`.
  *
- * Design notes (see the spec §3.2/§6 for the full derivation):
+ * Design notes (see `MESHMAPPER_OBSERVER_PHASE1_SPEC.md` §3 for the full
+ * derivation of the multi-broker shape; `MESHCORE_OBSERVER_PHASE2_SPEC.md`
+ * §3.2/§6 for the single-broker renewal-window derivation that still applies
+ * per audience):
+ * - One publisher owns N `ObserverBrokerConnection`s rather than N publishers
+ *   existing side by side. `stats()` costs a device round-trip and payload
+ *   construction is on the packet hot path, so both are done ONCE per event
+ *   and shared across every broker.
  * - Token minting happens at `start()` and again on a renewal timer — never
  *   per-packet. Minting is a WASM Ed25519 signature and is unaffordable at
- *   packet rate (Phase 1 §2.5).
+ *   packet rate.
  * - mqtt.js bakes `username`/`password` into the CONNECT packet, so renewal
- *   tears down the client and builds a fresh one with a fresh password and a
- *   fresh LWT (D-9) rather than trying to mutate an established connection.
- * - The renewal predicate deliberately widens the reference's threshold-only
- *   window by folding the check interval into it, closing a ~55-minute
- *   post-expiry hole the reference has. See `checkRenewal()` below and the
- *   spec §3.2 callout. Never hardcode the resulting 3900s constant — always
- *   derive it from `RENEWAL_CHECK_MS` / `RENEWAL_THRESHOLD_S`.
- * - Backpressure: `handleOtaPacket` gates on `client.isConnected()` itself
- *   and drops when the socket is down. mqtt.js queues QoS-0 publishes while
+ *   tears down the affected connections and builds fresh ones with a fresh
+ *   password and a fresh LWT (D-9) rather than trying to mutate an
+ *   established connection.
+ * - Backpressure: each connection gates on `client.isConnected()` itself and
+ *   drops when the socket is down. mqtt.js queues QoS-0 publishes while
  *   offline by default, which would grow an unbounded in-memory queue on a
  *   busy mesh with a broker that's down — never let a publish reach a
  *   disconnected client.
  * - Auth-rejection cooldown: below `MAX_AUTH_FAILURES` we let the client's
- *   own backoff retry with the *same* token (a fresh token signed with the
- *   same key/audience would be rejected identically — re-minting per
- *   attempt is the hot-loop we must avoid). At `MAX_AUTH_FAILURES` we hard
- *   stop: clear the renewal timer and disconnect, and stay stopped until an
- *   operator-driven config change / reconnect.
+ *   own backoff retry with the *same* token/credential (re-minting per
+ *   attempt is the hot-loop we must avoid). At `MAX_AUTH_FAILURES` the
+ *   OFFENDING CONNECTION hard-stops (disconnects and stays down until an
+ *   operator-driven config change) — this is scoped to that one broker
+ *   (#5014 deliberate behaviour change from the single-broker whole-publisher
+ *   stop; see spec §3.2/§8.1). Only when every connection has hard-stopped do
+ *   the publisher's timers clear and `isRunning()` go false.
  */
 import { createRequire } from 'module';
 import { MqttBrokerClient, type MqttBrokerClientOptions } from '../transports/mqttBrokerClient.js';
 import { logger } from '../../utils/logger.js';
 import type { OtaPacketEvent } from '../meshcoreVirtualNodeServer.js';
 import type { MeshCoreConfig } from '../meshcoreManager.js';
+import type { NormalizedObserverBroker } from '../meshcoreConfig.js';
 import {
   buildObserverPacketPayload,
   buildObserverStatusPayload,
@@ -70,12 +80,21 @@ import {
   getMeshCoreObserverCredentialStore,
   type ObserverCredentialLoadResult,
 } from './meshcoreObserverCredentialStore.js';
+import type { MeshCoreObserverStatus, MeshCoreObserverBrokerStatus } from './meshcoreObserverStatus.js';
+
+// Re-exported so every existing import site (`meshcoreManager.ts`, route
+// handlers, tests) keeps working unchanged — the types themselves live in
+// the dependency-free `meshcoreObserverStatus.ts` (#5014 Phase 1 WP1) so
+// WP4's status route can depend on the shape without pulling this file (and
+// its value imports of the credential store / token minter / package.json)
+// in.
+export type { MeshCoreObserverStatus, MeshCoreObserverBrokerStatus } from './meshcoreObserverStatus.js';
 
 // createRequire interop for package.json, same pattern as newsService.ts.
 const require = createRequire(import.meta.url);
 const appVersion: string = require('../../../package.json').version;
 
-/** Re-check the token's remaining life once an hour. */
+/** Re-check a token's remaining life once an hour. */
 export const RENEWAL_CHECK_MS = 3_600_000;
 /**
  * Safety margin (seconds) folded on top of `RENEWAL_CHECK_MS` when deciding
@@ -83,21 +102,24 @@ export const RENEWAL_CHECK_MS = 3_600_000;
  * interval itself must be part of the window, not just this margin.
  */
 export const RENEWAL_THRESHOLD_S = 300;
-/** Consecutive CONNACK auth rejections before the publisher hard-stops. */
+/** Consecutive CONNACK auth rejections before a connection hard-stops. */
 export const MAX_AUTH_FAILURES = 5;
 /**
  * How often the retained `online` status is republished with fresh device
  * stats (#4556). Matches `meshcoretomqtt`'s 5-minute stats loop, so battery /
  * uptime / noise floor on the analyzer track the device instead of freezing
  * at their connect-time values. Each tick costs two local bridge commands
- * (`get_stats core` + `radio`) — no RF, so it is safe on a fixed interval.
+ * (`get_stats core` + `radio`) — no RF, so it is safe on a fixed interval,
+ * and is read exactly ONCE per tick regardless of how many brokers are
+ * configured (#5014 §3.1).
  */
 export const STATUS_REFRESH_MS = 300_000;
 
 /** Strips anything shaped like a minted observer token (or a JWT-style secret) from a message. */
 const TOKEN_SHAPE_PATTERN = /[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[0-9A-Fa-f]{128}/g;
 
-/** Never let a token/password-shaped substring escape into a user-visible `lastError`. */
+/** Never let a token/password-shaped substring escape into a user-visible `lastError`. Module-level and
+ *  shared by every `ObserverBrokerConnection` — NOT duplicated per connection (#5014 spec §3.2). */
 function redactToken(message: string): string {
   return message.replace(TOKEN_SHAPE_PATTERN, '[REDACTED]');
 }
@@ -118,29 +140,9 @@ const LAST_ERROR = {
   authRejectedStatic: 'Broker rejected the observer username/password.',
 } as const;
 
-export interface MeshCoreObserverStatus {
-  /** `observer.enabled` AND every config field this auth mode requires. */
-  configured: boolean;
-  /**
-   * Auth mode in force for this publisher (#4595). `token` = Ed25519-signed
-   * token; `password` = static MQTT username/password.
-   */
-  authMode: 'token' | 'password';
-  /**
-   * The credential this mode needs exists AND is decryptable under the
-   * current SESSION_SECRET — a signing key in `token` mode, a stored
-   * username/password in `password` mode.
-   */
-  keyStored: boolean;
-  connected: boolean;
-  publishes: number;
-  /** Packets dropped because the socket was down when they arrived. */
-  dropped: number;
-  lastPublishAt: number | null;
-  lastError: string | null;
-  /** Unix SECONDS (matches `ObserverToken.expiresAt`). */
-  tokenExpiresAt: number | null;
-}
+/** Monotonic sequence for "most recently set" `lastError` aggregation (§5.1). Shared across every
+ *  connection/publisher in the process — only the relative order matters, never the absolute value. */
+let lastErrorSequence = 0;
 
 export interface MeshCoreObserverPublisherOptions {
   sourceId: string;
@@ -167,13 +169,22 @@ export interface MeshCoreObserverPublisherOptions {
    * Must resolve, not reject; a rejection is caught and treated as "no stats".
    */
   stats?: () => Promise<ObserverStatsInput | null>;
-  /** Injection seam for tests. Defaults to `mintObserverTokenForSourceDetailed`. */
-  mintToken?: (sourceId: string) => Promise<ObserverTokenResult>;
   /**
-   * Injection seam for tests (#4595). Defaults to the encrypted credential
-   * store's `load()`. Only called in `password` auth mode.
+   * Injection seam for tests (#5014: WIDENED — audience is now explicit,
+   * because brokers differ). Defaults to
+   * `(id, aud) => mintObserverTokenForSourceDetailed(id, aud)`.
    */
-  loadCredentials?: (sourceId: string) => Promise<ObserverCredentialLoadResult>;
+  mintToken?: (sourceId: string, audience: string) => Promise<ObserverTokenResult>;
+  /**
+   * Injection seam for tests (#4595; #5014: WIDENED to a per-broker key plus
+   * the legacy-fallback flag). Only called in `password` auth mode. Defaults
+   * to `resolveBrokerCredential` (module-local, below).
+   */
+  loadCredentials?: (
+    sourceId: string,
+    brokerKey: string,
+    legacy: boolean,
+  ) => Promise<ObserverCredentialLoadResult>;
   /** Injection seam for tests. Defaults to `(opts) => new MqttBrokerClient(opts)`. */
   createClient?: (opts: MqttBrokerClientOptions) => MqttBrokerClient;
 }
@@ -185,15 +196,65 @@ interface PermissionDeniedReason {
   message: string;
 }
 
-export class MeshCoreObserverPublisher {
-  private readonly options: MeshCoreObserverPublisherOptions;
-  private readonly mintTokenFn: (sourceId: string) => Promise<ObserverTokenResult>;
-  private readonly loadCredentialsFn: (sourceId: string) => Promise<ObserverCredentialLoadResult>;
-  private readonly createClientFn: (opts: MqttBrokerClientOptions) => MqttBrokerClient;
-  private readonly configured: boolean;
-  /** `token` (default) or `password` (#4595). Fixed for the publisher's life —
-   *  a mode change goes through reconfigureObserver, which builds a new one. */
-  private readonly authMode: 'token' | 'password';
+/**
+ * Default `loadCredentials` (#5014 spec §4.3). A per-broker credential always
+ * wins over the legacy one; only the LEGACY broker (the one derived from — or
+ * matching — the pre-#5014 top-level `brokerUrl`) falls back to the old
+ * single-credential row when it has no per-broker entry of its own. A
+ * non-legacy broker NEVER sees the legacy credential — that is the
+ * per-broker isolation guarantee.
+ */
+async function resolveBrokerCredential(
+  sourceId: string,
+  brokerKey: string,
+  legacy: boolean,
+): Promise<ObserverCredentialLoadResult> {
+  const store = getMeshCoreObserverCredentialStore();
+  const perBroker = await store.loadForBroker(sourceId, brokerKey);
+  if (perBroker.kind !== 'none' || !legacy) return perBroker;
+  return store.load(sourceId);
+}
+
+/** Everything a connection needs to resolve before it can open a socket. */
+type ResolvedCredential =
+  | { kind: 'ok'; username: string; password: string; publicKey: string; tokenExpiresAt: number | null }
+  | { kind: 'error'; message: string; keyStored: boolean };
+
+/** Constructor deps for {@link ObserverBrokerConnection}, supplied by the owning publisher. */
+interface BrokerConnectionDeps {
+  sourceId: string;
+  iataCode: string;
+  device: MeshCoreObserverPublisherOptions['device'];
+  /**
+   * Reads device stats for THIS connection's own connect-triggered online
+   * status publish (unchanged single-broker behaviour: a socket republishes
+   * its retained status the moment it connects, whether that is the initial
+   * `start()` or a post-renewal rebuild). This is intentionally a SEPARATE
+   * call path from the publisher's shared `STATUS_REFRESH_MS` tick, which
+   * reads stats exactly once centrally and hands the result to every
+   * connected connection directly via `publishOnlineStatus()` — see
+   * `MeshCoreObserverPublisher.refreshStatus()`. A connect event is not a
+   * refresh tick, so it is not bound by "stats() called at most once per
+   * tick".
+   */
+  readStats: () => Promise<ObserverStatsInput | null>;
+  createClient: (opts: MqttBrokerClientOptions) => MqttBrokerClient;
+  /** Called when this connection hard-stops on repeated auth rejection. */
+  onAuthHardStop: (key: string) => void;
+}
+
+/**
+ * Owns everything that is per-broker: the MQTT client, topics, counters, and
+ * auth-failure state (#5014 spec §3.2). Never throws out of any public
+ * method. A structural sibling of `MqttBridgePublisherPool`'s `PoolEntry`
+ * (client + publishes + lastPublishAt + lastError), kept private to this
+ * file rather than generalized — see spec §1.3 for why a shared abstraction
+ * with that pool is not worth it.
+ */
+class ObserverBrokerConnection {
+  readonly key: string;
+  readonly broker: NormalizedObserverBroker;
+  private readonly deps: BrokerConnectionDeps;
 
   private client: MqttBrokerClient | null = null;
   private topics: { region: string; packets: string; status: string } | null = null;
@@ -204,41 +265,42 @@ export class MeshCoreObserverPublisher {
   private dropped = 0;
   private lastPublishAt: number | null = null;
   private lastError: string | null = null;
+  private lastErrorSeq = 0;
   private tokenExpiresAt: number | null = null;
 
-  private running = false;
   private authFailures = 0;
   private authStopping = false;
-  private renewing = false;
-  private renewalTimer: ReturnType<typeof setInterval> | null = null;
-  private statusRefreshTimer: ReturnType<typeof setInterval> | null = null;
-  private refreshingStatus = false;
 
-  constructor(options: MeshCoreObserverPublisherOptions) {
-    this.options = options;
-    this.mintTokenFn = options.mintToken ?? mintObserverTokenForSourceDetailed;
-    this.loadCredentialsFn =
-      options.loadCredentials ?? ((sourceId) => getMeshCoreObserverCredentialStore().load(sourceId));
-    this.createClientFn = options.createClient ?? ((opts) => new MqttBrokerClient(opts));
-    // Inlined rather than importing `observerAuthMode` from meshcoreConfig.js:
-    // that module imports meshcoreManager, which imports this file.
-    this.authMode = options.config.authMode === 'password' ? 'password' : 'token';
-    this.configured = !!(
-      options.config.enabled &&
-      options.config.brokerUrl &&
-      options.config.iataCode &&
-      // A static-credential broker verifies no signature, so it has no
-      // audience to match — requiring one would report a correctly
-      // configured password-mode source as incomplete (#4595).
-      (this.authMode === 'password' || options.config.tokenAudience)
-    );
+  constructor(broker: NormalizedObserverBroker, deps: BrokerConnectionDeps) {
+    this.broker = broker;
+    this.key = broker.key;
+    this.deps = deps;
   }
 
-  /**
-   * Mint → connect → publish online status. Resolves even on failure — the
-   * failure reason lands in `getStatus().lastError`, never a thrown error.
-   */
-  async start(): Promise<void> {
+  /** Topic public key for this connection, or null before a successful start. */
+  get originId(): string | null {
+    return this.tokenPublicKey;
+  }
+
+  isConnected(): boolean {
+    return this.client?.isConnected() ?? false;
+  }
+
+  /** Exposed for the publisher's "most recently set" `lastError` aggregate (§5.1). Not part of the
+   *  public status shape — purely an internal ordering key. */
+  getLastErrorSeq(): number {
+    return this.lastErrorSeq;
+  }
+
+  /** Record an error originating OUTSIDE this connection (e.g. a renewal mint failure for this
+   *  connection's audience) without touching its socket. Public because the owning publisher, not
+   *  this connection itself, observes that failure. */
+  recordExternalError(message: string): void {
+    this.recordError(message);
+  }
+
+  /** Connect with a resolved credential. Records failures in `lastError`; never throws. */
+  async start(cred: ResolvedCredential): Promise<void> {
     // Reset the auth-failure state so a fresh start (e.g. a new instance
     // reused in tests, or any future restart path) is never poisoned by a
     // prior hard-stop — the guard is a concurrency latch, not a permanent
@@ -246,54 +308,21 @@ export class MeshCoreObserverPublisher {
     this.authStopping = false;
     this.authFailures = 0;
 
-    if (this.authMode === 'password') {
-      // Static-credential brokers (#4595). No signing, no expiry, therefore
-      // no renewal timer — the credentials are valid until the operator
-      // changes them.
-      const creds = await this.loadCredentialsFn(this.options.sourceId);
-      if (creds.kind !== 'ok') {
-        this.keyStored = false;
-        this.lastError =
-          creds.kind === 'none' ? LAST_ERROR.noCredentials : LAST_ERROR.credentialsRotated;
-        return;
-      }
-      const publicKey = this.options.device().publicKey;
-      if (!publicKey) {
-        this.keyStored = true;
-        this.lastError = LAST_ERROR.noPublicKey;
-        return;
-      }
-      await this.connectWithCredentials(creds.username, creds.password, publicKey);
-      this.armStatusRefreshTimer();
-      this.running = true;
+    if (cred.kind === 'error') {
+      this.keyStored = cred.keyStored;
+      this.recordError(cred.message);
       return;
     }
 
-    const result = await this.mintTokenFn(this.options.sourceId);
-    if (result.kind !== 'ok') {
-      this.keyStored = false;
-      this.lastError = this.mintFailureMessage(result);
-      return;
-    }
-
-    await this.connectWithToken(result.token);
-    this.armRenewalTimer();
-    this.armStatusRefreshTimer();
-    this.running = true;
+    this.tokenExpiresAt = cred.tokenExpiresAt;
+    await this.openSocket(cred.username, cred.password, cred.publicKey);
   }
 
-  /** Publish an explicit offline status, then disconnect. Idempotent. */
+  /** Publish offline status (best-effort) then disconnect({ flush: true }). Idempotent. */
   async stop(): Promise<void> {
-    this.clearRenewalTimer();
-    this.clearStatusRefreshTimer();
     const client = this.client;
-    if (!client) {
-      this.running = false;
-      return;
-    }
-
+    if (!client) return;
     this.client = null;
-    this.running = false;
 
     const identity = this.getIdentity();
     if (identity && this.topics) {
@@ -310,8 +339,7 @@ export class MeshCoreObserverPublisher {
       // has accepted the packet, not once it's actually on the wire. A
       // plain forced end() (the default used elsewhere in this class, e.g.
       // renewal/hard-stop) can close the socket before that QoS-0 packet is
-      // flushed, silently dropping the graceful-stop offline status (spec
-      // §2.4 / E2E criterion 8).
+      // flushed, silently dropping the graceful-stop offline status.
       await client.disconnect({ flush: true });
     } catch {
       // Best-effort.
@@ -319,40 +347,98 @@ export class MeshCoreObserverPublisher {
   }
 
   /**
-   * Sync, never throws. Call from the manager's `ota_packet` listener. No
-   * token minting on this path — see the module header.
+   * Sync, never throws. Drops (dropped++) when the socket is down. Takes a
+   * PRE-SERIALIZED buffer so the caller (the publisher) can build the
+   * payload once per distinct `originId` and share it across every broker on
+   * that origin (#5014 §3.3).
    */
-  handleOtaPacket(event: OtaPacketEvent): void {
+  publishPacket(payload: Buffer): void {
     const client = this.client;
-    if (!client || !client.isConnected() || !this.topics || !this.tokenPublicKey) {
+    if (!client || !client.isConnected() || !this.topics) {
       this.dropped++;
       return;
     }
 
-    const identity: ObserverPacketIdentity = {
-      origin: this.options.device().origin,
-      originId: this.tokenPublicKey,
-    };
-    const payload = buildObserverPacketPayload(event, identity);
-    if (!payload) return; // blank/missing raw_hex — mirrors VN handleOtaPacket.
-
     void client
-      .publish(this.topics.packets, Buffer.from(JSON.stringify(payload)), false)
+      .publish(this.topics.packets, payload, false)
       .then(() => {
         this.publishes++;
         this.lastPublishAt = Date.now();
       })
       .catch((err: unknown) => {
-        this.lastError = redactToken(err instanceof Error ? err.message : String(err));
+        this.recordError(redactToken(err instanceof Error ? err.message : String(err)));
       });
   }
 
-  getStatus(): MeshCoreObserverStatus {
+  /**
+   * A packet arrived but this connection never successfully started (no
+   * `originId` yet) — count it as dropped, matching today's single-broker
+   * behaviour when `tokenPublicKey` is null.
+   */
+  noteDropped(): void {
+    this.dropped++;
+  }
+
+  /**
+   * Publish the retained `online` status with the CALLER's already-read
+   * stats — see `BrokerConnectionDeps.readStats` for why there are two
+   * distinct call paths into this method (a connect event vs. the shared
+   * refresh tick).
+   *
+   * The client/topics are re-read at call time — a token renewal or a stop
+   * can swap or null them between when the caller read stats and when it
+   * calls this, and publishing to the stale client would either throw or
+   * write under the wrong credentials.
+   */
+  async publishOnlineStatus(stats: ObserverStatsInput | null): Promise<void> {
+    const client = this.client;
+    const identity = this.getIdentity();
+    if (!client || !identity || !this.topics) return;
+
+    const dev = this.deps.device();
+    const payload = buildObserverStatusPayload('online', identity, {
+      model: dev.model,
+      firmwareVersion: dev.firmwareVersion,
+      radio: dev.radio,
+      clientVersion: `meshmonitor/${appVersion}`,
+      stats,
+    });
+    await client
+      .publish(this.topics.status, Buffer.from(JSON.stringify(payload)), true)
+      .catch((err: unknown) => {
+        this.recordError(redactToken(err instanceof Error ? err.message : String(err)));
+      });
+  }
+
+  /** Tear down and reconnect with a fresh token (D-9: mqtt.js bakes creds into CONNECT). */
+  async rebuildWithToken(token: ObserverToken): Promise<void> {
+    const oldClient = this.client;
+    this.client = null;
+    if (oldClient) {
+      try {
+        await oldClient.disconnect();
+      } catch {
+        // Best-effort — proceed to bring the new client up regardless.
+      }
+    }
+    this.tokenExpiresAt = token.expiresAt;
+    await this.openSocket(`v1_${token.publicKey}`, token.token, token.publicKey);
+  }
+
+  getStatus(): MeshCoreObserverBrokerStatus {
     return {
-      configured: this.configured,
-      authMode: this.authMode,
+      key: this.key,
+      url: this.broker.url,
+      label: this.broker.label ?? null,
+      authMode: this.broker.authMode,
+      tokenAudience: this.broker.tokenAudience ?? null,
+      // Every entry in `config.brokers` already passed `normalizeObserverBrokers`'s
+      // per-mode completeness rule (token mode requires a tokenAudience,
+      // password mode requires nothing extra) — so a constructed connection
+      // is by definition "configured" for its own auth mode.
+      configured: true,
       keyStored: this.keyStored,
-      connected: this.client?.isConnected() ?? false,
+      connected: this.isConnected(),
       publishes: this.publishes,
       dropped: this.dropped,
       lastPublishAt: this.lastPublishAt,
@@ -361,31 +447,16 @@ export class MeshCoreObserverPublisher {
     };
   }
 
-  isRunning(): boolean {
-    return this.running;
-  }
+  // ── internals ────────────────────────────────────────────────────────
 
-  // ── internals ──────────────────────────────────────────────────────────
+  private recordError(message: string): void {
+    this.lastError = message;
+    this.lastErrorSeq = ++lastErrorSequence;
+  }
 
   private getIdentity(): ObserverPacketIdentity | null {
     if (!this.tokenPublicKey) return null;
-    return { origin: this.options.device().origin, originId: this.tokenPublicKey };
-  }
-
-  private mintFailureMessage(result: Exclude<ObserverTokenResult, { kind: 'ok' }>): string {
-    switch (result.kind) {
-      case 'not_configured':
-        return LAST_ERROR.notConfigured;
-      case 'no_key':
-        return LAST_ERROR.noKey;
-      case 'key_rotated':
-        return LAST_ERROR.keyRotated;
-      case 'mint_failed':
-        // The library error text can be verbose; log it at debug only and
-        // never let it surface as `lastError` (Phase 1 §5.5 logging discipline).
-        logger.debug(`[MeshCoreObserver:${this.options.sourceId}] mint failed: ${result.message}`);
-        return LAST_ERROR.mintFailed;
-    }
+    return { origin: this.deps.device().origin, originId: this.tokenPublicKey };
   }
 
   private buildClientOptions(
@@ -393,17 +464,12 @@ export class MeshCoreObserverPublisher {
     topics: { status: string },
   ): MqttBrokerClientOptions {
     const identity: ObserverPacketIdentity = {
-      origin: this.options.device().origin,
+      origin: this.deps.device().origin,
       originId: credentials.publicKey,
     };
     const lwt = buildObserverStatusPayload('offline', identity);
     return {
-      // Config completeness (brokerUrl/iataCode/tokenAudience all present) is
-      // guaranteed by `observerConfigFromSource` before this publisher is ever
-      // constructed (meshcoreManager only builds one when `observer` is
-      // non-undefined) — non-null assert rather than threading a narrower
-      // type through every read.
-      url: this.options.config.brokerUrl!,
+      url: this.broker.url,
       username: credentials.username,
       password: credentials.password,
       clientIdPrefix: 'meshmonitor-observer',
@@ -421,7 +487,7 @@ export class MeshCoreObserverPublisher {
     client.on('connect', () => {
       this.lastError = null;
       this.authFailures = 0;
-      void this.publishOnlineStatus();
+      void this.publishOnlineStatusOnConnect();
     });
     client.on('error', (err: Error) => {
       // `MqttBrokerClient` emits BOTH `permission-denied` and a raw `error`
@@ -431,17 +497,335 @@ export class MeshCoreObserverPublisher {
       // `err.message` (e.g. "Bad username or password").
       const code = (err as Error & { code?: number }).code;
       if (code === 4 || code === 5) return;
-      this.lastError = redactToken(err.message);
+      this.recordError(redactToken(err.message));
     });
     client.on('permission-denied', (reason: PermissionDeniedReason) => {
       if (reason.kind !== 'auth') return;
       this.authFailures++;
-      this.lastError =
-        this.authMode === 'password' ? LAST_ERROR.authRejectedStatic : LAST_ERROR.authRejected;
+      this.recordError(
+        this.broker.authMode === 'password' ? LAST_ERROR.authRejectedStatic : LAST_ERROR.authRejected,
+      );
       if (this.authFailures >= MAX_AUTH_FAILURES) {
         void this.hardStopOnAuthFailure();
       }
     });
+  }
+
+  private async publishOnlineStatusOnConnect(): Promise<void> {
+    const stats = await this.deps.readStats();
+    await this.publishOnlineStatus(stats);
+  }
+
+  /** Shared connect tail for both auth modes AND for renewal rebuilds. Never throws — a
+   *  `createClient` seam that throws (test-injected or otherwise) fails this connection closed
+   *  without taking down the others (#5014 §3.3 "start() never throws"). */
+  private async openSocket(username: string, password: string, publicKey: string): Promise<void> {
+    this.tokenPublicKey = publicKey;
+    this.keyStored = true;
+    this.topics = observerTopics(this.deps.iataCode, publicKey);
+
+    const opts = this.buildClientOptions({ username, password, publicKey }, this.topics);
+    let client: MqttBrokerClient;
+    try {
+      client = this.deps.createClient(opts);
+    } catch (err) {
+      this.recordError(redactToken(err instanceof Error ? err.message : String(err)));
+      this.keyStored = false;
+      this.tokenPublicKey = null;
+      this.topics = null;
+      return;
+    }
+    this.wireClientListeners(client);
+    this.client = client;
+    await client.connect();
+  }
+
+  private async hardStopOnAuthFailure(): Promise<void> {
+    if (this.authStopping) return;
+    this.authStopping = true;
+    const client = this.client;
+    this.client = null;
+    if (client) {
+      try {
+        await client.disconnect();
+      } catch {
+        // Best-effort.
+      }
+    }
+    this.deps.onAuthHardStop(this.key);
+  }
+}
+
+export class MeshCoreObserverPublisher {
+  private readonly options: MeshCoreObserverPublisherOptions;
+  private readonly mintTokenFn: (sourceId: string, audience: string) => Promise<ObserverTokenResult>;
+  private readonly loadCredentialsFn: (
+    sourceId: string,
+    brokerKey: string,
+    legacy: boolean,
+  ) => Promise<ObserverCredentialLoadResult>;
+  private readonly createClientFn: (opts: MqttBrokerClientOptions) => MqttBrokerClient;
+
+  /** One connection per `config.brokers` entry, built once at construction so `getStatus()` is
+   *  well-defined even before `start()` is ever called (mirrors the pre-#5014 single-broker
+   *  publisher, whose `configured` was always computable from the constructor alone). */
+  private readonly connections: ObserverBrokerConnection[];
+  /** audience -> current token. Only audiences with at least one successfully-minted token. */
+  private tokensByAudience = new Map<string, ObserverToken>();
+  /** Connection keys that have hard-stopped on repeated auth failure since the last `start()`. */
+  private readonly hardStoppedKeys = new Set<string>();
+
+  private running = false;
+  private renewing = false;
+  private renewalTimer: ReturnType<typeof setInterval> | null = null;
+  private statusRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  private refreshingStatus = false;
+
+  constructor(options: MeshCoreObserverPublisherOptions) {
+    this.options = options;
+    this.mintTokenFn = options.mintToken ?? ((sourceId, audience) => mintObserverTokenForSourceDetailed(sourceId, audience));
+    this.loadCredentialsFn =
+      options.loadCredentials ?? ((sourceId, brokerKey, legacy) => resolveBrokerCredential(sourceId, brokerKey, legacy));
+    this.createClientFn = options.createClient ?? ((opts) => new MqttBrokerClient(opts));
+
+    this.connections = options.config.brokers.map(
+      (broker) =>
+        new ObserverBrokerConnection(broker, {
+          sourceId: options.sourceId,
+          iataCode: options.config.iataCode,
+          device: options.device,
+          readStats: () => this.readStats(),
+          createClient: this.createClientFn,
+          onAuthHardStop: (key) => this.onConnectionAuthHardStop(key),
+        }),
+    );
+  }
+
+  /**
+   * Mint/load credentials for every broker → connect every socket → publish
+   * each one's online status. Resolves even on total failure — the failure
+   * reason(s) land in `getStatus().brokers[i].lastError`, never a thrown
+   * error (#5014 §3.3).
+   */
+  async start(): Promise<void> {
+    this.hardStoppedKeys.clear();
+
+    if (this.connections.length === 0) {
+      this.running = false;
+      return;
+    }
+
+    const credByKey = new Map<string, ResolvedCredential>();
+    await this.resolveTokenCredentials(credByKey);
+    await this.resolvePasswordCredentials(credByKey);
+
+    const results = await Promise.allSettled(
+      this.connections.map((c) =>
+        c.start(credByKey.get(c.key) ?? { kind: 'error', message: LAST_ERROR.notConfigured, keyStored: false }),
+      ),
+    );
+    for (const r of results) {
+      if (r.status === 'rejected') {
+        logger.debug(`[MeshCoreObserver:${this.options.sourceId}] connection start rejected: ${String(r.reason)}`);
+      }
+    }
+
+    // "Constructed" (spec §3.3 point 6) means a connection actually attempted
+    // to open a socket, i.e. its credential resolved — not merely that an
+    // `ObserverBrokerConnection` object exists. This preserves the
+    // pre-#5014 single-broker contract: a total mint/credential failure
+    // leaves the publisher NOT running and arms no timers.
+    const anyOk = Array.from(credByKey.values()).some((c) => c.kind === 'ok');
+    if (anyOk) {
+      if (this.tokensByAudience.size > 0) this.armRenewalTimer();
+      this.armStatusRefreshTimer();
+    }
+    this.running = anyOk;
+  }
+
+  /** Publish an explicit offline status on every broker, then disconnect. Idempotent. */
+  async stop(): Promise<void> {
+    this.clearRenewalTimer();
+    this.clearStatusRefreshTimer();
+    this.running = false;
+    this.hardStoppedKeys.clear();
+    await Promise.allSettled(this.connections.map((c) => c.stop()));
+  }
+
+  /**
+   * Sync, never throws. Call from the manager's `ota_packet` listener. No
+   * token minting on this path — see the module header. Groups connections
+   * by `originId` so the packet payload is `JSON.stringify`-ed exactly ONCE
+   * per distinct origin, then shared as one `Buffer` across every broker on
+   * that origin (#5014 §3.3) — in practice there is exactly one group, since
+   * every connection on a source derives the same origin (one signing key in
+   * token mode, one node public key in password mode).
+   */
+  handleOtaPacket(event: OtaPacketEvent): void {
+    const groups = new Map<string, ObserverBrokerConnection[]>();
+    for (const c of this.connections) {
+      const originId = c.originId;
+      if (!originId) {
+        // Never successfully started — matches today's behaviour when
+        // `tokenPublicKey` is null.
+        c.noteDropped();
+        continue;
+      }
+      const arr = groups.get(originId);
+      if (arr) arr.push(c);
+      else groups.set(originId, [c]);
+    }
+
+    for (const [originId, conns] of groups) {
+      const identity: ObserverPacketIdentity = { origin: this.options.device().origin, originId };
+      const payload = buildObserverPacketPayload(event, identity);
+      if (!payload) continue; // blank/missing raw_hex — mirrors VN handleOtaPacket.
+      const buf = Buffer.from(JSON.stringify(payload));
+      for (const c of conns) c.publishPacket(buf);
+    }
+  }
+
+  /**
+   * Aggregate status (#5014 §5.1). Every field below `brokers` is chosen so
+   * a single-broker source reports EXACTLY the values it reported pre-#5014:
+   * SUM for counters, MAX for `lastPublishAt`, MIN (non-null) for
+   * `tokenExpiresAt`, ANY for the booleans, and the most-recently-set
+   * non-null `lastError`.
+   */
+  getStatus(): MeshCoreObserverStatus {
+    const brokers = this.connections.map((c) => c.getStatus());
+    return {
+      configured: brokers.some((b) => b.configured),
+      authMode: brokers[0]?.authMode ?? this.options.config.authMode,
+      keyStored: brokers.some((b) => b.keyStored),
+      connected: brokers.some((b) => b.connected),
+      publishes: brokers.reduce((sum, b) => sum + b.publishes, 0),
+      dropped: brokers.reduce((sum, b) => sum + b.dropped, 0),
+      lastPublishAt: reduceNullable(brokers.map((b) => b.lastPublishAt), (a, b) => (a > b ? a : b)),
+      lastError: this.aggregateLastError(),
+      tokenExpiresAt: reduceNullable(brokers.map((b) => b.tokenExpiresAt), (a, b) => (a < b ? a : b)),
+      brokers,
+    };
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────
+
+  private aggregateLastError(): string | null {
+    let best: { message: string; seq: number } | null = null;
+    for (const c of this.connections) {
+      const message = c.getStatus().lastError;
+      if (message === null) continue;
+      const seq = c.getLastErrorSeq();
+      if (!best || seq > best.seq) best = { message, seq };
+    }
+    return best?.message ?? null;
+  }
+
+  /**
+   * Mint (or reuse) one token per DISTINCT audience among the token-mode
+   * connections, then fan the result out to every connection on that
+   * audience (#5014 §3.3/§3.4). A failed mint marks every connection on that
+   * audience with the mapped `LAST_ERROR` message and `keyStored: false`.
+   */
+  private async resolveTokenCredentials(credByKey: Map<string, ResolvedCredential>): Promise<void> {
+    const tokenConnections = this.connections.filter((c) => c.broker.authMode === 'token');
+    if (tokenConnections.length === 0) {
+      this.tokensByAudience = new Map();
+      return;
+    }
+
+    const audiences = Array.from(new Set(tokenConnections.map((c) => c.broker.tokenAudience!)));
+    const settled = await Promise.allSettled(
+      audiences.map(async (aud) => ({ aud, result: await this.mintTokenFn(this.options.sourceId, aud) })),
+    );
+
+    const tokenByAudience = new Map<string, ObserverToken>();
+    const errorByAudience = new Map<string, string>();
+    for (const outcome of settled) {
+      if (outcome.status === 'rejected') {
+        logger.debug(`[MeshCoreObserver:${this.options.sourceId}] token mint rejected: ${String(outcome.reason)}`);
+        continue;
+      }
+      const { aud, result } = outcome.value;
+      if (result.kind === 'ok') {
+        tokenByAudience.set(aud, result.token);
+      } else {
+        errorByAudience.set(aud, this.mintFailureMessage(result));
+      }
+    }
+    this.tokensByAudience = tokenByAudience;
+
+    for (const c of tokenConnections) {
+      const aud = c.broker.tokenAudience!;
+      const token = tokenByAudience.get(aud);
+      if (token) {
+        credByKey.set(c.key, {
+          kind: 'ok',
+          username: `v1_${token.publicKey}`,
+          password: token.token,
+          publicKey: token.publicKey,
+          tokenExpiresAt: token.expiresAt,
+        });
+      } else {
+        credByKey.set(c.key, {
+          kind: 'error',
+          message: errorByAudience.get(aud) ?? LAST_ERROR.mintFailed,
+          keyStored: false,
+        });
+      }
+    }
+  }
+
+  /** Load each password-mode connection's own credential (#5014 §3.3/§4.3). */
+  private async resolvePasswordCredentials(credByKey: Map<string, ResolvedCredential>): Promise<void> {
+    const passwordConnections = this.connections.filter((c) => c.broker.authMode === 'password');
+    if (passwordConnections.length === 0) return;
+
+    const publicKey = this.options.device().publicKey;
+    await Promise.allSettled(
+      passwordConnections.map(async (c) => {
+        if (!publicKey) {
+          credByKey.set(c.key, { kind: 'error', message: LAST_ERROR.noPublicKey, keyStored: true });
+          return;
+        }
+        const creds = await this.loadCredentialsFn(this.options.sourceId, c.key, c.broker.legacy);
+        if (creds.kind !== 'ok') {
+          credByKey.set(c.key, {
+            kind: 'error',
+            message: creds.kind === 'none' ? LAST_ERROR.noCredentials : LAST_ERROR.credentialsRotated,
+            keyStored: false,
+          });
+          return;
+        }
+        credByKey.set(c.key, {
+          kind: 'ok',
+          username: creds.username,
+          password: creds.password,
+          publicKey,
+          tokenExpiresAt: null,
+        });
+      }),
+    );
+  }
+
+  private mintFailureMessage(result: Exclude<ObserverTokenResult, { kind: 'ok' }>): string {
+    switch (result.kind) {
+      case 'not_configured':
+        return LAST_ERROR.notConfigured;
+      case 'no_key':
+        return LAST_ERROR.noKey;
+      case 'key_rotated':
+        return LAST_ERROR.keyRotated;
+      case 'mint_failed':
+        // The library error text can be verbose; log it at debug only and
+        // never let it surface as `lastError` (Phase 1 §5.5 logging discipline).
+        logger.debug(`[MeshCoreObserver:${this.options.sourceId}] mint failed: ${result.message}`);
+        return LAST_ERROR.mintFailed;
+    }
   }
 
   /**
@@ -462,94 +846,6 @@ export class MeshCoreObserverPublisher {
     }
   }
 
-  /**
-   * Publish the retained `online` status. Async because the device stats it
-   * carries cost a bridge round-trip; callers on the event path (`connect`)
-   * fire-and-forget it.
-   *
-   * The client/topics are re-read AFTER the await — a token renewal or a stop
-   * can swap or null them while the stats read is in flight, and publishing to
-   * the stale client would either throw or write under the wrong credentials.
-   *
-   * The re-read is then CAPTURED into a local so the null-check and the
-   * publish below see the same object. `stop()` nulls `this.client` before it
-   * awaits the disconnect, so re-reading the field per use could pass the
-   * check and then publish through a different (or absent) client. Worst case
-   * we publish through a socket that is closing, which the `.catch` absorbs.
-   */
-  private async publishOnlineStatus(): Promise<void> {
-    if (!this.client || !this.topics) return;
-
-    const stats = await this.readStats();
-
-    const client = this.client;
-    const identity = this.getIdentity();
-    if (!client || !identity || !this.topics) return;
-
-    const dev = this.options.device();
-    const payload = buildObserverStatusPayload('online', identity, {
-      model: dev.model,
-      firmwareVersion: dev.firmwareVersion,
-      radio: dev.radio,
-      clientVersion: `meshmonitor/${appVersion}`,
-      stats,
-    });
-    await client
-      .publish(this.topics.status, Buffer.from(JSON.stringify(payload)), true)
-      .catch((err: unknown) => {
-        this.lastError = redactToken(err instanceof Error ? err.message : String(err));
-      });
-  }
-
-  private async connectWithToken(token: ObserverToken): Promise<void> {
-    this.tokenExpiresAt = token.expiresAt;
-    await this.openSocket(`v1_${token.publicKey}`, token.token, token.publicKey);
-  }
-
-  /**
-   * Static-credential connect (#4595). Identical to the token path except
-   * that the MQTT username/password come from the encrypted credential store
-   * and the topic public key comes from the node itself (`get_self_info`)
-   * rather than from a signing key — a password-mode broker never sees a
-   * signature, so there is no key to derive it from. `tokenExpiresAt` stays
-   * null: nothing expires, so nothing renews.
-   */
-  private async connectWithCredentials(
-    username: string,
-    password: string,
-    publicKey: string,
-  ): Promise<void> {
-    this.tokenExpiresAt = null;
-    await this.openSocket(username, password, publicKey);
-  }
-
-  /** Shared connect tail for both auth modes. */
-  private async openSocket(username: string, password: string, publicKey: string): Promise<void> {
-    this.tokenPublicKey = publicKey;
-    this.keyStored = true;
-    this.topics = observerTopics(this.options.config.iataCode!, publicKey);
-
-    const opts = this.buildClientOptions({ username, password, publicKey }, this.topics);
-    const client = this.createClientFn(opts);
-    this.wireClientListeners(client);
-    this.client = client;
-    await client.connect();
-  }
-
-  /** D-9: mqtt.js bakes credentials in at CONNECT time — renewal tears down and rebuilds. */
-  private async rebuildClientWithToken(token: ObserverToken): Promise<void> {
-    const oldClient = this.client;
-    this.client = null;
-    if (oldClient) {
-      try {
-        await oldClient.disconnect();
-      } catch {
-        // Best-effort — proceed to bring the new client up regardless.
-      }
-    }
-    await this.connectWithToken(token);
-  }
-
   private armRenewalTimer(): void {
     this.clearRenewalTimer();
     this.renewalTimer = setInterval(() => {
@@ -566,15 +862,27 @@ export class MeshCoreObserverPublisher {
   }
 
   /**
-   * Republish the retained `online` status every `STATUS_REFRESH_MS` so the
-   * analyzer's battery / uptime / noise floor track the device instead of
-   * freezing at their connect-time values (#4556).
-   *
-   * Deliberately a separate timer from the renewal one: renewal is hourly and
-   * tears the socket down, while this is a cheap publish on the existing
-   * socket. Folding the two would either make stats hourly or make renewal
-   * five-minutely.
+   * Republish the retained `online` status on every CONNECTED broker every
+   * `STATUS_REFRESH_MS`, reading device stats exactly ONCE and sharing the
+   * result (#4556, #5014 §3.3). Skips entirely when nothing is connected
+   * (preserves the "never let a publish reach a disconnected client"
+   * invariant) and latches so a slow stats read can't stack ticks on a
+   * busy/unresponsive device.
    */
+  private async refreshStatus(): Promise<void> {
+    if (this.refreshingStatus) return;
+    const connected = this.connections.filter((c) => c.isConnected());
+    if (connected.length === 0) return;
+
+    this.refreshingStatus = true;
+    try {
+      const stats = await this.readStats();
+      await Promise.allSettled(connected.map((c) => c.publishOnlineStatus(stats)));
+    } finally {
+      this.refreshingStatus = false;
+    }
+  }
+
   private armStatusRefreshTimer(): void {
     this.clearStatusRefreshTimer();
     this.statusRefreshTimer = setInterval(() => {
@@ -591,66 +899,65 @@ export class MeshCoreObserverPublisher {
   }
 
   /**
-   * One refresh tick. Skips when the socket is down (a status publish to a
-   * disconnected client would sit in mqtt.js's offline queue — the same
-   * unbounded-queue hazard `handleOtaPacket` guards against) and latches so a
-   * slow stats read can't stack ticks on a busy/unresponsive device.
-   */
-  private async refreshStatus(): Promise<void> {
-    if (this.refreshingStatus) return;
-    if (!this.client?.isConnected()) return;
-
-    this.refreshingStatus = true;
-    try {
-      await this.publishOnlineStatus();
-    } finally {
-      this.refreshingStatus = false;
-    }
-  }
-
-  /**
    * Renew when `nowSeconds >= tokenExpiresAt - (RENEWAL_CHECK_MS/1000 +
-   * RENEWAL_THRESHOLD_S)`. The reference tests only the threshold on a
-   * coarser interval, which leaves an expiry hole — see the module header
-   * and spec §3.2/§6. Never hardcode the resulting window; always derive it
-   * from the two constants.
+   * RENEWAL_THRESHOLD_S)`, per DISTINCT audience — never hardcode the
+   * resulting window; always derive it from the two constants (see the
+   * module header / spec §3.2/§6 for why the check interval itself must be
+   * part of the window). Only the audiences that need renewal are re-minted;
+   * only the connections on those audiences are rebuilt (#5014 §3.3).
    */
   private async checkRenewal(): Promise<void> {
-    if (this.renewing || this.tokenExpiresAt === null) return;
+    if (this.renewing) return;
 
     const nowSeconds = Math.floor(Date.now() / 1000);
     const windowSeconds = RENEWAL_CHECK_MS / 1000 + RENEWAL_THRESHOLD_S;
-    if (nowSeconds < this.tokenExpiresAt - windowSeconds) return;
+    const dueAudiences = Array.from(this.tokensByAudience.entries())
+      .filter(([, token]) => nowSeconds >= token.expiresAt - windowSeconds)
+      .map(([aud]) => aud);
+    if (dueAudiences.length === 0) return;
 
     this.renewing = true;
     try {
-      const result = await this.mintTokenFn(this.options.sourceId);
-      if (result.kind !== 'ok') {
-        // Old client untouched — a transient mint failure must not tear down
-        // a working connection. Retried automatically on the next tick.
-        this.lastError = this.mintFailureMessage(result);
-        return;
-      }
-      await this.rebuildClientWithToken(result.token);
+      await Promise.allSettled(dueAudiences.map((aud) => this.renewAudience(aud)));
     } finally {
       this.renewing = false;
     }
   }
 
-  private async hardStopOnAuthFailure(): Promise<void> {
-    if (this.authStopping) return;
-    this.authStopping = true;
-    this.clearRenewalTimer();
-    this.clearStatusRefreshTimer();
-    const client = this.client;
-    this.client = null;
-    this.running = false;
-    if (client) {
-      try {
-        await client.disconnect();
-      } catch {
-        // Best-effort.
-      }
+  private async renewAudience(audience: string): Promise<void> {
+    const affected = this.connections.filter(
+      (c) => c.broker.authMode === 'token' && c.broker.tokenAudience === audience,
+    );
+    const result = await this.mintTokenFn(this.options.sourceId, audience);
+    if (result.kind !== 'ok') {
+      // Old sockets untouched — a transient mint failure must not tear down
+      // a working connection. Retried automatically on the next tick.
+      const message = this.mintFailureMessage(result);
+      for (const c of affected) c.recordExternalError(message);
+      return;
+    }
+    this.tokensByAudience.set(audience, result.token);
+    await Promise.allSettled(affected.map((c) => c.rebuildWithToken(result.token)));
+  }
+
+  private onConnectionAuthHardStop(key: string): void {
+    this.hardStoppedKeys.add(key);
+    const allStopped =
+      this.connections.length > 0 && this.connections.every((c) => this.hardStoppedKeys.has(c.key));
+    if (allStopped) {
+      this.clearRenewalTimer();
+      this.clearStatusRefreshTimer();
+      this.running = false;
     }
   }
+}
+
+/** Reduce a list of nullable numbers, ignoring nulls; null if every value is null. */
+function reduceNullable(values: Array<number | null>, pick: (a: number, b: number) => number): number | null {
+  let result: number | null = null;
+  for (const v of values) {
+    if (v === null) continue;
+    result = result === null ? v : pick(result, v);
+  }
+  return result;
 }

--- a/src/server/services/meshcoreObserverPublisher.ts
+++ b/src/server/services/meshcoreObserverPublisher.ts
@@ -925,9 +925,24 @@ export class MeshCoreObserverPublisher {
   }
 
   private async renewAudience(audience: string): Promise<void> {
+    // Exclude hard-stopped connections: a connection that hit
+    // MAX_AUTH_FAILURES is disconnected on purpose and its `authStopping`
+    // latch stays set until an operator-driven config change / reconnect
+    // (start()). Renewing its token and calling rebuildWithToken() would
+    // resurrect the socket and, because the latch is already set,
+    // hardStopOnAuthFailure() would early-return forever after -- the
+    // connection would then retry via mqtt.js's own backoff with NO way to
+    // hard-stop again. Skip it entirely, and skip minting altogether when
+    // every connection on this audience is dead (no point burning an hourly
+    // WASM signature for a token nothing will use).
     const affected = this.connections.filter(
-      (c) => c.broker.authMode === 'token' && c.broker.tokenAudience === audience,
+      (c) =>
+        c.broker.authMode === 'token' &&
+        c.broker.tokenAudience === audience &&
+        !this.hardStoppedKeys.has(c.key),
     );
+    if (affected.length === 0) return;
+
     const result = await this.mintTokenFn(this.options.sourceId, audience);
     if (result.kind !== 'ok') {
       // Old sockets untouched — a transient mint failure must not tear down

--- a/src/server/services/meshcoreObserverStatus.ts
+++ b/src/server/services/meshcoreObserverStatus.ts
@@ -1,0 +1,67 @@
+/**
+ * MeshCore Analyzer Observer status types (#5014 Phase 1 WP1).
+ *
+ * Types only — deliberately has no imports and no runtime logic. Split out of
+ * `meshcoreObserverPublisher.ts` (which value-imports the credential store,
+ * the token minter and `package.json`) so the new `GET /observer/status`
+ * route (WP4) can depend on the shape without pulling the publisher in, and
+ * so WP3 (publisher) and WP4 (routes) can be built in parallel without
+ * touching the same file. `meshcoreObserverPublisher.ts` re-exports both
+ * types from here, so every existing import site keeps working unchanged.
+ *
+ * See docs/internal/dev-notes/MESHMAPPER_OBSERVER_PHASE1_SPEC.md §5.1.
+ */
+
+/** Per-broker Analyzer Observer connection status (#5014 Phase 1). */
+export interface MeshCoreObserverBrokerStatus {
+  /** Stable identity. Same value as NormalizedObserverBroker.key. */
+  key: string;
+  /** Normalized broker URL. Non-secret, but see the strip rule in §5.4. */
+  url: string;
+  label: string | null;
+  authMode: 'token' | 'password';
+  tokenAudience: string | null;
+  /** This broker has every field its auth mode requires. */
+  configured: boolean;
+  /** Its credential exists and decrypts under the current SESSION_SECRET. */
+  keyStored: boolean;
+  connected: boolean;
+  publishes: number;
+  /** Packets dropped because THIS broker's socket was down. */
+  dropped: number;
+  lastPublishAt: number | null;
+  /** Token-redacted. */
+  lastError: string | null;
+  /** Unix SECONDS. Null in password mode. */
+  tokenExpiresAt: number | null;
+}
+
+/**
+ * Aggregate Analyzer Observer status for a source. Every field below the
+ * `brokers` array existed pre-#5014 and keeps its meaning for a
+ * single-broker source: the aggregation rules (§5.1) are chosen so a
+ * single-broker source produces exactly the values it produces today.
+ */
+export interface MeshCoreObserverStatus {
+  /** ANY broker configured. */
+  configured: boolean;
+  /** brokers[0].authMode. Legacy field, kept for existing consumers. */
+  authMode: 'token' | 'password';
+  /** ANY broker's credential present and decryptable. */
+  keyStored: boolean;
+  /** ANY broker connected. */
+  connected: boolean;
+  /** SUM over brokers. */
+  publishes: number;
+  /** SUM over brokers. */
+  dropped: number;
+  /** MAX over brokers (most recent). */
+  lastPublishAt: number | null;
+  /** Most recently set non-null broker lastError. Token-redacted. */
+  lastError: string | null;
+  /** MIN over non-null broker values (earliest expiry). */
+  tokenExpiresAt: number | null;
+
+  // ---- new (#5014 Phase 1) ----
+  brokers: MeshCoreObserverBrokerStatus[];
+}

--- a/src/server/services/meshcoreObserverToken.test.ts
+++ b/src/server/services/meshcoreObserverToken.test.ts
@@ -391,4 +391,120 @@ describe('meshcoreObserverToken', () => {
       expect(await mintObserverTokenForSource('missing')).toBeNull();
     });
   });
+
+  describe('mintObserverTokenForSourceDetailed — audienceOverride (#5014 Phase 1 WP3)', () => {
+    beforeEach(() => {
+      sourceRows.clear();
+      observerRows.clear();
+      setMeshCoreObserverKeyStoreForTesting(null);
+    });
+
+    it('with no override, behaves exactly as before (uses observer.tokenAudience)', async () => {
+      const keyStore = new MeshCoreObserverKeyStore('secretH'.repeat(8), true);
+      setMeshCoreObserverKeyStoreForTesting(keyStore);
+      const pub = await deriveObserverPublicKey(PRIV);
+      await keyStore.store('src-h', PRIV, pub, 'device');
+      sourceRows.set('src-h', {
+        id: 'src-h',
+        type: 'meshcore',
+        config: {
+          observer: { enabled: true, brokerUrl: 'mqtts://broker:8883', iataCode: 'MCO', tokenAudience: 'config-aud' },
+        },
+      });
+
+      const result = await mintObserverTokenForSourceDetailed('src-h');
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        const verified = await verifyAuthToken(result.token.token, pub);
+        expect(verified!.aud).toBe('config-aud');
+      }
+    });
+
+    it('an override audience wins over the config tokenAudience', async () => {
+      const keyStore = new MeshCoreObserverKeyStore('secretI'.repeat(8), true);
+      setMeshCoreObserverKeyStoreForTesting(keyStore);
+      const pub = await deriveObserverPublicKey(PRIV);
+      await keyStore.store('src-i', PRIV, pub, 'device');
+      sourceRows.set('src-i', {
+        id: 'src-i',
+        type: 'meshcore',
+        config: {
+          observer: { enabled: true, brokerUrl: 'mqtts://broker:8883', iataCode: 'MCO', tokenAudience: 'config-aud' },
+        },
+      });
+
+      const result = await mintObserverTokenForSourceDetailed('src-i', 'override-aud');
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        const verified = await verifyAuthToken(result.token.token, pub);
+        expect(verified!.aud).toBe('override-aud');
+      }
+    });
+
+    it('mints successfully with an override even when the config has no tokenAudience at all', async () => {
+      const keyStore = new MeshCoreObserverKeyStore('secretJ'.repeat(8), true);
+      setMeshCoreObserverKeyStoreForTesting(keyStore);
+      const pub = await deriveObserverPublicKey(PRIV);
+      await keyStore.store('src-j', PRIV, pub, 'device');
+      // Multi-broker config with brokers[] but no block-level tokenAudience —
+      // the per-broker publisher supplies each broker's own audience as the
+      // override.
+      sourceRows.set('src-j', {
+        id: 'src-j',
+        type: 'meshcore',
+        config: {
+          observer: {
+            enabled: true,
+            iataCode: 'MCO',
+            brokers: [{ url: 'mqtts://broker-a:8883', tokenAudience: 'broker-a-aud' }],
+          },
+        },
+      });
+
+      const result = await mintObserverTokenForSourceDetailed('src-j', 'broker-a-aud');
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        const verified = await verifyAuthToken(result.token.token, pub);
+        expect(verified!.aud).toBe('broker-a-aud');
+      }
+    });
+
+    it("still 'not_configured' for a missing source even with an override", async () => {
+      expect(await mintObserverTokenForSourceDetailed('missing', 'some-aud')).toEqual({ kind: 'not_configured' });
+    });
+
+    it("still 'not_configured' for a non-meshcore source even with an override", async () => {
+      sourceRows.set('src-mt2', { id: 'src-mt2', type: 'meshtastic_tcp', config: {} });
+      expect(await mintObserverTokenForSourceDetailed('src-mt2', 'some-aud')).toEqual({ kind: 'not_configured' });
+    });
+
+    it("still 'not_configured' when the observer block is absent/disabled even with an override", async () => {
+      sourceRows.set('src-k', { id: 'src-k', type: 'meshcore', config: {} });
+      expect(await mintObserverTokenForSourceDetailed('src-k', 'some-aud')).toEqual({ kind: 'not_configured' });
+
+      sourceRows.set('src-l', {
+        id: 'src-l',
+        type: 'meshcore',
+        config: { observer: { enabled: false, brokerUrl: 'mqtts://broker:8883', iataCode: 'MCO' } },
+      });
+      expect(await mintObserverTokenForSourceDetailed('src-l', 'some-aud')).toEqual({ kind: 'not_configured' });
+    });
+
+    it("still 'no_key' with an override when no key is stored", async () => {
+      const keyStore = new MeshCoreObserverKeyStore('secretM'.repeat(8), true);
+      setMeshCoreObserverKeyStoreForTesting(keyStore);
+      sourceRows.set('src-m', {
+        id: 'src-m',
+        type: 'meshcore',
+        // tokenAudience present so the block normalizes at all (a legacy
+        // token-mode entry with no audience is dropped by
+        // `normalizeObserverBrokers`, which would make this "not_configured"
+        // regardless of the override) — the override still wins over it.
+        config: {
+          observer: { enabled: true, brokerUrl: 'mqtts://broker:8883', iataCode: 'MCO', tokenAudience: 'config-aud' },
+        },
+      });
+      expect(await mintObserverTokenForSourceDetailed('src-m', 'some-aud')).toEqual({ kind: 'no_key' });
+    });
+  });
 });

--- a/src/server/services/meshcoreObserverToken.ts
+++ b/src/server/services/meshcoreObserverToken.ts
@@ -122,31 +122,47 @@ export type ObserverTokenResult =
   | { kind: 'mint_failed'; message: string };
 
 /**
- * Mint a token for a configured source: loads the stored signing key, reads
- * `observer.tokenAudience` from the source's saved config, derives the
- * public key, and signs. Unlike {@link mintObserverTokenForSource}, the
+ * Mint a token for a configured source: loads the stored signing key, derives
+ * the public key, and signs. Unlike {@link mintObserverTokenForSource}, the
  * failure reason is distinguishable — see {@link ObserverTokenResult}.
+ *
+ * `audienceOverride` (#5014 Phase 1 WP3): when supplied, THIS audience is
+ * used instead of `observer.tokenAudience` from the source's saved config,
+ * and the "no tokenAudience -> not_configured" gate is skipped — the source
+ * still needs to exist, be `meshcore`, and have an ENABLED observer block,
+ * but need not carry a top-level `tokenAudience` at all. This is what lets
+ * the multi-broker publisher mint one token per broker's own audience
+ * (`brokers[i].tokenAudience`), which is not necessarily the block-level
+ * mirror value. With no override, behaviour is byte-identical to before
+ * `audienceOverride` existed.
  *
  * Not exposed via any route — this is the publisher's (Phase 2) seam.
  */
-export async function mintObserverTokenForSourceDetailed(sourceId: string): Promise<ObserverTokenResult> {
+export async function mintObserverTokenForSourceDetailed(
+  sourceId: string,
+  audienceOverride?: string,
+): Promise<ObserverTokenResult> {
   const source = await databaseService.sources.getSource(sourceId);
   if (!source || source.type !== 'meshcore') return { kind: 'not_configured' };
 
   const cfg = (source.config ?? {}) as MeshCoreSourceConfig;
   const observer = observerConfigFromSource(cfg);
+  if (!observer) return { kind: 'not_configured' };
   // `observerConfigFromSource` only ever returns non-undefined once brokerUrl/
-  // iataCode/tokenAudience are all present (see its own definition of
-  // "incomplete"), but its declared type still marks tokenAudience optional —
-  // narrow explicitly so this stays type-safe if that contract ever loosens.
-  if (!observer || !observer.tokenAudience) return { kind: 'not_configured' };
+  // iataCode/tokenAudience are all present for `brokers[0]` (see its own
+  // definition of "incomplete"), but its declared type still marks
+  // `tokenAudience` optional — narrow explicitly so this stays type-safe if
+  // that contract ever loosens. An explicit override bypasses this gate
+  // entirely, since it supplies its own audience.
+  const audience = audienceOverride ?? observer.tokenAudience;
+  if (!audience) return { kind: 'not_configured' };
 
   const keyResult = await getMeshCoreObserverKeyStore().load(sourceId);
   if (keyResult.kind === 'none') return { kind: 'no_key' };
   if (keyResult.kind === 'key_rotated') return { kind: 'key_rotated' };
 
   try {
-    const token = await mintObserverToken(keyResult.privateKeyHex, observer.tokenAudience);
+    const token = await mintObserverToken(keyResult.privateKeyHex, audience);
     return { kind: 'ok', token };
   } catch (err) {
     // Never let a thrown error carry key material into the log at anything


### PR DESCRIPTION
## Summary
Phase 1 of the MeshMapper Observer epic (#5014). MeshMapper's MQTT ingestion uses the exact wire contract our per-source Analyzer Observer already speaks — topics, packet JSON, and Ed25519 JWT auth — so contributing coverage data to MeshMapper (and LetsMesh) needs only the ability to publish to **more than one broker at once**. This PR extends the observer from one broker to N, with per-broker connection state, counters, credentials, and tokens. Backend only; the broker-list UI with MeshMapper/LetsMesh presets is Phase 2.

Epic plan: `docs/internal/dev-notes/MESHMAPPER_OBSERVER_EPIC.md` · Spec: `docs/internal/dev-notes/MESHMAPPER_OBSERVER_PHASE1_SPEC.md`

## Changes
- **Config** (`meshcoreConfig.ts`): `observer.brokers[]` (url, authMode, tokenAudience, label); pure `normalizeObserverBrokers()` with dedupe + legacy synthesis; legacy single `brokerUrl` configs keep working unchanged (no DB migration — config is a JSON blob). Flat fields remain as mirrors of `brokers[0]`.
- **Publisher** (`meshcoreObserverPublisher.ts`): one publisher owning N `ObserverBrokerConnection`s — shared packet stream and device identity, payload serialized once per packet; per-broker connect state, publishes/dropped/lastError (token-redacted), drop-when-disconnected; token minting deduped by audience; one renewal + one status-refresh timer, stats read once per tick.
- **Behaviour change (deliberate):** `MAX_AUTH_FAILURES` now hard-stops only the offending connection, not the whole observer — a LetsMesh credential typo must not silence MeshMapper. Renewal excludes hard-stopped connections (caught in review: renewal previously would have resurrected them and disabled the latch).
- **Credentials** (`meshcoreObserverCredentialStore.ts`): the AES-256-GCM plaintext becomes a versioned v2 JSON document holding per-broker credentials + the legacy pair; lossless v1 upgrade, no schema/migration change. New `storeForBroker`/`loadForBroker`/`clearForBroker`/`listBrokers`. Legacy fallback lives in the publisher and applies only to the legacy broker — per-broker isolation guaranteed.
- **Routes** (`sourceObserverRoutes.ts`): new `GET /api/sources/:id/observer/status` (aggregate + per-broker; not-running synthesis from saved config) — closes the pre-existing "observer status has no consumer" gap. Credential GET/PUT/DELETE gain optional `brokerKey`, byte-compatible when omitted; unknown keys rejected (`UNKNOWN_BROKER`).
- **Validation** (`sourceRoutes.ts`): per-entry broker validation (scheme pre-check preserved), `MAX_OBSERVER_BROKERS` = 8, `DUPLICATE_BROKER_URL`, observer-block-only size cap (`MAX_OBSERVER_CONFIG_BYTES` = 1536; deliberately **no** whole-config guard — that would make existing >4KB SQLite/PG configs uneditable) plus a non-rejecting MySQL >4096 diagnostic warn. `stripObserverKeyMaterial` extended to `brokers[]` entries.
- `mintObserverTokenForSourceDetailed` gains an optional `audienceOverride`; byte-identical behavior without it.

## Issues Resolved
Relates to #5014 (Phase 1 of 2 — closes after Phase 2 UI).

## Documentation Updates
Epic plan + Phase 1 spec added under `docs/internal/dev-notes/`. User docs (`docs/features/meshcore-analyzer-observer.md`) stay accurate — the UI is unchanged until Phase 2, which carries the user-doc updates.

## Testing
- [x] Full Vitest suite: 17,548 passed / 0 failed, `success: true` (JSON reporter); 939 pending = PG/MySQL container skips (no schema change this phase)
- [x] `tsc -p tsconfig.server.json --noEmit` clean; `npm run lint:ci` ratchet gate passes (no in-repo FAIL lines)
- [x] New multi-broker suite (19 tests): concurrent 2-broker publish with byte-identical payloads, per-audience token dedupe + scoped renewal, per-broker drop/error/auth-hard-stop isolation, hard-stopped connections excluded from renewal, password-mode per-broker credentials, mixed modes, never-throw start/stop
- [x] Back-compat pinned: legacy config normalizes to one broker whose per-broker status mirrors every aggregate field; pre-#5014 credential rows load bit-for-bit; `GET /:id/status` strip still drops the whole observer object for non-`nodes:read` callers
- [ ] Reviewer check: `MAX_OBSERVER_BROKERS = 8` is a chosen cap (spec §8.4) — flag if you want a different number

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBktZBausKVUARXxqXV81u