### PR TITLE
chore(release): bump to 4.16.0-rc2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.16.0-rc1",
+  "version": "4.16.0-rc2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.16.0-rc1",
+  "version": "4.16.0-rc2",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.16.0-rc1
-appVersion: "4.16.0-rc1"
+version: 4.16.0-rc2
+appVersion: "4.16.0-rc2"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.16.0-rc1",
+  "version": "4.16.0-rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.16.0-rc1",
+      "version": "4.16.0-rc2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.16.0-rc1",
+  "version": "4.16.0-rc2",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump for the next release candidate. `v4.16.0-rc1` is already tagged, so this moves to `4.16.0-rc2`.

## Files

All five per CLAUDE.md:

| File | Change |
|---|---|
| `package.json` | `4.16.0-rc1` → `4.16.0-rc2` |
| `package-lock.json` | regenerated via `npm install --package-lock-only` |
| `helm/meshmonitor/Chart.yaml` | `version` **and** `appVersion` |
| `desktop/src-tauri/tauri.conf.json` | `version` |
| `desktop/package.json` | `version` |

The lockfile diff is the two version strings only — no dependency churn:

```
-  "version": "4.16.0-rc1",
+  "version": "4.16.0-rc2",
-      "version": "4.16.0-rc1",
+      "version": "4.16.0-rc2",
```

`git grep 4.16.0-rc1` comes back empty across tracked files.

## Since v4.16.0-rc1

Nine commits:

- `03c9ec4c` fix(packet-monitor): suppress firmware 2.8 NodeDB replays on RF transports (#5034)
- `8d4e1416` fix(meshcore): stop re-flooding a refused room password, and let users forget it (#5036)
- `97448c92` fix(meshbeacon): keep broadcast-target preset/region numeric over the config API (#5030)
- `440a1222` fix(config): initialize proto3-elided fields to their zero value (#5028)
- `30d9ed54` feat(observer-ui): broker-list editor, MeshMapper/LetsMesh presets, status surfaces (#5014 Phase 2)
- `ab663555` feat(automation): Duplicate button on automation rules (#5024)
- `f0639fb5` fix(automation-engine): add missing Arguments field to action.runScript (#5025)
- `02d20b55` feat(observer): multi-broker Analyzer Observer backend (#5014 Phase 1)
- `0902b77c` feat(admin): re-enable Save Security Config for remote nodes (#4736)

## Testing

Full suite green: `17708 passed, 0 failed`. The 939 pending are the PostgreSQL/MySQL suites, which skip without their containers — a version bump touches no schema, so this run wasn't gated on them.

Carries the `system-test` label, as release version-bump chores always do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S6dVMHduNHsn6jNRXX25k