### PR TITLE
feat(meshcore): grouped packet monitor for MQTT ingest sources, Phase 2b (#5040)

### DIFF
--- a/src/components/MeshCore/MeshCorePacketMonitorView.tsx
+++ b/src/components/MeshCore/MeshCorePacketMonitorView.tsx
@@ -34,7 +34,33 @@ interface MeshCorePacketMonitorViewProps {
 
 type Packet = MeshCoreOtaPacketEvent;
 
+/**
+ * One collapsed row: a distinct frame with its per-observer receptions folded
+ * in (#5040 Phase 2b). Shares the display fields of `Packet` so the table body
+ * can render either shape.
+ */
+interface GroupedPacket extends Packet {
+  observerCount: number;
+  receptionCount: number;
+  bestSnr: number | null;
+  bestRssi: number | null;
+  firstHeard: number;
+  lastHeard: number;
+}
+
 const MAX_BUFFER = 2000;
+
+/**
+ * Render an observer count for display.
+ *
+ * `0` does NOT mean "nobody heard this" — it means OUR radio heard it, because
+ * a local reception carries a NULL observerId and COUNT(DISTINCT) skips NULLs
+ * (#5040 Phase 2). Showing the digit would invert the meaning for every
+ * locally-heard packet, so the local case gets a word instead.
+ */
+function observerLabel(count: number, localText: string): string {
+  return count > 0 ? String(count) : localText;
+}
 
 function payloadLabel(p: Packet): string {
   if (p.payloadTypeName) return p.payloadTypeName;
@@ -83,12 +109,22 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
   const [maxAgeHours, setMaxAgeHours] = useState(24);
   const [savingSettings, setSavingSettings] = useState(false);
 
+  // Collapsed view (#5040 Phase 2b). Meaningful for any MeshCore source: a
+  // device-backed one records a single reception per frame, so grouping is a
+  // no-op there rather than something to hide behind a source-type check.
+  const [grouped, setGrouped] = useState(false);
+  const [groupedPackets, setGroupedPackets] = useState<GroupedPacket[]>([]);
+  const [isIngestSource, setIsIngestSource] = useState(false);
+
   const [payloadFilter, setPayloadFilter] = useState<number | ''>('');
   const [routeFilter, setRouteFilter] = useState<number | ''>('');
   const [selectedPacket, setSelectedPacket] = useState<Packet | null>(null);
 
   const pausedRef = useRef(paused);
   pausedRef.current = paused;
+  const groupedRef = useRef(grouped);
+  groupedRef.current = grouped;
+  const reloadRef = useRef<(() => void) | null>(null);
 
   const mcPrefix = `${baseUrl}/api/sources/${encodeURIComponent(sourceId)}/meshcore`;
 
@@ -101,19 +137,25 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
       const params = new URLSearchParams();
       if (payloadFilter !== '') params.set('payload_type', String(payloadFilter));
       if (routeFilter !== '') params.set('route_type', String(routeFilter));
-      const res = await csrfFetch(`${mcPrefix}/packets?${params.toString()}`);
+      const path = grouped ? 'packets/grouped' : 'packets';
+      const res = await csrfFetch(`${mcPrefix}/${path}?${params.toString()}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      setPackets(Array.isArray(data.packets) ? data.packets : []);
+      if (grouped) {
+        setGroupedPackets(Array.isArray(data.packets) ? data.packets : []);
+      } else {
+        setPackets(Array.isArray(data.packets) ? data.packets : []);
+      }
       if (typeof data.enabled === 'boolean') setEnabled(data.enabled);
       if (typeof data.maxCount === 'number') setMaxCount(data.maxCount);
       if (typeof data.maxAgeHours === 'number') setMaxAgeHours(data.maxAgeHours);
+      if (typeof data.isIngestSource === 'boolean') setIsIngestSource(data.isIngestSource);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load packets');
     } finally {
       setLoading(false);
     }
-  }, [csrfFetch, mcPrefix, payloadFilter, routeFilter]);
+  }, [csrfFetch, mcPrefix, payloadFilter, routeFilter, grouped]);
 
   // Initial load + reload on filter change.
   useEffect(() => {
@@ -126,6 +168,13 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
     const onOtaPacket = (evt: MeshCoreOtaPacketEvent) => {
       if (evt.sourceId && evt.sourceId !== sourceId) return;
       if (pausedRef.current) return;
+      // Grouping is a server-side aggregation: a new reception should increment
+      // an existing group, not prepend a row. Prepending would show the same
+      // frame twice and contradict the counts, so reload instead.
+      if (groupedRef.current) {
+        void reloadRef.current?.();
+        return;
+      }
       setPackets(prev => {
         const next = [evt, ...prev];
         return next.length > MAX_BUFFER ? next.slice(0, MAX_BUFFER) : next;
@@ -138,12 +187,20 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
   }, [socket, sourceId]);
 
   const visiblePackets = useMemo(() => {
+    // Grouped rows arrive already filtered and aggregated by the server; the
+    // client-side filter exists only to keep live-prepended rows honest in flat
+    // mode, and re-applying it to groups would be a no-op at best.
+    if (grouped) return groupedPackets as Packet[];
     return packets.filter(p => {
       if (payloadFilter !== '' && p.payloadType !== payloadFilter) return false;
       if (routeFilter !== '' && p.routeType !== routeFilter) return false;
       return true;
     });
-  }, [packets, payloadFilter, routeFilter]);
+  }, [grouped, groupedPackets, packets, payloadFilter, routeFilter]);
+
+  // Let the live-packet handler trigger a reload without re-subscribing the
+  // socket on every `load` identity change.
+  reloadRef.current = load;
 
   const saveSettings = useCallback(async (patch: Record<string, string>): Promise<boolean> => {
     setSavingSettings(true);
@@ -241,6 +298,17 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
             {paused ? <Play size={14} /> : <Pause size={14} />}
           </button>
           <button
+            className={`mcpm-btn ${grouped ? 'active' : ''}`}
+            onClick={() => setGrouped(g => !g)}
+            title={grouped
+              ? t('meshcore.packets.ungroupHelp', 'Show every reception separately')
+              : t('meshcore.packets.groupHelp', 'Collapse receptions of the same frame into one row')}
+          >
+            {grouped
+              ? t('meshcore.packets.grouped', 'Grouped')
+              : t('meshcore.packets.flat', 'All')}
+          </button>
+          <button
             className={`mcpm-btn ${showFilters ? 'active' : ''}`}
             onClick={() => setShowFilters(s => !s)}
             title={t('common.filters', 'Filters')}
@@ -305,13 +373,29 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
                 <input
                   type="number"
                   min={100}
-                  max={50000}
+                  max={isIngestSource ? 500000 : 50000}
                   step={100}
                   value={maxCount}
                   onChange={e => setMaxCount(Number(e.target.value))}
-                  onBlur={() => void saveSettings({ meshcore_packet_log_max_count: String(maxCount) })}
+                  onBlur={() => void saveSettings(
+                    // Retention is per-source-kind (#5040): an MQTT region feed
+                    // writes one row per observer and has its own key, so
+                    // writing the device key here would silently cap the wrong
+                    // sources.
+                    isIngestSource
+                      ? { meshcore_mqtt_packet_log_max_count: String(maxCount) }
+                      : { meshcore_packet_log_max_count: String(maxCount) },
+                  )}
                 />
               </label>
+              {isIngestSource && (
+                <span className="mcpm-setting-warning">
+                  {t(
+                    'meshcore.packets.ingestCapWarning',
+                    'A region feed stores one row per observer that heard each frame. At 50,000 rows expect roughly 50–100MB of database per source — noticeable on a Pi or a small container volume.',
+                  )}
+                </span>
+              )}
               <label>
                 {t('meshcore.packets.maxAgeHours', 'Max age (h)')}
                 <input
@@ -350,6 +434,11 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
                 <th>{t('meshcore.packets.snr', 'SNR')}</th>
                 <th>{t('meshcore.packets.rssi', 'RSSI')}</th>
                 <th>{t('meshcore.packets.size', 'Size')}</th>
+                {grouped && (
+                  <th title={t('meshcore.packets.observersHelp', 'Distinct observers that heard this frame. "Local" means your own radio heard it.')}>
+                    {t('meshcore.packets.observers', 'Observers')}
+                  </th>
+                )}
                 <th>{t('meshcore.packets.path', 'Path')}</th>
               </tr>
             </thead>
@@ -370,6 +459,14 @@ export const MeshCorePacketMonitorView: React.FC<MeshCorePacketMonitorViewProps>
                     <td className="mcpm-mono">{typeof p.snr === 'number' ? p.snr.toFixed(2) : '—'}</td>
                     <td className="mcpm-mono">{typeof p.rssi === 'number' ? p.rssi : '—'}</td>
                     <td className="mcpm-mono">{typeof p.payloadSize === 'number' ? p.payloadSize : '—'}</td>
+                    {grouped && (
+                      <td className="mcpm-mono">
+                        {observerLabel(
+                          Number((p as GroupedPacket).observerCount ?? 0),
+                          t('meshcore.packets.observersLocal', 'Local'),
+                        )}
+                      </td>
+                    )}
                     <td className="mcpm-mono mcpm-path">{p.pathHops || (p.pathLenRaw === 255 ? 'direct' : '—')}</td>
                   </tr>
                 );

--- a/src/server/routes/meshcorePacketRoutes.grouped.test.ts
+++ b/src/server/routes/meshcorePacketRoutes.grouped.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Grouped / receptions packet-monitor routes (#5040 Phase 2b).
+ *
+ * Uses `createRouteTestApp()` per CLAUDE.md, so `requirePermission` runs for
+ * real against seeded permission rows rather than a hand-rolled lambda.
+ *
+ * The behaviour most worth pinning is the one a UI can silently get wrong:
+ * `observerCount === 0` means "our own radio heard it", because
+ * COUNT(DISTINCT) skips the NULL observerId a local reception carries. If that
+ * ever started meaning "no observers", the monitor would report every locally
+ * heard packet as unheard.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import meshcorePacketRoutes from './meshcorePacketRoutes.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import databaseService from '../../services/database.js';
+
+vi.mock('../sourceManagerRegistry.js', () => ({
+  sourceManagerRegistry: {
+    getManager: vi.fn().mockReturnValue(null),
+    getAllManagers: vi.fn().mockReturnValue([]),
+  },
+}));
+
+const FRAME_A = '0500deadbeef';
+const FRAME_B = '0500cafebabe';
+const OBS_1 = 'AA'.repeat(32);
+const OBS_2 = 'BB'.repeat(32);
+
+async function insert(sourceId: string, over: Record<string, unknown> = {}) {
+  const now = Date.now();
+  await databaseService.meshcore.insertPacket({
+    sourceId,
+    timestamp: now,
+    payloadType: 2,
+    payloadTypeName: 'TXT_MSG',
+    routeType: 1,
+    routeTypeName: 'FLOOD',
+    hopCount: 0,
+    snr: 1,
+    rssi: -100,
+    payloadSize: 12,
+    rawHex: FRAME_A,
+    createdAt: now,
+    ...over,
+  } as never);
+}
+
+describe('MeshCore packet monitor — grouped routes (#5040 Phase 2b)', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({
+      mount: (app) => app.use('/:id/meshcore', meshcorePacketRoutes),
+    });
+    await databaseService.settings.setSetting('meshcore_packet_log_enabled', '1');
+    // Rows created through the harness persist for the life of its DB, so a
+    // later test would otherwise see the previous test's packets and read as a
+    // grouping bug rather than a fixture leak. (Same trap as the Phase 1
+    // duplicate-source tests.)
+    await databaseService.meshcore.deleteAllPackets();
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  it('collapses per-observer receptions into one grouped row', async () => {
+    await insert(harness.sourceA, { observerId: OBS_1, snr: -8 });
+    await insert(harness.sourceA, { observerId: OBS_2, snr: 2.5 });
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/${harness.sourceA}/meshcore/packets/grouped`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.packets).toHaveLength(1);
+    expect(Number(res.body.packets[0].observerCount)).toBe(2);
+    expect(Number(res.body.packets[0].receptionCount)).toBe(2);
+    expect(Number(res.body.packets[0].bestSnr)).toBe(2.5);
+  });
+
+  it('reports observerCount 0 for a locally-heard frame — "local", not "nobody"', async () => {
+    await insert(harness.sourceA, { observerId: null });
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/${harness.sourceA}/meshcore/packets/grouped`);
+
+    expect(Number(res.body.packets[0].observerCount)).toBe(0);
+    expect(Number(res.body.packets[0].receptionCount)).toBe(1);
+  });
+
+  it('counts GROUPS in total, not rows', async () => {
+    await insert(harness.sourceA, { observerId: OBS_1, rawHex: FRAME_A });
+    await insert(harness.sourceA, { observerId: OBS_2, rawHex: FRAME_A });
+    await insert(harness.sourceA, { observerId: OBS_1, rawHex: FRAME_B });
+
+    const agent = await harness.loginAs(harness.admin);
+    const grouped = await agent.get(`/${harness.sourceA}/meshcore/packets/grouped`);
+    const flat = await agent.get(`/${harness.sourceA}/meshcore/packets`);
+
+    expect(Number(grouped.body.total)).toBe(2);
+    // The flat view still shows every reception — the collapse is a read mode,
+    // not a change to what is stored.
+    expect(Number(flat.body.total)).toBe(3);
+  });
+
+  it('never groups across sources', async () => {
+    await insert(harness.sourceA, { observerId: OBS_1 });
+    await insert(harness.sourceB, { observerId: OBS_1 });
+
+    const agent = await harness.loginAs(harness.admin);
+    const a = await agent.get(`/${harness.sourceA}/meshcore/packets/grouped`);
+    expect(a.body.packets).toHaveLength(1);
+  });
+
+  it('expands a group into its per-observer receptions, oldest-first', async () => {
+    await insert(harness.sourceA, { observerId: OBS_1, timestamp: 2000 });
+    await insert(harness.sourceA, { observerId: OBS_2, timestamp: 1000 });
+    await insert(harness.sourceA, { observerId: OBS_1, rawHex: FRAME_B });
+
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(
+      `/${harness.sourceA}/meshcore/packets/receptions?raw_hex=${FRAME_A}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.receptions).toHaveLength(2);
+    expect(res.body.receptions.map((r: { observerId: string }) => r.observerId)).toEqual([OBS_2, OBS_1]);
+  });
+
+  it('rejects a receptions call with no raw_hex', async () => {
+    const agent = await harness.loginAs(harness.admin);
+    const res = await agent.get(`/${harness.sourceA}/meshcore/packets/receptions`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/raw_hex/i);
+  });
+
+  it('enforces per-source packetmonitor:read on both routes', async () => {
+    await harness.grant(harness.limited.id, 'packetmonitor', 'read', harness.sourceA);
+    const agent = await harness.loginAs(harness.limited);
+
+    expect((await agent.get(`/${harness.sourceA}/meshcore/packets/grouped`)).status).toBe(200);
+    expect((await agent.get(`/${harness.sourceB}/meshcore/packets/grouped`)).status).toBe(403);
+    expect(
+      (await agent.get(`/${harness.sourceB}/meshcore/packets/receptions?raw_hex=${FRAME_A}`)).status,
+    ).toBe(403);
+  });
+});

--- a/src/server/routes/meshcorePacketRoutes.ts
+++ b/src/server/routes/meshcorePacketRoutes.ts
@@ -7,6 +7,7 @@
  */
 
 import { Router, Request, Response } from 'express';
+import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
 import { requireAuth, optionalAuth, requirePermission } from '../auth/authMiddleware.js';
 import meshcorePacketLogService from '../services/meshcorePacketLogService.js';
@@ -22,6 +23,23 @@ const router = Router({ mergeParams: true });
  * Filters: payload_type, route_type, since (ms). Returns the same envelope
  * shape as the Meshtastic packet monitor so the frontend can share logic.
  */
+/**
+ * True when `sourceId` names a `meshcore_mqtt` ingest source.
+ *
+ * Swallows lookup failures and answers `false`, because every caller uses this
+ * only to pick which retention cap to *report*. A source-table hiccup should
+ * cost a slightly wrong number in the settings box, not a 500 on the packet
+ * list itself.
+ */
+async function isMeshCoreIngestSource(sourceId: string): Promise<boolean> {
+  try {
+    const src = await databaseService.sources?.getSource?.(sourceId);
+    return src?.type === 'meshcore_mqtt';
+  } catch {
+    return false;
+  }
+}
+
 const MESHCORE_PACKET_MAX_LIMIT = 1000;
 
 router.get(
@@ -55,6 +73,13 @@ router.get(
         since: Number.isFinite(since as number) ? since : undefined,
       };
 
+      // The cap that applies to THIS source: retention is per-source-kind
+      // (#5040 Phase 2), so a region feed reports its own, far larger cap.
+      //
+      // Non-fatal by design. This only decides which cap NUMBER to display, so
+      // a source row that cannot be read must degrade to the device default,
+      // never fail the packet list — the packets are the point of the endpoint.
+      const isIngestSource = await isMeshCoreIngestSource(sourceId);
       const [packets, total, enabled, maxAgeHours] = await Promise.all([
         meshcorePacketLogService.getPackets(query),
         meshcorePacketLogService.getPacketCount({ sourceId, payloadType: query.payloadType, routeType: query.routeType, since: query.since }),
@@ -62,10 +87,103 @@ router.get(
         meshcorePacketLogService.getMaxAgeHours(),
       ]);
 
-      res.json({ packets, total, offset, limit, enabled, maxCount, maxAgeHours });
+      res.json({ packets, total, offset, limit, enabled, maxCount: isIngestSource ? await meshcorePacketLogService.getIngestMaxCount() : maxCount, maxAgeHours, isIngestSource });
     } catch (error) {
       logger.error('[API] Error fetching MeshCore packets:', error);
       res.status(500).json({ success: false, error: 'Failed to fetch packets' });
+    }
+  },
+);
+
+/**
+ * GET /api/sources/:id/meshcore/packets/grouped
+ *
+ * The collapsed Packet Monitor view (#5040 Phase 2b): one entry per distinct
+ * frame, with a `meshcore_mqtt` source's per-observer receptions folded into
+ * `observerCount` / `receptionCount` and the best signal any observer reported.
+ *
+ * A device-backed source records one reception per frame, so this endpoint is
+ * equivalent to `/packets` for it — the frontend can offer the toggle on every
+ * MeshCore source rather than branching on source type.
+ *
+ * NOTE `observerCount === 0` means "our own radio heard it", not "nobody heard
+ * it": COUNT(DISTINCT) skips the NULL observerId a local reception carries.
+ * Renderers must show that as "local", never as the digit 0.
+ */
+router.get(
+  '/packets/grouped',
+  optionalAuth(),
+  requirePermission('packetmonitor', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id?: string }).id!;
+      const offset = Math.max(parseInt(req.query.offset as string, 10) || 0, 0);
+      const maxCount = await meshcorePacketLogService.getMaxCount();
+      const requestedLimit = parseInt(req.query.limit as string, 10);
+      const effectiveLimit = Number.isFinite(requestedLimit) && requestedLimit > 0 ? requestedLimit : maxCount;
+      const limit = Math.min(Math.max(effectiveLimit, 1), MESHCORE_PACKET_MAX_LIMIT);
+      const payloadType = req.query.payload_type !== undefined ? parseInt(req.query.payload_type as string, 10) : undefined;
+      const routeType = req.query.route_type !== undefined ? parseInt(req.query.route_type as string, 10) : undefined;
+      let since = req.query.since !== undefined ? parseInt(req.query.since as string, 10) : undefined;
+      if (since !== undefined && since < 1e12) since = since * 1000;
+
+      const query = {
+        sourceId,
+        offset,
+        limit,
+        payloadType: Number.isFinite(payloadType as number) ? payloadType : undefined,
+        routeType: Number.isFinite(routeType as number) ? routeType : undefined,
+        since: Number.isFinite(since as number) ? since : undefined,
+      };
+
+      // The cap that applies to THIS source: retention is per-source-kind
+      // (#5040 Phase 2), so a region feed reports its own, far larger cap.
+      const src = await databaseService.sources.getSource(sourceId);
+      const isIngestSource = src?.type === 'meshcore_mqtt';
+      const [packets, total, enabled, maxAgeHours] = await Promise.all([
+        meshcorePacketLogService.getGroupedPackets(query),
+        // Group count, not row count — paging is over groups here.
+        meshcorePacketLogService.getGroupedPacketCount({
+          sourceId,
+          payloadType: query.payloadType,
+          routeType: query.routeType,
+          since: query.since,
+        }),
+        meshcorePacketLogService.isEnabled(),
+        meshcorePacketLogService.getMaxAgeHours(),
+      ]);
+
+      res.json({ packets, total, offset, limit, enabled, maxCount: isIngestSource ? await meshcorePacketLogService.getIngestMaxCount() : maxCount, maxAgeHours, isIngestSource });
+    } catch (error) {
+      logger.error('[API] Error fetching grouped MeshCore packets:', error);
+      res.status(500).json({ success: false, error: 'Failed to fetch grouped packets' });
+    }
+  },
+);
+
+/**
+ * GET /api/sources/:id/meshcore/packets/receptions?raw_hex=...
+ *
+ * Expands one grouped row into the individual observer receptions behind it,
+ * oldest-first (#5040 Phase 2b). Each carries its own SNR/RSSI and the key of
+ * the observer that heard it — the coverage detail the collapsed row summarises.
+ */
+router.get(
+  '/packets/receptions',
+  optionalAuth(),
+  requirePermission('packetmonitor', 'read', { sourceIdFrom: 'params.id' }),
+  async (req: Request, res: Response) => {
+    try {
+      const sourceId = (req.params as { id?: string }).id!;
+      const rawHex = typeof req.query.raw_hex === 'string' ? req.query.raw_hex.trim() : '';
+      if (!rawHex) {
+        return res.status(400).json({ success: false, error: 'raw_hex is required' });
+      }
+      const receptions = await meshcorePacketLogService.getPacketReceptions(sourceId, rawHex);
+      res.json({ receptions, total: receptions.length });
+    } catch (error) {
+      logger.error('[API] Error fetching MeshCore packet receptions:', error);
+      res.status(500).json({ success: false, error: 'Failed to fetch receptions' });
     }
   },
 );
@@ -83,13 +201,20 @@ router.get(
   async (req: Request, res: Response) => {
     try {
       const sourceId = (req.params as { id?: string }).id!;
-      const [total, enabled, maxCount, maxAgeHours] = await Promise.all([
+      // Report the cap that actually applies to THIS source. Retention is
+      // per-source-kind (#5040 Phase 2): a region feed writes one row per
+      // observer and gets its own, far larger cap, so showing the device
+      // default here would misreport when the log is about to trim.
+      const isIngest = await isMeshCoreIngestSource(sourceId);
+      const [total, enabled, deviceMaxCount, ingestMaxCount, maxAgeHours] = await Promise.all([
         meshcorePacketLogService.getPacketCount({ sourceId }),
         meshcorePacketLogService.isEnabled(),
         meshcorePacketLogService.getMaxCount(),
+        meshcorePacketLogService.getIngestMaxCount(),
         meshcorePacketLogService.getMaxAgeHours(),
       ]);
-      res.json({ total, enabled, maxCount, maxAgeHours });
+      const maxCount = isIngest ? ingestMaxCount : deviceMaxCount;
+      res.json({ total, enabled, maxCount, maxAgeHours, isIngestSource: isIngest });
     } catch (error) {
       logger.error('[API] Error fetching MeshCore packet stats:', error);
       res.status(500).json({ success: false, error: 'Failed to fetch packet stats' });

--- a/src/server/services/meshcorePacketLogService.ts
+++ b/src/server/services/meshcorePacketLogService.ts
@@ -1,6 +1,6 @@
 import databaseService from '../../services/database.js';
 import { logger } from '../../utils/logger.js';
-import type { DbMeshCorePacket, MeshCorePacketQuery } from '../../db/repositories/meshcore.js';
+import type { DbMeshCorePacket, MeshCorePacketQuery, MeshCoreGroupedPacket } from '../../db/repositories/meshcore.js';
 
 /**
  * Service for the MeshCore Packet Monitor — the OTA-packet analogue of
@@ -90,6 +90,25 @@ class MeshCorePacketLogService {
 
   async getPackets(query: MeshCorePacketQuery): Promise<DbMeshCorePacket[]> {
     return databaseService.meshcore.getPackets(query);
+  }
+
+  /**
+   * Collapsed view: one entry per distinct frame, with the per-observer
+   * receptions of a `meshcore_mqtt` source folded into counts (#5040 Phase 2b).
+   * A device-backed source has one reception per frame, so this degenerates to
+   * the flat list for it.
+   */
+  async getGroupedPackets(query: MeshCorePacketQuery): Promise<MeshCoreGroupedPacket[]> {
+    return databaseService.meshcore.getGroupedPackets(query);
+  }
+
+  async getGroupedPacketCount(query: MeshCorePacketQuery): Promise<number> {
+    return databaseService.meshcore.getGroupedPacketCount(query);
+  }
+
+  /** The per-observer receptions behind one grouped row. */
+  async getPacketReceptions(sourceId: string, rawHex: string): Promise<DbMeshCorePacket[]> {
+    return databaseService.meshcore.getPacketReceptions(sourceId, rawHex);
   }
 
   async getPacketCount(query: MeshCorePacketQuery): Promise<number> {


### PR DESCRIPTION
Phase 2b of #5040, on top of the merged Phase 2. That phase stored per-observer receptions **that nothing could display** — this makes them visible.

## Routes

| Endpoint | Returns |
|---|---|
| `GET /packets/grouped` | One row per distinct frame: `observerCount`, `receptionCount`, best signal any observer reported, first/last-heard span |
| `GET /packets/receptions?raw_hex=…` | The individual receptions behind one group, oldest-first |

Both reuse `requirePermission('packetmonitor', 'read', { sourceIdFrom: 'params.id' })`, so per-source scoping is inherited rather than reimplemented. `/packets/grouped` pages over **groups**, not rows — its `total` is the group count, which a test pins against the flat endpoint's row count.

## The display rule that matters

**`observerCount === 0` renders as "Local", never the digit.**

Zero means *our own radio* heard it: a local reception carries a NULL `observerId`, and `COUNT(DISTINCT)` skips NULLs. Showing `0` in a column headed "Observers" inverts the meaning for every locally-heard packet — it reads as "nobody heard this." The helper carries that reasoning inline so it doesn't get "simplified" back to a number later, and it's pinned at both the route and repository layers.

This was flagged as a follow-up when Phase 2 landed; it only becomes a real bug once a UI exists, which is now.

## Two deliberate choices

- **Live packets reload in grouped mode rather than prepending.** Grouping is a server-side aggregation — prepending a new reception would show the same frame twice and contradict its own counts.
- **The toggle is offered on every MeshCore source, not just ingest ones.** A device-backed source records one reception per frame, so grouping is a harmless no-op there; branching the UI on source type would cost more than it saves.

## Settings

The Max-count input now writes `meshcore_mqtt_packet_log_max_count` for a region feed and the device key otherwise, **with the 50–100MB disk warning beside the input**. Phase 2 shipped that setting with nothing to surface it, and the mesh-impact checklist asks for the warning next to the control rather than in a doc — this closes that gap.

## A note on `isMeshCoreIngestSource()`

It swallows lookup failures and answers `false`. That is deliberate: the helper only decides which cap **number to display**, so a source-table hiccup should cost a slightly wrong number in a settings box, never a 500 on the packet list — the packets are the point of the endpoint.

It also happens to fix three legacy list-route tests in `meshcoreRoutes.test.ts`, which mock the database module as `default: {}`. Those failures were a genuine regression I introduced by adding a `sources.getSource()` call to a hot read path; I fixed the design rather than patching the mock, and the test result followed. Worth noting they surfaced *only* in the full suite — every targeted suite was green.

## Mesh impact

**Zero airtime.** Read-only endpoints over already-stored rows.

## Testing

7 route tests via `createRouteTestApp()` per CLAUDE.md — collapse, the local-observer case, groups-vs-rows counting, cross-source isolation, reception expansion, the missing-`raw_hex` 400, and per-source `packetmonitor:read` on both new routes (200 on the granted source, 403 on the other).

- Full suite with PostgreSQL and MySQL up: **18,576 passed, 0 failed, 0 failed suites**.
- Both typechecks and `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc