### PR TITLE
fix(meshbeacon): keep broadcast-target preset/region numeric over the config API (#5030)

### DIFF
--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -733,10 +733,13 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
           setMeshBeaconBroadcastOnRegion(mb.broadcastOnRegion ?? 0);
           setMeshBeaconBroadcastOnPreset(mb.broadcastOnPreset ?? null);
           setMeshBeaconBroadcastTargets(
+            // Narrow on `typeof`, not `??` (#5030): a non-numeric value here
+            // silently became a `<select value>` matching no `<option>`, so a
+            // configured target rendered as "Running config" / "UNSET".
             (Array.isArray(mb.broadcastTargets) ? mb.broadcastTargets : []).map((target: Record<string, unknown>) => ({
-              preset: (target?.preset as number) ?? null,
-              region: (target?.region as number) ?? 0,
-              channelIndex: (target?.channelIndex as number) ?? null,
+              preset: typeof target?.preset === 'number' ? target.preset : null,
+              region: typeof target?.region === 'number' ? target.region : 0,
+              channelIndex: typeof target?.channelIndex === 'number' ? target.channelIndex : null,
             }))
           );
         }

--- a/src/server/meshtasticManager.meshBeaconTargets.test.ts
+++ b/src/server/meshtasticManager.meshBeaconTargets.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+
+/**
+ * Regression tests for issue #5030 — MeshBeacon broadcast targets lost their
+ * preset and region on every reload.
+ *
+ * `broadcast_targets` is the only *repeated message* field the config API
+ * returns. Every other sub-message in `getCurrentConfig()` is spread into a
+ * plain object (which incidentally turns its enums into numbers), so the target
+ * entries stayed protobufjs `Message` instances. `res.json()` then serialized
+ * them via protobufjs's own `Message.toJSON()`, which uses `enums: String` —
+ * the UI received `{ preset: "MEDIUM_SLOW", region: "US" }`, matched no
+ * `<option>` value, and rendered every target as "Running config" / "UNSET".
+ *
+ * These tests go through a real decoded protobuf message and assert the values
+ * survive a JSON round-trip as numbers.
+ */
+
+// Stub the TCP transport so constructing a manager never touches a real socket
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+// Prevent the constructor's async position-recalc path from touching the DB
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    sources: {
+      getSource: vi.fn().mockResolvedValue(null),
+    },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+import { MeshtasticManager, normalizeBroadcastTargets } from './meshtasticManager.js';
+import { loadProtobufDefinitions, getProtobufRoot } from './protobufLoader.js';
+
+/** RegionCode.US and the two presets used below, as their wire values. */
+const REGION_US = 1;
+const PRESET_LONG_FAST = 0;
+const PRESET_MEDIUM_SLOW = 3;
+
+/**
+ * Build the exact object shape `processConfig` stores in `actualModuleConfig`:
+ * a decoded `ModuleConfig.meshBeacon` message, whose repeated targets are
+ * themselves message instances.
+ */
+function decodedMeshBeaconConfig(meshBeacon: Record<string, unknown>): any {
+  const ModuleConfig = getProtobufRoot()!.lookupType('meshtastic.ModuleConfig');
+  const encoded = ModuleConfig.encode(ModuleConfig.create({ meshBeacon })).finish();
+  const decoded = ModuleConfig.decode(encoded) as any;
+  // Mirrors `this.actualModuleConfig = { ...this.actualModuleConfig, ...parsed.data }`
+  return { ...decoded };
+}
+
+function makeManager(moduleConfig: any) {
+  const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+  (mgr as any).localNodeInfo = { nodeNum: 123, nodeId: '!0000007b', firmwareVersion: '2.8.0' };
+  (mgr as any).actualModuleConfig = moduleConfig;
+  return mgr;
+}
+
+describe('normalizeBroadcastTargets (#5030)', () => {
+  beforeAll(async () => {
+    await loadProtobufDefinitions();
+  });
+
+  it('keeps preset and region as numbers, not enum names', () => {
+    const targets = normalizeBroadcastTargets([
+      { preset: PRESET_MEDIUM_SLOW, region: REGION_US, channelIndex: 2 },
+    ]);
+    expect(targets).toEqual([{ preset: PRESET_MEDIUM_SLOW, region: REGION_US, channelIndex: 2 }]);
+  });
+
+  it('omits an absent optional preset instead of collapsing it to LONG_FAST', () => {
+    // On a decoded message an unset `optional preset` reads 0 off the prototype,
+    // so presence has to come from the own-property check, not the value.
+    const decoded = decodedMeshBeaconConfig({ broadcastTargets: [{ region: REGION_US }] });
+    const targets = normalizeBroadcastTargets(decoded.meshBeacon.broadcastTargets);
+    expect(targets).toEqual([{ region: REGION_US }]);
+    expect('preset' in targets[0]).toBe(false);
+    expect('channelIndex' in targets[0]).toBe(false);
+  });
+
+  it('preserves an explicit preset 0 (LONG_FAST), which is not the same as absent', () => {
+    const decoded = decodedMeshBeaconConfig({
+      broadcastTargets: [{ preset: PRESET_LONG_FAST, region: REGION_US, channelIndex: 0 }],
+    });
+    const targets = normalizeBroadcastTargets(decoded.meshBeacon.broadcastTargets);
+    expect(targets).toEqual([{ preset: PRESET_LONG_FAST, region: REGION_US, channelIndex: 0 }]);
+  });
+
+  it('returns an empty list for an absent or non-array value', () => {
+    expect(normalizeBroadcastTargets(undefined)).toEqual([]);
+    expect(normalizeBroadcastTargets(null)).toEqual([]);
+    expect(normalizeBroadcastTargets({} as unknown)).toEqual([]);
+  });
+});
+
+describe('getCurrentConfig — MeshBeacon broadcast targets survive JSON serialization (#5030)', () => {
+  beforeAll(async () => {
+    await loadProtobufDefinitions();
+  });
+
+  it('serializes target preset/region as numbers over the wire', () => {
+    const mgr = makeManager(
+      decodedMeshBeaconConfig({
+        flags: 2,
+        broadcastOfferRegion: REGION_US,
+        broadcastOnRegion: REGION_US,
+        broadcastIntervalSecs: 3600,
+        broadcastTargets: [
+          { preset: PRESET_MEDIUM_SLOW, region: REGION_US },
+          { preset: PRESET_LONG_FAST, region: REGION_US, channelIndex: 1 },
+        ],
+      }),
+    );
+
+    // The route does `res.json(config)`, so the round-trip — not the in-process
+    // object — is what the UI actually parses.
+    const wire = JSON.parse(JSON.stringify(mgr.getCurrentConfig()));
+    const targets = wire.moduleConfig.meshBeacon.broadcastTargets;
+
+    expect(targets).toEqual([
+      { preset: PRESET_MEDIUM_SLOW, region: REGION_US },
+      { preset: PRESET_LONG_FAST, region: REGION_US, channelIndex: 1 },
+    ]);
+    expect(typeof targets[0].preset).toBe('number');
+    expect(typeof targets[0].region).toBe('number');
+  });
+
+  it('returns an empty target list when the device sent none', () => {
+    const mgr = makeManager(decodedMeshBeaconConfig({ flags: 2 }));
+    const wire = JSON.parse(JSON.stringify(mgr.getCurrentConfig()));
+    expect(wire.moduleConfig.meshBeacon.broadcastTargets).toEqual([]);
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -113,6 +113,45 @@ const IGNORE_REAPPLY_COOLDOWN_MS = 60_000;
 const ACTIVE_NODE_TOKEN_WINDOW_SECONDS = 7200;
 const ACTIVE_NODE_TOKEN_WINDOW_DAYS = ACTIVE_NODE_TOKEN_WINDOW_SECONDS / 86_400;
 
+/** One normalized MeshBeacon `broadcast_targets` entry, as the config API returns it. */
+export interface NormalizedBroadcastTarget {
+  region: number;
+  preset?: number;
+  channelIndex?: number;
+}
+
+/**
+ * Flatten the MeshBeacon `broadcast_targets` list into plain numeric objects (#5030).
+ *
+ * Every other sub-message in `getCurrentConfig()` is spread into a plain object,
+ * which incidentally turns its enums into raw numbers. `broadcast_targets` is the
+ * only *repeated message* the config API returns, so its entries stayed protobufjs
+ * `Message` instances — and `res.json()` then serializes them through protobufjs's
+ * own `Message.toJSON()`, which uses `enums: String`. The UI received
+ * `{ preset: "MEDIUM_SLOW", region: "US" }`, matched no `<option>` value, and
+ * rendered every target as "Running config" / "UNSET".
+ *
+ * Presence is tested with `hasOwnProperty`, not `?? null`: on a decoded message an
+ * unset `optional preset` reads 0 off the prototype (indistinguishable from
+ * LONG_FAST), while an unset `optional channel_index` reads null. Only fields
+ * actually on the wire are emitted, so absence keeps meaning "use the running
+ * config" rather than collapsing to preset 0.
+ */
+export function normalizeBroadcastTargets(targets: unknown): NormalizedBroadcastTarget[] {
+  if (!Array.isArray(targets)) return [];
+  return targets.map((raw) => {
+    const target = (raw ?? {}) as Record<string, unknown>;
+    const present = (key: string) =>
+      Object.prototype.hasOwnProperty.call(target, key) && typeof target[key] === 'number';
+    return {
+      // Plain enum: 0/UNSET means "use the running config region".
+      region: typeof target.region === 'number' ? target.region : 0,
+      ...(present('preset') ? { preset: target.preset as number } : {}),
+      ...(present('channelIndex') ? { channelIndex: target.channelIndex as number } : {}),
+    };
+  });
+}
+
 /** Parsed auto-responder payload: list of messages to send, plus the
  * raw decoded JSON object (or `{}` if the payload was plain text) so
  * callers can read optional fields like `private`. */
@@ -5466,11 +5505,11 @@ class MeshtasticManager implements ISourceManager {
         // Transmit settings (#4802): broadcastOnRegion 0 = UNSET (running config);
         // broadcastIntervalSecs defaults to the firmware minimum 3600, not 0.
         broadcastOnRegion: moduleConfig.meshBeacon.broadcastOnRegion !== undefined ? moduleConfig.meshBeacon.broadcastOnRegion : 0,
-        broadcastIntervalSecs: moduleConfig.meshBeacon.broadcastIntervalSecs !== undefined ? moduleConfig.meshBeacon.broadcastIntervalSecs : 3600
+        broadcastIntervalSecs: moduleConfig.meshBeacon.broadcastIntervalSecs !== undefined ? moduleConfig.meshBeacon.broadcastIntervalSecs : 3600,
         // broadcastOfferPreset / broadcastOnPreset are `optional` — absence means
         // "advertise/use no preset" and must stay undefined rather than
-        // collapsing to LONG_FAST. broadcastOnChannel / broadcastTargets are
-        // passed through as-is.
+        // collapsing to LONG_FAST. broadcastOnChannel is passed through as-is.
+        broadcastTargets: normalizeBroadcastTargets(moduleConfig.meshBeacon.broadcastTargets)
       };
 
       moduleConfig = {


### PR DESCRIPTION
Fixes #5030.

## Root cause

Not firmware, and not the write path — the device stores the targets fine. MeshMonitor could not read them back.

`broadcast_targets` is the **only repeated message field** `/api/config/current` returns. Every other sub-message in `getCurrentConfig()` is spread into a plain object, which incidentally turns its enums into raw numbers. The target entries stayed protobufjs `Message` instances, so `res.json()` serialized them through protobufjs's own `Message.toJSON()` — which uses `enums: String`:

```json
"broadcastTargets": [{"preset":"VERY_LONG_SLOW","region":"US"},
                     {"preset":"MEDIUM_SLOW","region":"US","channelIndex":1}]
```

Both frontend parsers then discard the non-numeric value:

- `ConfigurationTab.tsx` — the string reaches `<select value=…>` and matches no `<option>`.
- `useAdminCommandsState.ts` `parseMeshBeaconConfig` — `num()` / `numOrNull()` fall back to `0` (UNSET) and `null` (Running config).

Which is exactly the reported symptom: the **row count survives, preset and region reset**. `channelIndex` (a plain uint32) survives too — that is the tell. The reboot isn't causal; it is just the first time the tab re-reads config from the device instead of showing in-memory React state.

The remote-admin load path is unaffected — it goes through `ModuleConfig.toObject(…, { enums: Number })` in `protobufService.decodeAdminMessage`.

## Fix

`normalizeBroadcastTargets()` flattens the list to plain numeric objects in `getCurrentConfig()`.

Presence is tested with `hasOwnProperty`, not `??`. On a decoded message an unset `optional preset` reads **0** off the prototype (indistinguishable from LONG_FAST), while an unset `optional channel_index` reads **null** — so only fields actually on the wire are emitted, and absence keeps meaning "use the running config" instead of collapsing to preset 0.

`ConfigurationTab`'s load now narrows on `typeof` rather than `??`, so a non-numeric value can never again reach a `<select>` as an unmatched value.

## Mesh impact

None. Read-path serialization only — no packets sent, no timers armed, no notifications.

## Testing

New `src/server/meshtasticManager.meshBeaconTargets.test.ts` (6 tests) drives a real decoded `ModuleConfig` message through `getCurrentConfig()` and asserts the values survive `JSON.parse(JSON.stringify(...))` as numbers — the round-trip is what the UI actually parses, so an in-process assertion would not have caught this. Also covers absent-vs-explicit-0 preset.

Verified red before the fix (the JSON-round-trip test fails with enum names), green after.

- Full Vitest suite: **17,653 passed, 0 failed** (939 skipped = the PostgreSQL/MySQL suites; no schema change here).
- `npm run lint:ci`: clean.
- `tsc --noEmit` on both tsconfigs: clean.

No screenshot: the visible change is a `<select>` showing the value the device already has, which needs a 2.8 node with targets configured to reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc