### PR TITLE
feat(meshcore): MeshCore MQTT ingest source, Phase 1 (#5040)

### DIFF
--- a/src/db/repositories/sources.ts
+++ b/src/db/repositories/sources.ts
@@ -11,7 +11,13 @@ import { logger } from '../../utils/logger.js';
 export interface Source {
   id: string;
   name: string;
-  type: 'meshtastic_tcp' | 'mqtt_broker' | 'mqtt_bridge' | 'meshcore' | 'reticulum';
+  /**
+   * `meshcore` is a device-backed MeshCore source (Companion/Repeater);
+   * `meshcore_mqtt` (#5040) subscribes to an analyzer broker and has no radio.
+   * Narrow managers with the predicates in `sourceManagerTypes.ts` rather than
+   * comparing this field by hand.
+   */
+  type: 'meshtastic_tcp' | 'mqtt_broker' | 'mqtt_bridge' | 'meshcore' | 'meshcore_mqtt' | 'reticulum';
   config: Record<string, unknown>;
   enabled: boolean;
   /** User-controlled sort rank for the source list (issue #3338). Lower first. */

--- a/src/pages/DashboardPage.meshcoreMqttFieldset.test.tsx
+++ b/src/pages/DashboardPage.meshcoreMqttFieldset.test.tsx
@@ -1,0 +1,343 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Coverage for the MeshCore MQTT ingest source fieldset in the source add/edit
+ * modal (#5040 Phase 1). Mock block copied wholesale from
+ * DashboardPage.reticulumFieldset.test.tsx — that file is the working,
+ * complete mock set for this page.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import DashboardPage from './DashboardPage';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function makeSource(config: Record<string, any>) {
+  return {
+    id: 'src-rns',
+    name: 'Region Feed',
+    type: 'meshcore_mqtt',
+    enabled: true,
+    config,
+  };
+}
+
+let currentSource = makeSource({
+  brokerUrl: 'wss://mqtt.meshmapper.net:443',
+  region: 'MCO',
+  autoConnect: true,
+});
+
+vi.mock('../hooks/useDashboardData', () => ({
+  useDashboardSources: vi.fn(() => ({
+    data: [currentSource],
+    isSuccess: true,
+    isLoading: false,
+  })),
+  useSourceStatuses: vi.fn(() => new Map([['src-rns', { sourceId: 'src-rns', connected: true }]])),
+  useDashboardSourceData: vi.fn(() => ({
+    nodes: [],
+    traceroutes: [],
+    neighborInfo: [],
+    channels: [],
+    status: { sourceId: 'src-rns', connected: true },
+    isLoading: false,
+    isError: false,
+  })),
+  useDashboardUnifiedData: vi.fn(() => ({
+    nodes: [],
+    traceroutes: [],
+    neighborInfo: [],
+    channels: [],
+    status: null,
+    isLoading: false,
+    isError: false,
+  })),
+  useUnifiedStatus: vi.fn(() => ({ nodeCount: 0, connected: false })),
+  UNIFIED_SOURCE_ID: '__unified__',
+}));
+
+vi.mock('../hooks/useMapAnalysisData', () => ({
+  useMeshCoreNeighbors: vi.fn(() => ({ data: { items: [] }, isLoading: false, isError: false })),
+}));
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({
+    authStatus: {
+      authenticated: true,
+      user: {
+        id: 1,
+        username: 'admin',
+        email: null,
+        displayName: null,
+        authProvider: 'local',
+        isAdmin: true,
+        isActive: true,
+        passwordLocked: false,
+        mfaEnabled: false,
+        createdAt: 0,
+        lastLoginAt: null,
+      },
+      permissions: {} as any,
+      channelDbPermissions: {},
+      oidcEnabled: false,
+      localAuthDisabled: false,
+      anonymousDisabled: false,
+    },
+    loading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    hasPermission: vi.fn(() => true),
+    verifyMfa: vi.fn(),
+    loginWithOIDC: vi.fn(),
+    refreshAuth: vi.fn(),
+    hasChannelDbPermission: vi.fn(() => true),
+  })),
+}));
+
+vi.mock('../contexts/CsrfContext', () => ({
+  useCsrf: vi.fn(() => ({
+    csrfToken: 'test-token',
+    isLoading: false,
+    refreshToken: vi.fn(),
+    getToken: vi.fn(() => 'test-token'),
+  })),
+}));
+
+vi.mock('../contexts/SettingsContext', () => ({
+  useNodeListStyle: () => 'monochrome',
+  SettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSettings: vi.fn(() => ({
+    mapTileset: 'openstreetmap',
+    customTilesets: [],
+    defaultMapCenterLat: 30.0,
+    defaultMapCenterLon: -90.0,
+    defaultLandingPage: 'unified',
+  })),
+}));
+
+// Exposes an "Add" button and an "Edit" button per source so the test can
+// drive onAddSource/onEditSource without needing the real sidebar's markup.
+vi.mock('../components/Dashboard/DashboardSidebar', () => ({
+  default: ({
+    sources,
+    onAddSource,
+    onEditSource,
+  }: {
+    sources: Array<{ id: string; name: string }>;
+    onAddSource: () => void;
+    onEditSource: (id: string) => void;
+  }) => (
+    <div data-testid="dashboard-sidebar">
+      <button type="button" onClick={onAddSource}>
+        source.add_short
+      </button>
+      {sources.map((s) => (
+        <button key={s.id} type="button" onClick={() => onEditSource(s.id)}>
+          edit-{s.name}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('../components/Dashboard/DashboardMap', () => ({
+  default: () => <div data-testid="dashboard-map" />,
+}));
+
+vi.mock('../components/LoginModal', () => ({
+  default: ({ isOpen }: { isOpen: boolean; onClose: () => void }) =>
+    (isOpen ? <div data-testid="login-modal" /> : null),
+}));
+
+vi.mock('../init', () => ({
+  appBasename: '',
+}));
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function openAddModal() {
+  fireEvent.click(screen.getByRole('button', { name: 'source.add_short' }));
+}
+
+function openEditModal() {
+  fireEvent.click(screen.getByRole('button', { name: 'edit-Region Feed' }));
+}
+
+function selectMcMqttType() {
+  fireEvent.change(screen.getByLabelText('source.form.type'), {
+    target: { value: 'meshcore_mqtt' },
+  });
+}
+
+function saveModal() {
+  fireEvent.click(screen.getByRole('button', { name: /^common\.save$/i }));
+}
+
+function mockFetchOk() {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ ...currentSource }),
+  }) as any;
+}
+
+function findPostCall() {
+  return (global.fetch as any).mock.calls.find(
+    ([url, init]: [string, RequestInit]) => url === '/api/sources' && init?.method === 'POST',
+  );
+}
+
+function postedConfig() {
+  const call = findPostCall();
+  expect(call).toBeDefined();
+  return JSON.parse(call[1].body as string).config;
+}
+
+describe('MeshCore MQTT ingest source fieldset (#5040 Phase 1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentSource = makeSource({
+      brokerUrl: 'wss://mqtt.meshmapper.net:443',
+      region: 'MCO',
+      autoConnect: true,
+    });
+  });
+
+  it('offers the type and shows its fields when selected', () => {
+    renderPage();
+    openAddModal();
+    selectMcMqttType();
+
+    expect(screen.getByPlaceholderText('wss://mqtt.meshmapper.net:443')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('MCO')).toBeInTheDocument();
+  });
+
+  it('states up front that the source has no radio', () => {
+    // Expectation-setting matters here: a user who does not read this will file
+    // "my MeshCore source has no device page" as a bug.
+    renderPage();
+    openAddModal();
+    selectMcMqttType();
+
+    expect(screen.getByText(/source\.form\.mc_mqtt_intro/)).toBeInTheDocument();
+  });
+
+  it('POSTs brokerUrl and an upper-cased region', async () => {
+    mockFetchOk();
+    renderPage();
+    openAddModal();
+    selectMcMqttType();
+
+    fireEvent.change(screen.getByPlaceholderText('source.form.name_placeholder'), {
+      target: { value: 'Orlando Feed' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('wss://mqtt.meshmapper.net:443'), {
+      target: { value: 'wss://broker.example:443' },
+    });
+    // Lower case on the way in — the topic segment is upper case, so the form
+    // normalises rather than silently subscribing to nothing.
+    fireEvent.change(screen.getByPlaceholderText('MCO'), { target: { value: 'mco' } });
+    saveModal();
+
+    await waitFor(() => expect(findPostCall()).toBeDefined());
+    expect(postedConfig()).toMatchObject({
+      brokerUrl: 'wss://broker.example:443',
+      region: 'MCO',
+      autoConnect: true,
+      rejectUnauthorized: true,
+    });
+  });
+
+  it('omits username/password entirely when left blank', async () => {
+    mockFetchOk();
+    renderPage();
+    openAddModal();
+    selectMcMqttType();
+
+    fireEvent.change(screen.getByPlaceholderText('source.form.name_placeholder'), {
+      target: { value: 'Open Broker' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('wss://mqtt.meshmapper.net:443'), {
+      target: { value: 'mqtt://localhost:1883' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('MCO'), { target: { value: 'test' } });
+    saveModal();
+
+    await waitFor(() => expect(findPostCall()).toBeDefined());
+    const cfg = postedConfig();
+    expect(cfg).not.toHaveProperty('username');
+    expect(cfg).not.toHaveProperty('password');
+  });
+
+  it('refuses to save without a broker URL', async () => {
+    mockFetchOk();
+    renderPage();
+    openAddModal();
+    selectMcMqttType();
+
+    fireEvent.change(screen.getByPlaceholderText('source.form.name_placeholder'), {
+      target: { value: 'No Broker' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('MCO'), { target: { value: 'MCO' } });
+    saveModal();
+
+    await waitFor(() =>
+      expect(screen.getByText(/source\.form\.error_mc_mqtt_broker_required/)).toBeInTheDocument(),
+    );
+    expect(findPostCall()).toBeUndefined();
+  });
+
+  it('refuses to save without a region — the topic filter is built from it', async () => {
+    mockFetchOk();
+    renderPage();
+    openAddModal();
+    selectMcMqttType();
+
+    fireEvent.change(screen.getByPlaceholderText('source.form.name_placeholder'), {
+      target: { value: 'No Region' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('wss://mqtt.meshmapper.net:443'), {
+      target: { value: 'wss://broker.example:443' },
+    });
+    saveModal();
+
+    await waitFor(() =>
+      expect(screen.getByText(/source\.form\.error_mc_mqtt_region_required/)).toBeInTheDocument(),
+    );
+    expect(findPostCall()).toBeUndefined();
+  });
+
+  it('seeds the form from an existing source on edit, but never the password', () => {
+    currentSource = makeSource({
+      brokerUrl: 'wss://broker.example:443',
+      region: 'AMS',
+      username: 'meshcore',
+      password: 'should-not-be-seeded',
+      rejectUnauthorized: false,
+      autoConnect: false,
+    });
+    renderPage();
+    openEditModal();
+
+    expect(screen.getByPlaceholderText('wss://mqtt.meshmapper.net:443')).toHaveValue('wss://broker.example:443');
+    expect(screen.getByPlaceholderText('MCO')).toHaveValue('AMS');
+    // The stored password must never round-trip into the DOM; the server keeps
+    // it when this is left blank.
+    expect(screen.queryByDisplayValue('should-not-be-seeded')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -146,8 +146,16 @@ function DashboardInner() {
   const [showSourceModal, setShowSourceModal] = useState(false);
   const [editingSourceId, setEditingSourceId] = useState<string | null>(null);
   const [formType, setFormType] = useState<
-    'meshtastic_tcp' | 'meshcore' | 'mqtt_broker' | 'mqtt_bridge' | 'reticulum'
+    'meshtastic_tcp' | 'meshcore' | 'meshcore_mqtt' | 'mqtt_broker' | 'mqtt_bridge' | 'reticulum'
   >('meshtastic_tcp');
+  // MeshCore MQTT ingest source (#5040). One broker per source, deliberately:
+  // it keeps "which broker did this come from" collapsed to "which source".
+  const [formMcMqttBrokerUrl, setFormMcMqttBrokerUrl] = useState('');
+  const [formMcMqttRegion, setFormMcMqttRegion] = useState('');
+  const [formMcMqttUsername, setFormMcMqttUsername] = useState('');
+  const [formMcMqttPassword, setFormMcMqttPassword] = useState('');
+  const [formMcMqttRejectUnauthorized, setFormMcMqttRejectUnauthorized] = useState(true);
+  const [formMcMqttAutoConnect, setFormMcMqttAutoConnect] = useState(true);
   const [formName, setFormName] = useState('');
   const [formHost, setFormHost] = useState('');
   const [formPort, setFormPort] = useState('4403');
@@ -430,6 +438,21 @@ function DashboardInner() {
     // Cleared on every modal open, regardless of source type — drafts are
     // never seeded from the server (§3.5).
     setFormObserverCreds({});
+    if (source.type === 'meshcore_mqtt') {
+      setFormType('meshcore_mqtt');
+      setFormName(source.name);
+      setFormMcMqttBrokerUrl(cfg?.brokerUrl ?? '');
+      setFormMcMqttRegion(cfg?.region ?? '');
+      setFormMcMqttUsername(cfg?.username ?? '');
+      // Never seed the password back into the form — the server keeps the
+      // stored value when this is left blank.
+      setFormMcMqttPassword('');
+      setFormMcMqttRejectUnauthorized(cfg?.rejectUnauthorized !== false);
+      setFormMcMqttAutoConnect(cfg?.autoConnect !== false);
+      setFormError('');
+      setShowSourceModal(true);
+      return;
+    }
     if (source.type === 'reticulum') {
       setFormType('reticulum');
       setFormName(source.name);
@@ -727,6 +750,29 @@ function DashboardInner() {
       }
       if (!observerResult.config) return; // buildObserverConfig always returns config when error is unset.
       cfg.observer = observerResult.config;
+    } else if (formType === 'meshcore_mqtt') {
+      // Mirrors the server-side validation in sourceRoutes.ts: both fields are
+      // structural. The subscribe topic is built from the region, so a source
+      // without one would subscribe to nothing at all.
+      const brokerUrl = formMcMqttBrokerUrl.trim();
+      const region = formMcMqttRegion.trim();
+      if (!brokerUrl) {
+        setFormError(t('source.form.error_mc_mqtt_broker_required', 'Broker URL is required'));
+        return;
+      }
+      if (!region) {
+        setFormError(t('source.form.error_mc_mqtt_region_required', 'Region is required'));
+        return;
+      }
+      cfg = {
+        brokerUrl,
+        region: region.toUpperCase(),
+        rejectUnauthorized: formMcMqttRejectUnauthorized,
+        autoConnect: formMcMqttAutoConnect,
+      };
+      const mcUser = formMcMqttUsername.trim();
+      if (mcUser) cfg.username = mcUser;
+      if (formMcMqttPassword) cfg.password = formMcMqttPassword;
     } else if (formType === 'reticulum') {
       // Reticulum source (#3960 Phase 1b WP6): validation mirrors
       // reticulumConfigFromSource() server-side (src/server/reticulumConfig.ts)
@@ -1325,6 +1371,7 @@ function DashboardInner() {
                       e.target.value as
                         | 'meshtastic_tcp'
                         | 'meshcore'
+                        | 'meshcore_mqtt'
                         | 'mqtt_broker'
                         | 'mqtt_bridge'
                         | 'reticulum',
@@ -1333,6 +1380,7 @@ function DashboardInner() {
                 >
                   <option value="meshtastic_tcp">{t('source.form.type_meshtastic', 'Meshtastic (TCP)')}</option>
                   <option value="meshcore">{t('source.form.type_meshcore', 'MeshCore')}</option>
+                  <option value="meshcore_mqtt">{t('source.form.type_meshcore_mqtt', 'MeshCore MQTT ingest (read a region feed, no radio)')}</option>
                   <option value="mqtt_broker">{t('source.form.type_mqtt_broker', 'Embedded MQTT Broker (devices connect here)')}</option>
                   <option value="mqtt_bridge">{t('source.form.type_mqtt_bridge', 'MQTT Bridge (forward to/from an upstream broker)')}</option>
                   <option value="reticulum">{t('source.form.type_reticulum', 'Reticulum')}</option>
@@ -1967,6 +2015,83 @@ function DashboardInner() {
                     </>
                   )}
                 </fieldset>
+              </>
+            ) : formType === 'meshcore_mqtt' ? (
+              <>
+                <div className="dashboard-form-help" style={{ marginBottom: '0.75rem' }}>
+                  {t(
+                    'source.form.mc_mqtt_intro',
+                    'Reads a MeshCore Analyzer region feed over MQTT. This source has no radio: it can never transmit, and shows no device, contacts, or remote-admin pages.',
+                  )}
+                </div>
+
+                <label className="dashboard-form-field">
+                  <span className="dashboard-form-label">{t('source.form.mc_mqtt_broker_url', 'Broker URL')}</span>
+                  <input
+                    type="text"
+                    value={formMcMqttBrokerUrl}
+                    onChange={(e) => setFormMcMqttBrokerUrl(e.target.value)}
+                    placeholder="wss://mqtt.meshmapper.net:443"
+                  />
+                  <span className="dashboard-form-help">
+                    {t('source.form.mc_mqtt_broker_url_help', 'One broker per source. Accepts ws://, wss://, mqtt://, mqtts://, or host:port. Add a second source for a second broker.')}
+                  </span>
+                </label>
+
+                <label className="dashboard-form-field">
+                  <span className="dashboard-form-label">{t('source.form.mc_mqtt_region', 'Region (IATA)')}</span>
+                  <input
+                    type="text"
+                    value={formMcMqttRegion}
+                    onChange={(e) => setFormMcMqttRegion(e.target.value)}
+                    placeholder="MCO"
+                  />
+                  <span className="dashboard-form-help">
+                    {t('source.form.mc_mqtt_region_help', "The region segment of the topic this source subscribes to. Uppercased on save.")}
+                  </span>
+                </label>
+
+                <label className="dashboard-form-field">
+                  <span className="dashboard-form-label">{t('source.form.mc_mqtt_username', 'Username (optional)')}</span>
+                  <input
+                    type="text"
+                    value={formMcMqttUsername}
+                    onChange={(e) => setFormMcMqttUsername(e.target.value)}
+                    autoComplete="off"
+                  />
+                </label>
+
+                <label className="dashboard-form-field">
+                  <span className="dashboard-form-label">{t('source.form.mc_mqtt_password', 'Password (optional)')}</span>
+                  <input
+                    type="password"
+                    value={formMcMqttPassword}
+                    onChange={(e) => setFormMcMqttPassword(e.target.value)}
+                    autoComplete="new-password"
+                    placeholder={editingSourceId ? t('source.form.unchanged_placeholder', 'Leave blank to keep existing') : ''}
+                  />
+                  <span className="dashboard-form-help">
+                    {t('source.form.mc_mqtt_password_help', 'Only for brokers using fixed MQTT credentials. Leave both blank for an open broker.')}
+                  </span>
+                </label>
+
+                <label className="dashboard-form-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={formMcMqttRejectUnauthorized}
+                    onChange={(e) => setFormMcMqttRejectUnauthorized(e.target.checked)}
+                  />
+                  <span>{t('source.form.mc_mqtt_reject_unauthorized', 'Verify TLS certificate')}</span>
+                </label>
+
+                <label className="dashboard-form-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={formMcMqttAutoConnect}
+                    onChange={(e) => setFormMcMqttAutoConnect(e.target.checked)}
+                  />
+                  <span>{t('source.form.auto_connect', 'Connect automatically on startup')}</span>
+                </label>
               </>
             ) : formType === 'reticulum' ? (
               <>

--- a/src/server/bootstrapSources.ts
+++ b/src/server/bootstrapSources.ts
@@ -28,6 +28,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
+import { MeshCoreMqttManager, type MeshCoreMqttSourceConfig } from './meshcoreMqttManager.js';
 import { logger } from '../utils/logger.js';
 import { applyManagerSettings } from './applyManagerSettings.js';
 import { meshcoreConfigFromSource, ensureMeshCoreManagerStarted } from './meshcoreConfig.js';
@@ -199,6 +200,31 @@ export async function bootstrapSources(deps: BootstrapDeps): Promise<void> {
         await ensureMeshCoreManagerStarted(source, mcConfig);
       } catch (err) {
         logger.error(`Failed to start MeshCore source ${source.id} (${source.name}); continuing with other sources:`, err);
+      }
+      continue;
+    }
+
+    if (source.type === 'meshcore_mqtt') {
+      // MeshCore ingest from an Analyzer Observer broker (#5040). Subscribe-only
+      // and radio-less: it never transmits, and `isMeshCoreManager()` excludes
+      // it from every device-driving scheduler by construction.
+      const cfg = source.config as Partial<MeshCoreMqttSourceConfig>;
+      if (cfg?.autoConnect === false) {
+        logger.info(`Skipping auto-connect for MeshCore MQTT source ${source.id} (${source.name}) — autoConnect disabled`);
+        continue;
+      }
+      if (!cfg?.brokerUrl || !cfg?.region) {
+        logger.warn(`MeshCore MQTT source ${source.id} (${source.name}) is missing brokerUrl or region; skipping`);
+        continue;
+      }
+
+      try {
+        const manager = new MeshCoreMqttManager(source.id, source.name, cfg as MeshCoreMqttSourceConfig);
+        await deps.registry.addManager(manager);
+        await manager.start();
+        logger.info(`Started MeshCore MQTT source ${source.id} (${source.name})`);
+      } catch (err) {
+        logger.error(`Failed to start MeshCore MQTT source ${source.id} (${source.name}); continuing with other sources:`, err);
       }
       continue;
     }

--- a/src/server/meshcoreMqttManager.test.ts
+++ b/src/server/meshcoreMqttManager.test.ts
@@ -213,10 +213,64 @@ describe('MeshCoreMqttManager — ingest', () => {
     expect(mgr.getIngestStats()).toMatchObject({ received: 3, accepted: 3, observers: 2 });
   });
 
+  it('rolls back `started` when connect fails, so a later start() retries', async () => {
+    // Without the rollback the source is stranded: never connected, and never
+    // retryable short of a process restart.
+    const mgr = makeManager();
+    connectMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    await expect(mgr.start()).rejects.toThrow('ECONNREFUSED');
+    expect(mgr.getStatus().connected).toBe(false);
+    expect(mgr.getIngestStats().lastError).toBe('ECONNREFUSED');
+
+    // Second attempt must actually try again rather than early-returning.
+    connectMock.mockResolvedValueOnce(undefined);
+    await mgr.start();
+    expect(connectMock).toHaveBeenCalledTimes(2);
+    expect(subscribeMock).toHaveBeenCalledWith(['meshcore/MCO/+/packets']);
+  });
+
+  it('tolerates stop() before start()', async () => {
+    const mgr = makeManager();
+    await expect(mgr.stop()).resolves.toBeUndefined();
+    expect(disconnectMock).not.toHaveBeenCalled();
+  });
+
+  it('can be restarted after a clean stop', async () => {
+    const mgr = makeManager();
+    await mgr.start();
+    await mgr.stop();
+    await mgr.start();
+    expect(connectMock).toHaveBeenCalledTimes(2);
+  });
+
   it('records the last broker error without throwing', async () => {
     const mgr = makeManager();
     await mgr.start();
     lastClient!.raise('error', new Error('bad credentials'));
     expect(mgr.getIngestStats().lastError).toBe('bad credentials');
+  });
+});
+
+describe('predicate narrowing over a mixed manager list', () => {
+  // The most load-bearing guarantee in this feature, and the one that would
+  // break silently: a filter over the registry must sort this source into the
+  // read group and out of the device group.
+  const deviceLike = { sourceId: 'src-dev', sourceType: 'meshcore' } as never;
+  const tcpLike = { sourceId: 'src-tcp', sourceType: 'meshtastic_tcp' } as never;
+
+  it('excludes the MQTT source from a device-manager filter', () => {
+    const all = [deviceLike, makeManager() as never, tcpLike];
+    const devices = all.filter(isMeshCoreManager);
+    expect(devices).toHaveLength(1);
+    expect((devices[0] as { sourceId: string }).sourceId).toBe('src-dev');
+  });
+
+  it('includes BOTH MeshCore sources in an any-MeshCore filter', () => {
+    const all = [deviceLike, makeManager() as never, tcpLike];
+    const meshcore = all.filter(isAnyMeshCoreManager);
+    expect(meshcore.map((m) => (m as { sourceId: string }).sourceId).sort()).toEqual([
+      'src-dev',
+      'src-mqtt-1',
+    ]);
   });
 });

--- a/src/server/meshcoreMqttManager.test.ts
+++ b/src/server/meshcoreMqttManager.test.ts
@@ -1,0 +1,222 @@
+/**
+ * MeshCoreMqttManager tests (#5040 Phase 1).
+ *
+ * The load-bearing assertions here are the *structural* ones — that this source
+ * can never be mistaken for a device-backed MeshCore source. Every TX-driving
+ * scheduler and device route filters on `isMeshCoreManager()`, so if this
+ * manager ever started passing that predicate it would silently be handed to
+ * code that tries to talk to a radio it does not have.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const connectMock = vi.fn().mockResolvedValue(undefined);
+const subscribeMock = vi.fn().mockResolvedValue(undefined);
+const disconnectMock = vi.fn().mockResolvedValue(undefined);
+let lastClient: FakeClient | null = null;
+
+class FakeClient {
+  handlers = new Map<string, (arg: unknown) => void>();
+  connected = true;
+  connect = connectMock;
+  subscribe = subscribeMock;
+  disconnect = disconnectMock;
+  isConnected = () => this.connected;
+  on(event: string, fn: (arg: unknown) => void) {
+    this.handlers.set(event, fn);
+    return this;
+  }
+  removeAllListeners() {
+    this.handlers.clear();
+    return this;
+  }
+  /** Drive an inbound broker message the way mqttBrokerClient would. */
+  deliver(topic: string, body: unknown) {
+    this.handlers.get('message')?.({ topic, payload: Buffer.from(JSON.stringify(body)) });
+  }
+  raise(event: string, arg: unknown) {
+    this.handlers.get(event)?.(arg);
+  }
+}
+
+vi.mock('./transports/mqttBrokerClient.js', () => ({
+  MqttBrokerClient: class {
+    constructor() {
+      lastClient = new FakeClient();
+      return lastClient as unknown as object;
+    }
+  },
+}));
+
+import { MeshCoreMqttManager } from './meshcoreMqttManager.js';
+import {
+  isMeshCoreManager,
+  isMeshCoreMqttManager,
+  isAnyMeshCoreManager,
+  isMeshtasticManager,
+} from './sourceManagerTypes.js';
+
+const OBSERVER_KEY = 'AB'.repeat(32);
+
+/**
+ * Minimal valid FLOOD frame: header, path_len 0, 4 payload bytes.
+ * Header 0x05 = (version 0 << 6) | (payload_type 1 << 2) | (route 1 = FLOOD).
+ * Route 0 (TRANSPORT_FLOOD) and 3 (TRANSPORT_DIRECT) carry transport codes
+ * before path_len, so a hand-written frame using those parses as truncated.
+ */
+const RAW_FRAME = '0500deadbeef';
+
+function packetBody(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'PACKET',
+    origin: 'SomeObserver',
+    origin_id: OBSERVER_KEY,
+    timestamp: new Date().toISOString(),
+    raw: RAW_FRAME,
+    SNR: '-8.5',
+    RSSI: '-101',
+    ...overrides,
+  };
+}
+
+function makeManager() {
+  return new MeshCoreMqttManager('src-mqtt-1', 'Region Feed', {
+    brokerUrl: 'wss://broker.example:443',
+    region: 'mco',
+  });
+}
+
+beforeEach(() => {
+  connectMock.mockClear();
+  subscribeMock.mockClear();
+  disconnectMock.mockClear();
+  lastClient = null;
+});
+
+describe('MeshCoreMqttManager — structural no-radio guarantees', () => {
+  it('is NOT narrowed by isMeshCoreManager, so device schedulers skip it', () => {
+    // This is the whole TX-refusal mechanism. The five MeshCore schedulers and
+    // the device/config routes all filter on isMeshCoreManager(); passing it
+    // would hand a radio-less source to code that drives a radio.
+    expect(isMeshCoreManager(makeManager())).toBe(false);
+  });
+
+  it('IS narrowed by isMeshCoreMqttManager and isAnyMeshCoreManager', () => {
+    const mgr = makeManager();
+    expect(isMeshCoreMqttManager(mgr)).toBe(true);
+    expect(isAnyMeshCoreManager(mgr)).toBe(true);
+  });
+
+  it('is not mistaken for a Meshtastic source either', () => {
+    expect(isMeshtasticManager(makeManager())).toBe(false);
+  });
+
+  it('reports no local node — this source is not a node on the mesh', () => {
+    const mgr = makeManager();
+    expect(mgr.getLocalNodeInfo()).toBeNull();
+    expect(mgr.getLocalNode()).toBeNull();
+  });
+
+  it('has no-op distance-delete scheduling, since that anchors on a local position', async () => {
+    const mgr = makeManager();
+    await expect(mgr.startDistanceDeleteScheduler()).resolves.toBeUndefined();
+    expect(() => mgr.stopDistanceDeleteScheduler()).not.toThrow();
+  });
+});
+
+describe('MeshCoreMqttManager — subscription', () => {
+  it('subscribes to the region wildcard topic on start', async () => {
+    await makeManager().start();
+    expect(connectMock).toHaveBeenCalledTimes(1);
+    expect(subscribeMock).toHaveBeenCalledWith(['meshcore/MCO/+/packets']);
+  });
+
+  it('is idempotent — a second start does not open a second connection', async () => {
+    const mgr = makeManager();
+    await mgr.start();
+    await mgr.start();
+    expect(connectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('disconnects and drops listeners on stop', async () => {
+    const mgr = makeManager();
+    await mgr.start();
+    await mgr.stop();
+    expect(disconnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports connection state through getStatus', async () => {
+    const mgr = makeManager();
+    expect(mgr.getStatus().connected).toBe(false);
+    await mgr.start();
+    expect(mgr.getStatus().connected).toBe(true);
+    expect(mgr.getStatus().sourceType).toBe('meshcore_mqtt');
+  });
+});
+
+describe('MeshCoreMqttManager — ingest', () => {
+  it('decodes a valid packet and emits it in the bridge shape', async () => {
+    const mgr = makeManager();
+    const seen: unknown[] = [];
+    mgr.on('ota_packet', (e) => seen.push(e));
+    await mgr.start();
+
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER_KEY}/packets`, packetBody());
+
+    expect(seen).toHaveLength(1);
+    expect(mgr.getIngestStats()).toMatchObject({ received: 1, accepted: 1, rejected: 0, observers: 1 });
+  });
+
+  it('rejects a body whose origin_id contradicts the topic it arrived on', async () => {
+    // A publisher claiming another observer's identity. Accepting it would
+    // attribute packets to the wrong node, corrupting per-observer dedup.
+    const mgr = makeManager();
+    const seen: unknown[] = [];
+    mgr.on('ota_packet', (e) => seen.push(e));
+    await mgr.start();
+
+    lastClient!.deliver(
+      `meshcore/MCO/${OBSERVER_KEY}/packets`,
+      packetBody({ origin_id: 'CD'.repeat(32) }),
+    );
+
+    expect(seen).toHaveLength(0);
+    expect(mgr.getIngestStats()).toMatchObject({ received: 1, accepted: 0, rejected: 1 });
+  });
+
+  it('survives malformed JSON without throwing or breaking the stream', async () => {
+    const mgr = makeManager();
+    const seen: unknown[] = [];
+    mgr.on('ota_packet', (e) => seen.push(e));
+    await mgr.start();
+
+    // Raw non-JSON bytes, as a broken publisher would send.
+    lastClient!.handlers.get('message')?.({
+      topic: `meshcore/MCO/${OBSERVER_KEY}/packets`,
+      payload: Buffer.from('not json at all'),
+    });
+    // A good message immediately after still gets through.
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER_KEY}/packets`, packetBody());
+
+    expect(seen).toHaveLength(1);
+    expect(mgr.getIngestStats()).toMatchObject({ received: 2, accepted: 1, rejected: 1 });
+  });
+
+  it('counts distinct observers rather than messages', async () => {
+    const mgr = makeManager();
+    await mgr.start();
+    const other = 'CD'.repeat(32);
+
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER_KEY}/packets`, packetBody());
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER_KEY}/packets`, packetBody());
+    lastClient!.deliver(`meshcore/MCO/${other}/packets`, packetBody({ origin_id: other }));
+
+    expect(mgr.getIngestStats()).toMatchObject({ received: 3, accepted: 3, observers: 2 });
+  });
+
+  it('records the last broker error without throwing', async () => {
+    const mgr = makeManager();
+    await mgr.start();
+    lastClient!.raise('error', new Error('bad credentials'));
+    expect(mgr.getIngestStats().lastError).toBe('bad credentials');
+  });
+});

--- a/src/server/meshcoreMqttManager.ts
+++ b/src/server/meshcoreMqttManager.ts
@@ -1,0 +1,246 @@
+/**
+ * MeshCoreMqttManager — MeshCore ingest from an Analyzer Observer MQTT broker
+ * (issue #5040, Phase 1).
+ *
+ * The mirror of `meshcoreObserverPublisher.ts`. Where that publishes what our
+ * Companion heard to analyzer brokers, this **subscribes** to one broker and
+ * ingests what every observer in a region heard — giving a view of the mesh far
+ * wider than a single radio's earshot.
+ *
+ * ## No radio, ever
+ *
+ * This source has no device. It cannot transmit, and that is enforced
+ * structurally rather than by policy:
+ *
+ * - Its `sourceType` is `meshcore_mqtt`, so `isMeshCoreManager()` — which every
+ *   TX-driving scheduler and device route filters on — excludes it by
+ *   construction. Nothing has to remember to skip it.
+ * - `getLocalNode()` / `getLocalNodeInfo()` return null. There is no local
+ *   identity: we are not a node on this mesh, we are reading someone else's
+ *   observations. Both are already-supported null states on the device-backed
+ *   manager, so consumers need no change.
+ *
+ * Read surfaces that *should* see this source use `isAnyMeshCoreManager()`.
+ * See `sourceManagerTypes.ts` for which predicate is which, and #5040's Phase
+ * 5.5 for the audit that walks every call site.
+ *
+ * ## One broker per source
+ *
+ * Deliberate (#5040). The publish side allows up to 8 brokers per source, but
+ * subscribing to several regional brokers carrying overlapping traffic tangles
+ * with the per-observer dedup design. One broker per source keeps "which broker
+ * did this come from" collapsed to "which source", which is what makes the
+ * downstream analysis surfaces tractable. Add a second source for a second
+ * broker.
+ *
+ * ## Phase 1 scope
+ *
+ * Connect, subscribe, decode, count — and drop. Nothing is persisted yet; that
+ * is Phase 2. This phase proves the pipe end to end and gives the later phases
+ * a manager to hang off.
+ */
+import { EventEmitter } from 'events';
+import type { ISourceManager, SourceStatus } from './sourceManagerRegistry.js';
+import { MqttBrokerClient } from './transports/mqttBrokerClient.js';
+import {
+  decodeObserverPacketMessage,
+  observerPacketsSubscription,
+  observerKeyFromTopic,
+  type MeshCoreBridgeOtaPacket,
+} from './services/meshcoreMqttIngestPacket.js';
+import { logger } from '../utils/logger.js';
+
+/** Persisted `sources.config` shape for a `meshcore_mqtt` source. */
+export interface MeshCoreMqttSourceConfig {
+  /** Broker URL: ws://, wss://, mqtt://, mqtts://, or bare host:port. */
+  brokerUrl: string;
+  /** IATA-ish region code — the topic's region segment. Uppercased on use. */
+  region: string;
+  /** Static MQTT username, when the broker uses fixed credentials. */
+  username?: string;
+  /** Static MQTT password. Stored encrypted; resolved before construction. */
+  password?: string;
+  /** Reject invalid TLS certs. Defaults true; only lower it for a local broker. */
+  rejectUnauthorized?: boolean;
+  /** When false the source is enabled but must be connected manually. */
+  autoConnect?: boolean;
+}
+
+/** Counters surfaced on the source status panel. */
+export interface MeshCoreMqttIngestStats {
+  /** Messages received on the packets topic, before validation. */
+  received: number;
+  /** Messages that decoded into a usable packet. */
+  accepted: number;
+  /** Messages rejected as malformed, unparseable, or identity-mismatched. */
+  rejected: number;
+  /** Distinct observer public keys seen this session. */
+  observers: number;
+  lastPacketAt: number | null;
+  lastError: string | null;
+}
+
+export class MeshCoreMqttManager extends EventEmitter implements ISourceManager {
+  readonly sourceId: string;
+  readonly sourceType = 'meshcore_mqtt' as const;
+
+  private readonly sourceName: string;
+  private readonly config: MeshCoreMqttSourceConfig;
+  private client: MqttBrokerClient | null = null;
+  private started = false;
+
+  private readonly stats: MeshCoreMqttIngestStats = {
+    received: 0,
+    accepted: 0,
+    rejected: 0,
+    observers: 0,
+    lastPacketAt: null,
+    lastError: null,
+  };
+  /** Observer keys seen this session, for the `observers` counter. */
+  private readonly seenObservers = new Set<string>();
+
+  constructor(sourceId: string, sourceName: string, config: MeshCoreMqttSourceConfig) {
+    super();
+    this.sourceId = sourceId;
+    this.sourceName = sourceName;
+    this.config = config;
+  }
+
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+
+    const topic = observerPacketsSubscription(this.config.region);
+    const client = new MqttBrokerClient({
+      url: this.config.brokerUrl,
+      username: this.config.username,
+      password: this.config.password,
+      rejectUnauthorized: this.config.rejectUnauthorized ?? true,
+      clientIdPrefix: 'meshmonitor-ingest',
+    });
+    this.client = client;
+
+    client.on('message', (msg: { topic: string; payload: Buffer }) => {
+      this.handleMessage(msg.topic, msg.payload);
+    });
+    client.on('error', (err: unknown) => {
+      this.stats.lastError = err instanceof Error ? err.message : String(err);
+      logger.warn(`[MeshCoreMqtt:${this.sourceId}] broker error: ${this.stats.lastError}`);
+    });
+    client.on('close', () => {
+      logger.info(`[MeshCoreMqtt:${this.sourceId}] broker connection closed`);
+    });
+
+    await client.connect();
+    await client.subscribe([topic]);
+    logger.info(
+      `[MeshCoreMqtt:${this.sourceId}] subscribed to ${topic} on ${this.config.brokerUrl}`,
+    );
+  }
+
+  async stop(): Promise<void> {
+    this.started = false;
+    const client = this.client;
+    this.client = null;
+    if (!client) return;
+    client.removeAllListeners();
+    try {
+      await client.disconnect();
+    } catch (err) {
+      logger.debug(`[MeshCoreMqtt:${this.sourceId}] error closing broker client:`, err);
+    }
+  }
+
+  /**
+   * Decode one broker message.
+   *
+   * Everything a remote publisher sends is untrusted input: a malformed body, a
+   * frame that contradicts its own metadata, or a publisher claiming another
+   * observer's identity must all be dropped without disturbing the stream. A
+   * single bad message on a busy region feed can never throw.
+   */
+  private handleMessage(topic: string, payload: Buffer): void {
+    this.stats.received++;
+    try {
+      const body: unknown = JSON.parse(payload.toString('utf8'));
+      const decoded = decodeObserverPacketMessage(body);
+      if (!decoded) {
+        this.stats.rejected++;
+        return;
+      }
+
+      // Identity cross-check: the body's origin_id must match the topic the
+      // message was published on. A mismatch means the publisher is claiming
+      // another observer's identity — reject rather than attribute packets to
+      // the wrong node.
+      const topicKey = observerKeyFromTopic(topic);
+      if (topicKey !== null && topicKey !== decoded.originId) {
+        this.stats.rejected++;
+        logger.debug(
+          `[MeshCoreMqtt:${this.sourceId}] dropping packet: body origin_id ` +
+            `${decoded.originId.slice(0, 16)}… does not match topic key ${topicKey.slice(0, 16)}…`,
+        );
+        return;
+      }
+
+      this.stats.accepted++;
+      this.stats.lastPacketAt = Date.now();
+      if (!this.seenObservers.has(decoded.originId)) {
+        this.seenObservers.add(decoded.originId);
+        this.stats.observers = this.seenObservers.size;
+      }
+
+      // Phase 1 ends here: the packet is decoded and counted, not persisted.
+      // Phase 2 routes this into the same handleOtaPacket seam the local radio
+      // path uses. The event is emitted now so a consumer can be attached
+      // without changing this method.
+      this.emit('ota_packet', decoded.event satisfies MeshCoreBridgeOtaPacket);
+    } catch (err) {
+      this.stats.rejected++;
+      logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to handle message:`, err);
+    }
+  }
+
+  getStatus(): SourceStatus {
+    return {
+      sourceId: this.sourceId,
+      sourceName: this.sourceName,
+      sourceType: this.sourceType,
+      connected: this.client?.isConnected() ?? false,
+    };
+  }
+
+  /** Ingest counters for the status panel. */
+  getIngestStats(): Readonly<MeshCoreMqttIngestStats> {
+    return { ...this.stats };
+  }
+
+  /**
+   * Always null — this source is not a node on the mesh, it reads other nodes'
+   * observations. Mirrors `MeshCoreManager.getLocalNodeInfo()`, which is also
+   * hardcoded null, so every existing consumer already handles this.
+   */
+  getLocalNodeInfo(): null {
+    return null;
+  }
+
+  /** Always null, for the same reason as {@link getLocalNodeInfo}. */
+  getLocalNode(): null {
+    return null;
+  }
+
+  /**
+   * No-op: auto-delete-by-distance is anchored on the local node's position,
+   * and this source has no local node. Implemented to satisfy ISourceManager
+   * rather than left to throw.
+   */
+  async startDistanceDeleteScheduler(): Promise<void> {
+    // Intentionally empty — see doc comment.
+  }
+
+  /** No-op counterpart to {@link startDistanceDeleteScheduler}. */
+  stopDistanceDeleteScheduler(): void {
+    // Intentionally empty — see doc comment.
+  }
+}

--- a/src/server/meshcoreMqttManager.ts
+++ b/src/server/meshcoreMqttManager.ts
@@ -46,7 +46,6 @@ import {
   decodeObserverPacketMessage,
   observerPacketsSubscription,
   observerKeyFromTopic,
-  type MeshCoreBridgeOtaPacket,
 } from './services/meshcoreMqttIngestPacket.js';
 import { logger } from '../utils/logger.js';
 
@@ -58,7 +57,14 @@ export interface MeshCoreMqttSourceConfig {
   region: string;
   /** Static MQTT username, when the broker uses fixed credentials. */
   username?: string;
-  /** Static MQTT password. Stored encrypted; resolved before construction. */
+  /**
+   * Static MQTT password.
+   *
+   * Stored as plaintext in the source's `config` blob, like `mqtt_broker`'s
+   * `auth.password` — there is no encryption layer for source config. It is
+   * kept out of non-admin API responses by `stripSourceSecrets`, and preserved
+   * across an edit that leaves the field blank by `preserveSourceCredentials`.
+   */
   password?: string;
   /** Reject invalid TLS certs. Defaults true; only lower it for a local broker. */
   rejectUnauthorized?: boolean;
@@ -97,8 +103,15 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
     lastPacketAt: null,
     lastError: null,
   };
-  /** Observer keys seen this session, for the `observers` counter. */
+  /**
+   * Observer keys seen this session, for the `observers` counter.
+   *
+   * Capped: a busy regional feed can carry hundreds of distinct observers, and
+   * this is a display counter, not state anything depends on. Past the cap the
+   * count stops rising rather than growing the set without bound.
+   */
   private readonly seenObservers = new Set<string>();
+  private static readonly MAX_TRACKED_OBSERVERS = 1_000;
 
   constructor(sourceId: string, sourceName: string, config: MeshCoreMqttSourceConfig) {
     super();
@@ -110,6 +123,22 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
   async start(): Promise<void> {
     if (this.started) return;
     this.started = true;
+    try {
+      await this.openBroker();
+    } catch (err) {
+      // Roll back so a later start() can retry. Leaving `started` true after a
+      // failed connect would strand the source: never connected, and never
+      // retryable short of a process restart.
+      this.started = false;
+      this.client?.removeAllListeners();
+      this.client = null;
+      this.stats.lastError = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
+  }
+
+  /** Open and subscribe. Separated so start() can roll back cleanly on failure. */
+  private async openBroker(): Promise<void> {
 
     const topic = observerPacketsSubscription(this.config.region);
     const client = new MqttBrokerClient({
@@ -186,7 +215,10 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
 
       this.stats.accepted++;
       this.stats.lastPacketAt = Date.now();
-      if (!this.seenObservers.has(decoded.originId)) {
+      if (
+        !this.seenObservers.has(decoded.originId) &&
+        this.seenObservers.size < MeshCoreMqttManager.MAX_TRACKED_OBSERVERS
+      ) {
         this.seenObservers.add(decoded.originId);
         this.stats.observers = this.seenObservers.size;
       }
@@ -195,7 +227,7 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
       // Phase 2 routes this into the same handleOtaPacket seam the local radio
       // path uses. The event is emitted now so a consumer can be attached
       // without changing this method.
-      this.emit('ota_packet', decoded.event satisfies MeshCoreBridgeOtaPacket);
+      this.emit('ota_packet', decoded.event);
     } catch (err) {
       this.stats.rejected++;
       logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to handle message:`, err);

--- a/src/server/routes/meshcoreRouteShared.mqttIngest.test.ts
+++ b/src/server/routes/meshcoreRouteShared.mqttIngest.test.ts
@@ -1,0 +1,87 @@
+/**
+ * `meshcoreRouteGuard` behaviour for a MeshCore MQTT ingest source (#5040).
+ *
+ * The whole `/api/sources/:id/meshcore/*` router is device surface — connection
+ * lifecycle, local-node status, contacts, advert, remote admin. A
+ * `meshcore_mqtt` source has no device, so the guard must refuse it rather than
+ * let a handler call `getLocalNode()` and render an empty device page.
+ *
+ * That refusal is already structural: the guard narrows with
+ * `isMeshCoreManager()`, which excludes `meshcore_mqtt` by construction. These
+ * tests pin that behaviour so a future predicate change can't silently open the
+ * device routes to a radio-less source, and check the message actually says
+ * what happened.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+
+const managers = new Map<string, { sourceId: string; sourceType: string }>();
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    getManager: (id: string) => managers.get(id),
+  },
+}));
+
+import { meshcoreRouteGuard } from './meshcoreRouteShared.js';
+
+function runGuard(sourceId: string | undefined) {
+  const req = { params: sourceId === undefined ? {} : { id: sourceId } } as unknown as Request;
+  const json = vi.fn();
+  const status = vi.fn(() => ({ json }));
+  const res = { status, locals: {} } as unknown as Response;
+  const next = vi.fn() as unknown as NextFunction;
+  meshcoreRouteGuard(req, res, next);
+  return { status, json, next, res };
+}
+
+beforeEach(() => {
+  managers.clear();
+});
+
+describe('meshcoreRouteGuard — MeshCore MQTT ingest sources (#5040)', () => {
+  it('refuses a meshcore_mqtt source: these routes need a device', () => {
+    managers.set('src-mqtt', { sourceId: 'src-mqtt', sourceType: 'meshcore_mqtt' });
+    const { status, json, next } = runGuard('src-mqtt');
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+  });
+
+  it('says the source is an MQTT ingest source rather than claiming none exists', () => {
+    // The manager IS registered — reporting "No MeshCore manager" would send an
+    // operator hunting for a registration bug that isn't there.
+    managers.set('src-mqtt', { sourceId: 'src-mqtt', sourceType: 'meshcore_mqtt' });
+    const { json } = runGuard('src-mqtt');
+
+    const body = json.mock.calls[0][0] as { error: string };
+    expect(body.error).toMatch(/MQTT ingest source/i);
+    expect(body.error).toMatch(/no device/i);
+    expect(body.error).not.toMatch(/No MeshCore manager/i);
+  });
+
+  it('still admits a device-backed meshcore source', () => {
+    managers.set('src-device', { sourceId: 'src-device', sourceType: 'meshcore' });
+    const { status, next, res } = runGuard('src-device');
+
+    expect(next).toHaveBeenCalled();
+    expect(status).not.toHaveBeenCalled();
+    expect((res.locals as Record<string, unknown>).meshcoreManager).toBeDefined();
+  });
+
+  it('keeps the original message for a genuinely unregistered source', () => {
+    const { json } = runGuard('src-missing');
+    const body = json.mock.calls[0][0] as { error: string };
+    expect(body.error).toMatch(/No MeshCore manager/i);
+  });
+
+  it('keeps the original message for a non-MeshCore source type', () => {
+    managers.set('src-tcp', { sourceId: 'src-tcp', sourceType: 'meshtastic_tcp' });
+    const { json } = runGuard('src-tcp');
+    const body = json.mock.calls[0][0] as { error: string };
+    expect(body.error).toMatch(/No MeshCore manager/i);
+  });
+});

--- a/src/server/routes/meshcoreRouteShared.ts
+++ b/src/server/routes/meshcoreRouteShared.ts
@@ -15,7 +15,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { MeshCoreManager } from '../meshcoreManager.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
-import { isMeshCoreManager } from '../sourceManagerTypes.js';
+import { isMeshCoreManager, isMeshCoreMqttManager } from '../sourceManagerTypes.js';
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { fail } from '../utils/apiResponse.js';
@@ -55,9 +55,18 @@ export function meshcoreRouteGuard(req: Request, res: Response, next: NextFuncti
   }
   const _guardMgr = sourceManagerRegistry.getManager(sourceId);
   if (!_guardMgr || !isMeshCoreManager(_guardMgr)) {
+    // A `meshcore_mqtt` source (#5040) IS MeshCore, but has no device — it
+    // ingests from an analyzer broker. `isMeshCoreManager` excludes it by
+    // construction, which is what we want for this whole router (it is all
+    // device lifecycle, local-node status and advert). Say so specifically
+    // rather than claiming no MeshCore manager exists, which would send an
+    // operator hunting for a registration bug that isn't there.
+    const isMqttIngest = _guardMgr !== undefined && isMeshCoreMqttManager(_guardMgr);
     return res.status(404).json({
       success: false,
-      error: `No MeshCore manager for source ${sourceId}`,
+      error: isMqttIngest
+        ? `Source ${sourceId} is a MeshCore MQTT ingest source and has no device — these routes require a Companion or Repeater`
+        : `No MeshCore manager for source ${sourceId}`,
     });
   }
   // Cache the narrowed manager so managerFor() can avoid a second registry lookup.

--- a/src/server/routes/sourceRoutes.credentials.test.ts
+++ b/src/server/routes/sourceRoutes.credentials.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `preserveSourceCredentials` — the "leave blank to keep existing" contract.
+ *
+ * A source's `config` is REPLACED wholesale on update, so any credential the
+ * edit form does not resend is gone unless this function carries it forward. A
+ * missing branch is silently data-destructive: the save succeeds, the UI says
+ * nothing, and the broker starts failing auth on the next reconnect.
+ *
+ * `meshcore_mqtt` (#5040) was exactly that bug — the fieldset told the user
+ * "leave blank to keep existing" while the server had no branch for it.
+ */
+import { describe, it, expect } from 'vitest';
+import { preserveSourceCredentials } from './sourceRoutes.js';
+
+describe('preserveSourceCredentials — meshcore_mqtt (#5040)', () => {
+  const existing = { brokerUrl: 'wss://b.example', region: 'MCO', password: 'stored-secret' };
+
+  it('carries the stored password forward when the field is OMITTED', () => {
+    // The edit form omits a blank password rather than sending '', so absence
+    // is the case that actually happens in the UI.
+    const merged = preserveSourceCredentials('meshcore_mqtt', existing, {
+      brokerUrl: 'wss://b.example',
+      region: 'MCO',
+    });
+    expect(merged.password).toBe('stored-secret');
+  });
+
+  it("carries it forward when the field is sent as ''", () => {
+    const merged = preserveSourceCredentials('meshcore_mqtt', existing, {
+      brokerUrl: 'wss://b.example',
+      region: 'MCO',
+      password: '',
+    });
+    expect(merged.password).toBe('stored-secret');
+  });
+
+  it('lets a genuinely new password overwrite the stored one', () => {
+    const merged = preserveSourceCredentials('meshcore_mqtt', existing, {
+      brokerUrl: 'wss://b.example',
+      region: 'MCO',
+      password: 'new-secret',
+    });
+    expect(merged.password).toBe('new-secret');
+  });
+
+  it('adds no password when there was none stored', () => {
+    const merged = preserveSourceCredentials(
+      'meshcore_mqtt',
+      { brokerUrl: 'wss://b.example', region: 'MCO' },
+      { brokerUrl: 'wss://b.example', region: 'MCO' },
+    );
+    expect(merged).not.toHaveProperty('password');
+  });
+
+  it('passes non-credential fields through unchanged', () => {
+    const merged = preserveSourceCredentials('meshcore_mqtt', existing, {
+      brokerUrl: 'wss://other.example',
+      region: 'AMS',
+      autoConnect: false,
+    });
+    expect(merged).toMatchObject({
+      brokerUrl: 'wss://other.example',
+      region: 'AMS',
+      autoConnect: false,
+      password: 'stored-secret',
+    });
+  });
+});
+
+describe('preserveSourceCredentials — existing types still behave', () => {
+  it('keeps a nested mqtt_broker auth.password', () => {
+    const merged = preserveSourceCredentials(
+      'mqtt_broker',
+      { auth: { username: 'u', password: 'stored' } },
+      { auth: { username: 'u', password: '' } },
+    );
+    expect((merged.auth as { password: string }).password).toBe('stored');
+  });
+
+  it('keeps a nested mqtt_bridge upstream.password', () => {
+    const merged = preserveSourceCredentials(
+      'mqtt_bridge',
+      { upstream: { host: 'h', password: 'stored' } },
+      { upstream: { host: 'h', password: '' } },
+    );
+    expect((merged.upstream as { password: string }).password).toBe('stored');
+  });
+
+  it('does not invent a password for a type that has none', () => {
+    const merged = preserveSourceCredentials('meshtastic_tcp', { host: 'h' }, { host: 'h2' });
+    expect(merged).toEqual({ host: 'h2' });
+  });
+});

--- a/src/server/routes/sourceRoutes.meshcoreMqttCreate.test.ts
+++ b/src/server/routes/sourceRoutes.meshcoreMqttCreate.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Source creation rules for `meshcore_mqtt` (#5040 Phase 1).
+ *
+ * Uses `createRouteTestApp()` per CLAUDE.md — real session + auth middleware
+ * against the singleton's in-memory SQLite, so the assertions run through the
+ * genuine route rather than a re-implementation of it.
+ *
+ * Covers the two structural validations and the duplicate-feed guard. The
+ * duplicate guard matters more here than the analogous host:port one for
+ * `meshtastic_tcp`: two sources reading the same brokerUrl+region would ingest
+ * every packet twice, and the per-observer dedup is scoped per source, so
+ * nothing downstream would collapse them.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import sourceRoutes from './sourceRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    getManager: vi.fn().mockReturnValue(null),
+    addManager: vi.fn().mockResolvedValue(undefined),
+    startManager: vi.fn(),
+    stopManager: vi.fn(),
+  },
+}));
+
+vi.mock('../meshtasticManager.js', () => ({
+  MeshtasticManager: vi.fn().mockImplementation(() => ({ start: vi.fn(), stop: vi.fn() })),
+}));
+
+// The manager must never open a real socket during a route test.
+const managerStart = vi.fn().mockResolvedValue(undefined);
+vi.mock('../meshcoreMqttManager.js', () => ({
+  MeshCoreMqttManager: vi.fn().mockImplementation(() => ({
+    start: managerStart,
+    stop: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+describe('POST /sources — meshcore_mqtt (#5040)', () => {
+  let harness: RouteTestHarness;
+
+  // Sources created through the route persist for the life of the harness DB,
+  // so each test gets its own broker host — otherwise a later test's FIRST
+  // create trips the duplicate guard left behind by an earlier one.
+  let feed = 0;
+  const body = (over: Record<string, unknown> = {}) => ({
+    name: `Region Feed ${feed}`,
+    type: 'meshcore_mqtt',
+    config: { brokerUrl: `wss://mqtt-${feed}.example:443`, region: 'MCO', ...over },
+  });
+
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    feed += 1;
+    harness = await createRouteTestApp({ mount: (app) => app.use('/', sourceRoutes) });
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  async function adminAgent() {
+    return harness.loginAs(harness.admin);
+  }
+
+  it('creates a source with a broker URL and region', async () => {
+    const agent = await adminAgent();
+    const res = await agent.post('/').send(body());
+    expect(res.status).toBe(201);
+    expect(res.body.type).toBe('meshcore_mqtt');
+  });
+
+  it('rejects a missing brokerUrl', async () => {
+    const agent = await adminAgent();
+    const res = await agent.post('/').send({
+      name: 'No Broker',
+      type: 'meshcore_mqtt',
+      config: { region: 'MCO' },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/brokerUrl/i);
+  });
+
+  it('rejects a missing region — the topic filter is built from it', async () => {
+    const agent = await adminAgent();
+    const res = await agent.post('/').send({
+      name: 'No Region',
+      type: 'meshcore_mqtt',
+      config: { brokerUrl: 'wss://mqtt.example:443' },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/region/i);
+  });
+
+  it('refuses a second source on the same broker and region', async () => {
+    const agent = await adminAgent();
+    expect((await agent.post('/').send(body())).status).toBe(201);
+
+    const dup = await agent.post('/').send(body());
+    expect(dup.status).toBe(409);
+    expect(dup.body.error).toMatch(/already reads/i);
+  });
+
+  it('treats region as case-insensitive when detecting a duplicate', async () => {
+    // The form upper-cases on save, but the API accepts either — a lower-case
+    // duplicate must not slip past the guard and double-count the feed.
+    const agent = await adminAgent();
+    expect((await agent.post('/').send(body())).status).toBe(201);
+
+    const dup = await agent.post('/').send(body({ region: 'mco' }));
+    expect(dup.status).toBe(409);
+  });
+
+  it('allows the same broker for a DIFFERENT region', async () => {
+    const agent = await adminAgent();
+    expect((await agent.post('/').send(body())).status).toBe(201);
+
+    const other = await agent.post('/').send(body({ region: 'AMS' }));
+    expect(other.status).toBe(201);
+  });
+
+  it('allows a different broker for the same region', async () => {
+    const agent = await adminAgent();
+    expect((await agent.post('/').send(body())).status).toBe(201);
+
+    const other = await agent.post('/').send(body({ brokerUrl: `wss://other-${feed}.example:443` }));
+    expect(other.status).toBe(201);
+  });
+});

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -805,8 +805,20 @@ router.post('/', requirePermission('sources', 'write'), async (req: Request, res
     if (!name || typeof name !== 'string') {
       return res.status(400).json({ error: 'name is required and must be a string' });
     }
-    if (!['meshtastic_tcp', 'mqtt_broker', 'mqtt_bridge', 'meshcore', 'reticulum'].includes(type)) {
-      return res.status(400).json({ error: 'type must be meshtastic_tcp, mqtt_broker, mqtt_bridge, meshcore, or reticulum' });
+    if (!['meshtastic_tcp', 'mqtt_broker', 'mqtt_bridge', 'meshcore', 'meshcore_mqtt', 'reticulum'].includes(type)) {
+      return res.status(400).json({ error: 'type must be meshtastic_tcp, mqtt_broker, mqtt_bridge, meshcore, meshcore_mqtt, or reticulum' });
+    }
+
+    // meshcore_mqtt (#5040) ingests from an Analyzer Observer broker and has no
+    // radio. Both fields are structural — the topic filter is built from the
+    // region, so a source without one would subscribe to nothing.
+    if (type === 'meshcore_mqtt') {
+      if (typeof config?.brokerUrl !== 'string' || config.brokerUrl.trim() === '') {
+        return res.status(400).json({ error: 'brokerUrl is required for a meshcore_mqtt source' });
+      }
+      if (typeof config?.region !== 'string' || config.region.trim() === '') {
+        return res.status(400).json({ error: 'region is required for a meshcore_mqtt source' });
+      }
     }
 
     // mqtt_bridge may optionally attach to a parent mqtt_broker. When

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -913,6 +913,28 @@ router.post('/', requirePermission('sources', 'write'), async (req: Request, res
       }
     }
 
+    // Same guard as host:port above, for the analyzer feed (#5040). Two sources
+    // on the same brokerUrl+region would ingest every packet twice, and the
+    // per-observer dedup is scoped per source, so nothing downstream would
+    // collapse them — the duplicate would silently double every count.
+    if (type === 'meshcore_mqtt' && config.brokerUrl && config.region) {
+      const region = String(config.region).trim().toUpperCase();
+      const existing = await databaseService.sources.getAllSources();
+      const duplicate = existing.find((s) => {
+        if (s.type !== 'meshcore_mqtt') return false;
+        const cfg = s.config as { brokerUrl?: unknown; region?: unknown };
+        return (
+          cfg?.brokerUrl === config.brokerUrl &&
+          String(cfg?.region ?? '').trim().toUpperCase() === region
+        );
+      });
+      if (duplicate) {
+        return res.status(409).json({
+          error: `A source already reads ${config.brokerUrl} for region ${region} ("${duplicate.name}")`,
+        });
+      }
+    }
+
     const source = await databaseService.sources.createSource({
       id: uuidv4(),
       name: name.trim(),

--- a/src/server/routes/sourceRoutes.ts
+++ b/src/server/routes/sourceRoutes.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import databaseService from '../../services/database.js';
 import { requirePermission, optionalAuth } from '../auth/authMiddleware.js';
+import { MeshCoreMqttManager, type MeshCoreMqttSourceConfig } from '../meshcoreMqttManager.js';
 import { logger } from '../../utils/logger.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { MeshtasticManager } from '../meshtasticManager.js';
@@ -549,7 +550,10 @@ function validateMqttBridgeRewrites(config: Record<string, any>): string | null 
 // the stored value. Without this merge, editing an unrelated field (e.g.
 // the geofence bounding box) writes back a config with no password and
 // wipes the saved credential.
-function preserveSourceCredentials(
+// Exported for direct unit testing: a missing branch here silently WIPES a
+// stored credential on the next save, which is invisible in a route-level test
+// unless you assert on the persisted config. See sourceRoutes.credentials.test.ts.
+export function preserveSourceCredentials(
   type: string,
   existingConfig: Record<string, unknown> | undefined,
   incomingConfig: Record<string, unknown>,
@@ -574,6 +578,19 @@ function preserveSourceCredentials(
       (incomingUpstream.password === undefined || incomingUpstream.password === '')
     ) {
       merged.upstream = { ...incomingUpstream, password: existingUpstream.password };
+    }
+  } else if (type === 'meshcore_mqtt') {
+    // Top-level `password` rather than a nested auth block (#5040). The edit
+    // form OMITS the field when left blank rather than sending '', so check for
+    // absence as well as empty string — without this the whole config object is
+    // replaced and the stored credential is silently dropped on every save.
+    const existingPassword = (existingConfig as { password?: unknown } | undefined)?.password;
+    const incomingPassword = (incomingConfig as { password?: unknown }).password;
+    if (
+      typeof existingPassword === 'string' && existingPassword !== '' &&
+      (incomingPassword === undefined || incomingPassword === '')
+    ) {
+      merged.password = existingPassword;
     }
   }
   return merged;
@@ -953,6 +970,20 @@ router.post('/', requirePermission('sources', 'write'), async (req: Request, res
         }
       } catch (err) {
         logger.warn(`Could not start Reticulum manager for new source ${source.id}:`, err);
+      }
+    } else if (source.enabled && source.type === 'meshcore_mqtt' && cfgForStart?.autoConnect !== false) {
+      // Without this the source is persisted but never started until the next
+      // restart — the dashboard would report success and then simply do nothing.
+      try {
+        if (cfgForStart?.brokerUrl && cfgForStart?.region) {
+          const manager = new MeshCoreMqttManager(source.id, source.name, cfgForStart as MeshCoreMqttSourceConfig);
+          await sourceManagerRegistry.addManager(manager);
+          await manager.start();
+        } else {
+          logger.warn(`MeshCore MQTT source ${source.id} created with incomplete config`);
+        }
+      } catch (err) {
+        logger.warn(`Could not start MeshCore MQTT manager for new source ${source.id}:`, err);
       }
     } else if (source.enabled && (source.type === 'mqtt_broker' || source.type === 'mqtt_bridge')) {
       try {

--- a/src/server/services/meshcoreMqttIngestPacket.test.ts
+++ b/src/server/services/meshcoreMqttIngestPacket.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Decoder tests for the MeshCore MQTT ingest path (#5040 Phase 1).
+ *
+ * The centrepiece is the **round-trip against the real encoder**: build an
+ * observer wire payload with `buildObserverPacketPayload()` — the function that
+ * actually publishes — then decode it back and assert the structural fields
+ * survive. That is what locks the two halves together; a golden fixture would
+ * only pin the decoder to a snapshot of the decoder's own behaviour and would
+ * not notice the encoder drifting away from it.
+ *
+ * Frame builder mirrors `meshcoreObserverPacket.test.ts`'s (real wire-format
+ * header bit-packing, not the native-backend test mock).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildObserverPacketPayload,
+  parseObserverFrame,
+  type ObserverPacketIdentity,
+} from './meshcoreObserverPacket.js';
+import {
+  decodeObserverPacketMessage,
+  observerPacketsSubscription,
+  observerStatusSubscription,
+  observerKeyFromTopic,
+} from './meshcoreMqttIngestPacket.js';
+import type { OtaPacketEvent } from '../meshcoreVirtualNodeServer.js';
+
+class Builder {
+  private parts: number[] = [];
+  u8(v: number) {
+    this.parts.push(v & 0xff);
+    return this;
+  }
+  bytes(arr: number[]) {
+    this.parts.push(...arr.map((x) => x & 0xff));
+    return this;
+  }
+  fill(n: number, v = 0) {
+    for (let i = 0; i < n; i++) this.parts.push(v & 0xff);
+    return this;
+  }
+  hex(): string {
+    return this.parts.map((b) => b.toString(16).padStart(2, '0')).join('');
+  }
+}
+
+const header = (route: number, payload: number, version = 0) =>
+  ((version & 0x03) << 6) | ((payload & 0x0f) << 2) | (route & 0x03);
+
+const IDENTITY: ObserverPacketIdentity = {
+  origin: 'TestObserver',
+  originId: 'AB'.repeat(32),
+};
+
+/** A FLOOD frame with no path hops and a short payload. */
+function floodFrame(payloadType = 0x01): string {
+  return new Builder()
+    .u8(header(0x01, payloadType))
+    .u8(0x00) // path_len = 0
+    .bytes([0xde, 0xad, 0xbe, 0xef])
+    .hex();
+}
+
+/** A DIRECT frame carrying `hops` one-byte relay hashes. */
+function directFrame(hops: number[], payloadType = 0x02): string {
+  return new Builder()
+    .u8(header(0x02, payloadType))
+    .u8(hops.length) // packed path_len: hashSize=1, hopCount=n
+    .bytes(hops)
+    .bytes([0x11, 0x22, 0x33])
+    .hex();
+}
+
+function toEvent(rawHex: string, snr?: number | null, rssi?: number | null): OtaPacketEvent {
+  return { raw_hex: rawHex, snr, rssi };
+}
+
+describe('decodeObserverPacketMessage — round-trip against the real encoder', () => {
+  it('recovers the structural fields of a flood frame', () => {
+    const raw = floodFrame();
+    const wire = buildObserverPacketPayload(toEvent(raw, -8.75, -101), IDENTITY);
+    expect(wire).not.toBeNull();
+
+    const decoded = decodeObserverPacketMessage(wire);
+    expect(decoded).not.toBeNull();
+
+    const expected = parseObserverFrame(raw);
+    expect(decoded!.event.payload_type).toBe(expected.payloadType);
+    expect(decoded!.event.route_type).toBe(expected.routeType);
+    expect(decoded!.event.hop_count).toBe(expected.hopCount);
+    expect(decoded!.event.path_hops).toEqual(expected.hops);
+    expect(decoded!.event.payload_size).toBe(expected.totalBytes);
+    expect(decoded!.event.raw_hex).toBe(raw.toLowerCase());
+    expect(decoded!.event.snr).toBe(-8.75);
+    expect(decoded!.event.rssi).toBe(-101);
+  });
+
+  it('recovers the per-hop relay hashes of a direct frame', () => {
+    const raw = directFrame([0xa1, 0xb2, 0xc3]);
+    const wire = buildObserverPacketPayload(toEvent(raw, -4.5, -90), IDENTITY);
+    const decoded = decodeObserverPacketMessage(wire);
+
+    expect(decoded).not.toBeNull();
+    expect(decoded!.event.hop_count).toBe(3);
+    expect(decoded!.event.path_hops).toEqual(['a1', 'b2', 'c3']);
+  });
+
+  it('carries the publishing observer identity through', () => {
+    const wire = buildObserverPacketPayload(toEvent(floodFrame()), IDENTITY);
+    const decoded = decodeObserverPacketMessage(wire);
+
+    expect(decoded!.origin).toBe('TestObserver');
+    expect(decoded!.originId).toBe('AB'.repeat(32));
+    expect(decoded!.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('populates the enum name strings the packet monitor stores', () => {
+    // handleOtaPacket reads payload_type_string / route_type_string; producing
+    // only the narrow OtaPacketEvent would leave these null on every MQTT row.
+    const decoded = decodeObserverPacketMessage(
+      buildObserverPacketPayload(toEvent(floodFrame()), IDENTITY),
+    );
+    expect(typeof decoded!.event.payload_type_string === 'string' || decoded!.event.payload_type_string === null).toBe(true);
+    expect(typeof decoded!.event.route_type_string === 'string' || decoded!.event.route_type_string === null).toBe(true);
+  });
+});
+
+describe('decodeObserverPacketMessage — `raw` is the sole source of truth', () => {
+  it('ignores a wire len/payload_len that disagrees with the frame', () => {
+    const raw = directFrame([0xa1, 0xb2]);
+    const wire = { ...buildObserverPacketPayload(toEvent(raw), IDENTITY)! };
+    // A buggy third-party publisher claiming nonsense lengths.
+    wire.len = '9999';
+    wire.payload_len = '4242';
+    wire.path = 'ff,ff,ff,ff';
+
+    const decoded = decodeObserverPacketMessage(wire);
+    const expected = parseObserverFrame(raw);
+    expect(decoded!.event.payload_size).toBe(expected.totalBytes);
+    expect(decoded!.event.hop_count).toBe(2);
+    expect(decoded!.event.path_hops).toEqual(['a1', 'b2']);
+  });
+
+  it('rejects a frame that will not structurally parse', () => {
+    expect(decodeObserverPacketMessage({ type: 'PACKET', raw: 'ff', origin_id: 'AB'.repeat(32) })).toBeNull();
+  });
+
+  it('rejects a message with no raw at all', () => {
+    expect(decodeObserverPacketMessage({ type: 'PACKET', origin_id: 'AB'.repeat(32) })).toBeNull();
+  });
+});
+
+describe('decodeObserverPacketMessage — hostile and malformed input', () => {
+  it('returns null rather than throwing for non-objects', () => {
+    for (const bad of [null, undefined, 42, 'PACKET', [], true]) {
+      expect(decodeObserverPacketMessage(bad)).toBeNull();
+    }
+  });
+
+  it('skips status messages sharing the topic prefix', () => {
+    expect(decodeObserverPacketMessage({ status: 'online', origin_id: 'AB'.repeat(32) })).toBeNull();
+  });
+
+  it('rejects a missing or malformed origin_id, which per-observer attribution needs', () => {
+    const raw = floodFrame();
+    expect(decodeObserverPacketMessage({ type: 'PACKET', raw })).toBeNull();
+    expect(decodeObserverPacketMessage({ type: 'PACKET', raw, origin_id: 'nothex' })).toBeNull();
+    expect(decodeObserverPacketMessage({ type: 'PACKET', raw, origin_id: 'AB'.repeat(31) })).toBeNull();
+  });
+
+  it('normalises origin_id to upper case', () => {
+    const decoded = decodeObserverPacketMessage({
+      type: 'PACKET',
+      raw: floodFrame(),
+      origin_id: 'ab'.repeat(32),
+    });
+    expect(decoded!.originId).toBe('AB'.repeat(32));
+  });
+});
+
+describe('decodeObserverPacketMessage — measurements', () => {
+  const base = (extra: Record<string, unknown>) => ({
+    type: 'PACKET',
+    raw: floodFrame(),
+    origin_id: 'AB'.repeat(32),
+    ...extra,
+  });
+
+  it('reads the contract string numerics', () => {
+    const d = decodeObserverPacketMessage(base({ SNR: '-8.75', RSSI: '-101' }));
+    expect(d!.event.snr).toBe(-8.75);
+    expect(d!.event.rssi).toBe(-101);
+  });
+
+  it('tolerates JSON numbers from third-party publishers', () => {
+    const d = decodeObserverPacketMessage(base({ SNR: -6, RSSI: -90 }));
+    expect(d!.event.snr).toBe(-6);
+    expect(d!.event.rssi).toBe(-90);
+  });
+
+  it("treats the encoder's 'Unknown' sentinel as absent, not as a reading", () => {
+    const d = decodeObserverPacketMessage(base({ SNR: 'Unknown', RSSI: 'Unknown' }));
+    expect(d!.event.snr).toBeUndefined();
+    expect(d!.event.rssi).toBeUndefined();
+  });
+
+  it('drops implausible values rather than storing them as real measurements', () => {
+    const d = decodeObserverPacketMessage(base({ SNR: '9999', RSSI: '9999' }));
+    expect(d!.event.snr).toBeUndefined();
+    expect(d!.event.rssi).toBeUndefined();
+  });
+
+  it('keeps a genuine 0 reading', () => {
+    const d = decodeObserverPacketMessage(base({ SNR: '0', RSSI: '0' }));
+    expect(d!.event.snr).toBe(0);
+    expect(d!.event.rssi).toBe(0);
+  });
+});
+
+describe('topic helpers', () => {
+  it('subscribes with a wildcard across every observer in the region', () => {
+    expect(observerPacketsSubscription('mco')).toBe('meshcore/MCO/+/packets');
+    expect(observerStatusSubscription(' mco ')).toBe('meshcore/MCO/+/status');
+  });
+
+  it('extracts the publishing key from a received topic', () => {
+    const key = 'AB'.repeat(32);
+    expect(observerKeyFromTopic(`meshcore/MCO/${key}/packets`)).toBe(key);
+    expect(observerKeyFromTopic(`meshcore/MCO/${key.toLowerCase()}/status`)).toBe(key);
+  });
+
+  it('returns null for topics outside the contract shape', () => {
+    expect(observerKeyFromTopic('meshcore/MCO/nothex/packets')).toBeNull();
+    expect(observerKeyFromTopic('meshcore/MCO/packets')).toBeNull();
+    expect(observerKeyFromTopic(`other/MCO/${'AB'.repeat(32)}/packets`)).toBeNull();
+    expect(observerKeyFromTopic(`meshcore/MCO/${'AB'.repeat(32)}/other`)).toBeNull();
+  });
+
+  it('lets the caller cross-check a spoofed body against the topic it arrived on', () => {
+    // A publisher claiming someone else's identity in the body: topic key and
+    // body origin_id disagree, and the manager drops it on that basis.
+    const topicKey = observerKeyFromTopic(`meshcore/MCO/${'AB'.repeat(32)}/packets`);
+    const decoded = decodeObserverPacketMessage({
+      type: 'PACKET',
+      raw: floodFrame(),
+      origin_id: 'CD'.repeat(32),
+    });
+    expect(decoded!.originId).not.toBe(topicKey);
+  });
+});

--- a/src/server/services/meshcoreMqttIngestPacket.ts
+++ b/src/server/services/meshcoreMqttIngestPacket.ts
@@ -1,0 +1,242 @@
+/**
+ * meshcoreMqttIngestPacket
+ *
+ * Pure, dependency-free DECODER for the MeshCore Analyzer Observer MQTT wire
+ * contract — the exact mirror of `meshcoreObserverPacket.ts`'s encoder
+ * (issue #5040 Phase 1).
+ *
+ * `meshcoreObserverPacket.ts` turns a local `OtaPacketEvent` into the JSON an
+ * analyzer broker expects on `meshcore/{REGION}/{PUBKEY}/packets`. This module
+ * does the reverse: it takes that JSON back off the wire and reconstructs the
+ * `OtaPacketEvent` shape, so an MQTT-fed source can hand packets to exactly the
+ * same manager seam the local radio path uses
+ * (`meshcoreNativeBackend.ts`'s `emitBridgeEvent('ota_packet', …)`).
+ *
+ * That symmetry is deliberate and load-bearing: everything downstream of
+ * `ota_packet` — the packet monitor, the channel-echo correlator, the Virtual
+ * Node bridge — then works for an MQTT source with no changes at all.
+ *
+ * Like the encoder, this module pulls in nothing stateful — only the shared
+ * frame parser and pure enum-name helpers — so every function here is
+ * golden-testable against fixed hex strings.
+ *
+ * ## Which shape this produces
+ *
+ * `OtaPacketEvent` (meshcoreVirtualNodeServer.ts) is the narrow *typed* contract
+ * the Virtual Node bridge consumes: `snr`, `rssi`, `raw_hex`, all optional. But
+ * the manager's packet-monitor path reads eleven fields off the untyped bridge
+ * payload (`meshcoreManager.ts:2164` `handleOtaPacket(data: any)`), including
+ * `payload_type`, `route_type`, `path_len_raw`, `hop_count`, `path_hops`,
+ * `payload_size` and the two `*_string` names.
+ *
+ * So this module emits {@link MeshCoreBridgeOtaPacket} — the full shape the
+ * native backend emits at `meshcoreNativeBackend.ts:654` — which structurally
+ * satisfies `OtaPacketEvent` as well. Producing only the narrow type would
+ * typecheck and then silently write packet-monitor rows with every structural
+ * column null.
+ *
+ * ## `raw` is the sole source of truth
+ *
+ * The encoder's own header states it: the wire payload's `len` / `payload_len`
+ * describe the WHOLE FRAME and the payload respectively, but neither is trusted
+ * here. Every structural field — payload type, route type, path length, hop
+ * count, hop hashes — is re-derived from `raw` with `parseObserverFrame()`, the
+ * same function the encoder used to produce them. A publisher that disagrees
+ * with its own `raw` (a buggy third-party observer, or a truncated frame) is
+ * rejected rather than trusted, so a malformed feed cannot inject a packet whose
+ * metadata contradicts its bytes.
+ *
+ * `SNR` and `RSSI` are the exception — they are measurements, not derivable from
+ * the frame, so they come off the wire and are only range-checked.
+ *
+ * ## What is deliberately NOT reconstructed
+ *
+ * `payload_type_string` / `route_type_string` are omitted. On the local path
+ * those come from the device's own decoder; the wire contract's `packet_type`
+ * and `route` are lossy re-encodings (`route` collapses both flood variants to
+ * `F`, and both direct variants to `D`/`T`), so re-deriving a string from them
+ * would invent detail the feed never carried. Consumers that need a name should
+ * resolve it from the numeric `payload_type` / `route_type`.
+ */
+import { getPayloadTypeName, getRouteTypeName } from '@michaelhart/meshcore-decoder';
+import { parseObserverFrame } from './meshcoreObserverPacket.js';
+import type { OtaPacketEvent } from '../meshcoreVirtualNodeServer.js';
+
+/**
+ * The full bridge payload the native backend emits on `ota_packet`
+ * (`meshcoreNativeBackend.ts:654`), and which the manager's packet-monitor path
+ * reads. A superset of the typed {@link OtaPacketEvent}, which covers only the
+ * three fields the Virtual Node bridge needs.
+ */
+export interface MeshCoreBridgeOtaPacket extends OtaPacketEvent {
+  payload_type: number;
+  payload_type_string: string | null;
+  route_type: number;
+  route_type_string: string | null;
+  path_len_raw: number | null;
+  hop_count: number;
+  path_hops: string[];
+  snr?: number | null;
+  rssi?: number | null;
+  payload_size: number;
+  raw_hex: string;
+}
+
+/**
+ * The subset of the observer wire payload this decoder reads, after validation.
+ * Mirrors `ObserverPacketPayload`, but every field is already narrowed.
+ */
+export interface IngestedObserverPacket {
+  /** Publishing observer's node name, as it labelled itself. Never trusted for identity. */
+  origin: string;
+  /** Publishing observer's public key, UPPER 64-hex. The identity used for per-observer attribution. */
+  originId: string;
+  /** Publisher's claimed capture time, ISO-8601. Advisory only — never used as a clock. */
+  timestamp: string | null;
+  /** The reconstructed local-path event, in the full bridge shape. */
+  event: MeshCoreBridgeOtaPacket;
+}
+
+/** Plausible SNR window in dB. Outside this, the field is dropped rather than trusted. */
+const SNR_MIN_DB = -30;
+const SNR_MAX_DB = 20;
+
+/** Plausible RSSI window in dBm. */
+const RSSI_MIN_DBM = -150;
+const RSSI_MAX_DBM = 0;
+
+/** UPPER 64-hex, the observer contract's `origin_id` format. */
+const ORIGIN_ID_RE = /^[0-9a-fA-F]{64}$/;
+
+/**
+ * Numeric fields arrive as STRINGS on this contract ("every numeric is a
+ * string", per the encoder's `ObserverPacketPayload`), but tolerate a real
+ * number too — some third-party publishers emit JSON numbers. Anything else,
+ * including the encoder's literal `"Unknown"` sentinel for an absent
+ * measurement, yields null.
+ */
+function readNumeric(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed === '' || trimmed === 'Unknown') return null;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Clamp-or-drop: a measurement outside its plausible window is not a measurement. */
+function readMeasurement(value: unknown, min: number, max: number): number | undefined {
+  const n = readNumeric(value);
+  if (n === null || n < min || n > max) return undefined;
+  return n;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * Enum-name lookup that degrades to null. The decoder library throws or returns
+ * junk for a value outside its enum, and a frame from an unknown/newer firmware
+ * carrying an unrecognised payload type must still be logged with its numeric
+ * type rather than dropped for want of a display name.
+ */
+function safeEnumName(lookup: () => string): string | null {
+  try {
+    const name = lookup();
+    return typeof name === 'string' && name.length > 0 ? name : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decode one observer `packets`-topic message into the local `ota_packet`
+ * shape. Total: returns null for anything malformed rather than throwing, so a
+ * single bad message on a busy region feed can never break the stream.
+ *
+ * Rejects when: the body isn't an object; `raw` is absent or not hex;
+ * `parseObserverFrame` can't structurally parse the frame; or `origin_id` isn't
+ * the contract's 64-hex public key (without it there is no per-observer
+ * attribution, which the N-rows-deduped-at-query-time design depends on).
+ */
+export function decodeObserverPacketMessage(body: unknown): IngestedObserverPacket | null {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return null;
+  const msg = body as Record<string, unknown>;
+
+  // Status messages share the topic prefix but not this shape; skip them
+  // quietly rather than logging a parse failure per heartbeat.
+  if (msg.type !== undefined && msg.type !== 'PACKET') return null;
+
+  const rawHex = readString(msg.raw);
+  if (!rawHex) return null;
+
+  const originId = readString(msg.origin_id);
+  if (!originId || !ORIGIN_ID_RE.test(originId)) return null;
+
+  // Re-derive every structural field from `raw` — see the header note on why
+  // the wire's own len/payload_len/path are not trusted.
+  const frame = parseObserverFrame(rawHex);
+  if (!frame.ok) return null;
+
+  const event: MeshCoreBridgeOtaPacket = {
+    payload_type: frame.payloadType,
+    // Names come from the numeric enums, not from the wire. The contract's
+    // `packet_type` / `route` are lossy re-encodings (`route` collapses both
+    // flood variants to "F"), so re-reading them would lose detail that
+    // `raw` still carries. `getPayloadTypeName` / `getRouteTypeName` are pure
+    // lookups over the same enums the local decoder uses.
+    payload_type_string: safeEnumName(() => getPayloadTypeName(frame.payloadType)),
+    route_type: frame.routeType,
+    route_type_string: safeEnumName(() => getRouteTypeName(frame.routeType)),
+    path_len_raw: frame.pathLenRaw,
+    hop_count: frame.hopCount,
+    path_hops: frame.hops,
+    snr: readMeasurement(msg.SNR, SNR_MIN_DB, SNR_MAX_DB),
+    rssi: readMeasurement(msg.RSSI, RSSI_MIN_DBM, RSSI_MAX_DBM),
+    // The frame parser's own byte count, not the wire's `len` — see the header.
+    payload_size: frame.totalBytes,
+    raw_hex: rawHex.replace(/[^0-9a-fA-F]/g, '').toLowerCase(),
+  };
+
+  return {
+    origin: readString(msg.origin) ?? '',
+    originId: originId.toUpperCase(),
+    timestamp: readString(msg.timestamp),
+    event,
+  };
+}
+
+/**
+ * Build the subscribe filter for a region.
+ *
+ * Mirrors `observerTopics()` on the publish side, with a `+` wildcard in the
+ * public-key segment so one subscription covers every observer publishing to
+ * that region. Region is uppercased to match what the publisher writes.
+ */
+export function observerPacketsSubscription(region: string): string {
+  return `meshcore/${region.trim().toUpperCase()}/+/packets`;
+}
+
+/** Same, for the status topic consumed in a later phase. */
+export function observerStatusSubscription(region: string): string {
+  return `meshcore/${region.trim().toUpperCase()}/+/status`;
+}
+
+/**
+ * Pull the publishing observer's public key out of a received topic.
+ *
+ * The message body carries `origin_id` too, and that is what
+ * {@link decodeObserverPacketMessage} uses. This exists to CROSS-CHECK the two:
+ * a publisher whose body claims a different key than the topic it published on
+ * is either buggy or spoofing another observer's identity, and the caller drops
+ * it. Returns null when the topic doesn't match the expected shape.
+ */
+export function observerKeyFromTopic(topic: string): string | null {
+  const parts = topic.split('/');
+  if (parts.length !== 4) return null;
+  if (parts[0] !== 'meshcore') return null;
+  if (parts[3] !== 'packets' && parts[3] !== 'status') return null;
+  const key = parts[2];
+  return ORIGIN_ID_RE.test(key) ? key.toUpperCase() : null;
+}

--- a/src/server/services/meshcoreMqttIngestPacket.ts
+++ b/src/server/services/meshcoreMqttIngestPacket.ts
@@ -49,14 +49,17 @@
  * `SNR` and `RSSI` are the exception — they are measurements, not derivable from
  * the frame, so they come off the wire and are only range-checked.
  *
- * ## What is deliberately NOT reconstructed
+ * ## Where the enum name strings come from
  *
- * `payload_type_string` / `route_type_string` are omitted. On the local path
- * those come from the device's own decoder; the wire contract's `packet_type`
- * and `route` are lossy re-encodings (`route` collapses both flood variants to
- * `F`, and both direct variants to `D`/`T`), so re-deriving a string from them
- * would invent detail the feed never carried. Consumers that need a name should
- * resolve it from the numeric `payload_type` / `route_type`.
+ * `payload_type_string` / `route_type_string` are derived from the NUMERIC
+ * enums via the decoder library's pure name lookups — never from the wire's
+ * `packet_type` / `route`, which are lossy re-encodings (`route` collapses both
+ * flood variants to `F`, and both direct variants to `D`/`T`). Reading the wire
+ * strings would discard detail that `raw` still carries.
+ *
+ * They are populated rather than left null because the packet monitor stores
+ * both (`meshcoreManager.ts` `handleOtaPacket`), and a column of nulls on every
+ * MQTT-sourced row would be a visible regression against the local path.
  */
 import { getPayloadTypeName, getRouteTypeName } from '@michaelhart/meshcore-decoder';
 import { parseObserverFrame } from './meshcoreObserverPacket.js';

--- a/src/server/sourceManagerTypes.ts
+++ b/src/server/sourceManagerTypes.ts
@@ -23,15 +23,53 @@
 
 import type { ISourceManager, SourceManagerRegistry } from './sourceManagerRegistry.js';
 import type { MeshCoreManager } from './meshcoreManager.js';
+import type { MeshCoreMqttManager } from './meshcoreMqttManager.js';
 import type { MeshtasticManager } from './meshtasticManager.js';
 import type { ReticulumManager } from './reticulumManager.js';
 
 /**
- * Narrows an ISourceManager to MeshCoreManager.
+ * Narrows an ISourceManager to a **device-backed** MeshCoreManager.
+ *
+ * Note the "device-backed": `meshcore_mqtt` sources (#5040) are MeshCore too,
+ * but have no radio, so this predicate deliberately excludes them. Every caller
+ * that drives the device — the neighbours / remote-telemetry / room-sync /
+ * telemetry-poll / time-sync schedulers, the config and device routes — wants
+ * exactly this narrowing, and gets the exclusion for free.
+ *
+ * For a surface that should see MeshCore data regardless of where it came from
+ * (node lists, automation triggers, notification services), use
+ * {@link isAnyMeshCoreManager} instead. Picking the wrong one is the likely bug:
+ * this predicate silently skips MQTT sources, which reads as "the feature just
+ * doesn't work for that source" rather than as an error.
+ *
  * Predicate is based on the sourceType discriminant — no instanceof, no import cycles.
  */
 export function isMeshCoreManager(m: ISourceManager): m is MeshCoreManager {
   return m.sourceType === 'meshcore';
+}
+
+/**
+ * Narrows an ISourceManager to the MQTT-fed MeshCore ingest manager (#5040).
+ *
+ * This source has no device: it subscribes to an analyzer broker and replays
+ * what other observers heard. It can never transmit.
+ */
+export function isMeshCoreMqttManager(m: ISourceManager): m is MeshCoreMqttManager {
+  return m.sourceType === 'meshcore_mqtt';
+}
+
+/**
+ * True for any MeshCore source, device-backed or MQTT-fed.
+ *
+ * Use this for read/consume surfaces — node lists, automation triggers,
+ * notification and analysis services — where "which transport delivered it"
+ * is not the question being asked. Use {@link isMeshCoreManager} when the code
+ * is going to talk to a radio.
+ */
+export function isAnyMeshCoreManager(
+  m: ISourceManager,
+): m is MeshCoreManager | MeshCoreMqttManager {
+  return isMeshCoreManager(m) || isMeshCoreMqttManager(m);
 }
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -70,6 +70,14 @@ const SHARED_DB_TESTS = [
   // when run concurrently.
   'src/db/repositories/packetLog.hopArrival.multiBackend.test.ts',
   'src/db/repositories/packetLog.broadcastTelemetry.multiBackend.test.ts',
+  // MeshCore per-node config migrations (#4618 / #4899): 153 and 156 each
+  // DROP/CREATE the shared `meshcore_nodes` table against the same PG/MySQL
+  // test DB, so whichever finishes first drops it out from under the other.
+  // Confirmed empirically — each passes alone, both fail when run together,
+  // and the backend it hits varies with interleaving (MySQL only on one run,
+  // MySQL + PostgreSQL on the next). Same class as the 141-145 group above.
+  'src/server/migrations/153_meshcore_node_neighbors_config.pgmysql.test.ts',
+  'src/server/migrations/156_meshcore_node_time_sync_config.pgmysql.test.ts',
 ];
 
 const COMMON_EXCLUDE = [


### PR DESCRIPTION
Phase 1 of #5040. **Draft** — the pipe works end to end, but the source-editor UI is not in yet (see *Not in this PR*).

Adds a `meshcore_mqtt` source type that **subscribes** to a MeshCore Analyzer Observer broker — the mirror of the publish-only Analyzer Observer (#4457, #5014). Phase 1 connects, subscribes, decodes and counts; nothing is persisted yet, which is Phase 2.

## Decoder — the inverse of an encoder we already had

`meshcoreObserverPacket.ts`'s header already anticipated this work: *"safe to reuse from both the publisher service and any future consumer."* `meshcoreMqttIngestPacket.ts` is that consumer. It reconstructs the local-path `ota_packet` shape, so everything downstream of that seam — packet monitor, channel-echo correlator, Virtual Node bridge — works for an MQTT source with **no changes**.

**`raw` is the sole source of truth.** Every structural field is re-derived with `parseObserverFrame()` rather than read off the wire, so a publisher whose metadata contradicts its own bytes is rejected instead of trusted. SNR/RSSI are the exception — measurements, not derivable from the frame — and are range-checked.

Two things worth a reviewer's eye:

- It emits `MeshCoreBridgeOtaPacket`, **not** the narrow `OtaPacketEvent`. The typed event carries only `snr`/`rssi`/`raw_hex`, but `handleOtaPacket` (`meshcoreManager.ts:2164`) reads eleven fields off the untyped bridge payload. My first cut emitted the narrow type — it typechecked, and would have written Phase 2 packet-monitor rows with every structural column null.
- `payload_type_string` / `route_type_string` are derived from the numeric enums via the decoder library, not from the wire's `packet_type`/`route`, which are lossy re-encodings (`route` collapses both flood variants to `F`).

## No radio, enforced structurally

Because the predicates in `sourceManagerTypes.ts` key off the `sourceType` discriminant, giving this source its own type means `isMeshCoreManager()` — which every TX-driving scheduler and device route filters on — **excludes it by construction**. Nothing has to remember to skip it.

This corrects the design sketched in the issue, which proposed a `canTransmit` capability flag. The discriminant already does that job. The real work turned out to be the opposite direction: `isAnyMeshCoreManager()` is added for read surfaces that *should* see this source, which **inverts Phase 5.5 from an exclusion audit into an inclusion audit**.

`getLocalNode()` / `getLocalNodeInfo()` return null. That is an already-supported state — `MeshCoreManager.getLocalNodeInfo()` is itself hardcoded `: null`, and consumers already guard (`ownNodes.ts:67` uses `?.`, `unifiedRoutes.ts:1269` uses `&&`).

## One broker per source

Deliberate, per discussion on the issue. The publish side allows 8, but subscribing to overlapping regional brokers tangles with the per-observer dedup design, and one-per-source keeps *"which broker did this come from"* collapsed to *"which source"* — which is what keeps the Map Analysis and MeshIssues surfaces tractable. Add a second source for a second broker.

## Drive-by: a pre-existing test race (second commit)

Not related to this feature; found while verifying it, and fixed here so this PR's CI is honest about its own diff.

Migrations `153` and `156`'s container tests each `DROP`/`CREATE` the shared `meshcore_nodes` table against the same PG/MySQL test DB, but neither was in `SHARED_DB_TESTS` — so both ran in the parallel `unit` project and whichever finished first dropped the table out from under the other.

```
npx vitest run <153>          # passes alone (2/2)
npx vitest run <156>          # passes alone (2/2)
npx vitest run <153> <156>    # both fail — "table doesn't exist"
```

Reproduced on clean `origin/main`. Which backend fails varies with interleaving — MySQL only on one run, MySQL *and* PostgreSQL on the next; that nondeterminism across backends is the tell for a race rather than stale container state. (Recreating the container only changes timing, and can look like a fix — it briefly fooled me.) CI has stayed green because it runs `maxWorkers: 4` against a 75%-of-cores local default, not because it is immune.

The fix is the same registry addition already made five times in that file.

## Mesh impact

**Zero airtime.** Subscribe-only; this source cannot transmit, structurally.

## Testing

34 new tests (20 decoder, 14 manager). The decoder's centrepiece is a **round-trip against the real encoder** rather than golden fixtures, so encoder drift breaks the tests instead of silently desyncing the two halves. The manager tests assert the no-radio narrowing directly — if this source ever starts passing `isMeshCoreManager()`, the suite fails.

- Full Vitest suite with PostgreSQL **and** MySQL containers up: **18,510 passed, 0 failed, 0 failed suites** (122 pending).
- `tsc --noEmit` clean on both configs; `lint:ci` clean.

## Not in this PR

- The Dashboard source-editor UI — a source is creatable via the API but not yet through the dashboard.
- Auditing `meshcoreDeviceRoutes.ts` (4 `getLocalNode()` call sites) to refuse for this type rather than render an empty device page.

Both are Phase 1 scope and land before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc