### PR TITLE
feat(meshcore): node discovery from adverts on MQTT ingest, Phase 3 (#5040)

### DIFF
--- a/src/server/meshcoreMqttManager.advert.test.ts
+++ b/src/server/meshcoreMqttManager.advert.test.ts
@@ -45,7 +45,7 @@ vi.mock('./transports/mqttBrokerClient.js', () => ({
   MqttBrokerClient: class { constructor() { lastClient = new FakeClient(); return lastClient as unknown as object; } },
 }));
 
-import { MeshCoreMqttManager } from './meshcoreMqttManager.js';
+import { MeshCoreMqttManager, advertLastHeardMs } from './meshcoreMqttManager.js';
 
 const OBSERVER = 'AA'.repeat(32);
 const NODE_KEY = '11'.repeat(32);
@@ -139,6 +139,21 @@ describe('ADVERT ingest (#5040 Phase 3)', () => {
     expect(upsertNode.mock.calls[0][0].lastHeard).toBe(1_600_000_000_000);
   });
 
+  it('caps a FUTURE advert timestamp at now', async () => {
+    // The timestamp is attacker-controlled in both directions. Uncapped, a
+    // forged future claim parks the node at the top of every "last heard" sort
+    // indefinitely, and no later genuine reception can displace it.
+    const before = Date.now();
+    await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER}/packets`,
+      body(advertFrame({ timestamp: 4_000_000_000, name: 'FromTheFuture' })));
+    await settle();
+
+    const stamped = upsertNode.mock.calls[0][0].lastHeard as number;
+    expect(stamped).toBeLessThanOrEqual(Date.now());
+    expect(stamped).toBeGreaterThanOrEqual(before);
+  });
+
   it('omits name rather than nulling it when the advert carries none', async () => {
     // upsertNode treats undefined as "not observed" and PRESERVES the stored
     // value; null would clobber a good name with nothing.
@@ -201,5 +216,29 @@ describe('ADVERT ingest (#5040 Phase 3)', () => {
     expect(upsertNode).toHaveBeenCalledTimes(2);
     // The packet itself still counted both times — node ingest is a side path.
     expect(mgr.getIngestStats().accepted).toBe(2);
+  });
+});
+
+describe('advertLastHeardMs', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('passes a past timestamp through, in milliseconds', () => {
+    expect(advertLastHeardMs(1_600_000_000, NOW)).toBe(1_600_000_000_000);
+  });
+
+  it('clamps a future timestamp to now', () => {
+    expect(advertLastHeardMs(4_000_000_000, NOW)).toBe(NOW);
+  });
+
+  it('treats the boundary as not-future', () => {
+    expect(advertLastHeardMs(NOW / 1000, NOW)).toBe(NOW);
+  });
+
+  it('returns undefined for absent or nonsense values', () => {
+    // undefined (not 0) so upsertNode PRESERVES any stored lastHeard rather
+    // than overwriting it with the epoch.
+    expect(advertLastHeardMs(0, NOW)).toBeUndefined();
+    expect(advertLastHeardMs(-1, NOW)).toBeUndefined();
+    expect(advertLastHeardMs(Number.NaN, NOW)).toBeUndefined();
   });
 });

--- a/src/server/meshcoreMqttManager.advert.test.ts
+++ b/src/server/meshcoreMqttManager.advert.test.ts
@@ -1,0 +1,205 @@
+/**
+ * ADVERT → node ingest for an MQTT region feed (#5040 Phase 3).
+ *
+ * Adverts are the only frame a region feed can turn into node knowledge: they
+ * are unencrypted and self-describing. Everything else is encrypted to someone
+ * else or carries no identity.
+ *
+ * These tests build REAL advert frames to the wire layout
+ * (pubkey 32 | timestamp 4 LE | signature 64 | appData) so they exercise the
+ * shipping decoder rather than a stub of it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const upsertNode = vi.fn().mockResolvedValue(undefined);
+const insertPacket = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      upsertNode: (...a: unknown[]) => upsertNode(...a),
+      insertPacket: (...a: unknown[]) => insertPacket(...a),
+    },
+    getSettingAsync: vi.fn().mockResolvedValue('0'),
+  },
+}));
+
+vi.mock('./services/meshcorePacketLogService.js', () => ({
+  default: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+}));
+
+let lastClient: FakeClient | null = null;
+class FakeClient {
+  handlers = new Map<string, (arg: unknown) => void>();
+  connect = vi.fn().mockResolvedValue(undefined);
+  subscribe = vi.fn().mockResolvedValue(undefined);
+  disconnect = vi.fn().mockResolvedValue(undefined);
+  isConnected = () => true;
+  on(e: string, fn: (arg: unknown) => void) { this.handlers.set(e, fn); return this; }
+  removeAllListeners() { this.handlers.clear(); return this; }
+  deliver(topic: string, body: unknown) {
+    this.handlers.get('message')?.({ topic, payload: Buffer.from(JSON.stringify(body)) });
+  }
+}
+vi.mock('./transports/mqttBrokerClient.js', () => ({
+  MqttBrokerClient: class { constructor() { lastClient = new FakeClient(); return lastClient as unknown as object; } },
+}));
+
+import { MeshCoreMqttManager } from './meshcoreMqttManager.js';
+
+const OBSERVER = 'AA'.repeat(32);
+const NODE_KEY = '11'.repeat(32);
+
+/** ADVERT flag bits (meshcorePacketDecode): 0x10 location, 0x80 name. */
+const FLAG_LOCATION = 0x10;
+const FLAG_NAME = 0x80;
+
+/**
+ * Build a wire-accurate ADVERT frame.
+ * header | path_len | pubkey(32) | timestamp(4 LE) | signature(64) | appData
+ */
+function advertFrame(opts: {
+  publicKey?: string;
+  timestamp?: number;
+  advType?: number;
+  lat?: number;
+  lon?: number;
+  name?: string;
+} = {}): string {
+  const bytes: number[] = [];
+  // route=FLOOD(1), payload_type=ADVERT(4)
+  bytes.push((4 << 2) | 1, 0x00);
+  const key = opts.publicKey ?? NODE_KEY;
+  for (let i = 0; i < 64; i += 2) bytes.push(parseInt(key.slice(i, i + 2), 16));
+  const ts = opts.timestamp ?? 1_700_000_000;
+  bytes.push(ts & 0xff, (ts >> 8) & 0xff, (ts >> 16) & 0xff, (ts >>> 24) & 0xff);
+  for (let i = 0; i < 64; i++) bytes.push(0xcd); // signature (not verified on ingest)
+
+  let flags = opts.advType ?? 1;
+  const tail: number[] = [];
+  if (opts.lat !== undefined && opts.lon !== undefined) {
+    flags |= FLAG_LOCATION;
+    for (const deg of [opts.lat, opts.lon]) {
+      const v = Math.round(deg * 1_000_000) | 0;
+      tail.push(v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >>> 24) & 0xff);
+    }
+  }
+  if (opts.name !== undefined) {
+    flags |= FLAG_NAME;
+    for (const ch of Buffer.from(opts.name, 'utf8')) tail.push(ch);
+  }
+  bytes.push(flags, ...tail);
+  return bytes.map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+function body(raw: string) {
+  return { type: 'PACKET', origin: 'Obs', origin_id: OBSERVER, raw, SNR: '-6', RSSI: '-90' };
+}
+
+async function started() {
+  const mgr = new MeshCoreMqttManager('src-mqtt', 'Feed', {
+    brokerUrl: 'wss://b.example', region: 'MCO',
+  });
+  await mgr.start();
+  return mgr;
+}
+
+/** Wait out the fire-and-forget ingest promise. */
+const settle = () => new Promise(r => setTimeout(r, 0));
+
+beforeEach(() => {
+  upsertNode.mockClear();
+  lastClient = null;
+});
+
+describe('ADVERT ingest (#5040 Phase 3)', () => {
+  it('creates a node from an advert carrying name and position', async () => {
+    const mgr = await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER}/packets`,
+      body(advertFrame({ name: 'Repeater One', lat: 28.5383, lon: -81.3792, advType: 2 })));
+    await settle();
+
+    expect(upsertNode).toHaveBeenCalledTimes(1);
+    const [node, sourceId] = upsertNode.mock.calls[0];
+    expect(sourceId).toBe('src-mqtt');
+    expect(node).toMatchObject({ publicKey: NODE_KEY, name: 'Repeater One', advType: 2 });
+    expect(node.latitude).toBeCloseTo(28.5383, 5);
+    expect(node.longitude).toBeCloseTo(-81.3792, 5);
+    expect(mgr.getIngestStats().advertsIngested).toBe(1);
+  });
+
+  it('stamps lastHeard from the advert timestamp, not our ingest time', async () => {
+    // A replayed or delayed publish must not make a silent node look freshly
+    // heard — the same failure class as the Meshtastic PhoneAPI replay (#5034).
+    await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER}/packets`,
+      body(advertFrame({ timestamp: 1_600_000_000, name: 'Old' })));
+    await settle();
+
+    expect(upsertNode.mock.calls[0][0].lastHeard).toBe(1_600_000_000_000);
+  });
+
+  it('omits name rather than nulling it when the advert carries none', async () => {
+    // upsertNode treats undefined as "not observed" and PRESERVES the stored
+    // value; null would clobber a good name with nothing.
+    await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER}/packets`, body(advertFrame({})));
+    await settle();
+
+    expect(upsertNode.mock.calls[0][0].name).toBeUndefined();
+  });
+
+  it('omits position (and its provenance tag) when the advert has no location', async () => {
+    await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER}/packets`, body(advertFrame({ name: 'NoFix' })));
+    await settle();
+
+    const node = upsertNode.mock.calls[0][0];
+    expect(node.latitude).toBeUndefined();
+    expect(node.positionSource).toBeUndefined();
+  });
+
+  it("tags an advert position as 'contact' so a telemetry fix keeps precedence", async () => {
+    await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER}/packets`,
+      body(advertFrame({ lat: 1.5, lon: 2.5 })));
+    await settle();
+
+    expect(upsertNode.mock.calls[0][0].positionSource).toBe('contact');
+  });
+
+  it('ingests an advert regardless of signature validity — decoded, not enforced', async () => {
+    // Deliberate (#5040): the signature bytes here are filler, and the node is
+    // still created. `appDataHex` exists so a caller CAN verify; ingest does not.
+    await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER}/packets`,
+      body(advertFrame({ name: 'Unsigned' })));
+    await settle();
+
+    expect(upsertNode).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores non-ADVERT frames', async () => {
+    const mgr = await started();
+    // A plain FLOOD text frame: header, path_len 0, payload.
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER}/packets`, body('0500deadbeef'));
+    await settle();
+
+    expect(upsertNode).not.toHaveBeenCalled();
+    expect(mgr.getIngestStats().advertsIngested).toBe(0);
+  });
+
+  it('survives a node-write failure without breaking the stream', async () => {
+    upsertNode.mockRejectedValueOnce(new Error('db down'));
+    const mgr = await started();
+
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER}/packets`, body(advertFrame({ name: 'A' })));
+    await settle();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER}/packets`, body(advertFrame({ name: 'B' })));
+    await settle();
+
+    expect(upsertNode).toHaveBeenCalledTimes(2);
+    // The packet itself still counted both times — node ingest is a side path.
+    expect(mgr.getIngestStats().accepted).toBe(2);
+  });
+});

--- a/src/server/meshcoreMqttManager.ts
+++ b/src/server/meshcoreMqttManager.ts
@@ -92,6 +92,19 @@ export interface MeshCoreMqttIngestStats {
   lastError: string | null;
 }
 
+/**
+ * Convert an ADVERT's self-reported unix-seconds timestamp into a `lastHeard`
+ * milliseconds value, or `undefined` when it carries none.
+ *
+ * Clamped to now: the value comes from an untrusted publisher, so a future
+ * claim is either a forgery or a node with a bad clock, and both would corrupt
+ * every "last heard" ordering that reads this column.
+ */
+export function advertLastHeardMs(timestampSec: number, nowMs: number = Date.now()): number | undefined {
+  if (!Number.isFinite(timestampSec) || timestampSec <= 0) return undefined;
+  return Math.min(timestampSec * 1000, nowMs);
+}
+
 export class MeshCoreMqttManager extends EventEmitter implements ISourceManager {
   readonly sourceId: string;
   readonly sourceType = 'meshcore_mqtt' as const;
@@ -333,7 +346,16 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
           positionSource: advert.latitude !== undefined ? 'contact' : undefined,
           // When the observer heard it, not when we ingested it — a replayed or
           // delayed publish must not make a silent node look freshly heard.
-          lastHeard: advert.timestamp > 0 ? advert.timestamp * 1000 : undefined,
+          //
+          // Capped at now, because the timestamp is attacker-controlled in both
+          // directions and only the stale one was guarded. A forged or
+          // misconfigured advert claiming a FUTURE time would otherwise park the
+          // node at the top of every "last heard" sort indefinitely, and no
+          // later genuine reception could displace it. Mirrors the Meshtastic
+          // NodeInfo path, which caps for the same reason
+          // (`meshtasticManager.ts`, "cap at current time to prevent future
+          // timestamps").
+          lastHeard: advertLastHeardMs(advert.timestamp),
         },
         this.sourceId,
       );

--- a/src/server/meshcoreMqttManager.ts
+++ b/src/server/meshcoreMqttManager.ts
@@ -49,6 +49,8 @@ import {
   type IngestedObserverPacket,
 } from './services/meshcoreMqttIngestPacket.js';
 import meshcorePacketLogService from './services/meshcorePacketLogService.js';
+import databaseService from '../services/database.js';
+import { decodeMeshCorePacket } from '../utils/meshcorePacketDecode.js';
 import { logger } from '../utils/logger.js';
 
 /** Persisted `sources.config` shape for a `meshcore_mqtt` source. */
@@ -84,6 +86,8 @@ export interface MeshCoreMqttIngestStats {
   rejected: number;
   /** Distinct observer public keys seen this session. */
   observers: number;
+  /** ADVERT frames turned into node create/updates. */
+  advertsIngested: number;
   lastPacketAt: number | null;
   lastError: string | null;
 }
@@ -102,6 +106,7 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
     accepted: 0,
     rejected: 0,
     observers: 0,
+    advertsIngested: 0,
     lastPacketAt: null,
     lastError: null,
   };
@@ -230,6 +235,7 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
       // reconstructing the bridge shape.
       this.emit('ota_packet', decoded.event);
       void this.persistPacket(decoded);
+      void this.ingestAdvert(decoded);
     } catch (err) {
       this.stats.rejected++;
       logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to handle message:`, err);
@@ -274,6 +280,66 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
       });
     } catch (err) {
       logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to persist packet:`, err);
+    }
+  }
+
+  /**
+   * Create or update a node from an ADVERT frame (#5040 Phase 3).
+   *
+   * Adverts are the only frame type a region feed can turn into node knowledge:
+   * they are unencrypted and self-describing (public key, name, device role,
+   * and optionally a position). Everything else on the feed is either encrypted
+   * to someone else or carries no identity.
+   *
+   * ## Signatures are decoded but NOT enforced
+   *
+   * An advert is self-signed, and this source ingests frames published by
+   * strangers, so a forged advert can create a node or move an existing one on
+   * THIS source. That is an accepted trade-off, decided deliberately (#5040):
+   *
+   * - Verification is not free — an Ed25519 check per advert on a busy regional
+   *   feed is real CPU on the ingest path.
+   * - The device-backed path does not verify either; the radio hands us
+   *   contacts without proof, so gating only the MQTT path would be
+   *   inconsistent without being complete.
+   * - Blast radius is bounded by per-source scoping: forged rows land in this
+   *   source's `meshcore_nodes` only, never in a device source's.
+   *
+   * `decodeMeshCorePacket` exposes `appDataHex` so a caller that DOES want
+   * proof can run `Ed25519SignatureVerifier.verifyAdvertisementSignature()` —
+   * the packet monitor can show validity per frame on demand. If this ever
+   * needs to become a gate, that is the hook, and it belongs here.
+   *
+   * Best-effort: a decode or write failure must never break the ingest stream.
+   */
+  private async ingestAdvert(decoded: IngestedObserverPacket): Promise<void> {
+    try {
+      const packet = decodeMeshCorePacket(decoded.event.raw_hex);
+      const advert = packet?.payload?.advert;
+      if (!advert?.publicKey) return;
+
+      await databaseService.meshcore.upsertNode(
+        {
+          publicKey: advert.publicKey,
+          // `undefined` means "not observed" to upsertNode, which then PRESERVES
+          // the stored value. Passing null would clobber a good name with
+          // nothing when an advert omits one.
+          name: advert.name ?? undefined,
+          advType: advert.advType,
+          latitude: advert.latitude,
+          longitude: advert.longitude,
+          // Same provenance tag the contact-sync path uses: an advert position
+          // is the static kind, so a real telemetry fix keeps precedence.
+          positionSource: advert.latitude !== undefined ? 'contact' : undefined,
+          // When the observer heard it, not when we ingested it — a replayed or
+          // delayed publish must not make a silent node look freshly heard.
+          lastHeard: advert.timestamp > 0 ? advert.timestamp * 1000 : undefined,
+        },
+        this.sourceId,
+      );
+      this.stats.advertsIngested++;
+    } catch (err) {
+      logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to ingest advert:`, err);
     }
   }
 

--- a/src/utils/meshcorePacketDecode.ts
+++ b/src/utils/meshcorePacketDecode.ts
@@ -82,6 +82,21 @@ export interface DecodedAdvert {
   feat1?: number;
   feat2?: number;
   name?: string;
+  /**
+   * The raw appData slice (everything after the 100-byte
+   * pubkey+timestamp+signature prefix), lowercase hex.
+   *
+   * Exposed because `Ed25519SignatureVerifier.verifyAdvertisementSignature()`
+   * signs over `publicKey + timestamp + appData` and needs those bytes
+   * verbatim — the parsed `flags`/`latitude`/`name` above cannot be
+   * re-serialised back to them reliably (optional fields, unknown future
+   * flags). Keeping it here means ONE decoder serves both the packet-monitor
+   * display and any caller that wants to check the signature (#5040 Phase 3).
+   *
+   * NOTE the ingest path deliberately does NOT gate node creation on signature
+   * validity — see the manager's advert handler for that decision.
+   */
+  appDataHex?: string;
 }
 
 export interface DecodedMeshCorePacket {
@@ -263,7 +278,9 @@ function decodeAdvert(payload: Uint8Array, errors: string[]): DecodedAdvert | un
     flags: 0,
   };
 
-  // appData: flags byte, then optional fields.
+  // appData: flags byte, then optional fields. Captured whole first, since the
+  // signature is computed over these exact bytes.
+  advert.appDataHex = bytesToHex(payload.subarray(100));
   let p = 100;
   if (p < payload.length) {
     const flags = payload[p++];


### PR DESCRIPTION
Phase 3 of #5040, on the merged Phase 2b. A region feed now creates and updates `meshcore_nodes` from the ADVERT frames it ingests — the only frame type a feed can turn into node knowledge, since everything else is encrypted to someone else or carries no identity.

## Much smaller than the plan assumed

The issue proposed decoding adverts through `@michaelhart/meshcore-decoder`. Two things already existed:

- **`decodeMeshCorePacket()` already does a full ADVERT decode** — public key, timestamp, advType, flags, lat/lon, name — and is already applied to this exact `rawHex` by the packet monitor's decode modal.
- **`upsertNode()` is already the single write choke point**, with Null-Island and out-of-range position rejection built in.

So this is wiring plus one decoder field, not protocol work. It also keeps **one** decoder rather than two that could disagree about the same bytes.

## Three details that are easy to get wrong

Each is pinned by a test:

| | |
|---|---|
| **`lastHeard` uses the advert's own timestamp**, not our ingest time | Same failure class as the firmware 2.8 replay bug (#5034) fixed earlier today: a delayed or replayed publish must not make a long-silent node look freshly heard |
| **Absent fields pass `undefined`, never `null`** | `upsertNode` reads `undefined` as "not observed" and *preserves* the stored value; `null` clobbers a good name or position with nothing when an advert simply omits it |
| **Advert positions tag `positionSource: 'contact'`** | So an established telemetry GNSS fix keeps precedence, matching the contact-sync path |

## Signatures: decoded, not enforced

An advert is self-signed, and this source ingests frames published by strangers — so **a forged advert can create or move a node on this source.** That is a deliberate trade-off, not an oversight:

- Verification is real per-advert Ed25519 CPU on the ingest path of a busy regional feed.
- The device-backed path doesn't verify either — the radio hands us contacts without proof, so gating only the MQTT path would be inconsistent without being complete.
- Per-source scoping bounds the blast radius: forged rows land in this source's `meshcore_nodes` only, never a device source's.

`DecodedAdvert` now exposes **`appDataHex`** so a caller that *does* want proof can run `Ed25519SignatureVerifier.verifyAdvertisementSignature()` — that verifier signs over `publicKey + timestamp + appData`, and the parsed `flags`/`latitude`/`name` cannot be re-serialised back to those bytes reliably (optional fields, unknown future flags). The packet monitor can use it to show validity per frame on demand.

Both the hook and the reasoning live at the ingest site, so if this should become a gate, there is one place to change and the trade-off is written down rather than rediscovered.

## Mesh impact

**Zero airtime.** Receive-and-store only; this source cannot transmit.

## Testing

8 tests that build **real wire-format advert frames** (`pubkey 32 | timestamp 4 LE | signature 64 | appData`) so they exercise the shipping decoder rather than a stub — covering name+position ingest, the `lastHeard` provenance rule, the undefined-vs-null distinction in both directions, the `contact` position tag, non-ADVERT frames being ignored, unsigned adverts still ingesting, and a node-write failure not breaking the packet stream.

- Full suite with PostgreSQL and MySQL up: **18,584 passed, 0 failed, 0 failed suites**.
- Both typechecks and `lint:ci` clean.

## Remaining on the epic

Phase 4 (channel messages via `ChannelCrypto` + stored PSKs), Phase 5 (status-topic device stats), Phase 5.5 (the shared multi-source **inclusion** audit), Phase 6 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc