### PR TITLE
fix(automation-engine): add missing Arguments field to action.runScript

### DIFF
--- a/docs/features/automation-engine.md
+++ b/docs/features/automation-engine.md
@@ -418,6 +418,14 @@ Runs a script file from the server's **`$DATA_DIR/scripts`** folder (the same di
 Responder uses) when the automation fires.
 
 - **Script** — picked from a dropdown of files in the scripts directory.
+- **Arguments** *(optional)* — CLI arguments passed to the script after its file path. Supports
+  `{{ var.x }}` and `{{ trigger.field }}` templates, resolved before the string is tokenized.
+  Splitting is shell-style: whitespace separates tokens, but a double-quoted phrase such as
+  `--text "hello world"` stays one arg, and `\"` inside double quotes emits a literal
+  double-quote. Single quotes preserve their contents verbatim. This is a splitter, not a shell:
+  `$var`, backticks, `$(...)`, globs, and pipes are passed through unchanged. An unterminated
+  quote fails the action cleanly, recorded as `invalid arguments` on the run log. The legacy
+  `{IP}` / `{PORT}` tokens from Timer Triggers are **not** available here — use `{{ }}` templates.
 - The trigger context is passed to the script as **`MM_*` environment variables**:
   `MM_TRIGGER_TYPE`, `MM_SOURCE_ID`, `MM_NODE_NUM`, `MM_TIMESTAMP`, and each trigger field as
   `MM_<UPPER_SNAKE_NAME>` (object values are JSON-stringified). Message-style aliases (`MESSAGE`,

--- a/src/components/automations/catalog.ts
+++ b/src/components/automations/catalog.ts
@@ -764,6 +764,9 @@ export const ACTIONS: BlockDef[] = [
     description: 'Run a script from the server’s scripts folder. The trigger context is passed as MM_* environment variables; the script’s JSON output can be stored in a variable.',
     fields: [
       { name: 'scriptPath', label: 'Script', kind: 'scriptselect', help: 'A script file in the server’s scripts directory ($DATA_DIR/scripts).' },
+      { name: 'args', label: 'Arguments', kind: 'text', tokens: true, advanced: true,
+        placeholder: 'e.g. --from {{ trigger.from }} --text "{{ trigger.text }}"',
+        help: 'Optional CLI arguments. Supports {{ var.x }} and {{ trigger.field }} templates. Shell-style quoting is honored, so "hello world" stays one arg.' },
       { name: 'resultVariable', label: 'Store result in', kind: 'variable', advanced: true, help: 'Optional. Stores the script’s JSON output in this variable — use a "json" variable and index it later as {{ var.name.field }}.' },
       { name: 'timeoutSeconds', label: 'Timeout (seconds)', kind: 'number', advanced: true, placeholder: '30' },
     ],

--- a/src/server/services/automation/actionExecutor.test.ts
+++ b/src/server/services/automation/actionExecutor.test.ts
@@ -949,6 +949,56 @@ describe('executeAction', () => {
     await expect(executeAction(node('action.runScript', {}), ctx({}), deps)).rejects.toThrow(/no scriptPath/);
   });
 
+  it('runScript: no args field means the dep is called without scriptArgs', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(node('action.runScript', { scriptPath: 'foo.sh' }), ctx({}), deps);
+    const call = calls.find((x) => x.fn === 'runScript')!;
+    expect(call.args.scriptArgs).toBeUndefined();
+  });
+
+  it('runScript: an empty/whitespace-only args field is treated as no args', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(node('action.runScript', { scriptPath: 'foo.sh', args: '   ' }), ctx({}), deps);
+    const call = calls.find((x) => x.fn === 'runScript')!;
+    expect(call.args.scriptArgs).toBeUndefined();
+  });
+
+  it('runScript: whitespace-separated args become an argv array', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(node('action.runScript', { scriptPath: 'foo.sh', args: '--foo bar' }), ctx({}), deps);
+    const call = calls.find((x) => x.fn === 'runScript')!;
+    expect(call.args.scriptArgs).toEqual(['--foo', 'bar']);
+  });
+
+  it('runScript: {{ trigger.field }} templates interpolate before tokenization', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.runScript', { scriptPath: 'foo.sh', args: '--text {{ trigger.text }}' }),
+      ctx({ text: 'hello' }),
+      deps,
+    );
+    const call = calls.find((x) => x.fn === 'runScript')!;
+    expect(call.args.scriptArgs).toEqual(['--text', 'hello']);
+  });
+
+  it('runScript: shell-style quotes keep a spaced value as one arg', async () => {
+    const { calls, deps } = recorder();
+    await executeAction(
+      node('action.runScript', { scriptPath: 'foo.sh', args: '--x "hello world"' }),
+      ctx({}),
+      deps,
+    );
+    const call = calls.find((x) => x.fn === 'runScript')!;
+    expect(call.args.scriptArgs).toEqual(['--x', 'hello world']);
+  });
+
+  it('runScript: an unterminated quote fails the action with a clean error', async () => {
+    const { deps } = recorder();
+    await expect(
+      executeAction(node('action.runScript', { scriptPath: 'foo.sh', args: '--x "unterminated' }), ctx({}), deps),
+    ).rejects.toThrow(/invalid arguments/);
+  });
+
   it('delay: waits the requested seconds via the injected sleep', async () => {
     const { deps } = recorder();
     const slept: number[] = [];

--- a/src/server/services/automation/actionExecutor.ts
+++ b/src/server/services/automation/actionExecutor.ts
@@ -10,6 +10,7 @@ import { type AutomationNode, AUTOMATION_DELAY_MAX_SECONDS, parseSendMaxAttempts
 import { type EngineEvalContext, interpolateAsync, resolveOperand } from './engineContext.js';
 import { isTxDisabledError } from '../../errors/txDisabledError.js';
 import { hopCountEmoji } from '../../../utils/hopEmoji.js';
+import { tokenizeArgv } from '../../utils/argvTokenizer.js';
 
 export type NodeManageOp = 'favorite' | 'unfavorite' | 'ignore' | 'unignore' | 'delete';
 
@@ -61,8 +62,11 @@ export interface ActionDeps {
    *  Throws on an unreachable/unsupported source so the run-log records a failed step. */
   rebootDevice(a: { sourceId: string | null; seconds?: number; targetNodeNum?: number }): Promise<unknown>;
   notify(a: { sourceId: string | null; title: string; body: string; type?: string; urls?: string[] }): Promise<unknown>;
-  /** Run a user script file (in $DATA_DIR/scripts) with the given env. Never throws — returns the outcome. */
-  runScript(a: { scriptPath: string; env: Record<string, string>; timeoutMs?: number }):
+  /** Run a user script file (in $DATA_DIR/scripts) with the given env. Never throws — returns the outcome.
+   *  `scriptArgs` is the already-tokenized argv the executor built from the
+   *  action's Arguments field. Omitted or empty means the script runs with no
+   *  argv beyond the interpreter + script path. */
+  runScript(a: { scriptPath: string; scriptArgs?: string[]; env: Record<string, string>; timeoutMs?: number }):
     Promise<{ success: boolean; returnValue?: unknown; stdout: string; error?: string }>;
   /** Pause for `ms` (action.delay). Optional/injectable so tests don't wait in real time. */
   sleep?(ms: number): Promise<void>;
@@ -186,7 +190,25 @@ export async function executeAction(node: AutomationNode, ctx: EngineEvalContext
       if (!scriptPath) throw new Error('action.runScript: no scriptPath');
       const timeoutMs = p.timeoutSeconds != null && Number.isFinite(Number(p.timeoutSeconds))
         ? Math.max(1, Number(p.timeoutSeconds)) * 1000 : undefined;
-      const result = await deps.runScript({ scriptPath, env: triggerEnv(ctx), timeoutMs });
+
+      // Arguments field: interpolate {{ var.x }} / {{ trigger.field }} templates,
+      // then split the result with shell-style quote handling into argv. An
+      // unterminated quote fails the action cleanly so the run-log records why
+      // rather than silently truncating argv.
+      const rawArgs = typeof p.args === 'string' ? p.args : '';
+      let scriptArgs: string[] | undefined;
+      if (rawArgs.trim().length > 0) {
+        const interpolated = await interpolateAsync(rawArgs, ctx);
+        try {
+          const tokens = tokenizeArgv(interpolated);
+          if (tokens.length > 0) scriptArgs = tokens;
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          throw new Error(`action.runScript: invalid arguments — ${reason}`, { cause: err });
+        }
+      }
+
+      const result = await deps.runScript({ scriptPath, scriptArgs, env: triggerEnv(ctx), timeoutMs });
       if (!result.success) throw new Error(`script "${scriptPath}" failed: ${result.error ?? 'non-zero exit'}`);
       // Store the script's JSON result into a variable (usable later as
       // {{ var.NAME.a.b }}); fall back to trimmed stdout when there's no JSON.

--- a/src/server/services/automation/meshActionDeps.ts
+++ b/src/server/services/automation/meshActionDeps.ts
@@ -267,10 +267,10 @@ export function createMeshActionDeps(): ActionDeps {
       return r;
     },
 
-    async runScript({ scriptPath, env, timeoutMs }) {
+    async runScript({ scriptPath, scriptArgs, env, timeoutMs }) {
       // runUserScript resolves the path under $DATA_DIR/scripts (traversal-safe),
       // picks the interpreter, and never throws — returns { success, ... }.
-      return runUserScript({ scriptPath, env, timeoutMs });
+      return runUserScript({ scriptPath, scriptArgs, env, timeoutMs });
     },
   };
 }

--- a/src/server/utils/argvTokenizer.test.ts
+++ b/src/server/utils/argvTokenizer.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { tokenizeArgv, ArgvTokenizerError } from './argvTokenizer.js';
+
+describe('tokenizeArgv', () => {
+  it('returns [] for empty input', () => {
+    expect(tokenizeArgv('')).toEqual([]);
+  });
+
+  it('returns [] for whitespace-only input', () => {
+    expect(tokenizeArgv('   ')).toEqual([]);
+    expect(tokenizeArgv('\t\n \r')).toEqual([]);
+  });
+
+  it('splits plain whitespace-separated tokens', () => {
+    expect(tokenizeArgv('foo bar baz')).toEqual(['foo', 'bar', 'baz']);
+  });
+
+  it('collapses runs of whitespace between tokens', () => {
+    expect(tokenizeArgv('a    b\t\tc\n\nd')).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(tokenizeArgv('   foo bar   ')).toEqual(['foo', 'bar']);
+  });
+
+  it('treats a double-quoted phrase as one arg with spaces preserved', () => {
+    expect(tokenizeArgv('--text "hello world"')).toEqual(['--text', 'hello world']);
+  });
+
+  it('treats a single-quoted phrase as one arg with contents verbatim', () => {
+    expect(tokenizeArgv("'a b' \"c d\" e f")).toEqual(['a b', 'c d', 'e', 'f']);
+  });
+
+  it('single quotes keep backslashes literal', () => {
+    expect(tokenizeArgv("'hello\\ world'")).toEqual(['hello\\ world']);
+  });
+
+  it('honors a backslash-escaped space outside quotes', () => {
+    expect(tokenizeArgv('hello\\ world')).toEqual(['hello world']);
+  });
+
+  it('honors \\" inside double quotes to embed a literal double-quote', () => {
+    expect(tokenizeArgv('--path "with \\"quote\\""')).toEqual(['--path', 'with "quote"']);
+  });
+
+  it('honors \\\\ inside double quotes to embed a literal backslash', () => {
+    expect(tokenizeArgv('"a\\\\b"')).toEqual(['a\\b']);
+  });
+
+  it('translates \\n and \\t inside double quotes', () => {
+    expect(tokenizeArgv('"line1\\nline2"')).toEqual(['line1\nline2']);
+    expect(tokenizeArgv('"col1\\tcol2"')).toEqual(['col1\tcol2']);
+  });
+
+  it('leaves an unknown \\x sequence inside double quotes as literal \\x', () => {
+    expect(tokenizeArgv('"a\\zb"')).toEqual(['a\\zb']);
+  });
+
+  it('does not special-case =: --flag=value with spaces splits at the first space', () => {
+    expect(tokenizeArgv('--flag=value with spaces')).toEqual([
+      '--flag=value',
+      'with',
+      'spaces',
+    ]);
+  });
+
+  it('adjacent quoted and unquoted pieces join into one token', () => {
+    expect(tokenizeArgv('a"b c"d')).toEqual(['ab cd']);
+    expect(tokenizeArgv("hello'world me'")).toEqual(['helloworld me']);
+  });
+
+  it('an empty double-quoted string yields one empty argument', () => {
+    expect(tokenizeArgv('foo "" bar')).toEqual(['foo', '', 'bar']);
+  });
+
+  it('a trailing bare backslash is emitted as a literal backslash', () => {
+    expect(tokenizeArgv('foo\\')).toEqual(['foo\\']);
+  });
+
+  it('throws on an unterminated double quote', () => {
+    expect(() => tokenizeArgv('--text "hello')).toThrow(ArgvTokenizerError);
+    expect(() => tokenizeArgv('--text "hello')).toThrow(/unterminated double quote/);
+  });
+
+  it('throws on an unterminated single quote', () => {
+    expect(() => tokenizeArgv("--text 'hello")).toThrow(ArgvTokenizerError);
+    expect(() => tokenizeArgv("--text 'hello")).toThrow(/unterminated single quote/);
+  });
+
+  it('does not expand shell constructs', () => {
+    // $var, backticks, $() are all preserved verbatim; this is a splitter, not a shell.
+    expect(tokenizeArgv('$FOO `pwd` $(date)')).toEqual(['$FOO', '`pwd`', '$(date)']);
+  });
+});

--- a/src/server/utils/argvTokenizer.ts
+++ b/src/server/utils/argvTokenizer.ts
@@ -1,0 +1,132 @@
+/**
+ * Shell-style argv tokenizer for the Automation Engine's action.runScript
+ * Arguments field. Splits a single string into argv with quote and backslash
+ * handling that matches user expectations from POSIX shells, minus every
+ * expansion. This is NOT a shell: it does not expand `$var`, backticks,
+ * `$(...)`, globs, or handle redirects and pipes. Callers that want template
+ * expansion (e.g. `{{ event.field }}`) run their template pass BEFORE
+ * tokenizing.
+ *
+ * Rules:
+ *   - Whitespace between tokens is a separator (any run of ASCII whitespace).
+ *   - Single quotes (`'`) preserve their contents verbatim. Backslashes inside
+ *     single quotes have no special meaning. Newlines are allowed.
+ *   - Double quotes (`"`) preserve whitespace and allow `\\`, `\"`, `\n`, `\t`
+ *     escapes; any other `\x` inside double quotes is emitted verbatim as `\x`.
+ *   - A bare backslash outside quotes escapes the next character literally
+ *     (`hello\ world` yields one token `hello world`). A trailing bare
+ *     backslash is treated as a literal backslash.
+ *   - Empty or all-whitespace input returns `[]`.
+ *   - An unterminated single or double quote throws so the caller can fail the
+ *     action cleanly rather than silently truncating argv.
+ */
+
+/** Thrown when a quote opens and the string ends before it closes. */
+export class ArgvTokenizerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ArgvTokenizerError';
+  }
+}
+
+function isWhitespace(ch: string): boolean {
+  return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r' || ch === '\v' || ch === '\f';
+}
+
+/**
+ * Split `input` into a list of arguments with shell-style quote and escape
+ * handling. Returns an empty array for empty or whitespace-only input.
+ *
+ * @throws {ArgvTokenizerError} on an unterminated quote.
+ */
+export function tokenizeArgv(input: string): string[] {
+  const argv: string[] = [];
+  const buf: string[] = [];
+  let inToken = false;
+
+  const flush = () => {
+    if (inToken) {
+      argv.push(buf.join(''));
+      buf.length = 0;
+      inToken = false;
+    }
+  };
+
+  const len = input.length;
+  let i = 0;
+  while (i < len) {
+    const ch = input[i];
+
+    if (isWhitespace(ch)) {
+      flush();
+      i++;
+      continue;
+    }
+
+    if (ch === "'") {
+      inToken = true;
+      const start = i;
+      i++;
+      while (i < len && input[i] !== "'") {
+        buf.push(input[i]);
+        i++;
+      }
+      if (i >= len) {
+        throw new ArgvTokenizerError(
+          `unterminated single quote starting at position ${start}`,
+        );
+      }
+      i++;
+      continue;
+    }
+
+    if (ch === '"') {
+      inToken = true;
+      const start = i;
+      i++;
+      while (i < len && input[i] !== '"') {
+        if (input[i] === '\\' && i + 1 < len) {
+          const next = input[i + 1];
+          if (next === '"' || next === '\\') {
+            buf.push(next);
+            i += 2;
+            continue;
+          }
+          if (next === 'n') { buf.push('\n'); i += 2; continue; }
+          if (next === 't') { buf.push('\t'); i += 2; continue; }
+          buf.push('\\', next);
+          i += 2;
+          continue;
+        }
+        buf.push(input[i]);
+        i++;
+      }
+      if (i >= len) {
+        throw new ArgvTokenizerError(
+          `unterminated double quote starting at position ${start}`,
+        );
+      }
+      i++;
+      continue;
+    }
+
+    if (ch === '\\') {
+      inToken = true;
+      if (i + 1 < len) {
+        buf.push(input[i + 1]);
+        i += 2;
+      } else {
+        buf.push('\\');
+        i++;
+      }
+      continue;
+    }
+
+    inToken = true;
+    buf.push(ch);
+    i++;
+  }
+
+  flush();
+  return argv;
+}


### PR DESCRIPTION
Fixes #5023

## Summary

The new Automation Engine's `Run a script` action never exposed the CLI arguments field that Timer Triggers / Auto-Responder always had, even though the underlying script runner (`scriptRunner.ts`) already supports `scriptArgs`. Users could not pass positional flags to any script triggered by the engine.

## What changed

- **Catalog** (`src/components/automations/catalog.ts`): add an advanced Arguments field on `action.runScript`, right after Script and before Store result in. Tokens on (highlighted and typo-checked), placeholder shows the `{{ trigger.field }}` idiom.
- **Executor** (`src/server/services/automation/actionExecutor.ts`): interpolate `{{ var.x }}` and `{{ trigger.field }}` templates through the existing engineContext, then tokenize the string with a new shell-style tokenizer before handing `scriptArgs` to the deps. An unterminated quote throws a clean `invalid arguments` error that the run log records instead of silently truncating argv.
- **`ActionDeps.runScript` interface**: accept `scriptArgs?: string[]`.
- **`meshActionDeps.runScript`**: forward the argv to `runUserScript`.
- **New utility** `src/server/utils/argvTokenizer.ts` with unit tests. Whitespace splits, single quotes preserve verbatim, double quotes allow `\\`, `\"`, `\n`, `\t` escapes, bare backslash escapes outside quotes. No env, glob, or subshell expansion.
- **Docs**: extend `docs/features/automation-engine.md` `Run a script` section with the new field, the token syntax, and the shell-style quoting rules.

## Token style + tokenization decisions

- **Templates:** Automation Engine only (`{{ var.x }}`, `{{ trigger.field }}`). Legacy `{IP}`/`{PORT}` tokens from Timer Triggers are NOT supported here — mixing token systems would collide with literal `{...}` args and the two systems live on different rails.
- **Split:** shell-style with quote handling. Diverges intentionally from Timer Triggers' whitespace-only split so the common `--text "hello world"` idiom works. `$var`, backticks, `$(...)`, globs, and pipes pass through unchanged; this is a splitter, not a shell.

## Test plan

- [x] `vitest run src/server/utils/argvTokenizer.test.ts src/server/services/automation/actionExecutor.test.ts` — 112 pass (20 tokenizer + 6 new executor + prior). success:true, 0 failed.
- [x] Broader `vitest run src/server/services/automation/ src/server/utils/` — 1316 pass.
- [x] `tsc -p tsconfig.server.json --noEmit` — clean.
- [x] `npm run lint:ci` — no new baseline violations from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G