### PR TITLE
fix(config): warn instead of silently failing on Range Test for firmware 2.8+ (#5031)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -4106,6 +4106,7 @@
   "rangetest_config.save": "Save Results to File",
   "rangetest_config.save_description": "Save range test results to RangeTest.csv (ESP32 only)",
   "rangetest_config.save_button": "Save Range Test Config",
+  "rangetest_config.removed_in_28": "Range Test was removed in Meshtastic 2.8 and is not available on this firmware. These settings cannot be changed.",
   "cannedmsg_config.title": "Canned Messages",
   "cannedmsg_config.view_docs": "View Canned Messages Documentation",
   "cannedmsg_config.enabled": "Enable Canned Messages",

--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -302,7 +302,7 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
   const [meshBeaconBroadcastTargets, setMeshBeaconBroadcastTargets] = useState<BroadcastTarget[]>([]);
 
   // Supported modules tracking (for unsupported firmware detection)
-  const [supportedModules, setSupportedModules] = useState<{ statusmessage: boolean; trafficManagement: boolean; meshBeacon: boolean } | null>(null);
+  const [supportedModules, setSupportedModules] = useState<{ statusmessage: boolean; trafficManagement: boolean; meshBeacon: boolean; rangeTest?: boolean } | null>(null);
 
   // Serial Config State
   const [serialEnabled, setSerialEnabled] = useState(false);
@@ -2531,6 +2531,11 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
             setSender={setRangeTestSender}
             save={rangeTestSave}
             setSave={setRangeTestSave}
+            // Range Test was removed in firmware 2.8 (#5031). Unlike the
+            // "requires firmware X" gates above, this one must fail OPEN: only
+            // a node that positively reports 2.8+ disables the section, so an
+            // unknown/absent firmware version keeps the previous behaviour.
+            isDisabled={supportedModules?.rangeTest === false}
             isSaving={isSaving}
             onSave={handleSaveRangeTestConfig}
           />

--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -302,6 +302,11 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
   const [meshBeaconBroadcastTargets, setMeshBeaconBroadcastTargets] = useState<BroadcastTarget[]>([]);
 
   // Supported modules tracking (for unsupported firmware detection)
+  // `rangeTest` is optional on purpose (#5031). The backend always sends it, but
+  // it is the one gate that must fail OPEN, so the type keeps "absent" a legal
+  // state — a response from an older server, or a shape change, then reads as
+  // "supported" rather than flashing a removal notice at a node that still has
+  // the module. The consumer below tests `=== false` for the same reason.
   const [supportedModules, setSupportedModules] = useState<{ statusmessage: boolean; trafficManagement: boolean; meshBeacon: boolean; rangeTest?: boolean } | null>(null);
 
   // Serial Config State

--- a/src/components/configuration/RangeTestConfigSection.firmware28.test.tsx
+++ b/src/components/configuration/RangeTestConfigSection.firmware28.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Range Test vs. firmware 2.8 (#5031).
+ *
+ * The Range Test module was removed outright in Meshtastic firmware 2.8. On a
+ * 2.8+ node the section must stay visible and explain itself — hiding it makes
+ * users think MeshMonitor broke — with every control switched off so a save
+ * that the firmware would silently drop can't be attempted.
+ *
+ * The gate fails OPEN: `isDisabled` is only ever true when the backend
+ * positively reported a 2.8+ firmware, so an unknown version behaves exactly as
+ * it did before this change.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, fallback?: string) => fallback ?? key }),
+}));
+
+const saveBarCalls: Array<{ hasChanges: boolean }> = [];
+vi.mock('../../hooks/useSaveBar', () => ({
+  useSaveBar: (opts: { hasChanges: boolean }) => {
+    saveBarCalls.push({ hasChanges: opts.hasChanges });
+  },
+}));
+
+import RangeTestConfigSection from './RangeTestConfigSection';
+
+const REMOVED_NOTICE = /removed in Meshtastic 2\.8/i;
+
+const baseProps = {
+  enabled: true,
+  setEnabled: vi.fn(),
+  sender: 60,
+  setSender: vi.fn(),
+  save: false,
+  setSave: vi.fn(),
+  isSaving: false,
+  onSave: vi.fn(async () => {}),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  saveBarCalls.length = 0;
+});
+
+describe('RangeTestConfigSection — firmware 2.8 removal notice', () => {
+  it('renders the normal editable UI when the module is supported (pre-2.8)', () => {
+    render(<RangeTestConfigSection {...baseProps} isDisabled={false} />);
+
+    expect(screen.queryByText(REMOVED_NOTICE)).toBeNull();
+
+    const enabledBox = document.getElementById('rangetestEnabled') as HTMLInputElement;
+    const senderInput = document.getElementById('rangetestSender') as HTMLInputElement;
+    const saveBox = document.getElementById('rangetestSave') as HTMLInputElement;
+
+    expect(enabledBox.disabled).toBe(false);
+    expect(senderInput.disabled).toBe(false);
+    expect(saveBox.disabled).toBe(false);
+  });
+
+  it('behaves exactly as today when the firmware version is unknown (prop omitted)', () => {
+    render(<RangeTestConfigSection {...baseProps} />);
+
+    expect(screen.queryByText(REMOVED_NOTICE)).toBeNull();
+    expect((document.getElementById('rangetestEnabled') as HTMLInputElement).disabled).toBe(false);
+    expect((document.getElementById('rangetestSender') as HTMLInputElement).disabled).toBe(false);
+  });
+
+  it('shows the removal notice and disables every control on 2.8+', () => {
+    render(<RangeTestConfigSection {...baseProps} isDisabled={true} />);
+
+    expect(screen.getByText(REMOVED_NOTICE)).toBeTruthy();
+
+    expect((document.getElementById('rangetestEnabled') as HTMLInputElement).disabled).toBe(true);
+    expect((document.getElementById('rangetestSender') as HTMLInputElement).disabled).toBe(true);
+    expect((document.getElementById('rangetestSave') as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it('keeps the section visible rather than hiding it, so users know nothing broke', () => {
+    render(<RangeTestConfigSection {...baseProps} isDisabled={true} />);
+
+    // The title and the settings the user came looking for are still on screen.
+    expect(screen.getByText('rangetest_config.title')).toBeTruthy();
+    expect(screen.getByText('rangetest_config.enabled')).toBeTruthy();
+    expect(screen.getByText('rangetest_config.sender')).toBeTruthy();
+  });
+
+  it('never offers a save while the module is removed, even with pending edits', () => {
+    // Render with values that differ from the section's own captured baseline by
+    // re-rendering with a changed value: the ref baseline is the first render's.
+    const { rerender } = render(<RangeTestConfigSection {...baseProps} isDisabled={true} />);
+    rerender(<RangeTestConfigSection {...baseProps} sender={999} isDisabled={true} />);
+
+    expect(saveBarCalls.length).toBeGreaterThan(1);
+    expect(saveBarCalls.every(c => c.hasChanges === false)).toBe(true);
+  });
+
+  it('does offer a save for pending edits when the module IS supported', () => {
+    const { rerender } = render(<RangeTestConfigSection {...baseProps} isDisabled={false} />);
+    rerender(<RangeTestConfigSection {...baseProps} sender={999} isDisabled={false} />);
+
+    expect(saveBarCalls[saveBarCalls.length - 1].hasChanges).toBe(true);
+  });
+});

--- a/src/components/configuration/RangeTestConfigSection.module.css
+++ b/src/components/configuration/RangeTestConfigSection.module.css
@@ -1,0 +1,32 @@
+/*
+ * Range Test config section (#5031).
+ *
+ * Range Test was removed from Meshtastic firmware in 2.8, so on a 2.8+ node the
+ * section stays visible but explains itself and switches its controls off. The
+ * notice is styled as a caution rather than an error: nothing is broken, the
+ * firmware simply no longer carries the module.
+ */
+
+.removedNotice {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--color-warning);
+  border-radius: 0.5rem;
+  background-color: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  color: var(--color-warning);
+  line-height: 1.4;
+}
+
+.removedNoticeIcon {
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+/* Grey the controls out and make them inert while the module is unavailable. */
+.disabledControls {
+  opacity: 0.4;
+  pointer-events: none;
+}

--- a/src/components/configuration/RangeTestConfigSection.tsx
+++ b/src/components/configuration/RangeTestConfigSection.tsx
@@ -1,6 +1,8 @@
 import React, { useRef, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSaveBar } from '../../hooks/useSaveBar';
+import { UiIcon } from '../icons';
+import styles from './RangeTestConfigSection.module.css';
 
 interface RangeTestConfigSectionProps {
   enabled: boolean;
@@ -9,6 +11,14 @@ interface RangeTestConfigSectionProps {
   setSender: (value: number) => void;
   save: boolean;
   setSave: (value: boolean) => void;
+  /**
+   * True when the connected node's firmware no longer carries the Range Test
+   * module — it was removed in Meshtastic 2.8 (#5031). The section stays
+   * visible with an explanatory notice rather than disappearing, so users don't
+   * conclude MeshMonitor broke. Defaults to false, which is also what an
+   * unknown firmware version resolves to: fail open to the old behaviour.
+   */
+  isDisabled?: boolean;
   isSaving: boolean;
   onSave: () => Promise<void>;
 }
@@ -20,6 +30,7 @@ const RangeTestConfigSection: React.FC<RangeTestConfigSectionProps> = ({
   setSender,
   save,
   setSave,
+  isDisabled = false,
   isSaving,
   onSave
 }) => {
@@ -56,11 +67,12 @@ const RangeTestConfigSection: React.FC<RangeTestConfigSectionProps> = ({
     };
   }, [onSave, enabled, sender, save]);
 
-  // Register with SaveBar
+  // Register with SaveBar. A removed module must never offer a save — the
+  // firmware would drop the admin message silently.
   useSaveBar({
     id: 'rangetest-config',
     sectionName: t('rangetest_config.title'),
-    hasChanges,
+    hasChanges: hasChanges && !isDisabled,
     isSaving,
     onSave: handleSave,
     onDismiss: resetChanges
@@ -85,61 +97,78 @@ const RangeTestConfigSection: React.FC<RangeTestConfigSectionProps> = ({
         </a>
       </h3>
 
-      {/* Enable Module */}
-      <div className="setting-item">
-        <label htmlFor="rangetestEnabled" style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
-          <input
-            id="rangetestEnabled"
-            type="checkbox"
-            checked={enabled}
-            onChange={(e) => setEnabled(e.target.checked)}
-            style={{ marginTop: '0.2rem', flexShrink: 0 }}
-          />
-          <div style={{ flex: 1 }}>
-            <div>{t('rangetest_config.enabled')}</div>
-            <span className="setting-description">{t('rangetest_config.enabled_description')}</span>
-          </div>
-        </label>
-      </div>
-
-      {enabled && (
-        <>
-          {/* Sender Interval */}
-          <div className="setting-item">
-            <label htmlFor="rangetestSender">
-              {t('rangetest_config.sender')}
-              <span className="setting-description">{t('rangetest_config.sender_description')}</span>
-            </label>
-            <input
-              id="rangetestSender"
-              type="number"
-              min="0"
-              max="65535"
-              value={sender}
-              onChange={(e) => setSender(parseInt(e.target.value) || 0)}
-              className="setting-input"
-              placeholder="0"
-            />
-          </div>
-
-          {/* Save Results */}
-          <div className="setting-item">
-            <label htmlFor="rangetestSave" style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
-              <input
-                id="rangetestSave"
-                type="checkbox"
-                checked={save}
-                onChange={(e) => setSave(e.target.checked)}
-                style={{ marginTop: '0.2rem', flexShrink: 0 }}
-              />
-              <div style={{ flex: 1 }}>
-                <div>{t('rangetest_config.save')}</div>
-                <span className="setting-description">{t('rangetest_config.save_description')}</span>
-              </div>
-            </label>
-          </div>
-        </>
+      {isDisabled && (
+        <div className={styles.removedNotice} role="status">
+          <span className={styles.removedNoticeIcon}><UiIcon name="alert" /></span>
+          <span>
+            {t(
+              'rangetest_config.removed_in_28',
+              'Range Test was removed in Meshtastic 2.8 and is not available on this firmware. These settings cannot be changed.'
+            )}
+          </span>
+        </div>
       )}
+
+      <div className={isDisabled ? styles.disabledControls : undefined}>
+        {/* Enable Module */}
+        <div className="setting-item">
+          <label htmlFor="rangetestEnabled" style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+            <input
+              id="rangetestEnabled"
+              type="checkbox"
+              checked={enabled}
+              disabled={isDisabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+              style={{ marginTop: '0.2rem', flexShrink: 0 }}
+            />
+            <div style={{ flex: 1 }}>
+              <div>{t('rangetest_config.enabled')}</div>
+              <span className="setting-description">{t('rangetest_config.enabled_description')}</span>
+            </div>
+          </label>
+        </div>
+
+        {enabled && (
+          <>
+            {/* Sender Interval */}
+            <div className="setting-item">
+              <label htmlFor="rangetestSender">
+                {t('rangetest_config.sender')}
+                <span className="setting-description">{t('rangetest_config.sender_description')}</span>
+              </label>
+              <input
+                id="rangetestSender"
+                type="number"
+                min="0"
+                max="65535"
+                value={sender}
+                disabled={isDisabled}
+                onChange={(e) => setSender(parseInt(e.target.value) || 0)}
+                className="setting-input"
+                placeholder="0"
+              />
+            </div>
+
+            {/* Save Results */}
+            <div className="setting-item">
+              <label htmlFor="rangetestSave" style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem', width: '100%' }}>
+                <input
+                  id="rangetestSave"
+                  type="checkbox"
+                  checked={save}
+                  disabled={isDisabled}
+                  onChange={(e) => setSave(e.target.checked)}
+                  style={{ marginTop: '0.2rem', flexShrink: 0 }}
+                />
+                <div style={{ flex: 1 }}>
+                  <div>{t('rangetest_config.save')}</div>
+                  <span className="setting-description">{t('rangetest_config.save_description')}</span>
+                </div>
+              </label>
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/server/meshtasticManager.moduleSupport.test.ts
+++ b/src/server/meshtasticManager.moduleSupport.test.ts
@@ -93,6 +93,73 @@ describe('MeshtasticManager — module support gating (firmware version, not con
     });
   });
 
+  describe('supportsRangeTest (removed in 2.8 - inverse gate, #5031)', () => {
+    // Range Test is the one module gated by an UPPER bound: it was removed
+    // outright in firmware 2.8 (confirmed by garth, a Meshtastic maintainer),
+    // so support means "older than 2.8.0".
+    it('returns true for 2.7.26', () => {
+      expect((makeManager('2.7.26') as any).supportsRangeTest()).toBe(true);
+    });
+
+    it('returns true for the last 2.7.x builds', () => {
+      expect((makeManager('2.7.99') as any).supportsRangeTest()).toBe(true);
+    });
+
+    it('returns false at the exact removal threshold 2.8.0', () => {
+      expect((makeManager('2.8.0') as any).supportsRangeTest()).toBe(false);
+    });
+
+    it('returns false for 2.8.x with a commit-hash suffix', () => {
+      expect((makeManager('2.8.4.abc1234') as any).supportsRangeTest()).toBe(false);
+    });
+
+    it('returns false for a 2.8.0 pre-release suffix', () => {
+      expect((makeManager('2.8.0-alpha.1') as any).supportsRangeTest()).toBe(false);
+    });
+
+    it('returns false for a future major (3.0.0)', () => {
+      expect((makeManager('3.0.0') as any).supportsRangeTest()).toBe(false);
+    });
+
+    it('fails OPEN when the firmware version is unknown', () => {
+      // Unknown version must NOT disable the UI - that would look like a bug.
+      expect((makeManager(undefined) as any).supportsRangeTest()).toBe(true);
+    });
+
+    it('fails OPEN when the firmware version is unparseable', () => {
+      expect((makeManager('unknown') as any).supportsRangeTest()).toBe(true);
+      expect((makeManager('v2.8.0') as any).supportsRangeTest()).toBe(true);
+      expect((makeManager('') as any).supportsRangeTest()).toBe(true);
+    });
+  });
+
+  describe('parseFirmwareVersion edge cases', () => {
+    const parse = (v: string) => (makeManager(undefined) as any).parseFirmwareVersion(v);
+
+    it('parses a plain three-part version', () => {
+      expect(parse('2.7.11')).toEqual({ major: 2, minor: 7, patch: 11 });
+    });
+
+    it('parses a version with a trailing commit-hash segment', () => {
+      expect(parse('2.8.0.abcdef1')).toEqual({ major: 2, minor: 8, patch: 0 });
+    });
+
+    it('parses a pre-release suffixed version', () => {
+      expect(parse('2.8.0-alpha.1')).toEqual({ major: 2, minor: 8, patch: 0 });
+    });
+
+    it('parses multi-digit components without truncation', () => {
+      expect(parse('10.11.12')).toEqual({ major: 10, minor: 11, patch: 12 });
+    });
+
+    it('returns null for a v-prefixed or otherwise unparseable string', () => {
+      expect(parse('v2.8.0')).toBeNull();
+      expect(parse('2.8')).toBeNull();
+      expect(parse('')).toBeNull();
+      expect(parse('unknown')).toBeNull();
+    });
+  });
+
   describe('getCurrentConfig().supportedModules', () => {
     // Regression: a 2.7.24 device that has never had Traffic Management or
     // StatusMessage configured sends an all-default config. Proto3 omits an
@@ -106,6 +173,27 @@ describe('MeshtasticManager — module support gating (firmware version, not con
 
       expect(supportedModules.trafficManagement).toBe(false);
       expect(supportedModules.statusmessage).toBe(true);
+      // Range Test still exists on 2.7.x (#5031).
+      expect(supportedModules.rangeTest).toBe(true);
+    });
+
+    it('reports rangeTest unsupported on 2.8.0, where the module was removed (#5031)', () => {
+      const mgr = makeManager('2.8.0');
+      (mgr as any).actualModuleConfig = {};
+
+      const { supportedModules } = mgr.getCurrentConfig();
+
+      expect(supportedModules.rangeTest).toBe(false);
+      expect(supportedModules.trafficManagement).toBe(true);
+    });
+
+    it('reports rangeTest supported when the firmware version is unknown (fail open, #5031)', () => {
+      const mgr = makeManager(undefined);
+      (mgr as any).actualModuleConfig = {};
+
+      const { supportedModules } = mgr.getCurrentConfig();
+
+      expect(supportedModules.rangeTest).toBe(true);
     });
 
     it('reports trafficManagement unsupported on 2.7.25 — the issue #3491 case', () => {

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -5369,7 +5369,7 @@ class MeshtasticManager implements ISourceManager {
   /**
    * Get the current device configuration
    */
-  getCurrentConfig(): { deviceConfig: any; moduleConfig: any; localNodeInfo: any; supportedModules: { statusmessage: boolean; trafficManagement: boolean; meshBeacon: boolean } } {
+  getCurrentConfig(): { deviceConfig: any; moduleConfig: any; localNodeInfo: any; supportedModules: { statusmessage: boolean; trafficManagement: boolean; meshBeacon: boolean; rangeTest: boolean } } {
     logger.debug(`[CONFIG] getCurrentConfig called - hopLimit=${this.actualDeviceConfig?.lora?.hopLimit}`);
 
     // Apply Proto3 defaults to device config if it exists
@@ -5622,7 +5622,8 @@ class MeshtasticManager implements ISourceManager {
         // otherwise report as unsupported. See firmwareVersionAtLeast().
         statusmessage: this.supportsStatusMessage(),
         trafficManagement: this.supportsTrafficManagement(),
-        meshBeacon: this.supportsMeshBeacon()
+        meshBeacon: this.supportsMeshBeacon(),
+        rangeTest: this.supportsRangeTest()
       }
     };
   }
@@ -13577,6 +13578,24 @@ class MeshtasticManager implements ISourceManager {
    */
   supportsMeshBeacon(): boolean {
     return this.firmwareVersionAtLeast(2, 8, 0);
+  }
+
+  /**
+   * Check if the local device firmware still has the Range Test module (#5031).
+   *
+   * Range Test was REMOVED outright in firmware 2.8 (confirmed by garth, a
+   * Meshtastic core maintainer). This is the inverse of every other gate above:
+   * support is capped at an upper bound rather than requiring a minimum, so the
+   * expression is a negation of `firmwareVersionAtLeast(2, 8, 0)`.
+   *
+   * That negation also gives us the fail-open behaviour we want. When the
+   * firmware version is unknown or unparseable, `firmwareVersionAtLeast` returns
+   * false, so this returns true and the UI keeps working exactly as it did
+   * before. Only a node that positively reports 2.8.0 or newer gets the
+   * "removed from this firmware" notice.
+   */
+  supportsRangeTest(): boolean {
+    return !this.firmwareVersionAtLeast(2, 8, 0);
   }
 
   /**


### PR DESCRIPTION
## Summary

The Range Test module was removed outright in Meshtastic firmware 2.8 (confirmed by garth, a Meshtastic core maintainer). MeshMonitor still offered the whole Range Test section on a 2.8 node, and a save there is a silent no-op: the firmware decodes the admin message and drops it, so the UI reports success and nothing sticks.

Range Test now joins the existing firmware-version module gate, and the section explains itself instead of failing quietly.

## Screenshot

![Range Test section on pre-2.8 firmware vs 2.8+](https://raw.githubusercontent.com/Yeraze/meshmonitor/956f7a7981937a2be71625362f3ff77866460bca/rangetest-5031.png)

Left: firmware 2.7.x, or an unknown version — unchanged. Right: firmware 2.8+ — caution notice, controls greyed and inert.

## What changed

**Backend** (`src/server/meshtasticManager.ts`)
- New `supportsRangeTest()`, added to the `getCurrentConfig().supportedModules` payload alongside `statusmessage` / `trafficManagement` / `meshBeacon`.
- It is the first gate in that family with an **upper** bound rather than a minimum: `!firmwareVersionAtLeast(2, 8, 0)`. No new comparator — the existing `parseFirmwareVersion` / `firmwareVersionAtLeast` pair already handles `2.8.0`, `2.8.4.abc1234` and `2.8.0-alpha.1`.

**Frontend**
- `RangeTestConfigSection` takes an optional `isDisabled`. When set it renders a caution notice, marks every input `disabled`, and never arms the SaveBar for the section.
- `ConfigurationTab` passes `isDisabled={supportedModules?.rangeTest === false}`.

**Styling / i18n**
- New `RangeTestConfigSection.module.css` (CSS module, not the frozen global sheets), semantic `var(--color-warning)` tokens with no fallbacks.
- `UiIcon name="alert"` for the caution mark — no hardcoded emoji.
- New `rangetest_config.removed_in_28` key in `public/locales/en.json`, with an inline English fallback in the component so an untranslated locale still reads correctly.

## Two decisions worth a look

**1. Disabled, not hidden.** The issue offered either. A section that vanishes reads as "MeshMonitor broke" and generates a support question; a section that stays and explains itself reads as "the firmware changed". The current values also stay legible, which matters to anyone auditing what their node used to be set to.

**2. The gate fails open.** `firmwareVersionAtLeast` returns false for an unknown or unparseable version, so the negation returns *supported* and the UI behaves exactly as it does today. Only a node that positively reports 2.8.0 or newer is gated.

That is also why the frontend tests `supportedModules?.rangeTest === false` rather than the `!supportedModules?.x` form the sibling sections use. The sibling form is deliberately fail-*closed* — a "requires firmware 2.8" section should stay locked until proven otherwise — but applied here it would flash the removal notice on every page load while `/api/config/current` is still in flight.

## Not touched

`configRoutes` / `adminRoutes` still accept a `rangetest` module-config write. The UI can no longer reach it on 2.8+, and remote-admin callers may legitimately target an older node, so blocking it server-side would be a behaviour change beyond this issue.

## Mesh impact

None. No packet is sent, no timer armed, no notification fired. The change removes an admin write path on 2.8+ rather than adding one.

## Testing

- `src/server/meshtasticManager.moduleSupport.test.ts` — 2.7.x supported, 2.8.0 threshold, 2.8.x with a commit-hash suffix, `2.8.0-alpha.1`, `3.0.0`, plus fail-open for unknown / unparseable / empty; and `parseFirmwareVersion` edge cases (plain, hash-suffixed, pre-release, multi-digit, `v`-prefixed → null).
- `src/components/configuration/RangeTestConfigSection.firmware28.test.tsx` — pre-2.8 renders normally, omitted prop behaves as today, 2.8+ shows the notice and disables all three controls, the section stays visible, and the SaveBar never arms while gated.
- Full Vitest suite: `success: true`, 18,687 tests, 0 failed, 0 failed suites, 109 skipped (the PostgreSQL/MySQL suites — no schema or migration change here).
- `npm run lint:ci` — no in-repo FAIL lines.
- `tsc --noEmit` clean.

Fixes #5031

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S6dVMHduNHsn6jNRXX25k
