### PR TITLE
fix(packet-monitor): suppress firmware 2.8 NodeDB replays on RF transports (#5034)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -6067,6 +6067,11 @@ class MeshtasticManager implements ISourceManager {
         // (0/absent = unknown, never collapse). Genuine local TX is logged on a
         // different path and is never deduped here.
         const dedupPacketId = meshPacket.id ? Number(meshPacket.id) : 0;
+        // NOTE: rx_time is the device's receive clock in unix SECONDS (protobuf
+        // uint32), not the milliseconds of the `Date.now()` below. The mixed
+        // units are harmless here because rx_time only ever becomes an opaque
+        // token in the dedup key — it is never compared against the ms clock or
+        // used as a duration. Do not start doing arithmetic across the two.
         const dedupRxTime = meshPacket.rxTime != null ? Number(meshPacket.rxTime) : null;
         if (dedupPacketId && isDuplicatePacketLog(
           this.recentPacketLogKeys,

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -77,7 +77,7 @@ import {
   recordMqttEcho,
   matchesMqttEcho,
 } from './services/mqttProxyBridge.js';
-import { isDuplicatePacketLog, packetLogDedupKey } from './services/packetLogDedup.js';
+import { isDuplicatePacketLog, packetLogDedupKey, dedupTtlForTransport } from './services/packetLogDedup.js';
 import { NodeDbMaintenanceService } from './services/nodeDbMaintenanceService.js';
 import { AutoAnnounceService } from './services/autoAnnounceService.js';
 import { AdminTransactionService } from './services/adminTransactionService.js';
@@ -6056,16 +6056,29 @@ class MeshtasticManager implements ISourceManager {
         const spoof = this.assessLocalSpoof(meshPacket);
 
         // Drop exact-duplicate receptions the firmware delivers twice, or that a
-        // reconnect replays, from the Packet Monitor (#4811). The key folds in
-        // relay_node + transport, so a rebroadcast via a different relay or the
-        // same packet over LoRa vs MQTT keeps its own row. Only guard when we
-        // have a real packet id (0/absent = unknown, never collapse). Genuine
-        // local TX is logged on a different path and is never deduped here.
+        // reconnect/PhoneAPI NodeDB replay re-delivers, from the Packet Monitor
+        // (#4811, #5034). The key folds in relay_node + transport, so a
+        // rebroadcast via a different relay or the same packet over LoRa vs MQTT
+        // keeps its own row, and rx_time, so a genuine re-reception of the same
+        // id survives while a replay of a cached one collapses. On RF the window
+        // is hours (a same-(id,relay,rx_time) repeat there cannot be real); MQTT
+        // and multicast UDP keep the short window because per-gateway receptions
+        // of one id are real data. Only guard when we have a real packet id
+        // (0/absent = unknown, never collapse). Genuine local TX is logged on a
+        // different path and is never deduped here.
         const dedupPacketId = meshPacket.id ? Number(meshPacket.id) : 0;
+        const dedupRxTime = meshPacket.rxTime != null ? Number(meshPacket.rxTime) : null;
         if (dedupPacketId && isDuplicatePacketLog(
           this.recentPacketLogKeys,
-          packetLogDedupKey(fromNum, dedupPacketId, meshPacket.relayNode, meshPacket.transportMechanism),
-          Date.now()
+          packetLogDedupKey(
+            fromNum,
+            dedupPacketId,
+            meshPacket.relayNode,
+            meshPacket.transportMechanism,
+            dedupRxTime
+          ),
+          Date.now(),
+          dedupTtlForTransport(meshPacket.transportMechanism)
         )) {
           logger.debug(`📦 Skipping duplicate packet-log entry for id ${dedupPacketId} from ${fromNum}`);
         } else {

--- a/src/server/services/packetLogDedup.test.ts
+++ b/src/server/services/packetLogDedup.test.ts
@@ -2,8 +2,13 @@ import { describe, it, expect } from 'vitest';
 import {
   packetLogDedupKey,
   isDuplicatePacketLog,
+  isRfTransport,
+  dedupTtlForTransport,
   PACKET_LOG_DEDUP_TTL_MS,
+  PACKET_LOG_DEDUP_RF_TTL_MS,
+  PACKET_LOG_DEDUP_MAX_ENTRIES,
 } from './packetLogDedup';
+import { TransportMechanism } from '../constants/meshtastic';
 
 /**
  * Packet Monitor recently-seen guard (issue #4811). Verifies that exact
@@ -62,5 +67,127 @@ describe('isDuplicatePacketLog', () => {
     // A later call past the TTL prunes both stale entries before recording.
     isDuplicatePacketLog(seen, packetLogDedupKey(10, 3, 0, 0), 1_000 + PACKET_LOG_DEDUP_TTL_MS + 1);
     expect(seen.size).toBe(1);
+  });
+});
+
+/**
+ * Firmware 2.8 PhoneAPI NodeDB replay (issue #5034).
+ *
+ * The firmware periodically re-delivers each node's cached position/telemetry
+ * with the ORIGINAL packet id, a stabilized rx_snr/hop set, and
+ * transport_mechanism forced to TRANSPORT_LORA — so a replay is byte-alike to a
+ * fresh LoRa reception on every field except `rx_time`, which keeps the original
+ * first-heard timestamp. They arrive ~hourly, so the 30s window from #4811 never
+ * spanned them.
+ */
+describe('RF replay suppression (#5034)', () => {
+  const HOUR_MS = 60 * 60 * 1000;
+
+  describe('isRfTransport', () => {
+    it('treats every LoRa radio as RF', () => {
+      expect(isRfTransport(TransportMechanism.LORA)).toBe(true);
+      expect(isRfTransport(TransportMechanism.LORA_ALT1)).toBe(true);
+      expect(isRfTransport(TransportMechanism.LORA_ALT2)).toBe(true);
+      expect(isRfTransport(TransportMechanism.LORA_ALT3)).toBe(true);
+    });
+
+    it('treats an absent transport as RF (pre-2.8 firmware omits the field)', () => {
+      expect(isRfTransport(undefined)).toBe(true);
+      expect(isRfTransport(null)).toBe(true);
+    });
+
+    it('does NOT treat MQTT or multicast UDP as RF', () => {
+      expect(isRfTransport(TransportMechanism.MQTT)).toBe(false);
+      expect(isRfTransport(TransportMechanism.MULTICAST_UDP)).toBe(false);
+    });
+  });
+
+  describe('dedupTtlForTransport', () => {
+    it('gives RF the long window and everything else the short one', () => {
+      expect(dedupTtlForTransport(TransportMechanism.LORA)).toBe(PACKET_LOG_DEDUP_RF_TTL_MS);
+      expect(dedupTtlForTransport(undefined)).toBe(PACKET_LOG_DEDUP_RF_TTL_MS);
+      expect(dedupTtlForTransport(TransportMechanism.MQTT)).toBe(PACKET_LOG_DEDUP_TTL_MS);
+      expect(dedupTtlForTransport(TransportMechanism.MULTICAST_UDP)).toBe(PACKET_LOG_DEDUP_TTL_MS);
+    });
+
+    it('uses an RF window long enough to span the observed ~1h replay interval', () => {
+      expect(PACKET_LOG_DEDUP_RF_TTL_MS).toBeGreaterThan(HOUR_MS);
+    });
+  });
+
+  it('folds rx_time into the key so a re-reception of one id stays distinct', () => {
+    const replay = packetLogDedupKey(10, 999, 0, TransportMechanism.LORA, 1_788_402_926);
+    const fresh = packetLogDedupKey(10, 999, 0, TransportMechanism.LORA, 1_788_420_034);
+    expect(replay).not.toBe(fresh);
+    expect(replay).toBe(packetLogDedupKey(10, 999, 0, TransportMechanism.LORA, 1_788_402_926));
+  });
+
+  it('folds an absent rx_time to a stable token', () => {
+    expect(packetLogDedupKey(10, 999, 0, 1, null)).toBe(packetLogDedupKey(10, 999, 0, 1));
+    expect(packetLogDedupKey(10, 999, 0, 1, undefined)).toBe(packetLogDedupKey(10, 999, 0, 1, null));
+  });
+
+  it('suppresses hourly replays of a cached reception, then logs a genuine new one', () => {
+    const seen = new Map<string, number>();
+    const rfTtl = dedupTtlForTransport(TransportMechanism.LORA);
+    // The device's own receive time for the reception the firmware cached.
+    const cachedRxTime = 1_788_402_926;
+    const replayKey = packetLogDedupKey(10, 999, 0, TransportMechanism.LORA, cachedRxTime);
+
+    // 06:15 — the genuine reception. Logged.
+    let now = 0;
+    expect(isDuplicatePacketLog(seen, replayKey, now, rfTtl)).toBe(false);
+
+    // 07:20, 08:20, 09:20 … — PhoneAPI replays the same cached packet. Each
+    // carries the same rx_time, so each collapses, and each refreshes the entry
+    // so suppression persists indefinitely while they keep arriving.
+    for (let hour = 1; hour <= 5; hour++) {
+      now = hour * HOUR_MS;
+      expect(isDuplicatePacketLog(seen, replayKey, now, rfTtl)).toBe(true);
+    }
+
+    // 11:30 — the node is genuinely heard again: new rx_time, so a new row.
+    now = 5 * HOUR_MS + 10 * 60 * 1000;
+    const freshKey = packetLogDedupKey(10, 999, 0, TransportMechanism.LORA, cachedRxTime + 19_000);
+    expect(isDuplicatePacketLog(seen, freshKey, now, rfTtl)).toBe(false);
+
+    // …and replays of the NEW reception collapse against it in turn.
+    expect(isDuplicatePacketLog(seen, freshKey, now + HOUR_MS, rfTtl)).toBe(true);
+  });
+
+  it('still keeps a flood rebroadcast heard via a different relay', () => {
+    const seen = new Map<string, number>();
+    const rfTtl = dedupTtlForTransport(TransportMechanism.LORA);
+    const rxTime = 1_788_402_926;
+    // Same packet id and rx_time, different relay -> a distinct reception with
+    // its own SNR/hop data, which is the point of the packet monitor.
+    expect(isDuplicatePacketLog(seen, packetLogDedupKey(10, 999, 1, 1, rxTime), 0, rfTtl)).toBe(false);
+    expect(isDuplicatePacketLog(seen, packetLogDedupKey(10, 999, 2, 1, rxTime), 0, rfTtl)).toBe(false);
+  });
+
+  it('does NOT extend the window for MQTT, where repeats are real receptions', () => {
+    const seen = new Map<string, number>();
+    const mqttTtl = dedupTtlForTransport(TransportMechanism.MQTT);
+    const key = packetLogDedupKey(10, 999, 0, TransportMechanism.MQTT, 1_788_402_926);
+    expect(isDuplicatePacketLog(seen, key, 0, mqttTtl)).toBe(false);
+    // An hour later the same MQTT tuple is logged again rather than swallowed.
+    expect(isDuplicatePacketLog(seen, key, HOUR_MS, mqttTtl)).toBe(false);
+  });
+
+  it('caps retained entries, evicting oldest-inserted first', () => {
+    const seen = new Map<string, number>();
+    const rfTtl = dedupTtlForTransport(TransportMechanism.LORA);
+    const maxEntries = 3;
+    for (let id = 1; id <= 5; id++) {
+      isDuplicatePacketLog(seen, packetLogDedupKey(10, id, 0, 1, 1_788_402_926), 0, rfTtl, maxEntries);
+    }
+    expect(seen.size).toBeLessThan(maxEntries + 1);
+    // The newest survives; the first-inserted was evicted.
+    expect(seen.has(packetLogDedupKey(10, 5, 0, 1, 1_788_402_926))).toBe(true);
+    expect(seen.has(packetLogDedupKey(10, 1, 0, 1, 1_788_402_926))).toBe(false);
+  });
+
+  it('has a sane default entry cap', () => {
+    expect(PACKET_LOG_DEDUP_MAX_ENTRIES).toBeGreaterThan(1_000);
   });
 });

--- a/src/server/services/packetLogDedup.test.ts
+++ b/src/server/services/packetLogDedup.test.ts
@@ -155,6 +155,48 @@ describe('RF replay suppression (#5034)', () => {
     expect(isDuplicatePacketLog(seen, freshKey, now + HOUR_MS, rfTtl)).toBe(true);
   });
 
+  it('keeps suppressing an hourly replay past the TTL boundary (hit refreshes expiry)', () => {
+    // Regression for the review finding on #5038: without refreshing the expiry
+    // on a hit, a replay cadence slower than the TTL leaks one duplicate row
+    // every window — an hourly replay against a 6h window escaped every 6h.
+    const seen = new Map<string, number>();
+    const rfTtl = dedupTtlForTransport(TransportMechanism.LORA);
+    const key = packetLogDedupKey(10, 999, 0, TransportMechanism.LORA, 1_788_402_926);
+
+    expect(isDuplicatePacketLog(seen, key, 0, rfTtl)).toBe(false);
+
+    // Walk hourly replays well past two full TTL windows. Every one must stay
+    // suppressed — not just the ones inside the first window.
+    for (let hour = 1; hour <= 15; hour++) {
+      expect(isDuplicatePacketLog(seen, key, hour * HOUR_MS, rfTtl)).toBe(true);
+    }
+    expect(15 * HOUR_MS).toBeGreaterThan(2 * PACKET_LOG_DEDUP_RF_TTL_MS);
+  });
+
+  it('still lets a tuple through once the repeats actually stop for a full TTL', () => {
+    // The flip side of refresh-on-hit: suppression must not become permanent.
+    // Once the replays stop, the entry ages out and a later genuine packet with
+    // the same tuple is logged again.
+    const seen = new Map<string, number>();
+    const rfTtl = dedupTtlForTransport(TransportMechanism.LORA);
+    const key = packetLogDedupKey(10, 999, 0, TransportMechanism.LORA, 1_788_402_926);
+
+    expect(isDuplicatePacketLog(seen, key, 0, rfTtl)).toBe(false);
+    expect(isDuplicatePacketLog(seen, key, HOUR_MS, rfTtl)).toBe(true);
+    // Silence for longer than the window after that last hit.
+    expect(isDuplicatePacketLog(seen, key, HOUR_MS + rfTtl + 1, rfTtl)).toBe(false);
+  });
+
+  it('gives API and INTERNAL transports the short window', () => {
+    // API is a client-injected packet, not an RF replay. INTERNAL is locally
+    // generated and is already excluded from the packet log upstream, but must
+    // not be mistaken for RF if that filter order ever changes.
+    expect(isRfTransport(TransportMechanism.API)).toBe(false);
+    expect(isRfTransport(TransportMechanism.INTERNAL)).toBe(false);
+    expect(dedupTtlForTransport(TransportMechanism.API)).toBe(PACKET_LOG_DEDUP_TTL_MS);
+    expect(dedupTtlForTransport(TransportMechanism.INTERNAL)).toBe(PACKET_LOG_DEDUP_TTL_MS);
+  });
+
   it('still keeps a flood rebroadcast heard via a different relay', () => {
     const seen = new Map<string, number>();
     const rfTtl = dedupTtlForTransport(TransportMechanism.LORA);

--- a/src/server/services/packetLogDedup.ts
+++ b/src/server/services/packetLogDedup.ts
@@ -1,5 +1,5 @@
 /**
- * Recently-seen guard for the Packet Monitor (issue #4811).
+ * Recently-seen guard for the Packet Monitor (issues #4811, #5034).
  *
  * The packet_log table has no de-duplication, so a packet the firmware delivers
  * twice (a 2.8-nightly symptom) or that a reconnect/replay re-inserts produces
@@ -10,46 +10,149 @@
  * via a different relay, or the same packet arriving over both LoRa and MQTT —
  * keep their own key and are NOT collapsed. Those carry different SNR / hop /
  * transport data and are exactly what a packet monitor is for. Only an exact
- * (sender, id, relay, transport) repeat within the TTL window is dropped.
+ * (sender, id, relay, transport, rx_time) repeat within the TTL window is
+ * dropped.
+ *
+ * ## Why `rxTime` is in the key, and why RF gets a long TTL (#5034)
+ *
+ * Firmware 2.8's `PhoneAPI` periodically replays each NodeDB entry's cached
+ * position/telemetry to the connected client, synthesizing POSITION_APP /
+ * TELEMETRY_APP packets from stored data instead of reporting real receptions
+ * (firmware PR #10413; see also issue #4192). Firmware PR #11014 *stabilized*
+ * the packet id, `rx_snr` and hop fields across those replays, and
+ * `transport_mechanism` is deliberately forced to `TRANSPORT_LORA` for iOS
+ * client compatibility — so a replay is indistinguishable from a fresh LoRa
+ * reception on every field except one: `rx_time` keeps the original
+ * first-heard timestamp.
+ *
+ * These replays arrive roughly hourly, so the 30s window from #4811 could never
+ * span them and the Packet Monitor accumulated one duplicate row per hour per
+ * node (#5034).
+ *
+ * Two changes make the guard catch them without collapsing real traffic:
+ *
+ * 1. **`rxTime` joins the key.** A genuine new reception of the same packet id
+ *    carries a new `rx_time`, so it gets its own key and its own row no matter
+ *    how long the window is. A replay repeats the cached `rx_time` and collapses.
+ *    This also self-heals: when the node is genuinely heard again, `rx_time`
+ *    advances, one new row appears, and later replays dedup against that.
+ * 2. **RF transports get {@link PACKET_LOG_DEDUP_RF_TTL_MS} instead of 30s.**
+ *    The TTL only has to exceed the gap between consecutive replays (~1h), not
+ *    how stale they are. On RF an exact (sender, id, relay, rx_time) repeat
+ *    arriving hours later cannot be a real second reception: firmware's own
+ *    `wasSeenRecently` dedup stops a relay re-flooding an id it already
+ *    forwarded, so the only sources of such a repeat are replays and
+ *    double-deliveries.
+ *
+ * **MQTT and multicast UDP keep the short window.** There the same packet id
+ * legitimately arrives many times — once per gateway/broker that saw it — and
+ * those per-gateway receptions are the point of the MQTT monitor, so a long TTL
+ * would destroy real data. Only the RF transports, where the replay lives, get
+ * the long window.
  *
  * In-memory and TTL-bounded; the store lives per-source on the manager, so no
  * schema change and no cross-source leakage.
  */
 
-/** How long a (from,id,relay,transport) tuple suppresses a repeat. */
+import { TransportMechanism } from '../constants/meshtastic.js';
+
+/**
+ * How long a non-RF (MQTT / multicast UDP / API) tuple suppresses a repeat.
+ * Deliberately short: per-gateway receptions of one packet id are real data.
+ */
 export const PACKET_LOG_DEDUP_TTL_MS = 30_000;
 
 /**
+ * How long an RF (LoRa) tuple suppresses a repeat. Must exceed the interval
+ * between consecutive PhoneAPI replays (observed ~1h in #5034), not their
+ * staleness — each replay refreshes the entry, so suppression persists as long
+ * as they keep arriving. Six hours leaves generous headroom for a slower replay
+ * cadence on other firmware builds.
+ */
+export const PACKET_LOG_DEDUP_RF_TTL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Cap on retained entries, so a busy mesh can't grow the map without bound over
+ * the 6h RF window. Well above a realistic 6h distinct-packet count; eviction is
+ * oldest-inserted-first, which at worst lets one duplicate row through.
+ */
+export const PACKET_LOG_DEDUP_MAX_ENTRIES = 20_000;
+
+/**
+ * True when `transportMechanism` denotes arrival over a LoRa radio — the
+ * transports where a same-(id, relay, rx_time) repeat cannot be a real second
+ * reception. `undefined`/`null` counts as RF: pre-2.8 firmware omits the field
+ * and the insert path already defaults it to LORA.
+ */
+export function isRfTransport(transportMechanism: number | null | undefined): boolean {
+  if (transportMechanism == null) return true;
+  return (
+    transportMechanism === TransportMechanism.LORA ||
+    transportMechanism === TransportMechanism.LORA_ALT1 ||
+    transportMechanism === TransportMechanism.LORA_ALT2 ||
+    transportMechanism === TransportMechanism.LORA_ALT3
+  );
+}
+
+/**
+ * Pick the suppression window for a packet's transport: the long RF window where
+ * a repeat must be a replay, the short one where repeats are real per-gateway
+ * receptions.
+ */
+export function dedupTtlForTransport(transportMechanism: number | null | undefined): number {
+  return isRfTransport(transportMechanism) ? PACKET_LOG_DEDUP_RF_TTL_MS : PACKET_LOG_DEDUP_TTL_MS;
+}
+
+/**
  * Build the dedup key. `relayNode`/`transportMechanism` are folded in so distinct
- * relay/transport copies of one packet id survive; absent values collapse to a
- * stable empty token.
+ * relay/transport copies of one packet id survive; `rxTime` is folded in so a
+ * genuine re-reception (new device receive time) survives the long RF window
+ * while a firmware replay (cached receive time) collapses. Absent values collapse
+ * to a stable empty token.
  */
 export function packetLogDedupKey(
   fromNum: number,
   packetId: number,
   relayNode: number | null | undefined,
-  transportMechanism: number | null | undefined
+  transportMechanism: number | null | undefined,
+  rxTime?: number | null
 ): string {
-  return `${fromNum}:${packetId}:${relayNode ?? ''}:${transportMechanism ?? ''}`;
+  return `${fromNum}:${packetId}:${relayNode ?? ''}:${transportMechanism ?? ''}:${rxTime ?? ''}`;
 }
 
 /**
  * Prune expired entries, then test-and-record `key`. Returns true when `key` was
  * already present (unexpired) — i.e. this is a duplicate that should NOT be
  * logged again. Mutates `seen` in place.
+ *
+ * Pass the per-transport TTL from {@link dedupTtlForTransport}; the default keeps
+ * the short window for callers that don't care.
  */
 export function isDuplicatePacketLog(
   seen: Map<string, number>,
   key: string,
   now: number,
-  ttlMs: number = PACKET_LOG_DEDUP_TTL_MS
+  ttlMs: number = PACKET_LOG_DEDUP_TTL_MS,
+  maxEntries: number = PACKET_LOG_DEDUP_MAX_ENTRIES
 ): boolean {
-  // Prune expired entries. The map is bounded by traffic within the TTL window,
-  // so this stays cheap.
+  // Prune expired entries first, so the size cap below only ever evicts live
+  // ones. O(size) per packet, and size is bounded by `maxEntries` — a ~20k-entry
+  // Map sweep is well under a millisecond, so this stays cheap even with the 6h
+  // RF window holding far more keys than the old 30s one did.
   for (const [k, expiresAt] of seen) {
     if (expiresAt <= now) seen.delete(k);
   }
   if (seen.has(key)) return true;
+
+  // Bound memory over the 6h RF window. Map iteration is insertion-ordered, so
+  // this drops the longest-standing entries — the ones least likely to still be
+  // replaying. At worst an evicted key lets one duplicate row through.
+  while (seen.size >= maxEntries) {
+    const oldest = seen.keys().next();
+    if (oldest.done) break;
+    seen.delete(oldest.value);
+  }
+
   seen.set(key, now + ttlMs);
   return false;
 }

--- a/src/server/services/packetLogDedup.ts
+++ b/src/server/services/packetLogDedup.ts
@@ -83,6 +83,15 @@ export const PACKET_LOG_DEDUP_MAX_ENTRIES = 20_000;
  * transports where a same-(id, relay, rx_time) repeat cannot be a real second
  * reception. `undefined`/`null` counts as RF: pre-2.8 firmware omits the field
  * and the insert path already defaults it to LORA.
+ *
+ * Everything else gets the short window, deliberately:
+ * - `MQTT` / `MULTICAST_UDP` — repeats are real per-gateway/per-peer receptions.
+ * - `API` — a client-injected packet, not an RF replay.
+ * - `INTERNAL` (0) — locally generated. These never reach the dedup call today:
+ *   `isPhantomInternalPacket` and `shouldExcludeFromPacketLog` drop them from the
+ *   packet log first. Left on the short window rather than special-cased, since
+ *   treating a local packet as RF would be the wrong default if that filter order
+ *   ever changes.
  */
 export function isRfTransport(transportMechanism: number | null | undefined): boolean {
   if (transportMechanism == null) return true;
@@ -142,7 +151,17 @@ export function isDuplicatePacketLog(
   for (const [k, expiresAt] of seen) {
     if (expiresAt <= now) seen.delete(k);
   }
-  if (seen.has(key)) return true;
+
+  // A hit REFRESHES the expiry rather than just reporting the duplicate. Without
+  // this, a replay stream slower than the TTL is only suppressed until the
+  // original entry ages out — with a 6h window and an hourly replay that leaks
+  // one duplicate row every 6 hours, forever. Refreshing makes suppression
+  // persist for as long as the repeats keep arriving, which is the invariant the
+  // RF window is sized around.
+  if (seen.has(key)) {
+    seen.set(key, now + ttlMs);
+    return true;
+  }
 
   // Bound memory over the 6h RF window. Map iteration is insertion-ordered, so
   // this drops the longest-standing entries — the ones least likely to still be

--- a/src/server/services/packetLogDedup.ts
+++ b/src/server/services/packetLogDedup.ts
@@ -118,6 +118,13 @@ export function dedupTtlForTransport(transportMechanism: number | null | undefin
  * genuine re-reception (new device receive time) survives the long RF window
  * while a firmware replay (cached receive time) collapses. Absent values collapse
  * to a stable empty token.
+ *
+ * `rxTime` is unix SECONDS (the device's receive clock), unrelated to the
+ * millisecond `now` the TTL uses — it is only ever an opaque token here.
+ *
+ * Every field is numeric, so the unescaped `:` separator is injective: no value
+ * can contain the delimiter, and split positions are unambiguous. That stops
+ * holding if a free-form string field is ever added to the key — escape it then.
  */
 export function packetLogDedupKey(
   fromNum: number,


### PR DESCRIPTION
Fixes #5034. This is the Packet Monitor face of #4192, which that issue flagged as "a related but distinct display issue" and left open.

## Root cause

Firmware 2.8's `PhoneAPI` periodically re-delivers each NodeDB entry's cached position/telemetry to the connected client, synthesizing POSITION_APP/TELEMETRY_APP packets from stored data rather than reporting real receptions (firmware PR #10413). Two firmware details make these indistinguishable from live traffic:

- Firmware PR #11014 **stabilized** the packet id, `rx_snr` and hop fields across replays — which is exactly what produces the reporter's "same packet id, different time".
- `transport_mechanism` is **deliberately forced to `TRANSPORT_LORA`** for iOS client compatibility, so a client cannot use it to detect a replay. (This is why the reporter's packet detail showed transport `1` despite having no MQTT at all.)

`rx_time` is the one field firmware keeps honest — it stays at the original first-heard timestamp.

The reporter's screenshots confirm the shape. Comparing the hourly repeats against the genuine rows for the same sender:

| | hourly repeats | genuine rows |
|---|---|---|
| RSSI | N/A | −101 / −103 |
| `hop_start` | 7 | 6 |
| `payload_size` | 23 | 34 |
| SNR | frozen in blocks | steps only here |

A sender's `hop_start` doesn't vary per packet, and the SNR only moves when a genuine row lands. The detail popup is decisive: `rx_time` 02:35:26 UTC on a row stamped 07:20:34 UTC — the device handed us a reception 4h45m old, with no genuine row at 02:35.

Replays arrive ~hourly, so #4811's 30s window could never span them. #4192 fixed this for node `lastHeard` via `replayGuard.ts`; the `packet_log` insert path never consulted it (and that guard's 6h staleness threshold would have missed this 4h45m case anyway).

## Fix

Two changes, so the guard catches replays without collapsing real traffic:

1. **`rx_time` joins the dedup key.** A genuine re-reception of the same packet id carries a new `rx_time`, so it keeps its own row no matter how long the window is; a replay repeats the cached `rx_time` and collapses. This self-heals: when the node is truly heard again, `rx_time` advances, one new row appears, and later replays dedup against that one.
2. **RF transports get a 6h window instead of 30s.** The TTL only has to exceed the gap between consecutive replays (~1h), not how stale they are — each replay refreshes the entry, so suppression persists while they keep arriving.

### Why RF only

On RF an exact `(sender, id, relay, rx_time)` repeat arriving hours later cannot be a real second reception: firmware's own `wasSeenRecently` stops a relay re-flooding an id it already forwarded. **MQTT and multicast UDP keep the 30s window on purpose** — there the same packet id legitimately arrives once per gateway that saw it, and those per-gateway receptions are the whole point of the MQTT monitor, so a long window would destroy real data.

Two RF cases where the same `(from, id)` *is* genuinely real are both preserved:

- **Flood rebroadcast** via a different relay — `relay_node` is still in the key (unchanged from #4812), so each relay's copy keeps its own row and its own SNR/hop data.
- **`want_ack` retransmission** — retries land seconds apart, inside the short window, collapsing exactly as they did before this PR.

Also adds a 20k entry cap with oldest-first eviction, since a 6h window retains far more keys than 30s did. Worst case an evicted key lets one duplicate row through.

**MeshCore needs no equivalent.** Its OTA feed is the unconditional `LogRxData` (0x88) push of frames actually received, so there is no PhoneAPI-style replay; `meshcorePacketLogService` has no dedup and doesn't need one.

## Mesh impact

None. Receive-path logging only — no packets sent, no timers armed, no notifications.

## Testing

12 new tests in `packetLogDedup.test.ts` (18 total in the file), including the full #5034 scenario: a genuine reception, five hourly replays suppressed, a real re-reception logged, then replays of *that* suppressed. Plus per-transport TTL selection, the flood-rebroadcast-survives case, MQTT keeping the short window, and cap eviction.

Verified red first — dropping `PACKET_LOG_DEDUP_RF_TTL_MS` back to 30s fails the hourly-replay test.

- Full Vitest suite: **18,435 passed, 0 failed, 0 failed suites** — with the PostgreSQL and MySQL containers running, so all three backends were covered (122 pending).
- `npm run lint:ci`: clean.
- `tsc --noEmit` on both tsconfigs: clean.

## Deliberately out of scope

Per #4192, the Packet Monitor's Timestamp column stores `Date.now()` rather than `rx_time`, so any replay that does slip through still displays as freshly received. Separate fix, worth doing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc