### PR TITLE
feat(automation): Duplicate button on automation rules (#5024)

### DIFF
--- a/src/components/automations/AutomationsPage.tsx
+++ b/src/components/automations/AutomationsPage.tsx
@@ -131,6 +131,22 @@ function AutomationsList() {
     await navigator.clipboard?.writeText(JSON.stringify(data, null, 2));
     alert('Exported JSON copied to clipboard.');
   };
+  // TODO(#5024): component test for the duplicate handler.
+  const duplicate = async (a: Automation) => {
+    const suggested = `${a.name} (copy)`;
+    const name = window.prompt('Name for the duplicate:', suggested);
+    if (name === null) return;
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    try {
+      const created = await apiService.post<Automation>(`/api/automations/${a.id}/duplicate`, { name: trimmed });
+      await load();
+      // Open the disabled clone in the editor so the user can review before enabling.
+      setEditing(created);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to duplicate');
+    }
+  };
 
   if (editing) return <AutomationEditor automation={editing} onClose={() => { setEditing(null); void load(); }} />;
   if (browsing) return (
@@ -187,6 +203,7 @@ function AutomationsList() {
               <button className="ae-btn" onClick={() => setRunsFor(a)}>Runs</button>
               <button className="ae-btn" onClick={() => setTraceFor(a)} title="Live debug trace of this rule">Trace</button>
               <button className="ae-btn" onClick={() => exportOne(a)}>Export</button>
+              <button className="ae-btn" onClick={() => duplicate(a)} title="Create a disabled copy of this rule">Duplicate</button>
               <button className="ae-btn ae-btn--danger" onClick={() => remove(a)}>Delete</button>
             </div>
           </div>

--- a/src/server/routes/automationRoutes.duplicate.test.ts
+++ b/src/server/routes/automationRoutes.duplicate.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Automation "Duplicate" route (#5024).
+ *
+ * `POST /api/automations/:id/duplicate` copies a source rule verbatim (config,
+ * description) with a caller-supplied or defaulted name, forces enabled=false,
+ * and returns the new row. Same permission gate as create/edit.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+vi.mock('../services/automation/automationEngineSingleton.js', () => ({
+  getAutomationEngine: vi.fn(),
+  reloadAutomations: vi.fn().mockResolvedValue(undefined),
+}));
+
+import automationRouter from './automationRoutes.js';
+import databaseService from '../../services/database.js';
+
+const VALID_CONFIG = JSON.stringify({
+  nodes: [
+    { id: 'trg', type: 'trigger.message', fields: {} },
+    { id: 'act', type: 'action.nothing', fields: {} },
+  ],
+  edges: [{ source: 'trg', target: 'act' }],
+});
+
+async function seedSource(name: string, extras: Partial<{ description: string; enabled: boolean }> = {}) {
+  return databaseService.automations.createAutomation({
+    name,
+    description: extras.description ?? 'Source description',
+    enabled: extras.enabled ?? true,
+    config: VALID_CONFIG,
+    createdByUserId: null,
+  });
+}
+
+describe('POST /api/automations/:id/duplicate', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/api/automations', automationRouter),
+    });
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('rejects a user without automations:write with 403 and does not insert', async () => {
+    const source = await seedSource('Alpha');
+    const agent = await harness.loginAs(harness.limited);
+    const before = (await databaseService.automations.listAutomations()).length;
+    const res = await agent.post(`/api/automations/${source.id}/duplicate`).send({ name: 'clone' });
+    expect(res.status).toBe(403);
+    const after = (await databaseService.automations.listAutomations()).length;
+    expect(after).toBe(before);
+  });
+
+  it('creates a disabled clone with the requested name and identical config', async () => {
+    const source = await seedSource('Alpha', { description: 'orig' });
+    await harness.grant(harness.limited.id, 'automations', 'write');
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post(`/api/automations/${source.id}/duplicate`).send({ name: 'Copy of Alpha' });
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBeTruthy();
+    expect(res.body.id).not.toBe(source.id);
+    expect(res.body.name).toBe('Copy of Alpha');
+    expect(res.body.enabled).toBe(false);
+    expect(res.body.description).toBe('orig');
+    // config is persisted as a JSON string; deep-equal after re-parse both sides.
+    expect(JSON.parse(res.body.config)).toEqual(JSON.parse(source.config));
+  });
+
+  it('defaults the name to "<source name> (copy)" when the body has no name', async () => {
+    const source = await seedSource('Alpha');
+    await harness.grant(harness.limited.id, 'automations', 'write');
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post(`/api/automations/${source.id}/duplicate`).send({});
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Alpha (copy)');
+    expect(res.body.enabled).toBe(false);
+  });
+
+  it('defaults the name when the body is empty (no Content-Type)', async () => {
+    const source = await seedSource('Beta');
+    await harness.grant(harness.limited.id, 'automations', 'write');
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post(`/api/automations/${source.id}/duplicate`);
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Beta (copy)');
+  });
+
+  it('returns 404 with AUTOMATION_NOT_FOUND when the source id is unknown', async () => {
+    await harness.grant(harness.limited.id, 'automations', 'write');
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post('/api/automations/missing-id/duplicate').send({ name: 'clone' });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('AUTOMATION_NOT_FOUND');
+  });
+
+  it('rejects an over-long name with 400 INVALID_NAME', async () => {
+    const source = await seedSource('Gamma');
+    await harness.grant(harness.limited.id, 'automations', 'write');
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post(`/api/automations/${source.id}/duplicate`).send({ name: 'x'.repeat(201) });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_NAME');
+  });
+
+  it('trims leading/trailing whitespace on the caller-supplied name', async () => {
+    const source = await seedSource('Delta');
+    await harness.grant(harness.limited.id, 'automations', 'write');
+    const agent = await harness.loginAs(harness.limited);
+    const res = await agent.post(`/api/automations/${source.id}/duplicate`).send({ name: '   Padded Name   ' });
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Padded Name');
+  });
+});

--- a/src/server/routes/automationRoutes.ts
+++ b/src/server/routes/automationRoutes.ts
@@ -277,6 +277,37 @@ router.post('/', canWrite, async (req: Request, res: Response) => {
   }
 });
 
+router.post('/:id/duplicate', canWrite, async (req: Request, res: Response) => {
+  try {
+    const source = await databaseService.automations.getAutomation(req.params.id);
+    if (!source) return fail(res, 404, 'AUTOMATION_NOT_FOUND', 'automation not found');
+    const rawName = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
+    if (rawName.length > 200) {
+      return fail(res, 400, 'INVALID_NAME', 'name must be 200 characters or fewer');
+    }
+    const name = rawName.length > 0 ? rawName : `${source.name} (copy)`;
+    // Duplicates land DISABLED so the user reviews before flipping them on
+    // (mirrors the /import path). Uniqueness on `name` is not enforced by the
+    // table, matching the plain POST / handler, so no collision check here.
+    const created = await databaseService.automations.createAutomation({
+      name,
+      description: source.description,
+      enabled: false,
+      config: source.config,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- #5024 matches the sibling create/import handlers; a typed AuthenticatedRequest cleanup is out of scope for this PR
+      createdByUserId: (req as any).user?.id ?? null,
+    });
+    // The clone is disabled, so the running engine has nothing to pick up, but
+    // reload so a follow-up enable via the toggle sees the new row without a
+    // separate refresh cycle.
+    await reloadAutomations();
+    res.status(201).json(created);
+  } catch (error) {
+    logger.error('Error duplicating automation:', error);
+    return fail(res, 500, 'INTERNAL_ERROR', 'Failed to duplicate automation');
+  }
+});
+
 router.post('/import', canWrite, async (req: Request, res: Response) => {
   try {
     const { name, description, config } = req.body ?? {};


### PR DESCRIPTION
## Summary

Adds a Duplicate button to each rule row in the Automation Engine list. Click prompts for a name (defaulting to `<source name> (copy)`), copies the source rule's config and description verbatim, forces `enabled: false`, and opens the disabled clone in the editor so the user can review before enabling.

## Changes

- **Backend:** new `POST /api/automations/:id/duplicate` route, gated on the same `automations:write` permission as create/edit. Returns 400 `INVALID_NAME` for a name over 200 chars; 404 `AUTOMATION_NOT_FOUND` when the source id is unknown. Name uniqueness is not enforced (matching the existing create/import handlers).
- **Frontend:** `duplicate` handler uses `window.prompt` for the rename dialog (mirrors the Delete confirm's interaction style). On success, `load()` refreshes the list and `setEditing(created)` opens the disabled clone for review.
- **Tests:** 7 new route tests (`automationRoutes.duplicate.test.ts`) covering the happy path, defaulted name, whitespace trim, empty body, 404 on unknown id, 400 on over-long name, and the permission gate. Uses the real `createRouteTestApp` harness (real SQLite + real auth middleware).

## Test plan

- [x] `npx vitest run src/server/routes/automationRoutes.duplicate.test.ts` — 7/7 pass
- [x] `npx vitest run src/server/services/automation/ src/server/routes/automation` — 691/691 pass
- [x] `npx tsc -p tsconfig.server.json --noEmit` — clean
- [ ] Manual: click Duplicate on a rule, enter a name, verify the clone lands disabled and opens for review

Fixes #5024

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoeACr8xRZXakQF13LnG3G