### PR TITLE
feat(meshcore): MeshCore MQTT ingest — packet monitor, Phase 2 (#5040)

### DIFF
--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -172,6 +172,11 @@ import { migration as createMeshIssuesMigration, runMigration154Postgres, runMig
 import { migration as clearStaleKeyMismatchMigration, runMigration155Postgres, runMigration155Mysql } from '../server/migrations/155_clear_stale_key_mismatch.js';
 import { migration as meshcoreNodeTimeSyncConfigMigration, runMigration156Postgres, runMigration156Mysql } from '../server/migrations/156_meshcore_node_time_sync_config.js';
 import { migration as meshcoreRoomSyncFailuresMigration, runMigration157Postgres, runMigration157Mysql } from '../server/migrations/157_meshcore_room_sync_failures.js';
+import {
+  migration as meshcorePacketLogObserverMigration,
+  runMigration158Postgres,
+  runMigration158Mysql,
+} from '../server/migrations/158_meshcore_packet_log_observer.js';
 
 // ============================================================================
 // Registry
@@ -2528,4 +2533,23 @@ registry.register({
   sqlite: (db) => meshcoreRoomSyncFailuresMigration.up(db),
   postgres: (client) => runMigration157Postgres(client),
   mysql: (pool) => runMigration157Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 158: per-observer attribution on meshcore_packet_log (#5040 Phase 2).
+// A meshcore_mqtt source ingests what every observer in a region heard, so one
+// OTA packet lands once per observer. Those copies are receptions, not
+// duplicates — differing SNR/RSSI per observer IS the coverage data — so the
+// table becomes N-rows-per-packet for those sources and dedupes at query time,
+// mirroring mqtt_packet_log. NULL observerId = heard by our own radio.
+// Idempotent across SQLite / PostgreSQL / MySQL.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 158,
+  name: 'meshcore_packet_log_observer',
+  settingsKey: 'migration_158_meshcore_packet_log_observer',
+  sqlite: (db) => meshcorePacketLogObserverMigration.up(db),
+  postgres: (client) => runMigration158Postgres(client),
+  mysql: (pool) => runMigration158Mysql(pool),
 });

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -1896,19 +1896,39 @@ export class MeshCoreRepository extends BaseRepository {
     const total = await this.getPacketCount({ sourceId });
     if (total <= maxCount) return 0;
 
-    // Find the cutoff id: keep the newest `maxCount` rows, delete the rest.
+    // Find the cutoff row: keep the newest `maxCount`, delete everything older.
     const survivors = await this.db
-      .select({ id: meshcorePacketLog.id })
+      .select({ id: meshcorePacketLog.id, timestamp: meshcorePacketLog.timestamp })
       .from(meshcorePacketLog)
       .where(eq(meshcorePacketLog.sourceId, sourceId))
       .orderBy(desc(meshcorePacketLog.timestamp), desc(meshcorePacketLog.id))
       .limit(maxCount);
     if (survivors.length === 0) return 0;
-    const oldestKeptId = Number(survivors[survivors.length - 1].id);
+    const boundary = survivors[survivors.length - 1];
+    const oldestKeptId = Number(boundary.id);
+    const oldestKeptTs = Number(boundary.timestamp);
 
-    await this.db
+    // The delete predicate must mirror the survivor ORDER BY exactly:
+    // `timestamp < ts OR (timestamp = ts AND id < id)`. A bare `id < oldestKeptId`
+    // silently assumes ids rise with timestamps. They normally do — both write
+    // paths stamp Date.now() at insert — but a backwards clock step (NTP) breaks
+    // it, and then a row with a HIGH id and an OLD timestamp falls out of the
+    // survivor set while escaping the delete, so the log grows past its cap.
+    // Measured: with one such row, a trim to 3 left 4.
+    //
+    // Note the failure is over-RETENTION, not data loss: the reverse case (a low
+    // id with a NEW timestamp, which would delete a row that should survive)
+    // cannot arise while timestamps are assigned at insert.
+    const deleted = await this.db
       .delete(meshcorePacketLog)
-      .where(and(eq(meshcorePacketLog.sourceId, sourceId), lt(meshcorePacketLog.id, oldestKeptId)));
+      .where(and(
+        eq(meshcorePacketLog.sourceId, sourceId),
+        or(
+          lt(meshcorePacketLog.timestamp, oldestKeptTs),
+          and(eq(meshcorePacketLog.timestamp, oldestKeptTs), lt(meshcorePacketLog.id, oldestKeptId)),
+        ),
+      ));
+    void deleted;
     return total - survivors.length;
   }
 

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -1919,7 +1919,7 @@ export class MeshCoreRepository extends BaseRepository {
     // Note the failure is over-RETENTION, not data loss: the reverse case (a low
     // id with a NEW timestamp, which would delete a row that should survive)
     // cannot arise while timestamps are assigned at insert.
-    const deleted = await this.db
+    await this.db
       .delete(meshcorePacketLog)
       .where(and(
         eq(meshcorePacketLog.sourceId, sourceId),
@@ -1928,7 +1928,6 @@ export class MeshCoreRepository extends BaseRepository {
           and(eq(meshcorePacketLog.timestamp, oldestKeptTs), lt(meshcorePacketLog.id, oldestKeptId)),
         ),
       ));
-    void deleted;
     return total - survivors.length;
   }
 

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -158,7 +158,49 @@ export interface DbMeshCorePacket {
   rssi?: number | null;
   payloadSize?: number | null;
   rawHex?: string | null;
+  /**
+   * 64-hex key of the observer that heard this copy (#5040 Phase 2). NULL when
+   * our own radio heard it, which is every row from a device-backed source.
+   * A `meshcore_mqtt` source writes one row per observer that heard the frame.
+   */
+  observerId?: string | null;
   createdAt: number;
+}
+
+/**
+ * One deduplicated MeshCore packet — a group of observer receptions (#5040
+ * Phase 2).
+ *
+ * A `meshcore_mqtt` source stores one row per observer that heard a frame, so
+ * the raw table is a reception log. This is the collapsed view: one entry per
+ * distinct frame, carrying how many observers heard it and the best signal any
+ * of them reported.
+ *
+ * Frames are identified by `rawHex` — the decoder already treats the raw bytes
+ * as the sole source of truth, and MeshCore has no packet id on the wire to
+ * group by the way Meshtastic does.
+ */
+export interface MeshCoreGroupedPacket {
+  rawHex: string | null;
+  timestamp: number;
+  payloadType: number;
+  payloadTypeName: string | null;
+  routeType: number | null;
+  routeTypeName: string | null;
+  pathLenRaw: number | null;
+  hopCount: number | null;
+  pathHops: string | null;
+  payloadSize: number | null;
+  /** Best (highest) SNR any observer reported for this frame. */
+  bestSnr: number | null;
+  /** Best (highest, i.e. least negative) RSSI any observer reported. */
+  bestRssi: number | null;
+  /** Distinct observers that heard it. 0 for a locally-heard frame (observerId NULL). */
+  observerCount: number;
+  /** Total rows in the group — receptions, not distinct observers. */
+  receptionCount: number;
+  firstHeard: number;
+  lastHeard: number;
 }
 
 /**
@@ -1729,6 +1771,90 @@ export class MeshCoreRepository extends BaseRepository {
       .limit(query.limit ?? 100)
       .offset(query.offset ?? 0);
     return this.normalizeBigInts(result) as unknown as DbMeshCorePacket[];
+  }
+
+  /**
+   * Query deduplicated packets — one row per distinct frame within a source,
+   * collapsing the per-observer receptions a `meshcore_mqtt` source writes
+   * (#5040 Phase 2). Newest-first, paginated.
+   *
+   * Group key mirrors `mqttPacketLog.getGroupedPackets`'s handling of the
+   * missing-identity edge: a frame with no `rawHex` cannot be grouped with
+   * anything, so it falls back to `-id` — unique, and negative so it can never
+   * collide with a real hex value.
+   *
+   * `observerCount` counts DISTINCT observerId, so a locally-heard frame
+   * (observerId NULL) reports 0 rather than 1 — SQL COUNT(DISTINCT) skips
+   * NULLs on all three backends. That is the intended reading: nobody
+   * *else* heard it, we did.
+   */
+  async getGroupedPackets(query: MeshCorePacketQuery = {}): Promise<MeshCoreGroupedPacket[]> {
+    const t = this.tables.meshcorePacketLog;
+    const groupKey = sql`COALESCE(${t.rawHex}, CAST(-${t.id} AS CHAR(24)))`;
+    const conditions = this.buildPacketConditions(query);
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+    const rows = await this.db
+      .select({
+        rawHex: sql<string | null>`MAX(${t.rawHex})`,
+        timestamp: sql<number>`MAX(${t.timestamp})`,
+        payloadType: sql<number>`MAX(${t.payloadType})`,
+        payloadTypeName: sql<string | null>`MAX(${t.payloadTypeName})`,
+        routeType: sql<number | null>`MAX(${t.routeType})`,
+        routeTypeName: sql<string | null>`MAX(${t.routeTypeName})`,
+        pathLenRaw: sql<number | null>`MAX(${t.pathLenRaw})`,
+        hopCount: sql<number | null>`MAX(${t.hopCount})`,
+        pathHops: sql<string | null>`MAX(${t.pathHops})`,
+        payloadSize: sql<number | null>`MAX(${t.payloadSize})`,
+        bestSnr: sql<number | null>`MAX(${t.snr})`,
+        bestRssi: sql<number | null>`MAX(${t.rssi})`,
+        observerCount: sql<number>`COUNT(DISTINCT ${t.observerId})`,
+        receptionCount: sql<number>`COUNT(*)`,
+        firstHeard: sql<number>`MIN(${t.timestamp})`,
+        lastHeard: sql<number>`MAX(${t.timestamp})`,
+      })
+      .from(t)
+      .where(whereClause)
+      .groupBy(t.sourceId, groupKey)
+      .orderBy(sql`MAX(${t.timestamp}) DESC`)
+      .limit(query.limit ?? 100)
+      .offset(query.offset ?? 0);
+    return this.normalizeBigInts(rows) as unknown as MeshCoreGroupedPacket[];
+  }
+
+  /**
+   * Count groups matching the same filters as {@link getGroupedPackets}.
+   *
+   * Uses a subquery over the grouped rows rather than `COUNT(DISTINCT a, b)`,
+   * which MySQL does not support — same portability constraint the MQTT
+   * grouped count documents.
+   */
+  async getGroupedPacketCount(query: MeshCorePacketQuery = {}): Promise<number> {
+    const t = this.tables.meshcorePacketLog;
+    const groupKey = sql`COALESCE(${t.rawHex}, CAST(-${t.id} AS CHAR(24)))`;
+    const conditions = this.buildPacketConditions(query);
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+    const grouped = this.db
+      .select({ k: sql`1` })
+      .from(t)
+      .where(whereClause)
+      .groupBy(t.sourceId, groupKey)
+      .as('grouped');
+    const res = await this.db.select({ count: sql<number>`COUNT(*)` }).from(grouped);
+    return Number(res[0]?.count ?? 0);
+  }
+
+  /**
+   * Per-observer reception detail for one frame, oldest-first — the expansion
+   * behind a grouped row's `observerCount`.
+   */
+  async getPacketReceptions(sourceId: string, rawHex: string): Promise<DbMeshCorePacket[]> {
+    const t = this.tables.meshcorePacketLog;
+    const rows = await this.db
+      .select()
+      .from(t)
+      .where(and(eq(t.sourceId, sourceId), eq(t.rawHex, rawHex)))
+      .orderBy(t.timestamp, t.id);
+    return this.normalizeBigInts(rows) as unknown as DbMeshCorePacket[];
   }
 
   /**

--- a/src/db/repositories/meshcorePacketLog.grouped.multidb.test.ts
+++ b/src/db/repositories/meshcorePacketLog.grouped.multidb.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Grouped packet queries across PostgreSQL and MySQL (#5040 Phase 2).
+ *
+ * The SQLite suite (`meshcorePacketLog.grouped.test.ts`) proves the semantics.
+ * This one proves the SQL is portable, because the grouping key is the one
+ * piece of hand-written SQL in the feature:
+ *
+ *   COALESCE(rawHex, CAST(-id AS CHAR(24)))
+ *
+ * That coalesces a TEXT column with a number, so it needs an explicit cast, and
+ * the three backends disagree about cast type names. `CHAR` is the portable
+ * spelling: MySQL accepts only its own list (BINARY, CHAR, DECIMAL, SIGNED …
+ * and NOT `TEXT`), PostgreSQL accepts CHAR as bpchar, and SQLite resolves any
+ * type name containing "CHAR" to TEXT affinity. Writing `CAST(… AS TEXT)`
+ * instead — which reads more natural — is a **syntax error on MySQL**.
+ *
+ * A review of #5046 raised exactly this portability question, and the honest
+ * answer was that the grouped query was only ever exercised on SQLite. These
+ * tests close that: the same assertions run on the real containers.
+ *
+ * Registered in SHARED_DB_TESTS — it DROP/CREATEs `meshcore_packet_log`.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import pg from 'pg';
+import mysql from 'mysql2/promise';
+import { drizzle as drizzlePostgres } from 'drizzle-orm/node-postgres';
+import { drizzle as drizzleMysql } from 'drizzle-orm/mysql2';
+import { MeshCoreRepository, type DbMeshCorePacket } from './meshcore.js';
+import * as schema from '../schema/index.js';
+import { postgresAvailable, mysqlAvailable } from './test-utils.js';
+
+const { Pool } = pg;
+
+const FRAME_A = '0500deadbeef';
+const FRAME_B = '0500cafebabe';
+const OBS_1 = 'AA'.repeat(32);
+const OBS_2 = 'BB'.repeat(32);
+
+function packet(overrides: Partial<DbMeshCorePacket> = {}): DbMeshCorePacket {
+  const now = 1_700_000_000_000;
+  return {
+    sourceId: 'src-mqtt',
+    timestamp: now,
+    payloadType: 2,
+    payloadTypeName: 'TXT_MSG',
+    routeType: 1,
+    routeTypeName: 'FLOOD',
+    pathLenRaw: 0x41,
+    hopCount: 1,
+    pathHops: 'a3',
+    snr: 1,
+    rssi: -100,
+    payloadSize: 24,
+    rawHex: FRAME_A,
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+/** Assertions shared by both backends, so neither can drift from the other. */
+function sharedGroupedBehaviour(getRepo: () => MeshCoreRepository) {
+  it('collapses observer receptions and reports the best signal', async () => {
+    const repo = getRepo();
+    await repo.insertPacket(packet({ observerId: OBS_1, snr: -9, rssi: -120, timestamp: 100 }));
+    await repo.insertPacket(packet({ observerId: OBS_2, snr: 3.5, rssi: -70, timestamp: 200 }));
+
+    const grouped = await repo.getGroupedPackets({ sourceId: 'src-mqtt' });
+    expect(grouped).toHaveLength(1);
+    expect(Number(grouped[0].observerCount)).toBe(2);
+    expect(Number(grouped[0].receptionCount)).toBe(2);
+    expect(Number(grouped[0].bestSnr)).toBe(3.5);
+    expect(Number(grouped[0].bestRssi)).toBe(-70);
+    expect(Number(grouped[0].firstHeard)).toBe(100);
+    expect(Number(grouped[0].lastHeard)).toBe(200);
+  });
+
+  it('keeps distinct frames apart and counts groups not rows', async () => {
+    const repo = getRepo();
+    await repo.insertPacket(packet({ rawHex: FRAME_A, observerId: OBS_1 }));
+    await repo.insertPacket(packet({ rawHex: FRAME_A, observerId: OBS_2 }));
+    await repo.insertPacket(packet({ rawHex: FRAME_B, observerId: OBS_1 }));
+
+    expect(await repo.getGroupedPackets({ sourceId: 'src-mqtt' })).toHaveLength(2);
+    expect(Number(await repo.getGroupedPacketCount({ sourceId: 'src-mqtt' }))).toBe(2);
+    expect(Number(await repo.getPacketCount({ sourceId: 'src-mqtt' }))).toBe(3);
+  });
+
+  it('does NOT collapse rows that lack a rawHex — the CAST fallback must yield distinct keys', async () => {
+    // The portability assertion that matters. If the cast silently produced
+    // NULL, GROUP BY would treat the rows as equal and merge them into one
+    // bogus entry — which is exactly the failure a wrong cast type name gives.
+    const repo = getRepo();
+    await repo.insertPacket(packet({ rawHex: null, observerId: OBS_1 }));
+    await repo.insertPacket(packet({ rawHex: null, observerId: OBS_2 }));
+
+    expect(await repo.getGroupedPackets({ sourceId: 'src-mqtt' })).toHaveLength(2);
+  });
+
+  it('reports observerCount 0 for a locally-heard frame', async () => {
+    const repo = getRepo();
+    await repo.insertPacket(packet({ observerId: null }));
+    const [g] = await repo.getGroupedPackets({ sourceId: 'src-mqtt' });
+    expect(Number(g.observerCount)).toBe(0);
+    expect(Number(g.receptionCount)).toBe(1);
+  });
+}
+
+const PG_CREATE = `
+  DROP TABLE IF EXISTS meshcore_packet_log CASCADE;
+  CREATE TABLE meshcore_packet_log (
+    id SERIAL PRIMARY KEY,
+    "sourceId" TEXT NOT NULL,
+    timestamp BIGINT NOT NULL,
+    "payloadType" INTEGER NOT NULL,
+    "payloadTypeName" TEXT,
+    "routeType" INTEGER,
+    "routeTypeName" TEXT,
+    "pathLenRaw" INTEGER,
+    "hopCount" INTEGER,
+    "pathHops" TEXT,
+    snr REAL,
+    rssi INTEGER,
+    "payloadSize" INTEGER,
+    "rawHex" TEXT,
+    "observerId" TEXT,
+    "createdAt" BIGINT NOT NULL
+  );
+`;
+
+const MYSQL_CREATE = `
+  CREATE TABLE meshcore_packet_log (
+    id SERIAL PRIMARY KEY,
+    sourceId VARCHAR(255) NOT NULL,
+    timestamp BIGINT NOT NULL,
+    payloadType INT NOT NULL,
+    payloadTypeName VARCHAR(32),
+    routeType INT,
+    routeTypeName VARCHAR(32),
+    pathLenRaw INT,
+    hopCount INT,
+    pathHops VARCHAR(512),
+    snr DOUBLE,
+    rssi INT,
+    payloadSize INT,
+    rawHex TEXT,
+    observerId VARCHAR(64),
+    createdAt BIGINT NOT NULL
+  );
+`;
+
+describe.skipIf(!postgresAvailable)('grouped packet queries — PostgreSQL', () => {
+  let pool: pg.Pool;
+  let repo: MeshCoreRepository;
+
+  beforeAll(async () => {
+    pool = new Pool({
+      host: 'localhost',
+      port: 5433,
+      user: 'test',
+      password: 'test',
+      database: 'meshmonitor_test',
+      connectionTimeoutMillis: 5000,
+    });
+    repo = new MeshCoreRepository(drizzlePostgres(pool, { schema }) as never, 'postgres');
+    await pool.query(PG_CREATE);
+  });
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query('DROP TABLE IF EXISTS meshcore_packet_log CASCADE');
+      await pool.end();
+    }
+  });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM meshcore_packet_log');
+  });
+
+  sharedGroupedBehaviour(() => repo);
+});
+
+describe.skipIf(!mysqlAvailable)('grouped packet queries — MySQL', () => {
+  let pool: mysql.Pool;
+  let repo: MeshCoreRepository;
+
+  beforeAll(async () => {
+    pool = mysql.createPool({
+      host: 'localhost',
+      port: 3307,
+      user: 'test',
+      password: 'test',
+      database: 'meshmonitor_test',
+    });
+    repo = new MeshCoreRepository(drizzleMysql(pool, { schema, mode: 'default' }) as never, 'mysql');
+    await pool.query('DROP TABLE IF EXISTS meshcore_packet_log');
+    await pool.query(MYSQL_CREATE);
+  });
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query('DROP TABLE IF EXISTS meshcore_packet_log');
+      await pool.end();
+    }
+  });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM meshcore_packet_log');
+  });
+
+  sharedGroupedBehaviour(() => repo);
+});

--- a/src/db/repositories/meshcorePacketLog.grouped.test.ts
+++ b/src/db/repositories/meshcorePacketLog.grouped.test.ts
@@ -1,0 +1,180 @@
+/**
+ * MeshCore packet log — query-time dedup of per-observer receptions
+ * (#5040 Phase 2).
+ *
+ * A `meshcore_mqtt` source writes ONE ROW PER OBSERVER that heard a frame, so
+ * the raw table is a reception log. These tests pin the collapsed read view:
+ * one entry per distinct frame, carrying how many observers heard it and the
+ * best signal any of them reported.
+ *
+ * The failure this guards against is silent: if the grouping key or the
+ * DISTINCT were wrong, the monitor would either show the same packet eight
+ * times or under-report coverage, and neither looks like an error.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { MeshCoreRepository, type DbMeshCorePacket } from './meshcore.js';
+import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
+
+const FRAME_A = '0500deadbeef';
+const FRAME_B = '0500cafebabe';
+const OBS_1 = 'AA'.repeat(32);
+const OBS_2 = 'BB'.repeat(32);
+const OBS_3 = 'CC'.repeat(32);
+
+function makePacket(sourceId: string, overrides: Partial<DbMeshCorePacket> = {}): DbMeshCorePacket {
+  const now = 1_700_000_000_000;
+  return {
+    sourceId,
+    timestamp: now,
+    payloadType: 0x02,
+    payloadTypeName: 'TXT_MSG',
+    routeType: 0x01,
+    routeTypeName: 'FLOOD',
+    pathLenRaw: 0x41,
+    hopCount: 1,
+    pathHops: 'a3',
+    snr: 6.25,
+    rssi: -42,
+    payloadSize: 24,
+    rawHex: FRAME_A,
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+describe('MeshCoreRepository — grouped packet queries (#5040)', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: MeshCoreRepository;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    repo = new MeshCoreRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('collapses three observer receptions of one frame into a single row', async () => {
+    for (const [i, obs] of [OBS_1, OBS_2, OBS_3].entries()) {
+      await repo.insertPacket(
+        makePacket('src-mqtt', { observerId: obs, timestamp: 1000 + i, snr: 1 + i }),
+      );
+    }
+
+    const grouped = await repo.getGroupedPackets({ sourceId: 'src-mqtt' });
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0]).toMatchObject({
+      rawHex: FRAME_A,
+      observerCount: 3,
+      receptionCount: 3,
+    });
+  });
+
+  it('reports the BEST signal any observer heard, not an arbitrary one', async () => {
+    await repo.insertPacket(makePacket('src-mqtt', { observerId: OBS_1, snr: -12, rssi: -120 }));
+    await repo.insertPacket(makePacket('src-mqtt', { observerId: OBS_2, snr: 4.5, rssi: -80 }));
+    await repo.insertPacket(makePacket('src-mqtt', { observerId: OBS_3, snr: -3, rssi: -99 }));
+
+    const [g] = await repo.getGroupedPackets({ sourceId: 'src-mqtt' });
+    expect(g.bestSnr).toBe(4.5);
+    // "Best" RSSI is the least negative.
+    expect(g.bestRssi).toBe(-80);
+  });
+
+  it('spans first and last heard across the group', async () => {
+    await repo.insertPacket(makePacket('src-mqtt', { observerId: OBS_1, timestamp: 5000 }));
+    await repo.insertPacket(makePacket('src-mqtt', { observerId: OBS_2, timestamp: 9000 }));
+
+    const [g] = await repo.getGroupedPackets({ sourceId: 'src-mqtt' });
+    expect(g.firstHeard).toBe(5000);
+    expect(g.lastHeard).toBe(9000);
+  });
+
+  it('keeps distinct frames separate', async () => {
+    await repo.insertPacket(makePacket('src-mqtt', { observerId: OBS_1, rawHex: FRAME_A }));
+    await repo.insertPacket(makePacket('src-mqtt', { observerId: OBS_2, rawHex: FRAME_A }));
+    await repo.insertPacket(makePacket('src-mqtt', { observerId: OBS_1, rawHex: FRAME_B }));
+
+    const grouped = await repo.getGroupedPackets({ sourceId: 'src-mqtt' });
+    expect(grouped).toHaveLength(2);
+    expect(grouped.map((g) => g.rawHex).sort()).toEqual([FRAME_B, FRAME_A].sort());
+  });
+
+  it('never groups across sources', async () => {
+    // Same frame bytes on two sources are two different observations of the
+    // mesh, and per-source scoping is a hard rule.
+    await repo.insertPacket(makePacket('src-a', { observerId: OBS_1 }));
+    await repo.insertPacket(makePacket('src-b', { observerId: OBS_1 }));
+
+    expect(await repo.getGroupedPackets({ sourceId: 'src-a' })).toHaveLength(1);
+    expect(await repo.getGroupedPackets({ sourceId: 'src-b' })).toHaveLength(1);
+  });
+
+  it('reports observerCount 0 for a locally-heard frame', async () => {
+    // A device-backed source leaves observerId NULL — nobody ELSE heard it, we
+    // did. COUNT(DISTINCT) skips NULLs, which is the intended reading.
+    await repo.insertPacket(makePacket('src-device', { observerId: null }));
+
+    const [g] = await repo.getGroupedPackets({ sourceId: 'src-device' });
+    expect(g.observerCount).toBe(0);
+    expect(g.receptionCount).toBe(1);
+  });
+
+  it('does not collapse distinct frames that both lack a rawHex', async () => {
+    // Without a frame identity there is nothing to group on, so each row must
+    // stay its own group rather than merging into one bogus entry.
+    await repo.insertPacket(makePacket('src-mqtt', { rawHex: null, observerId: OBS_1 }));
+    await repo.insertPacket(makePacket('src-mqtt', { rawHex: null, observerId: OBS_2 }));
+
+    const grouped = await repo.getGroupedPackets({ sourceId: 'src-mqtt' });
+    expect(grouped).toHaveLength(2);
+  });
+
+  it('counts groups, not rows', async () => {
+    await repo.insertPacket(makePacket('src-mqtt', { observerId: OBS_1, rawHex: FRAME_A }));
+    await repo.insertPacket(makePacket('src-mqtt', { observerId: OBS_2, rawHex: FRAME_A }));
+    await repo.insertPacket(makePacket('src-mqtt', { observerId: OBS_1, rawHex: FRAME_B }));
+
+    expect(await repo.getGroupedPacketCount({ sourceId: 'src-mqtt' })).toBe(2);
+    // The raw reception count is still 3 — the collapsed view is a read
+    // concern, the table keeps every reception.
+    expect(await repo.getPacketCount({ sourceId: 'src-mqtt' })).toBe(3);
+  });
+
+  it('orders groups newest-first by their most recent reception', async () => {
+    await repo.insertPacket(makePacket('src-mqtt', { rawHex: FRAME_A, observerId: OBS_1, timestamp: 100 }));
+    await repo.insertPacket(makePacket('src-mqtt', { rawHex: FRAME_B, observerId: OBS_1, timestamp: 200 }));
+    // A late reception of the OLDER frame lifts it back to the top.
+    await repo.insertPacket(makePacket('src-mqtt', { rawHex: FRAME_A, observerId: OBS_2, timestamp: 300 }));
+
+    const grouped = await repo.getGroupedPackets({ sourceId: 'src-mqtt' });
+    expect(grouped.map((g) => g.rawHex)).toEqual([FRAME_A, FRAME_B]);
+  });
+
+  it('honours the existing filters', async () => {
+    await repo.insertPacket(makePacket('src-mqtt', { rawHex: FRAME_A, payloadType: 0x02 }));
+    await repo.insertPacket(makePacket('src-mqtt', { rawHex: FRAME_B, payloadType: 0x09 }));
+
+    const grouped = await repo.getGroupedPackets({ sourceId: 'src-mqtt', payloadType: 0x09 });
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].rawHex).toBe(FRAME_B);
+  });
+
+  it('expands a group back into its per-observer receptions', async () => {
+    await repo.insertPacket(makePacket('src-mqtt', { observerId: OBS_1, timestamp: 200, snr: 1 }));
+    await repo.insertPacket(makePacket('src-mqtt', { observerId: OBS_2, timestamp: 100, snr: 2 }));
+    await repo.insertPacket(makePacket('src-mqtt', { rawHex: FRAME_B, observerId: OBS_3 }));
+
+    const receptions = await repo.getPacketReceptions('src-mqtt', FRAME_A);
+    expect(receptions).toHaveLength(2);
+    // Oldest-first.
+    expect(receptions.map((r) => r.observerId)).toEqual([OBS_2, OBS_1]);
+  });
+});

--- a/src/db/repositories/meshcorePacketLog.retention.test.ts
+++ b/src/db/repositories/meshcorePacketLog.retention.test.ts
@@ -1,0 +1,87 @@
+/**
+ * `trimPacketsToCount` retention boundary (#5040 Phase 2 review follow-up).
+ *
+ * The delete predicate has to mirror the survivor `ORDER BY` exactly. A bare
+ * `id < oldestKeptId` assumes ids rise with timestamps — true while both write
+ * paths stamp `Date.now()` at insert, false after a backwards clock step, and
+ * the failure is silent: the log simply grows past its configured cap.
+ *
+ * This matters more for a `meshcore_mqtt` source than a device one, since a
+ * region feed writes many rows per second and leans on the cap for its disk
+ * bound.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { MeshCoreRepository, type DbMeshCorePacket } from './meshcore.js';
+import * as schema from '../schema/index.js';
+import { createTestDb } from '../../server/test-helpers/testDb.js';
+
+function packet(over: Partial<DbMeshCorePacket> = {}): DbMeshCorePacket {
+  return {
+    sourceId: 'src-mqtt',
+    timestamp: 1000,
+    payloadType: 2,
+    rawHex: 'aa',
+    createdAt: 1000,
+    ...over,
+  };
+}
+
+describe('trimPacketsToCount — retention boundary', () => {
+  let db: Database.Database;
+  let drizzleDb: BetterSQLite3Database<typeof schema>;
+  let repo: MeshCoreRepository;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.sqlite;
+    drizzleDb = t.db;
+    repo = new MeshCoreRepository(drizzleDb, 'sqlite');
+  });
+
+  afterEach(() => db.close());
+
+  it('trims to exactly maxCount when every row shares one timestamp', async () => {
+    // A region feed writes a burst of observer receptions within the same
+    // millisecond, so this is the common case, not an edge case.
+    for (let i = 0; i < 10; i++) await repo.insertPacket(packet({ timestamp: 5000 }));
+
+    await repo.trimPacketsToCount('src-mqtt', 4);
+    expect(await repo.getPacketCount({ sourceId: 'src-mqtt' })).toBe(4);
+  });
+
+  it('trims to exactly maxCount when a high-id row carries an OLD timestamp', async () => {
+    // The regression: a backwards clock step (NTP) inserts a row whose id is
+    // highest but whose timestamp is oldest. Under `id < oldestKeptId` it fell
+    // out of the survivor set AND escaped the delete — a trim to 3 left 4.
+    for (let i = 0; i < 5; i++) await repo.insertPacket(packet({ timestamp: 1000 + i }));
+    await repo.insertPacket(packet({ timestamp: 1 }));
+
+    await repo.trimPacketsToCount('src-mqtt', 3);
+    expect(await repo.getPacketCount({ sourceId: 'src-mqtt' })).toBe(3);
+  });
+
+  it('keeps the NEWEST rows, not an arbitrary subset', async () => {
+    for (let i = 0; i < 6; i++) await repo.insertPacket(packet({ timestamp: 100 + i }));
+
+    await repo.trimPacketsToCount('src-mqtt', 2);
+    const remaining = await repo.getPackets({ sourceId: 'src-mqtt', limit: 10 });
+    expect(remaining.map((r) => r.timestamp)).toEqual([105, 104]);
+  });
+
+  it('never trims another source', async () => {
+    for (let i = 0; i < 5; i++) await repo.insertPacket(packet({ sourceId: 'src-a', timestamp: 100 + i }));
+    for (let i = 0; i < 5; i++) await repo.insertPacket(packet({ sourceId: 'src-b', timestamp: 100 + i }));
+
+    await repo.trimPacketsToCount('src-a', 1);
+    expect(await repo.getPacketCount({ sourceId: 'src-a' })).toBe(1);
+    expect(await repo.getPacketCount({ sourceId: 'src-b' })).toBe(5);
+  });
+
+  it('is a no-op when the log is already under the cap', async () => {
+    await repo.insertPacket(packet());
+    expect(await repo.trimPacketsToCount('src-mqtt', 10)).toBe(0);
+    expect(await repo.getPacketCount({ sourceId: 'src-mqtt' })).toBe(1);
+  });
+});

--- a/src/db/schema/meshcorePacketLog.ts
+++ b/src/db/schema/meshcorePacketLog.ts
@@ -38,6 +38,13 @@ export const meshcorePacketLogSqlite = sqliteTable('meshcore_packet_log', {
   payloadSize: integer('payloadSize'),
   /** Full raw OTA packet as a lowercase hex string. */
   rawHex: text('rawHex'),
+  /**
+   * 64-hex public key of the observer that heard THIS copy (#5040 Phase 2).
+   * NULL means our own radio heard it — device-backed sources never set this,
+   * so they keep one row per packet. A `meshcore_mqtt` source writes one row
+   * per observer, deduped at query time.
+   */
+  observerId: text('observerId'),
   createdAt: integer('createdAt').notNull(),
 });
 
@@ -59,6 +66,7 @@ export const meshcorePacketLogPostgres = pgTable('meshcore_packet_log', {
   rssi: pgInteger('rssi'),
   payloadSize: pgInteger('payloadSize'),
   rawHex: pgText('rawHex'),
+  observerId: pgText('observerId'),
   createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
 });
 
@@ -80,5 +88,6 @@ export const meshcorePacketLogMysql = mysqlTable('meshcore_packet_log', {
   rssi: myInt('rssi'),
   payloadSize: myInt('payloadSize'),
   rawHex: myText('rawHex'),
+  observerId: myVarchar('observerId', { length: 64 }),
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
 });

--- a/src/server/constants/settings.ts
+++ b/src/server/constants/settings.ts
@@ -102,6 +102,9 @@ export const VALID_SETTINGS_KEYS = [
   'packet_log_max_age_hours',
   'meshcore_packet_log_enabled',
   'meshcore_packet_log_max_count',
+  // Separate cap for meshcore_mqtt region feeds (#5040) — far higher volume
+  // than one radio's earshot, so it cannot share the device-source cap.
+  'meshcore_mqtt_packet_log_max_count',
   'meshcore_packet_log_max_age_hours',
   'mqtt_packet_log_enabled',
   'mqtt_packet_log_max_count',

--- a/src/server/meshcoreMqttManager.ts
+++ b/src/server/meshcoreMqttManager.ts
@@ -46,7 +46,9 @@ import {
   decodeObserverPacketMessage,
   observerPacketsSubscription,
   observerKeyFromTopic,
+  type IngestedObserverPacket,
 } from './services/meshcoreMqttIngestPacket.js';
+import meshcorePacketLogService from './services/meshcorePacketLogService.js';
 import { logger } from '../utils/logger.js';
 
 /** Persisted `sources.config` shape for a `meshcore_mqtt` source. */
@@ -223,14 +225,55 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
         this.stats.observers = this.seenObservers.size;
       }
 
-      // Phase 1 ends here: the packet is decoded and counted, not persisted.
-      // Phase 2 routes this into the same handleOtaPacket seam the local radio
-      // path uses. The event is emitted now so a consumer can be attached
-      // without changing this method.
+      // Emitted for the same consumers the local radio path feeds (Virtual
+      // Node bridge, channel-echo correlation) — the whole point of
+      // reconstructing the bridge shape.
       this.emit('ota_packet', decoded.event);
+      void this.persistPacket(decoded);
     } catch (err) {
       this.stats.rejected++;
       logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to handle message:`, err);
+    }
+  }
+
+  /**
+   * Write one reception to the MeshCore packet monitor (#5040 Phase 2).
+   *
+   * One row PER OBSERVER, not per packet: the same frame heard by eight
+   * observers is eight rows, differing in SNR/RSSI and stamped with who heard
+   * it. That is the coverage data a region feed exists to provide, and
+   * collapsing it here would throw it away — the repository's grouped queries
+   * dedupe at read time instead.
+   *
+   * Gated on the same opt-in setting as the local packet monitor, and
+   * best-effort: a DB failure must never break the ingest stream.
+   */
+  private async persistPacket(decoded: IngestedObserverPacket): Promise<void> {
+    try {
+      if (!(await meshcorePacketLogService.isEnabled())) return;
+      const now = Date.now();
+      const e = decoded.event;
+      await meshcorePacketLogService.logPacket({
+        sourceId: this.sourceId,
+        // Our ingest time, not the publisher's claimed `timestamp` — a remote
+        // clock is untrusted input and would corrupt ordering and retention.
+        timestamp: now,
+        payloadType: e.payload_type,
+        payloadTypeName: e.payload_type_string,
+        routeType: e.route_type,
+        routeTypeName: e.route_type_string,
+        pathLenRaw: e.path_len_raw,
+        hopCount: e.hop_count,
+        pathHops: e.path_hops.length > 0 ? e.path_hops.join(',') : null,
+        snr: e.snr ?? null,
+        rssi: e.rssi ?? null,
+        payloadSize: e.payload_size,
+        rawHex: e.raw_hex,
+        observerId: decoded.originId,
+        createdAt: now,
+      });
+    } catch (err) {
+      logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to persist packet:`, err);
     }
   }
 

--- a/src/server/migrations/158_meshcore_packet_log_observer.pgmysql.test.ts
+++ b/src/server/migrations/158_meshcore_packet_log_observer.pgmysql.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Migration 158 — PostgreSQL / MySQL container behaviour (#5040 Phase 2).
+ *
+ * Seeds a minimal `meshcore_packet_log` against the live test containers
+ * (localhost:5433 / :3307), runs the ADD-COLUMN + CREATE-INDEX migration,
+ * asserts the column and index exist and that a second run is a no-op.
+ *
+ * MySQL detail worth pinning: `rawHex` is TEXT there, so the index needs a
+ * prefix length (`rawHex(64)`) — without it MySQL errors with "BLOB/TEXT
+ * column used in key specification without a key length", which would only
+ * surface on a MySQL deployment.
+ *
+ * A silent skip still reports `success: true`; confirm via `numPendingTests`
+ * in the JSON reporter (CLAUDE.md, Multi-Database section).
+ *
+ * Registered in `SHARED_DB_TESTS` because it DROP/CREATEs a table shared with
+ * every other suite touching `meshcore_packet_log` — see the 153/156 race.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import mysql from 'mysql2/promise';
+import { runMigration158Postgres, runMigration158Mysql } from './158_meshcore_packet_log_observer.js';
+import { postgresAvailable, mysqlAvailable } from '../../db/repositories/test-utils.js';
+
+const { Pool: PgPool } = pg;
+const INDEX = 'idx_meshcore_packet_log_source_raw';
+
+describe.skipIf(!postgresAvailable)('migration 158 — PostgreSQL (container)', () => {
+  let pool: InstanceType<typeof PgPool>;
+
+  beforeAll(async () => {
+    pool = new PgPool({
+      host: 'localhost',
+      port: 5433,
+      user: 'test',
+      password: 'test',
+      database: 'meshmonitor_test',
+    });
+    await pool.query('DROP TABLE IF EXISTS meshcore_packet_log CASCADE');
+    await pool.query(`
+      CREATE TABLE meshcore_packet_log (
+        id SERIAL PRIMARY KEY,
+        "sourceId" TEXT NOT NULL,
+        timestamp BIGINT NOT NULL,
+        "payloadType" INTEGER NOT NULL,
+        "rawHex" TEXT,
+        "createdAt" BIGINT NOT NULL
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query('DROP TABLE IF EXISTS meshcore_packet_log CASCADE');
+      await pool.end();
+    }
+  });
+
+  it('adds observerId and the dedup index, and is idempotent', async () => {
+    const client = await pool.connect();
+    try {
+      await runMigration158Postgres(client);
+      await expect(runMigration158Postgres(client)).resolves.toBeUndefined();
+    } finally {
+      client.release();
+    }
+
+    const cols = await pool.query(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name = 'meshcore_packet_log' AND column_name = 'observerId'`,
+    );
+    expect(cols.rowCount).toBe(1);
+
+    const idx = await pool.query(
+      `SELECT indexname FROM pg_indexes
+       WHERE tablename = 'meshcore_packet_log' AND indexname = $1`,
+      [INDEX],
+    );
+    expect(idx.rowCount).toBe(1);
+  });
+
+  it('accepts a NULL observerId for a locally-heard row', async () => {
+    const now = Date.now();
+    await pool.query(
+      `INSERT INTO meshcore_packet_log ("sourceId", timestamp, "payloadType", "rawHex", "createdAt")
+       VALUES ($1, $2, $3, $4, $5)`,
+      ['src-device', now, 2, '0500dead', now],
+    );
+    const res = await pool.query(
+      `SELECT "observerId" FROM meshcore_packet_log WHERE "sourceId" = 'src-device'`,
+    );
+    expect(res.rows[0].observerId).toBeNull();
+  });
+});
+
+describe.skipIf(!mysqlAvailable)('migration 158 — MySQL (container)', () => {
+  let pool: mysql.Pool;
+
+  beforeAll(async () => {
+    pool = mysql.createPool({
+      host: 'localhost',
+      port: 3307,
+      user: 'test',
+      password: 'test',
+      database: 'meshmonitor_test',
+    });
+    await pool.query('DROP TABLE IF EXISTS meshcore_packet_log');
+    await pool.query(`
+      CREATE TABLE meshcore_packet_log (
+        id SERIAL PRIMARY KEY,
+        sourceId VARCHAR(255) NOT NULL,
+        timestamp BIGINT NOT NULL,
+        payloadType INT NOT NULL,
+        rawHex TEXT,
+        createdAt BIGINT NOT NULL
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query('DROP TABLE IF EXISTS meshcore_packet_log');
+      await pool.end();
+    }
+  });
+
+  it('adds observerId and a PREFIXED index (TEXT needs a key length), idempotently', async () => {
+    await runMigration158Mysql(pool);
+    await expect(runMigration158Mysql(pool)).resolves.toBeUndefined();
+
+    const [cols] = await pool.query(
+      `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'meshcore_packet_log'
+         AND COLUMN_NAME = 'observerId'`,
+    );
+    expect((cols as unknown[]).length).toBe(1);
+
+    const [idx] = await pool.query(
+      `SELECT INDEX_NAME FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'meshcore_packet_log'
+         AND INDEX_NAME = ?`,
+      [INDEX],
+    );
+    expect((idx as unknown[]).length).toBeGreaterThan(0);
+  });
+});

--- a/src/server/migrations/158_meshcore_packet_log_observer.ts
+++ b/src/server/migrations/158_meshcore_packet_log_observer.ts
@@ -1,0 +1,111 @@
+/**
+ * Migration 158: per-observer attribution on `meshcore_packet_log` (#5040 Phase 2).
+ *
+ * A `meshcore_mqtt` source ingests what EVERY observer in a region heard, so
+ * one over-the-air packet arrives once per observer that heard it. Those copies
+ * are not duplicates to be collapsed on the way in — differing SNR/RSSI per
+ * observer is precisely the coverage data that makes a region feed worth
+ * reading. The table therefore becomes a *reception* log for these sources
+ * (N rows per packet), deduped at query time, exactly as `mqtt_packet_log`
+ * already is for per-gateway Meshtastic receptions.
+ *
+ *   observerId  TEXT  64-hex public key of the observer that heard this copy.
+ *                     NULL for a locally-heard packet (device-backed sources),
+ *                     which is every existing row.
+ *
+ * NULL is the correct backfill, not a sentinel: existing rows came from this
+ * install's own radio via `LogRxData`, and there is no observer key to name
+ * because we WERE the observer. Queries distinguish the two on `IS NULL`
+ * rather than on the source type, so a device-backed source keeps its
+ * one-row-per-packet behaviour with no branching.
+ *
+ * The index is on (sourceId, rawHex) — the query-time dedup groups receptions
+ * of the same frame within a source, and `rawHex` is the frame identity (the
+ * decoder already treats it as the sole source of truth). Deliberately NOT on
+ * observerId alone: no query asks "everything one observer heard" without also
+ * scoping to a source.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 158';
+const TABLE = 'meshcore_packet_log';
+const COLUMN = 'observerId';
+const INDEX = 'idx_meshcore_packet_log_source_raw';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding ${TABLE}.${COLUMN}...`);
+
+    try {
+      db.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${COLUMN} TEXT`);
+      logger.debug(`${LABEL} (SQLite): added ${TABLE}.${COLUMN}`);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (message.includes('duplicate column')) {
+        logger.debug(`${LABEL} (SQLite): ${TABLE}.${COLUMN} already exists, skipping`);
+      } else {
+        logger.error(`${LABEL} (SQLite): could not add ${TABLE}.${COLUMN}:`, message);
+        throw e;
+      }
+    }
+
+    db.exec(`CREATE INDEX IF NOT EXISTS ${INDEX} ON ${TABLE} (sourceId, rawHex)`);
+    logger.debug(`${LABEL} (SQLite): ensured ${INDEX}`);
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration158Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding ${TABLE}.${COLUMN}...`);
+
+  await client.query(`ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS "${COLUMN}" TEXT`);
+  await client.query(`CREATE INDEX IF NOT EXISTS ${INDEX} ON ${TABLE} ("sourceId", "rawHex")`);
+  logger.debug(`${LABEL} (PostgreSQL): ensured ${TABLE}.${COLUMN} and ${INDEX}`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration158Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding ${TABLE}.${COLUMN}...`);
+
+  const conn = await pool.getConnection();
+  try {
+    const [cols] = await conn.query(
+      `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+      [TABLE, COLUMN],
+    );
+    if (!Array.isArray(cols) || cols.length === 0) {
+      await conn.query(`ALTER TABLE ${TABLE} ADD COLUMN ${COLUMN} VARCHAR(64)`);
+      logger.debug(`${LABEL} (MySQL): added ${TABLE}.${COLUMN}`);
+    } else {
+      logger.debug(`${LABEL} (MySQL): ${TABLE}.${COLUMN} already exists, skipping`);
+    }
+
+    // MySQL has no CREATE INDEX IF NOT EXISTS — pre-check information_schema.
+    const [idx] = await conn.query(
+      `SELECT INDEX_NAME FROM information_schema.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?`,
+      [TABLE, INDEX],
+    );
+    if (!Array.isArray(idx) || idx.length === 0) {
+      // rawHex is TEXT on MySQL, so the index needs a prefix length.
+      await conn.query(`CREATE INDEX ${INDEX} ON ${TABLE} (sourceId, rawHex(64))`);
+      logger.debug(`${LABEL} (MySQL): created ${INDEX}`);
+    } else {
+      logger.debug(`${LABEL} (MySQL): ${INDEX} already exists, skipping`);
+    }
+  } finally {
+    conn.release();
+  }
+}

--- a/src/server/services/meshcorePacketLogService.ts
+++ b/src/server/services/meshcorePacketLogService.ts
@@ -13,6 +13,17 @@ class MeshCorePacketLogService {
   private readonly CLEANUP_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
   private readonly DEFAULT_MAX_COUNT = 1000;
   private readonly DEFAULT_MAX_AGE_HOURS = 24;
+  /**
+   * Row cap for a `meshcore_mqtt` region feed (#5040 Phase 2).
+   *
+   * Deliberately far above the 1,000 a device-backed source gets. A region feed
+   * carries what EVERY observer heard, one row per observer, so 1,000 rows is
+   * minutes of history on a busy region and the monitor is useless. 50,000 is
+   * roughly 50-100MB of SQLite per source at typical row sizes — noticeable on
+   * a Pi, which is why the UI warns next to the input rather than burying it in
+   * docs. User-configurable via `meshcore_mqtt_packet_log_max_count`.
+   */
+  private readonly DEFAULT_INGEST_MAX_COUNT = 50_000;
 
   constructor() {
     this.startCleanupScheduler();
@@ -38,10 +49,23 @@ class MeshCorePacketLogService {
       const cutoff = Date.now() - maxAgeHours * 60 * 60 * 1000;
       let removed = await databaseService.meshcore.deletePacketsOlderThan(cutoff);
 
-      const maxCount = await this.getMaxCount();
+      // Row caps are applied PER SOURCE, and the two source kinds have very
+      // different volume profiles: a device-backed source logs its own radio's
+      // earshot, while a meshcore_mqtt source logs what every observer in a
+      // region heard, one row per observer (#5040 Phase 2). A single cap cannot
+      // serve both — raising it for a region feed would bloat every device
+      // source's log too — so each kind reads its own setting.
+      const deviceMaxCount = await this.getMaxCount();
+      const ingestMaxCount = await this.getIngestMaxCount();
+      const ingestSourceIds = new Set(
+        (await databaseService.sources.getAllSources())
+          .filter((src) => src.type === 'meshcore_mqtt')
+          .map((src) => src.id),
+      );
       const sourceIds = await databaseService.meshcore.getPacketLogSourceIds();
       for (const sourceId of sourceIds) {
-        removed += await databaseService.meshcore.trimPacketsToCount(sourceId, maxCount);
+        const cap = ingestSourceIds.has(sourceId) ? ingestMaxCount : deviceMaxCount;
+        removed += await databaseService.meshcore.trimPacketsToCount(sourceId, cap);
       }
 
       if (removed > 0) {
@@ -86,6 +110,13 @@ class MeshCorePacketLogService {
     const raw = await databaseService.getSettingAsync('meshcore_packet_log_max_count');
     const n = raw ? parseInt(raw, 10) : NaN;
     return Number.isFinite(n) && n > 0 ? n : this.DEFAULT_MAX_COUNT;
+  }
+
+  /** Row cap for meshcore_mqtt ingest sources; see DEFAULT_INGEST_MAX_COUNT. */
+  async getIngestMaxCount(): Promise<number> {
+    const raw = await databaseService.getSettingAsync('meshcore_mqtt_packet_log_max_count');
+    const n = raw ? parseInt(raw, 10) : NaN;
+    return Number.isFinite(n) && n > 0 ? n : this.DEFAULT_INGEST_MAX_COUNT;
   }
 
   async getMaxAgeHours(): Promise<number> {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -78,6 +78,11 @@ const SHARED_DB_TESTS = [
   // MySQL + PostgreSQL on the next). Same class as the 141-145 group above.
   'src/server/migrations/153_meshcore_node_neighbors_config.pgmysql.test.ts',
   'src/server/migrations/156_meshcore_node_time_sync_config.pgmysql.test.ts',
+  // Migration 158 (#5040 Phase 2) DROP/CREATEs `meshcore_packet_log` against
+  // the same shared PG/MySQL test DB. Added here on arrival rather than after
+  // it starts racing something — the 153/156 pair showed the failure mode is
+  // nondeterministic and reads as an unrelated "table doesn't exist".
+  'src/server/migrations/158_meshcore_packet_log_observer.pgmysql.test.ts',
 ];
 
 const COMMON_EXCLUDE = [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -83,6 +83,7 @@ const SHARED_DB_TESTS = [
   // it starts racing something — the 153/156 pair showed the failure mode is
   // nondeterministic and reads as an unrelated "table doesn't exist".
   'src/server/migrations/158_meshcore_packet_log_observer.pgmysql.test.ts',
+  'src/db/repositories/meshcorePacketLog.grouped.multidb.test.ts',
 ];
 
 const COMMON_EXCLUDE = [


### PR DESCRIPTION
Phase 2 of #5040, on top of the merged Phase 1. Ingested packets now land in the MeshCore packet monitor — **one row per observer that heard the frame**, deduped at query time.

## Why N rows and not one

A region feed carries what *every* observer heard. Those copies are not duplicates to collapse on the way in: differing SNR/RSSI per observer is exactly the coverage data that makes a region feed worth reading. So the table becomes a *reception* log for these sources and dedupes at read time, the same shape `mqtt_packet_log` already uses for per-gateway Meshtastic receptions.

## Migration 158

Adds `observerId` plus a `(sourceId, rawHex)` index for the grouped read.

**NULL is the correct backfill, not a sentinel.** Existing rows came from this install's own radio via `LogRxData`, and there is no observer key to name because we *were* the observer. Queries distinguish the two on `IS NULL` rather than on source type, so a device-backed source keeps one-row-per-packet with no branching.

**MySQL needs a prefix length** on that index (`rawHex(64)`) because `rawHex` is TEXT there — without it MySQL raises *"BLOB/TEXT column used in key specification without a key length"*, which would surface only on a MySQL deployment. The container test pins it.

## Query-time dedup

`getGroupedPackets` / `getGroupedPacketCount` / `getPacketReceptions`, mirroring the MQTT repo's grouped queries. One row per distinct frame within a source, carrying `observerCount`, `receptionCount`, the best signal any observer reported, and the first/last-heard span.

Frames are identified by **`rawHex`** — MeshCore has no wire packet id to group by the way Meshtastic does, and the decoder already treats the raw bytes as the sole source of truth. A `-id` fallback keeps rows lacking a `rawHex` as their own groups rather than merging into one bogus entry.

**`observerCount` is 0, not 1, for a locally-heard frame.** `COUNT(DISTINCT)` skips NULLs on all three backends, and the intended reading is "nobody *else* heard it, we did." Pinned by a test so it doesn't get "fixed" later.

## Retention: split by source kind

Per the policy call on the issue — configurable, generous defaults — with one wrinkle worth stating, because it changes the shape:

Caps apply **per source**, and a device source and a region feed share this table. A single knob would either starve the feed or bloat every device log. So `meshcore_mqtt` sources read the new `meshcore_mqtt_packet_log_max_count` (**default 50,000**, user-configurable), while device sources keep their existing 1,000.

For scale: the MeshCore log defaults to 1,000 rows and the Meshtastic MQTT log to 5,000. A region feed logs what every observer heard, one row each — 1,000 rows is minutes of history on a busy region, and the monitor is useless. 50,000 is roughly 50–100MB of SQLite per source, which is noticeable on a Pi, so that warning belongs next to the input rather than in docs.

**No ingest rate cap**, also per the issue: retention already bounds disk, and dropping packets at ingest would silently skew the per-observer coverage data — under-reporting exactly the observers that are busiest.

## Mesh impact

**Zero airtime.** Receive-and-store only; this source cannot transmit.

## Testing

14 new tests — 11 on the grouped queries (collapse, best-signal, cross-source isolation, the NULL-observer case, the no-rawHex fallback, group-vs-row counting, ordering, filter passthrough, reception expansion) and 3 on the migration across both container backends.

The container test is registered in `SHARED_DB_TESTS` **on arrival** rather than after it starts racing something — it DROP/CREATEs `meshcore_packet_log`, the exact pattern that made 153/156 flaky in the Phase 1 PR.

- Full suite with PostgreSQL and MySQL up: **18,556 passed, 0 failed, 0 failed suites**. Migration 158's container test ran on both backends with 0 skipped.
- Both typechecks and `lint:ci` clean.

## Not in this PR

Routes and UI to surface the grouped view — Phase 2 as scoped on the issue is the storage and dedup layer. A natural Phase 2b if the monitor should be visible before Phase 3 (advert-derived nodes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc