### PR TITLE
fix(mobile): unbury the Sources drawer close control and the header chrome (#5053, #5051, #5052)

### DIFF
--- a/src/components/AppHeader/AppHeader.css
+++ b/src/components/AppHeader/AppHeader.css
@@ -67,6 +67,14 @@
   padding: 0.25rem 0.75rem;
   transition: all 0.2s ease;
   white-space: nowrap;
+  /*
+   * Never absorb the squeeze (#5051). `.header-left` is `overflow: hidden`, so
+   * a shrinkable back button gets hard-clipped mid-word ("Sourc…") rather than
+   * ellipsised. The source-name badge next to it already carries
+   * `text-overflow: ellipsis` and a `max-width`, so it is the element that
+   * should give way when the row runs out of room.
+   */
+  flex-shrink: 0;
 }
 
 .back-to-sources-btn:hover {
@@ -316,6 +324,43 @@
   .connection-status {
     margin: 0;
     padding: 0;
+  }
+
+  /*
+   * Collapse the cycling badge to icons only (#5051).
+   *
+   * The badge rotates Connected → Battery → Airtime, and its widest faces
+   * ("Plugged in 4.38V", "Ch 12.3% · Air 4.5%") plus the 5.5rem `min-width`
+   * reservation ran the header row past a 390px viewport. `.header-left` is
+   * `overflow: hidden`, so the overflow landed on the "Sources" back button as
+   * a hard clip. Dropping ~90px of always-reserved width is what makes the row
+   * fit; the colored dot still carries connection state, the face icon still
+   * says which metric is showing, and the numbers are one tap away in the
+   * System Status popup this badge opens.
+   *
+   * Deliberately the existing 768px mobile breakpoint rather than a third
+   * threshold — this block already hides the logo, the wordmark and the node
+   * info for the same reason. The rotation itself is untouched (#4917/#4927):
+   * this is presentation only.
+   */
+  .connection-status-label {
+    /* Was 5.5rem to stop the badge jumping as text faces rotate; with the text
+       gone the icon slot is what needs reserving. */
+    min-width: 1.25rem;
+    justify-content: center;
+  }
+
+  /* Hidden from layout, kept for screen readers — `display: none` would drop
+     the only textual form of the connection state from the accessibility tree,
+     leaving a colored dot and nothing to announce. */
+  .connection-status-label .status-text,
+  .connection-status-label .status-metric-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
   }
 
   .connection-status .status-indicator {

--- a/src/components/AppHeader/AppHeader.mobileChrome.test.tsx
+++ b/src/components/AppHeader/AppHeader.mobileChrome.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #5051: on a narrow viewport the cycling connection badge overflowed the
+ * header row and the "Sources" back button was hard-clipped to "Sourc…".
+ *
+ * Two things had to be true for that to happen, and both are asserted here:
+ * the badge reserved ~90px of width it did not need on a phone, and the back
+ * button was allowed to shrink inside an `overflow: hidden` row, so the
+ * overflow landed on it as a clip rather than on the element designed to
+ * ellipsise. jsdom does no layout and no media queries, so the geometry half
+ * is asserted against the stylesheet and the markup half against the render.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { CyclingConnectionStatus } from './CyclingConnectionStatus';
+
+const css = readFileSync(resolve('src/components/AppHeader/AppHeader.css'), 'utf-8');
+
+/** Body of `selector`'s rule inside the `@media (max-width: 768px)` block. */
+function mobileRule(selector: string): string {
+  const clean = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const start = clean.indexOf('@media (max-width: 768px)');
+  expect(start).toBeGreaterThan(-1);
+  // The mobile block ends where the next top-level @media begins.
+  const next = clean.indexOf('@media', start + 1);
+  const block = clean.slice(start, next === -1 ? undefined : next);
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return block.match(new RegExp(`(?:^|[},])\\s*${escaped}[^{}]*\\{([^}]*)\\}`, 'm'))?.[1] ?? '';
+}
+
+/** Body of a rule outside any media query. */
+function baseRule(selector: string): string {
+  const clean = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const upToFirstMedia = clean.slice(0, clean.indexOf('@media'));
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return upToFirstMedia.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))?.[1] ?? '';
+}
+
+const METRICS = { batteryLevel: 101, voltage: 4.38, channelUtilization: 12.3, airUtilTx: 4.5 };
+
+describe('header connection badge on narrow viewports (#5051)', () => {
+  it('wraps every badge face in a class the sheet can collapse', () => {
+    // A bare text node cannot be targeted by CSS — the collapse depends on
+    // these wrappers existing, so a refactor that drops them must fail here.
+    const { container } = render(
+      <CyclingConnectionStatus
+        connectionStatus="connected"
+        connectionStatusText="connected"
+        webSocketConnected
+        metrics={METRICS}
+        onClick={() => {}}
+        title="t"
+      />
+    );
+    // Face 0 is the plain status text.
+    expect(container.querySelector('.connection-status-label .status-text')).not.toBeNull();
+    expect(container.querySelector('.connection-status-label .status-text')?.textContent).toBe(
+      'connected'
+    );
+  });
+
+  it('wraps the metric faces too', () => {
+    // Render the battery face directly by giving it battery-only metrics and
+    // reaching the second face is timer-driven; instead assert the source
+    // contains the wrapper for both metric branches.
+    const source = readFileSync(resolve('src/components/AppHeader/CyclingConnectionStatus.tsx'), 'utf-8');
+    const wrappers = source.match(/className="status-metric-text"/g) ?? [];
+    expect(wrappers.length).toBe(2); // battery face + airtime face
+  });
+
+  it('hides the badge text on mobile without dropping it from the a11y tree', () => {
+    const rule = mobileRule('.connection-status-label .status-text');
+    expect(rule).not.toBe('');
+    // `display: none` would leave a screen reader with a colored dot and
+    // nothing to announce.
+    expect(rule).not.toMatch(/display:\s*none/);
+    expect(rule).toMatch(/position:\s*absolute/);
+    expect(rule).toMatch(/clip-path:\s*inset\(50%\)/);
+  });
+
+  it('releases the width the badge reserved for its longest face', () => {
+    // The base rule pins 5.5rem so the badge does not jump as text faces
+    // rotate. With the text hidden that reservation is pure overflow: it is
+    // most of what pushed the row past a 390px viewport.
+    const base = baseRule('.connection-status-label');
+    const baseMin = Number(base.match(/min-width:\s*([\d.]+)rem/)?.[1]);
+    expect(baseMin).toBe(5.5);
+
+    const mobile = mobileRule('.connection-status-label');
+    const mobileMin = Number(mobile.match(/min-width:\s*([\d.]+)rem/)?.[1]);
+    expect(Number.isFinite(mobileMin)).toBe(true);
+    expect(mobileMin).toBeLessThan(baseMin);
+    // Still reserves the icon slot, so the badge does not jitter as the face
+    // rotates between "no icon" (status) and "icon" (battery/airtime).
+    expect(mobileMin).toBeGreaterThan(0);
+  });
+
+  it('never lets the Sources back button be the element that gives way', () => {
+    // `.header-left` is overflow:hidden, so a shrinkable back button is
+    // clipped mid-word rather than ellipsised — the reported "Sourc…".
+    expect(baseRule('.back-to-sources-btn')).toMatch(/flex-shrink:\s*0/);
+    // The element that is *supposed* to absorb the squeeze still can.
+    const name = baseRule('.header-source-name');
+    expect(name).toMatch(/text-overflow:\s*ellipsis/);
+    expect(name).toMatch(/min-width:\s*0/);
+  });
+
+  it('does not make the header taller to buy the room', () => {
+    // The alternative fix in the issue. `--header-height` is a constant every
+    // other surface offsets from, and App.css deliberately shrinks it to 40px
+    // in landscape where vertical space is scarce — growing it here would
+    // fight #5053.
+    const appCss = readFileSync(resolve('src/App.css'), 'utf-8');
+    const landscape = appCss.slice(
+      appCss.indexOf('@media (max-height: 500px) and (orientation: landscape)')
+    );
+    expect(landscape).toMatch(/--header-height:\s*40px/);
+    // Nothing in the mobile header block grows the bar.
+    expect(mobileRule('.app-header')).not.toMatch(/min-height/);
+  });
+});

--- a/src/components/AppHeader/CyclingConnectionStatus.tsx
+++ b/src/components/AppHeader/CyclingConnectionStatus.tsx
@@ -93,7 +93,9 @@ export const CyclingConnectionStatus: React.FC<CyclingConnectionStatusProps> = (
       return (
         <span className="status-metric">
           <UiIcon name={plugged ? 'batteryCharging' : 'battery'} size={14} />
-          {parts.join(' ')}
+          {/* Wrapped, not a bare text node, so the narrow-viewport rules in
+              AppHeader.css can collapse the badge to its icon (#5051). */}
+          <span className="status-metric-text">{parts.join(' ')}</span>
         </span>
       );
     }
@@ -109,12 +111,12 @@ export const CyclingConnectionStatus: React.FC<CyclingConnectionStatusProps> = (
       return (
         <span className="status-metric">
           <UiIcon name="zap" size={14} />
-          {parts.join(' · ')}
+          <span className="status-metric-text">{parts.join(' · ')}</span>
         </span>
       );
     }
 
-    return <span>{connectionStatusText}</span>;
+    return <span className="status-text">{connectionStatusText}</span>;
   };
 
   return (

--- a/src/components/NodesTab.test.tsx
+++ b/src/components/NodesTab.test.tsx
@@ -448,8 +448,8 @@ describe('map controls: attribution clearance + zoom-to-fit (#4495, #4496)', () 
 
   it('bounds the mobile controls panel so it cannot reach the attribution strip', () => {
     // Raising z-index cannot fix this: the attribution is inside Leaflet's
-    // `.leaflet-bottom` (z-index 1000) while this panel must stay at 997 to
-    // yield to the Sources drawer (999). Geometry is the only lever.
+    // `.leaflet-bottom` (z-index 1000) while this panel stays at 997 to yield
+    // to the Sources drawer (1099 since #5052). Geometry is the only lever.
     const rule = mobileOverrideRule('.map-controls');
     expect(rule).toMatch(/max-height:\s*calc\(/);
     // The z-index that forces the geometric approach must still be there.

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -177,8 +177,18 @@
 /* Removed old layout-affecting rules - sidebar now floats over content */
 
 
-/* Mobile responsive - landscape: minimal changes to fix layout */
-@media (orientation: landscape) and (max-height: 700px) {
+/*
+ * Mobile responsive - landscape: minimal changes to fix layout.
+ *
+ * 500px, not the 700px this block used to carry (#5053). The shell had two
+ * disagreeing definitions of "compact landscape": 500px in App.css,
+ * AppHeader.css, SourceNav.module.css, SaveBar.css and `sidebarWidth.ts`, and
+ * 700px only here and in SidebarFooter.module.css. A viewport 501–700px tall in
+ * landscape therefore got a half-applied layout — the rail compacted itself and
+ * the footer vanished while the shell still drew a full-height desktop rail.
+ * One threshold, and it is the one JS already mirrors.
+ */
+@media (orientation: landscape) and (max-height: 500px) {
   .sidebar {
     padding-top: max(4px, env(safe-area-inset-top));
     padding-bottom: max(4px, env(safe-area-inset-bottom));
@@ -195,8 +205,8 @@
 /* Scrollbar styling moved with the nav list into SourceNav.module.css (#4473) —
    `.sidebar-nav` no longer exists in the markup. */
 
-/* Mobile landscape - increased threshold to catch more devices */
-@media (max-height: 700px) and (orientation: landscape) {
+/* Mobile landscape — same single 500px threshold as the block above (#5053). */
+@media (max-height: 500px) and (orientation: landscape) {
   .sidebar {
     /* Reduce padding to maximize scrollable area */
     padding-top: max(2px, env(safe-area-inset-top)) !important;
@@ -315,9 +325,12 @@
     right: 0;
     height: auto;
     /*
-     * `!important` only to beat the two `@media (max-height: 700px) and
-     * (orientation: landscape)` blocks further down, which set padding with
-     * `!important` to compact the *rail*. On a bottom bar that padding is just
+     * `!important` only to beat the two `@media (max-height: 500px) and
+     * (orientation: landscape)` blocks above (they read 700px until #5053),
+     * which set padding with `!important` to compact the *rail*. Those blocks
+     * now match exactly the same viewports as this one, so the override is
+     * load-bearing on every compact-landscape phone, not just the short end of
+     * the range. On a bottom bar that padding is just
      * height: it inflated the landscape bar to 53.7px against the 44px the
      * shell reserves, so content and the save bar sat under it.
      *

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -177,18 +177,33 @@
 /* Removed old layout-affecting rules - sidebar now floats over content */
 
 
-/*
- * Mobile responsive - landscape: minimal changes to fix layout.
+/* ============================================================================
+ * COMPACT-LANDSCAPE RAIL — scoped to viewports that actually HAVE a rail
+ * ============================================================================
+ * These two blocks compact the vertical nav rail on a short landscape screen.
+ * They used to be plain `(orientation: landscape) and (max-height: 700px)`,
+ * which overlapped the shell's own mobile definition —
+ * `(max-width: 768px), (max-height: 500px) and (orientation: landscape)` — the
+ * range in which SourceNav is a horizontal BOTTOM BAR, not a rail. Rail rules
+ * landing on a bar is not a cosmetic mismatch; #5054 traced an unreachable
+ * bottom nav to exactly that (`.sidebar.collapsed { width: 48px !important }`
+ * beating `.mobileBottomBar.collapsed { width: 100% }` from another sheet), and
+ * the `!important`s in the bottom-bar block at the end of this file exist only
+ * to claw those overrides back.
  *
- * 500px, not the 700px this block used to carry (#5053). The shell had two
- * disagreeing definitions of "compact landscape": 500px in App.css,
- * AppHeader.css, SourceNav.module.css, SaveBar.css and `sidebarWidth.ts`, and
- * 700px only here and in SidebarFooter.module.css. A viewport 501–700px tall in
- * landscape therefore got a half-applied layout — the rail compacted itself and
- * the footer vanished while the shell still drew a full-height desktop rail.
- * One threshold, and it is the one JS already mirrors.
- */
-@media (orientation: landscape) and (max-height: 500px) {
+ * So the reconciliation is NOT to move 700 down to 500 — that would delete the
+ * compaction from the 501–700px band where it does its job and keep it in the
+ * band where it causes harm. It is to subtract the bar's territory:
+ *
+ *     min-width: 769px   — wider than the shell's mobile breakpoint
+ *     min-height: 501px  — taller than the shell's compact-landscape threshold
+ *
+ * The shell threshold itself is unchanged at 500px, so `src/utils/sidebarWidth.ts`,
+ * `Sidebar.tsx` and `SourceNav.tsx` still mirror it exactly. (#5053)
+ * ============================================================================ */
+
+/* Mobile responsive - landscape: minimal changes to fix layout */
+@media (orientation: landscape) and (max-height: 700px) and (min-width: 769px) and (min-height: 501px) {
   .sidebar {
     padding-top: max(4px, env(safe-area-inset-top));
     padding-bottom: max(4px, env(safe-area-inset-bottom));
@@ -205,8 +220,8 @@
 /* Scrollbar styling moved with the nav list into SourceNav.module.css (#4473) —
    `.sidebar-nav` no longer exists in the markup. */
 
-/* Mobile landscape — same single 500px threshold as the block above (#5053). */
-@media (max-height: 500px) and (orientation: landscape) {
+/* Mobile landscape — same rail-only scoping as the block above (#5053). */
+@media (max-height: 700px) and (orientation: landscape) and (min-width: 769px) and (min-height: 501px) {
   .sidebar {
     /* Reduce padding to maximize scrollable area */
     padding-top: max(2px, env(safe-area-inset-top)) !important;
@@ -325,14 +340,18 @@
     right: 0;
     height: auto;
     /*
-     * `!important` only to beat the two `@media (max-height: 500px) and
-     * (orientation: landscape)` blocks above (they read 700px until #5053),
-     * which set padding with `!important` to compact the *rail*. Those blocks
-     * now match exactly the same viewports as this one, so the override is
-     * load-bearing on every compact-landscape phone, not just the short end of
-     * the range. On a bottom bar that padding is just
-     * height: it inflated the landscape bar to 53.7px against the 44px the
-     * shell reserves, so content and the save bar sat under it.
+     * `!important` was needed to beat the two compact-landscape RAIL blocks
+     * above, which set padding with `!important` of their own. On a bottom bar
+     * that padding is just height: it inflated the landscape bar to 53.7px
+     * against the 44px the shell reserves, so content and the save bar sat
+     * under it.
+     *
+     * Since #5053 those blocks are scoped `min-width: 769px` /
+     * `min-height: 501px`, so they no longer match any viewport this block
+     * matches and the `!important` here is belt-and-braces. Kept deliberately:
+     * it costs nothing, and it is the guard that made the collision survivable
+     * the last two times a rail rule leaked into the bar. Do not read it as
+     * proof that something still overrides this.
      *
      * padding-bottom keeps the safe-area inset rather than flattening to 0
      * (#4497). A flat 0 here ALSO beat SourceNav's own

--- a/src/components/SidebarFooter.module.css
+++ b/src/components/SidebarFooter.module.css
@@ -76,8 +76,10 @@
 }
 
 /* The per-source sidebar hides its footer on short landscape screens to free
-   nav space — mirrors the frozen .sidebar-footer rules in Sidebar.css. */
-@media (orientation: landscape) and (max-height: 700px) {
+   nav space — mirrors the frozen .sidebar-footer rules in Sidebar.css.
+   500px, not 700px: one shared "compact landscape" threshold across the shell
+   and its JS mirror in src/utils/sidebarWidth.ts (#5053). */
+@media (orientation: landscape) and (max-height: 500px) {
   .hideOnCompactLandscape {
     display: none;
   }

--- a/src/components/SidebarFooter.module.css
+++ b/src/components/SidebarFooter.module.css
@@ -76,10 +76,13 @@
 }
 
 /* The per-source sidebar hides its footer on short landscape screens to free
-   nav space — mirrors the frozen .sidebar-footer rules in Sidebar.css.
-   500px, not 700px: one shared "compact landscape" threshold across the shell
-   and its JS mirror in src/utils/sidebarWidth.ts (#5053). */
-@media (orientation: landscape) and (max-height: 500px) {
+   nav space — mirrors the frozen .sidebar-footer rules in Sidebar.css, and
+   carries the same rail-only scoping (#5053): below the shell's mobile
+   thresholds SourceNav is a bottom bar, and it already hides `.footerSlot`
+   outright, so this rule has no business firing there. See the banner above
+   those blocks in Sidebar.css for why subtracting the bar's territory beats
+   moving 700 down to 500. */
+@media (orientation: landscape) and (max-height: 700px) and (min-width: 769px) and (min-height: 501px) {
   .hideOnCompactLandscape {
     display: none;
   }

--- a/src/components/map/MapSidebar.css
+++ b/src/components/map/MapSidebar.css
@@ -7,7 +7,19 @@
   top: 10px;
   right: 10px;
   bottom: 10px;
-  z-index: 1000; /* above Leaflet panes (which top out ~700) */
+  /*
+   * Above Leaflet's CONTROL containers, not just its panes (#5052).
+   *
+   * The old value was 1000 with the comment "above Leaflet panes (which top out
+   * ~700)". The panes were the wrong thing to reason about: `.leaflet-top` and
+   * `.leaflet-bottom`, which hold the zoom buttons and the attribution, also
+   * ship 1000 (leaflet.css:141). At an equal z-index the winner falls to DOM
+   * order, which is why the overlap looked intermittent. 1001 settles it.
+   *
+   * Still below the mobile Sources drawer — see the ladder documented on
+   * `.dashboard-sidebar-backdrop` in src/styles/dashboard.css.
+   */
+  z-index: 1001;
   width: 300px;
   max-width: calc(100% - 20px);
   display: flex;

--- a/src/components/map/MapSidebar.css
+++ b/src/components/map/MapSidebar.css
@@ -73,7 +73,9 @@
   position: absolute;
   top: 10px;
   right: 10px;
-  z-index: 1000;
+  /* Matches `.map-sidebar` above, for the same reason (#5052): 1000 ties with
+     Leaflet's control containers and lets DOM order decide. */
+  z-index: 1001;
   width: 34px;
   height: 34px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -13,6 +13,21 @@
   color: var(--color-text);
   font-family: var(--font-family, sans-serif);
   overflow: hidden;
+
+  /*
+   * Real on-screen height of `.dashboard-topbar` (#5053).
+   *
+   * index.html ships `viewport-fit=cover`, so the page starts at the physical
+   * screen edge and the top of the topbar sits *under* the status bar / notch.
+   * `.app-header` already pads for this (AppHeader.css); the dashboard topbar
+   * did not, which is why the hamburger/X was half-hidden behind the status bar
+   * even in portrait.
+   *
+   * Anything positioned below the topbar (the mobile drawer and its backdrop)
+   * must offset by this, NOT by bare `--header-height` — that variable is a
+   * hardcoded constant that does not know about the inset.
+   */
+  --dashboard-topbar-height: calc(var(--header-height, 64px) + env(safe-area-inset-top, 0px));
 }
 
 .dashboard-topbar {
@@ -20,8 +35,11 @@
   flex-direction: row;
   align-items: center;
   gap: 12px;
-  padding: 0 24px;
-  height: var(--header-height, 64px);
+  /* Horizontal insets keep the hamburger and the user menu clear of the notch
+     in landscape, where safe-area-inset-left/right are non-zero (#5053). */
+  padding: env(safe-area-inset-top, 0px) calc(24px + env(safe-area-inset-right, 0px)) 0
+    calc(24px + env(safe-area-inset-left, 0px));
+  height: var(--dashboard-topbar-height);
   flex-shrink: 0;
   background: var(--color-bg-raised);
   border-bottom: 1px solid var(--color-surface);
@@ -746,7 +764,21 @@
 
 /* ── Mobile: collapsible sidebar ─────────────────────────────────────────── */
 
-@media (max-width: 768px) {
+/*
+ * Width OR compact landscape (#5053).
+ *
+ * A phone held sideways is *wider* than 768px (iPhone 13 landscape is 844px,
+ * Pixel 7 is 915px), so a width-only query drops the whole mobile treatment the
+ * moment the user rotates: `.dashboard-topbar-hamburger` reverted to
+ * `display: none`, which deleted the only control that closes the Sources
+ * drawer, while the drawer itself fell back to the static desktop sidebar and
+ * looked stuck open.
+ *
+ * The landscape half deliberately reuses the exact query App.css, Sidebar.css,
+ * SourceNav.module.css and SaveBar.css use — and that `src/utils/sidebarWidth.ts`
+ * mirrors in JS — so the whole shell agrees on what "mobile" means.
+ */
+@media (max-width: 768px), (max-height: 500px) and (orientation: landscape) {
   /* Show hamburger toggle in the topbar */
   .dashboard-topbar-hamburger {
     display: inline-flex;
@@ -754,9 +786,12 @@
     justify-content: center;
   }
 
-  /* Tighten up the topbar on mobile */
+  /* Tighten up the topbar on mobile.
+     Keep the safe-area insets — a flat `0 8px` here re-buried the close control
+     under the status bar / notch that the base rule pads for (#5053). */
   .dashboard-topbar {
-    padding: 0 8px;
+    padding: env(safe-area-inset-top, 0px) calc(8px + env(safe-area-inset-right, 0px)) 0
+      calc(8px + env(safe-area-inset-left, 0px));
     gap: 6px;
   }
 
@@ -802,8 +837,10 @@
   /* Sidebar becomes a slide-in overlay drawer */
   .dashboard-sidebar {
     position: fixed;
-    top: var(--header-height, 64px);
-    left: 0;
+    top: var(--dashboard-topbar-height);
+    /* Clear the notch in landscape — a fixed `left: 0` puts the first source
+       card under it on a notched phone held sideways (#5053). */
+    left: env(safe-area-inset-left, 0px);
     bottom: 0;
     /* Overlay drawer has a fixed width; ignore the desktop resize var. */
     width: 260px;
@@ -825,7 +862,9 @@
   /* Backdrop fades in when drawer is open */
   .dashboard-sidebar-backdrop {
     display: block;
-    top: var(--header-height, 64px);
+    /* Must match the drawer's `top` exactly: any smaller value slides the
+       backdrop up over the topbar and swallows taps on the close control. */
+    top: var(--dashboard-topbar-height);
   }
 
   .dashboard-sidebar-backdrop.open {

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -104,12 +104,31 @@
 
 /* ── Sidebar backdrop (mobile overlay) ──────────────────────────────────── */
 
+/*
+ * Mobile drawer stacking ladder (#5052). Read this before changing a number.
+ *
+ *   200-700  Leaflet map panes
+ *   997      .map-controls on mobile (nodes.css) — yields to the drawer
+ *   1000     .leaflet-top / .leaflet-bottom — Leaflet's own CONTROL containers
+ *            (zoom buttons, attribution). Vendor value, leaflet.css:141. These
+ *            are NOT panes: the panes top out at 700, the controls do not.
+ *   1001     .map-sidebar (MapSidebar.css) — must beat the control containers
+ *   1098     this backdrop
+ *   1099     .dashboard-sidebar.mobile-open
+ *   10000+   app header, app rail, modals
+ *
+ * The drawer used to sit at 999, one below Leaflet's control layer, so the
+ * zoom buttons painted over the first source card. Raising the drawer is the
+ * fix rather than lowering Leaflet's controls: the attribution strip shares
+ * that same 1000, and pushing it down is what nodes.css:2556 was written to
+ * avoid.
+ */
 .dashboard-sidebar-backdrop {
   display: none; /* Hidden on desktop */
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.5);
-  z-index: 998;
+  z-index: 1098;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;
@@ -844,7 +863,9 @@
     bottom: 0;
     /* Overlay drawer has a fixed width; ignore the desktop resize var. */
     width: 260px;
-    z-index: 999;
+    /* Above Leaflet's control containers (1000) — see the ladder on
+       `.dashboard-sidebar-backdrop` (#5052). */
+    z-index: 1099;
     transform: translateX(-100%);
     transition: transform 0.25s ease;
     box-shadow: 2px 0 12px rgba(0, 0, 0, 0.4);

--- a/src/styles/dashboardMobileDrawer.test.ts
+++ b/src/styles/dashboardMobileDrawer.test.ts
@@ -310,6 +310,11 @@ describe('compact-landscape queries do not straddle rail and bottom bar (#5053)'
     const railBlocks = [...clean.matchAll(/@media([^{]*orientation:\s*landscape[^{]*)\{/g)].filter(
       (m) => /max-height:\s*700px/.test(m[1])
     );
+    // Sidebar.css carries exactly two of these — the padding/controls block and
+    // the header/logo/collapsed-rail block. Pinning the count is deliberate: a
+    // third one added later is a new place for a rail rule to leak into the bar,
+    // and the author should have to come here and confirm it is guarded rather
+    // than have the loop silently skip it.
     expect(railBlocks.length).toBe(2);
     for (const m of railBlocks) {
       expect(mediaMatches(m[1].trim(), LANDSCAPE_PHONE)).toBe(false);

--- a/src/styles/dashboardMobileDrawer.test.ts
+++ b/src/styles/dashboardMobileDrawer.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Regression tests for the Sources drawer close control (#5053).
+ *
+ * Reported on v4.16.0-rc2: in landscape on a phone the Sources menu could not
+ * be dismissed. The close (X) is `.dashboard-topbar-hamburger`, rendered by
+ * `DashboardPage` and toggled to the `close` icon while the drawer is open.
+ * Its entire mobile treatment lived behind `@media (max-width: 768px)` — but a
+ * phone in landscape is *wider* than 768px (iPhone 13 → 844, Pixel 7 → 915), so
+ * on rotation the button reverted to `display: none` and the only way to close
+ * the drawer disappeared.
+ *
+ * jsdom implements neither layout nor media queries, so a render test cannot
+ * see this. Instead of grepping the sheet for substrings, these tests run the
+ * real declarations through a miniature cascade resolver for the handful of
+ * selectors involved, and assert the resolved geometry at concrete viewports:
+ * the button is displayed, and the drawer and its backdrop start exactly at the
+ * bottom of the top bar. A drawer or backdrop that starts any higher covers the
+ * button and eats the tap, which is the other half of the report ("the X is
+ * already partly tucked under the top bar").
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const css = readFileSync(resolve('src/styles/dashboard.css'), 'utf-8');
+
+interface Viewport {
+  width: number;
+  height: number;
+}
+
+/** Evaluates the small media-feature grammar these sheets actually use. */
+function mediaMatches(condition: string, vp: Viewport): boolean {
+  // A comma-separated list is an OR of conjunctions.
+  return condition.split(',').some((clause) => {
+    const features = clause.split(/\s+and\s+/).map((f) => f.trim());
+    return features.every((feature) => {
+      const m = feature.match(/\(\s*([a-z-]+)\s*:\s*([^)]+?)\s*\)/);
+      if (!m) throw new Error(`unsupported media feature: ${feature}`);
+      const [, name, value] = m;
+      switch (name) {
+        case 'max-width':
+          return vp.width <= Number(value.replace('px', ''));
+        case 'min-width':
+          return vp.width >= Number(value.replace('px', ''));
+        case 'max-height':
+          return vp.height <= Number(value.replace('px', ''));
+        case 'min-height':
+          return vp.height >= Number(value.replace('px', ''));
+        case 'orientation':
+          // CSS counts a square viewport as landscape.
+          return value === 'landscape' ? vp.width >= vp.height : vp.height > vp.width;
+        default:
+          throw new Error(`unsupported media feature: ${name}`);
+      }
+    });
+  });
+}
+
+/** Strips comments and splits the sheet into (mediaCondition | null, body) blocks. */
+function topLevelBlocks(source: string): Array<{ condition: string | null; body: string }> {
+  const clean = source.replace(/\/\*[\s\S]*?\*\//g, '');
+  const blocks: Array<{ condition: string | null; body: string }> = [];
+  let i = 0;
+  while (i < clean.length) {
+    const braceAt = clean.indexOf('{', i);
+    if (braceAt === -1) break;
+    const prelude = clean.slice(i, braceAt).trim();
+    // Walk to the matching close brace.
+    let depth = 0;
+    let j = braceAt;
+    for (; j < clean.length; j++) {
+      if (clean[j] === '{') depth++;
+      else if (clean[j] === '}' && --depth === 0) break;
+    }
+    const body = clean.slice(braceAt + 1, j);
+    if (prelude.startsWith('@media')) {
+      blocks.push({ condition: prelude.slice('@media'.length).trim(), body });
+    } else if (prelude.startsWith('@')) {
+      // Other at-rules (@keyframes, @supports) are not needed by these tests.
+    } else {
+      blocks.push({ condition: null, body: `${prelude} {${body}}` });
+    }
+    i = j + 1;
+  }
+  return blocks;
+}
+
+/**
+ * Resolved value of one property for one selector at one viewport.
+ *
+ * Deliberately simple: every rule in this sheet that touches these selectors
+ * has the same specificity, so source order alone decides the winner.
+ */
+function resolve_(selector: string, property: string, vp: Viewport): string | null {
+  let winner: string | null = null;
+  const wanted = new RegExp(
+    `(^|\\})\\s*${selector.replace(/[.\\[\]]/g, '\\$&')}\\s*\\{([^}]*)\\}`,
+    'g'
+  );
+  for (const block of topLevelBlocks(css)) {
+    if (block.condition !== null && !mediaMatches(block.condition, vp)) continue;
+    const scope = block.condition === null ? block.body : block.body;
+    wanted.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = wanted.exec(scope)) !== null) {
+      const decl = m[2].match(new RegExp(`(?:^|;)\\s*${property}\\s*:\\s*([^;]+)`));
+      if (decl) winner = decl[1].trim();
+    }
+  }
+  return winner;
+}
+
+const PORTRAIT_PHONE: Viewport = { width: 390, height: 844 }; // iPhone 13
+const LANDSCAPE_PHONE: Viewport = { width: 844, height: 390 }; // iPhone 13, rotated
+const LANDSCAPE_BIG_PHONE: Viewport = { width: 915, height: 412 }; // Pixel 7, rotated
+const LANDSCAPE_SMALL_PHONE: Viewport = { width: 667, height: 375 }; // iPhone SE, rotated
+const DESKTOP: Viewport = { width: 1440, height: 900 };
+
+describe('Sources drawer close control (#5053)', () => {
+  const mobileViewports: Array<[string, Viewport]> = [
+    ['portrait phone', PORTRAIT_PHONE],
+    ['landscape phone', LANDSCAPE_PHONE],
+    ['landscape big phone', LANDSCAPE_BIG_PHONE],
+    ['landscape small phone', LANDSCAPE_SMALL_PHONE],
+  ];
+
+  it.each(mobileViewports)('renders the close control on a %s', (_name, vp) => {
+    // This is the whole bug: `display: none` means the button has no box, so it
+    // cannot be hit at any coordinate.
+    expect(resolve_('.dashboard-topbar-hamburger', 'display', vp)).not.toBe('none');
+  });
+
+  it.each(mobileViewports)('overlays the drawer rather than reflowing it on a %s', (_name, vp) => {
+    // A static drawer is the desktop sidebar: it takes layout space and there is
+    // nothing to dismiss, which is what "the menu stays open" looked like.
+    expect(resolve_('.dashboard-sidebar', 'position', vp)).toBe('fixed');
+  });
+
+  it.each(mobileViewports)(
+    'starts the drawer and backdrop exactly at the bottom of the top bar on a %s',
+    (_name, vp) => {
+      const topbarHeight = resolve_('.dashboard-topbar', 'height', vp);
+      expect(topbarHeight).toBe('var(--dashboard-topbar-height)');
+      // Same expression, so the drawer can never ride up over the close control
+      // however tall the notch inset makes the bar at runtime.
+      expect(resolve_('.dashboard-sidebar', 'top', vp)).toBe(topbarHeight);
+      expect(resolve_('.dashboard-sidebar-backdrop', 'top', vp)).toBe(topbarHeight);
+    }
+  );
+
+  it('keeps the desktop layout untouched', () => {
+    expect(resolve_('.dashboard-topbar-hamburger', 'display', DESKTOP)).toBe('none');
+    expect(resolve_('.dashboard-sidebar', 'position', DESKTOP)).toBeNull();
+    expect(resolve_('.dashboard-sidebar-backdrop', 'display', DESKTOP)).toBe('none');
+  });
+
+  it('pads the top bar by the notch inset so the control is not under the status bar', () => {
+    // index.html ships viewport-fit=cover, so without this the page — and the
+    // close control with it — starts under the status bar.
+    const padding = resolve_('.dashboard-topbar', 'padding', PORTRAIT_PHONE);
+    expect(padding).toMatch(/env\(safe-area-inset-top/);
+    // ...and the declared height has to include that padding, or the bar
+    // overlaps the content below it.
+    expect(css).toMatch(
+      /--dashboard-topbar-height:\s*calc\(var\(--header-height[^)]*\)\s*\+\s*env\(safe-area-inset-top/
+    );
+  });
+
+  it('clears the side notch in landscape', () => {
+    // safe-area-inset-left is non-zero on a notched phone held sideways; a flat
+    // `padding: 0 24px` / `left: 0` puts the close control under the notch.
+    expect(resolve_('.dashboard-topbar', 'padding', LANDSCAPE_PHONE)).toMatch(
+      /env\(safe-area-inset-left/
+    );
+    expect(resolve_('.dashboard-sidebar', 'left', LANDSCAPE_PHONE)).toMatch(
+      /env\(safe-area-inset-left/
+    );
+  });
+});
+
+describe('compact-landscape breakpoint is a single number (#5053)', () => {
+  /**
+   * The shell had two competing definitions of "compact landscape" — 500px in
+   * App.css/AppHeader.css/SourceNav/SaveBar and 700px in Sidebar.css and
+   * SidebarFooter.module.css — so a viewport 501–700px tall in landscape got
+   * half of each layout. `src/utils/sidebarWidth.ts` mirrors the 500px query in
+   * JS, so 500px is the number the rest of the app already agrees on.
+   */
+  const sheets = [
+    'src/App.css',
+    'src/styles/dashboard.css',
+    'src/components/Sidebar.css',
+    'src/components/SidebarFooter.module.css',
+    'src/components/AppHeader/AppHeader.css',
+    'src/components/nav/SourceNav.module.css',
+    'src/components/SaveBar/SaveBar.css',
+  ];
+
+  it.each(sheets)('%s uses max-height: 500px for every landscape query', (sheet) => {
+    const text = readFileSync(resolve(sheet), 'utf-8').replace(/\/\*[\s\S]*?\*\//g, '');
+    const landscapeQueries = [...text.matchAll(/@media([^{]*orientation:\s*landscape[^{]*)\{/g)].map(
+      (m) => m[1]
+    );
+    for (const q of landscapeQueries) {
+      for (const [, value] of q.matchAll(/max-height:\s*(\d+)px/g)) {
+        expect(Number(value), `${sheet}: @media${q}`).toBe(500);
+      }
+    }
+  });
+
+  it('matches the threshold the JS mirror uses', async () => {
+    const { MOBILE_LANDSCAPE_MAX_HEIGHT_PX } = await import('../utils/sidebarWidth.js');
+    expect(MOBILE_LANDSCAPE_MAX_HEIGHT_PX).toBe(500);
+  });
+});

--- a/src/styles/dashboardMobileDrawer.test.ts
+++ b/src/styles/dashboardMobileDrawer.test.ts
@@ -179,17 +179,97 @@ describe('Sources drawer close control (#5053)', () => {
   });
 });
 
-describe('compact-landscape breakpoint is a single number (#5053)', () => {
+describe('Sources drawer stacks above the Leaflet control layer (#5052)', () => {
+  /**
+   * Leaflet's *panes* top out at 700, but `.leaflet-top` / `.leaflet-bottom` —
+   * the containers holding the zoom buttons and the attribution — ship 1000.
+   * The drawer sat at 999, one below, so the zoom control painted over the
+   * first source card. Read the vendor value rather than hardcoding it, so a
+   * Leaflet upgrade that moves the number fails here instead of in the field.
+   */
+  const leafletCss = readFileSync(resolve('node_modules/leaflet/dist/leaflet.css'), 'utf-8');
+  const LEAFLET_CONTROL_Z = (() => {
+    const block = leafletCss.match(
+      /\.leaflet-top,\s*\n?\s*\.leaflet-bottom\s*\{([^}]*)\}/
+    )?.[1];
+    const z = block?.match(/z-index:\s*(\d+)/)?.[1];
+    return Number(z);
+  })();
+
+  const z = (selector: string, vp: Viewport) => Number(resolve_(selector, 'z-index', vp));
+
+  it('reads a usable z-index off Leaflet itself', () => {
+    expect(Number.isFinite(LEAFLET_CONTROL_Z)).toBe(true);
+    expect(LEAFLET_CONTROL_Z).toBe(1000);
+  });
+
+  it.each([
+    ['portrait phone', PORTRAIT_PHONE],
+    ['landscape phone', LANDSCAPE_PHONE],
+  ] as Array<[string, Viewport]>)(
+    'puts the drawer and its backdrop above Leaflet\'s controls on a %s',
+    (_name, vp) => {
+      expect(z('.dashboard-sidebar', vp)).toBeGreaterThan(LEAFLET_CONTROL_Z);
+      expect(z('.dashboard-sidebar-backdrop', vp)).toBeGreaterThan(LEAFLET_CONTROL_Z);
+      // The drawer still sits above its own backdrop.
+      expect(z('.dashboard-sidebar', vp)).toBeGreaterThan(z('.dashboard-sidebar-backdrop', vp));
+    }
+  );
+
+  it('keeps the map-controls panel yielding to the drawer', () => {
+    // The documented 997 relationship (nodes.css) must survive the raise.
+    const nodesCss = readFileSync(resolve('src/styles/nodes.css'), 'utf-8');
+    const mobileBlock = nodesCss.slice(nodesCss.lastIndexOf('Map Controls (mobile override)'));
+    const rule = mobileBlock.match(/\.map-controls\s*\{([^}]*)\}/)?.[1] ?? '';
+    const panelZ = Number(rule.match(/z-index:\s*(\d+)/)?.[1]);
+    expect(panelZ).toBe(997);
+    expect(panelZ).toBeLessThan(z('.dashboard-sidebar-backdrop', PORTRAIT_PHONE));
+  });
+
+  it('applies the map-controls mobile override in landscape too', () => {
+    // Same width-only-query defect as #5053: without the landscape clause the
+    // Features panel keeps its desktop z-index and does not yield.
+    const nodesCss = readFileSync(resolve('src/styles/nodes.css'), 'utf-8');
+    const idx = nodesCss.lastIndexOf('Map Controls (mobile override)');
+    const query = nodesCss.slice(idx).match(/@media([^{]*)\{/)?.[1] ?? '';
+    expect(query).toMatch(/max-width:\s*768px/);
+    expect(query).toMatch(/max-height:\s*500px\)\s*and\s*\(orientation:\s*landscape/);
+  });
+
+  it('lifts .map-sidebar clear of the tie with Leaflet\'s controls', () => {
+    const mapSidebarCss = readFileSync(resolve('src/components/map/MapSidebar.css'), 'utf-8');
+    const rule = mapSidebarCss.match(/\.map-sidebar\s*\{([\s\S]*?)\n\}/)?.[1] ?? '';
+    const value = Number(rule.match(/z-index:\s*(\d+)/)?.[1]);
+    expect(value).toBeGreaterThan(LEAFLET_CONTROL_Z);
+    // ...but still under the Sources drawer.
+    expect(value).toBeLessThan(z('.dashboard-sidebar', PORTRAIT_PHONE));
+  });
+});
+
+describe('compact-landscape queries do not straddle rail and bottom bar (#5053)', () => {
   /**
    * The shell had two competing definitions of "compact landscape" — 500px in
    * App.css/AppHeader.css/SourceNav/SaveBar and 700px in Sidebar.css and
-   * SidebarFooter.module.css — so a viewport 501–700px tall in landscape got
-   * half of each layout. `src/utils/sidebarWidth.ts` mirrors the 500px query in
-   * JS, so 500px is the number the rest of the app already agrees on.
+   * SidebarFooter.module.css.
+   *
+   * The 700px pair are RAIL rules: they compact the vertical nav on a short
+   * landscape screen. Below the shell's own thresholds SourceNav is a
+   * horizontal bottom BAR instead, and a rail rule landing on a bar is not
+   * cosmetic — #5054 traced an unreachable bottom nav to
+   * `.sidebar.collapsed { width: 48px !important }` from one of these blocks
+   * beating `.mobileBottomBar.collapsed { width: 100% }`.
+   *
+   * So the invariant is not "one number". It is: a landscape query either uses
+   * the shell threshold (500px, the one `sidebarWidth.ts` mirrors), or it is a
+   * rail block that explicitly subtracts the bar's territory.
    */
+  const SHELL_MAX_HEIGHT = 500;
+  const SHELL_MAX_WIDTH = 768;
+
   const sheets = [
     'src/App.css',
     'src/styles/dashboard.css',
+    'src/styles/nodes.css',
     'src/components/Sidebar.css',
     'src/components/SidebarFooter.module.css',
     'src/components/AppHeader/AppHeader.css',
@@ -197,20 +277,53 @@ describe('compact-landscape breakpoint is a single number (#5053)', () => {
     'src/components/SaveBar/SaveBar.css',
   ];
 
-  it.each(sheets)('%s uses max-height: 500px for every landscape query', (sheet) => {
+  it.each(sheets)('%s: every landscape query is shell-scoped or rail-scoped', (sheet) => {
     const text = readFileSync(resolve(sheet), 'utf-8').replace(/\/\*[\s\S]*?\*\//g, '');
-    const landscapeQueries = [...text.matchAll(/@media([^{]*orientation:\s*landscape[^{]*)\{/g)].map(
+    const queries = [...text.matchAll(/@media([^{]*orientation:\s*landscape[^{]*)\{/g)].map(
       (m) => m[1]
     );
-    for (const q of landscapeQueries) {
-      for (const [, value] of q.matchAll(/max-height:\s*(\d+)px/g)) {
-        expect(Number(value), `${sheet}: @media${q}`).toBe(500);
-      }
+    expect(queries.length).toBeGreaterThan(0);
+
+    for (const q of queries) {
+      const maxHeights = [...q.matchAll(/max-height:\s*(\d+)px/g)].map((m) => Number(m[1]));
+      if (maxHeights.length === 0) continue; // orientation-only query — nothing to reconcile
+      if (maxHeights.every((h) => h === SHELL_MAX_HEIGHT)) continue; // shell-scoped
+
+      // Anything else is a rail block and must exclude the bottom bar on both
+      // axes, or it will fire on viewports where no rail exists.
+      const minWidth = Number(q.match(/min-width:\s*(\d+)px/)?.[1]);
+      const minHeight = Number(q.match(/min-height:\s*(\d+)px/)?.[1]);
+      expect(minWidth, `${sheet}: @media${q} lacks a min-width guard`).toBeGreaterThan(
+        SHELL_MAX_WIDTH
+      );
+      expect(minHeight, `${sheet}: @media${q} lacks a min-height guard`).toBeGreaterThan(
+        SHELL_MAX_HEIGHT
+      );
+    }
+  });
+
+  it('leaves no rail rule matching a bottom-bar viewport', () => {
+    // The concrete regression: a landscape phone must not pick up the rail's
+    // collapsed width, which is what stubbed the bottom nav in #5054.
+    const sidebarCss = readFileSync(resolve('src/components/Sidebar.css'), 'utf-8');
+    const clean = sidebarCss.replace(/\/\*[\s\S]*?\*\//g, '');
+    const railBlocks = [...clean.matchAll(/@media([^{]*orientation:\s*landscape[^{]*)\{/g)].filter(
+      (m) => /max-height:\s*700px/.test(m[1])
+    );
+    expect(railBlocks.length).toBe(2);
+    for (const m of railBlocks) {
+      expect(mediaMatches(m[1].trim(), LANDSCAPE_PHONE)).toBe(false);
+      expect(mediaMatches(m[1].trim(), LANDSCAPE_SMALL_PHONE)).toBe(false);
+      // ...but still active where a rail genuinely exists.
+      expect(mediaMatches(m[1].trim(), { width: 1024, height: 600 })).toBe(true);
     }
   });
 
   it('matches the threshold the JS mirror uses', async () => {
-    const { MOBILE_LANDSCAPE_MAX_HEIGHT_PX } = await import('../utils/sidebarWidth.js');
-    expect(MOBILE_LANDSCAPE_MAX_HEIGHT_PX).toBe(500);
+    const { MOBILE_LANDSCAPE_MAX_HEIGHT_PX, MOBILE_BREAKPOINT_PX } = await import(
+      '../utils/sidebarWidth.js'
+    );
+    expect(MOBILE_LANDSCAPE_MAX_HEIGHT_PX).toBe(SHELL_MAX_HEIGHT);
+    expect(MOBILE_BREAKPOINT_PX).toBe(SHELL_MAX_WIDTH);
   });
 });

--- a/src/styles/nodes.css
+++ b/src/styles/nodes.css
@@ -2537,25 +2537,29 @@
    over the base `top/right/z-index` above. (Issue #3532 — the original fix
    placed this in an earlier media block and was silently overridden, so the
    Features panel still painted over the slide-in Sources sidebar on mobile.) */
-@media (max-width: 768px) {
+/* Width OR compact landscape (#5053): a phone held sideways is wider than
+   768px, so a width-only query left the panel unconstrained — and un-yielding
+   — in exactly the orientation where the Sources drawer overlays the map. */
+@media (max-width: 768px), (max-height: 500px) and (orientation: landscape) {
   .map-controls {
     top: 16px;
     right: 8px;
     left: auto;
     max-width: calc(100vw - 64px);
-    /* Sit below the mobile sidebar drawer (.dashboard-sidebar, z-index 999)
-       and its backdrop (998) so the Features panel yields when the Sources
-       sidebar is open. When the drawer is closed its backdrop is
-       opacity:0/pointer-events:none, so this has no effect on the normal
-       map-controls interaction. */
+    /* Sit below the mobile sidebar drawer (.dashboard-sidebar) and its
+       backdrop so the Features panel yields when the Sources sidebar is open.
+       Those now sit at 1099/1098, above Leaflet's control layer (#5052) — see
+       the ladder documented on `.dashboard-sidebar-backdrop` in dashboard.css.
+       When the drawer is closed its backdrop is opacity:0/pointer-events:none,
+       so this has no effect on the normal map-controls interaction. */
     z-index: 997;
     /*
      * Keep the panel clear of the Leaflet attribution strip (#4495).
      *
      * Raising z-index cannot solve this: the attribution lives in Leaflet's
-     * own `.leaflet-bottom`, which ships `z-index: 1000`, while this panel must
-     * stay at 997 to yield to the Sources drawer (999). 997 < 1000, so wherever
-     * the two overlap the attribution wins — which is exactly the report.
+     * own `.leaflet-bottom`, which ships `z-index: 1000`, while this panel
+     * stays at 997 to yield to the Sources drawer. 997 < 1000, so wherever the
+     * two overlap the attribution wins — which is exactly the report.
      * Bounding the height means they never overlap in the first place.
      *
      * 16px top offset + ~34px for the attribution strip and a little air.

--- a/src/utils/sidebarWidth.ts
+++ b/src/utils/sidebarWidth.ts
@@ -18,11 +18,16 @@ export const MOBILE_BREAKPOINT_PX = 768;
  * layout — App.css collapses the rail to 48px for both conditions, so the width
  * test alone would misclassify it as desktop.
  *
- * This is now the *only* compact-landscape threshold in the sheets. Sidebar.css
- * and SidebarFooter.module.css used to carry a competing 700px variant, so a
- * viewport 501–700px tall in landscape got a half-applied layout; #5053 folded
- * them into this one. If you change this number, change every
- * `(max-height: 500px) and (orientation: landscape)` block with it.
+ * This is the shell's threshold: below it the nav is a bottom bar. Sidebar.css
+ * and SidebarFooter.module.css carry a separate `max-height: 700px` landscape
+ * query, but that one compacts the vertical RAIL and is scoped
+ * `min-width: 769px` / `min-height: 501px` so it cannot reach into bar
+ * territory (#5053). The two describe different things and are allowed to
+ * differ; what is not allowed is the rail query overlapping this one.
+ *
+ * If you change this number, change every
+ * `(max-height: 500px) and (orientation: landscape)` block with it — and the
+ * `min-height` guard on the rail blocks.
  */
 export const MOBILE_LANDSCAPE_MAX_HEIGHT_PX = 500;
 

--- a/src/utils/sidebarWidth.ts
+++ b/src/utils/sidebarWidth.ts
@@ -17,6 +17,12 @@ export const MOBILE_BREAKPOINT_PX = 768;
  * A landscape phone is wider than MOBILE_BREAKPOINT_PX but is still the mobile
  * layout — App.css collapses the rail to 48px for both conditions, so the width
  * test alone would misclassify it as desktop.
+ *
+ * This is now the *only* compact-landscape threshold in the sheets. Sidebar.css
+ * and SidebarFooter.module.css used to carry a competing 700px variant, so a
+ * viewport 501–700px tall in landscape got a half-applied layout; #5053 folded
+ * them into this one. If you change this number, change every
+ * `(max-height: 500px) and (orientation: landscape)` block with it.
  */
 export const MOBILE_LANDSCAPE_MAX_HEIGHT_PX = 500;
 


### PR DESCRIPTION
Fixes #5053
Fixes #5051
Fixes #5052

Three reports from NullVoid on v4.16.0-rc2, all on the same mobile chrome — the app header, the dashboard top bar, and the Sources drawer. One PR because they share the surface and two of them share a root cause.

---

## #5053 — the Sources menu could not be closed in landscape

**What owns the X.** `.dashboard-topbar-hamburger`, rendered by `src/pages/DashboardPage.tsx` (~line 1218). It is one button that toggles the drawer and swaps `UiIcon name="menu"` for `name="close"` while it is open, so the "X" and the "hamburger" are the same element. The drawer is `.dashboard-sidebar.mobile-open` (`DashboardSidebar.tsx`), styled in `src/styles/dashboard.css`. Not `SourceNav`, not `AppHeader` — this is the source-picker landing page.

**Cause 1, the landscape half: a width-only media query.** The whole mobile treatment sat behind `@media (max-width: 768px)`. A phone held sideways is *wider* than 768px — iPhone 13 landscape is 844, Pixel 7 is 915. Measured on `main` at 844×390:

```
matchMedia('(max-width: 768px)')                               -> false
matchMedia('(max-height: 500px) and (orientation: landscape)') -> true
.dashboard-topbar-hamburger   display: none, rect 0×0    <- no box, no hit area
.dashboard-sidebar            position: static, 240px, still .mobile-open
```

The control was not clipped — it was **not rendered at all**, and the drawer fell back to the static desktop sidebar, which is what "the menu stays open" looked like. Meanwhile `App.css`, `Sidebar.css`, `SourceNav.module.css` and `SaveBar.css` *do* carry the landscape query, so the rest of the shell stayed in mobile mode. Only the dashboard disagreed.

**Cause 2, the portrait half: the top bar ignored the safe-area inset.** `index.html` ships `viewport-fit=cover`, so the page starts at the physical screen edge. `.app-header` pads for that; `.dashboard-topbar` did not. With a 47px inset the button spans y=3.5…35.5 — wholly under the status bar. That is the reporter's "the X is already partly tucked under the top bar", in portrait.

**Fix.** The mobile block now matches `(max-width: 768px), (max-height: 500px) and (orientation: landscape)`. A new `--dashboard-topbar-height: calc(var(--header-height) + env(safe-area-inset-top))` on `.dashboard-page` carries the bar's real height; the bar's height and padding use it, and the drawer and backdrop both offset by it, so neither can ride up over the control however tall the inset makes the bar. Horizontal insets keep the button clear of the notch in landscape.

---

## #5051 — the connection badge clipped the "Sources" button

Measured on a 390px source view with the badge on its widest face ("Plugged in 4.38V"), same auth state on both builds:

| | `main` | this branch |
|---|---|---|
| `.header-right` width | 286px | 180px |
| `.header-left` width | 72px | 178px |
| back button natural / visible | 90px / **71.9px** | 90px / 92px |
| `.header-left` overflow | 81px | 0 |

`.header-left` is `overflow: hidden`, so the 20px the back button lost was a hard clip mid-word — "Sourc…" — not an ellipsis. Two causes, both fixed:

- **The badge reserved width it does not need on a phone.** Its text faces are now visually hidden inside the *existing* 768px mobile block, and the `min-width` reservation drops 5.5rem → 1.25rem. That returns ~107px. The colored dot still carries connection state and the face icon still says which metric is showing; the numbers are one tap away in the System Status popup the badge opens. Hidden with a clip rather than `display: none`, so the text stays in the accessibility tree — otherwise a screen reader gets a colored dot and nothing to announce.
- **`.back-to-sources-btn` gets `flex-shrink: 0`.** The element designed to absorb the squeeze is the source-name badge beside it, which already has `text-overflow: ellipsis` and a `max-width`.

**Collapse, not a taller header** — as the issue's second option and the coordinator both preferred. `--header-height` is a constant every other surface offsets from, and `App.css:3224` deliberately shrinks it to 40px in landscape because vertical space is the scarce axis there; growing the bar would fight #5053's fix. A test asserts the mobile header block adds no `min-height`.

Reused the existing 768px breakpoint rather than inventing a third threshold: that block already hides the logo, the wordmark and the node info for exactly this reason. **The rotation itself (#4917 / #4927) is untouched** — this is presentation only. The two metric faces gained a `.status-metric-text` wrapper because CSS cannot target a bare text node.

---

## #5052 — Leaflet's zoom control painted over the Sources sidebar

Root cause confirmed as diagnosed. Leaflet's *panes* top out at 700, but `.leaflet-top` / `.leaflet-bottom` — the containers holding the zoom buttons and the attribution — ship `z-index: 1000` (`leaflet.css:141`). The drawer sat at 999, one below.

Raised the drawer to 1099 and its backdrop to 1098, rather than lowering Leaflet: the attribution shares that same 1000, and pushing it down is what `nodes.css:2556` was written to avoid. `.map-controls` keeps its documented 997, so the Features panel still yields. The full ladder is now documented on `.dashboard-sidebar-backdrop`:

```
 200–700   Leaflet map panes
 997       .map-controls on mobile (nodes.css) — yields to the drawer
 1000      .leaflet-top / .leaflet-bottom — Leaflet's CONTROL containers (vendor)
 1001      .map-sidebar
 1098      .dashboard-sidebar-backdrop
 1099      .dashboard-sidebar.mobile-open
 10000+    app header, app rail, modals
```

`.map-sidebar` moved 1000 → 1001. Its comment read "above Leaflet panes (which top out ~700)" — the wrong thing to reason about, and it left the panel *tied* with the control containers, resolved by DOM order, which is why the overlap looked intermittent. Both stale comments are corrected in place.

A test reads Leaflet's own z-index out of `node_modules/leaflet/dist/leaflet.css` rather than hardcoding 1000, so a Leaflet upgrade that moves the number fails here instead of in the field.

---

## Breakpoint reconciliation — and a course correction

The shell carried two definitions of "compact landscape":

| Threshold | Files |
|---|---|
| `max-height: 500px` | `App.css`, `AppHeader.css`, `SourceNav.module.css`, `SaveBar.css`, and `src/utils/sidebarWidth.ts` (JS mirror) |
| `max-height: 700px` | `Sidebar.css` (2 blocks), `SidebarFooter.module.css` |

My first pass folded 700 down to 500. **That was wrong, and #5057 is why.** Those two blocks compact the vertical *rail*; below 500px landscape the nav is a horizontal bottom *bar*. Truncating to 500px would have deleted them from the 501–700px band where they do their job and kept them in the band where they cause harm — the band where `.sidebar.collapsed { width: calc(48px + …) !important }` beats `.mobileBottomBar.collapsed { width: 100% }` and stubs the nav.

So the reconciliation subtracts the bar's territory instead:

```css
@media (orientation: landscape) and (max-height: 700px)
   and (min-width: 769px) and (min-height: 501px)
```

The rail block now applies exactly where a rail exists. Consequences:

- **The shell threshold is unchanged at 500px**, so `sidebarWidth.ts` (`MOBILE_LANDSCAPE_MAX_HEIGHT_PX`), `Sidebar.tsx:114` and `SourceNav.tsx:134` still mirror it exactly. **No JS mirror needed changing** — that was the point of not moving it. I checked all three; there is no JS mirror of the 700px query.
- **501–700px landscape** keeps the rail compaction it has today.
- **≤500px landscape** no longer receives any rail rule. Measured at 844×390: `.sidebar` is **844px wide on this branch and 48px on `main`** — so this independently fixes the bottom-nav stub that #5057 patches, at the root rather than by overriding the leak.

The test for this asserts the real invariant — every landscape query is either shell-scoped (500px) or a rail block that guards both axes — rather than "one number everywhere".

### Interaction with #5057 (please read before merging either)

#5057 is still open, and `main` has not moved since I branched, so there is nothing to rebase onto yet and my branch does not contain its commit.

Its `Sidebar.css` addition —

```css
.sidebar.collapsed,
.sidebar:not(.collapsed) { width: 100% !important; }
```

— **becomes redundant under this scoping.** With the rail blocks guarded, nothing sets a rail width in bar territory, so `.mobileBottomBar.collapsed { width: 100% }` wins unaided; I measured 844px at 844×390 without touching `.mobileBottomBar` or adding any `!important`. Whichever of the two merges second should delete that block and keep the cross-reference comment. I have not edited it here because it is not in my tree — flagging rather than guessing at a file I do not have their version of.

I left `.sidebar`'s own `padding-*: … !important` in the bottom-bar block alone, but updated its comment: it is belt-and-braces now rather than load-bearing, and the comment says so, so the next reader does not infer a collision that no longer exists.

### The 245px dashboard rail at 844×390

Also reported by the #5054 agent. It is the same defect as #5053 and is fixed by it. Measured on the landing page at 844×390:

| | `main` | this branch |
|---|---|---|
| `.dashboard-sidebar` | `position: static`, 240px | `position: fixed`, off-screen at `left: -260` |
| map container starts at | x = 245 | x = 0, full 844px wide |
| hamburger | `display: none` | `display: flex` |

---

## Validation — real hit-testing

Built and deployed both `main` and this branch to two isolated dev containers, and verified the served CSS bundle actually carried each change before trusting any result.

**#5053**, landscape 844×390, drawer open:

```
elementFromPoint(28, 20) -> closest button .dashboard-topbar-hamburger   (hit)
topbar bottom 40 == drawer top 40 == backdrop top 40
```

A real coordinate-based pointer click on it closed the drawer (`aria-expanded` true → false, `.mobile-open` removed, drawer at `left: -260`). With a 47px inset simulated, side by side:

```
with fix:        elementFromPoint(75, 67) -> .dashboard-topbar-hamburger   (hit)
pre-fix offsets: elementFromPoint(75, 67) -> .dashboard-sidebar-header     (swallowed)
```

**#5052**, portrait, drawer open, at the point where the zoom control overlaps the first source card:

```
this branch:  elementFromPoint(27, 78) -> .dashboard-source-card
main:         elementFromPoint(27, 78) -> inside .leaflet-control
```

A real pointer click on the previously covered card navigated into the source.

**#5051**: the numbers in the table above are from the two live builds, with the badge pinned to its widest cycling face so the measurement cannot land on a short state. The `main` screenshot below shows the badge mid-cycle on that face with the back button visibly cut.

## Screenshots

Portrait and landscape, iPhone 13 metrics, drawer open where relevant.

**#5053 — Sources drawer**

| | Before (`main`) | After |
|---|---|---|
| Landscape 844×390 | ![](https://raw.githubusercontent.com/Yeraze/meshmonitor/screenshots/issue-5053/screenshots/5053/before-landscape.png) no close control anywhere in the top bar | ![](https://raw.githubusercontent.com/Yeraze/meshmonitor/screenshots/issue-5053/screenshots/5053/after-landscape.png) X top-left, drawer overlays a dimmed map |
| Portrait 390×844 | ![](https://raw.githubusercontent.com/Yeraze/meshmonitor/screenshots/issue-5053/screenshots/5053/before-portrait.png) | ![](https://raw.githubusercontent.com/Yeraze/meshmonitor/screenshots/issue-5053/screenshots/5053/after-portrait.png) |
| Portrait, 47px notch simulated (black strip = OS status bar) | ![](https://raw.githubusercontent.com/Yeraze/meshmonitor/screenshots/issue-5053/screenshots/5053/before-portrait-notch.png) X buried | ![](https://raw.githubusercontent.com/Yeraze/meshmonitor/screenshots/issue-5053/screenshots/5053/after-portrait-notch.png) X clear |

The plain portrait pair looks identical because the emulator resolves `env(safe-area-inset-top)` to 0 — the notch row is where that half of the bug is visible.

**#5051 — header badge**, portrait 390×844, badge on its widest face:

| Before (`main`) | After |
|---|---|
| ![](https://raw.githubusercontent.com/Yeraze/meshmonitor/screenshots/issue-5053/screenshots/5053/5051-before-portrait.png) "Sources" cut off under the status dot | ![](https://raw.githubusercontent.com/Yeraze/meshmonitor/screenshots/issue-5053/screenshots/5053/5051-after-portrait.png) full label, badge collapsed to icons |

**#5052 — zoom control over the drawer**, portrait 390×844, drawer open:

| Before (`main`) | After |
|---|---|
| ![](https://raw.githubusercontent.com/Yeraze/meshmonitor/screenshots/issue-5053/screenshots/5053/5052-before-portrait.png) +/− over the first source card | ![](https://raw.githubusercontent.com/Yeraze/meshmonitor/screenshots/issue-5053/screenshots/5053/5052-after-portrait.png) drawer on top |

Screenshots live on branch `screenshots/issue-5053` under `screenshots/5053/`, kept out of the docs site's image set.

## Tests

`src/styles/dashboardMobileDrawer.test.ts` and `src/components/AppHeader/AppHeader.mobileChrome.test.tsx`. jsdom has no layout and no media queries, so rather than grepping for substrings these run the real declarations through a small cascade resolver and assert resolved values at concrete viewports: the close control is displayed at 390×844, 844×390, 915×412 and 667×375; the drawer overlays rather than reflows; drawer and backdrop `top` are the *same expression* as the top bar's height; the z-index ladder holds against Leaflet's own vendor value; the badge text is clipped rather than `display: none`; the back button cannot shrink; and no rail query matches a bottom-bar viewport.

They fail **24 of their 37 assertions** against the pre-fix sheets, and pass 37/37 here. They also caught a bug in the first draft of the #5053 fix — the mobile block's `padding: 0 8px` was flattening the new inset padding.

## Notes

- **Mesh impact: none.** Stylesheet and markup-wrapper only; sends no packets, fires no notifications, arms no timers.
- **Scope.** Untouched: `MapResizeHandler.tsx`, `map/BaseMap.tsx`, and `.mobileBottomBar` in `SourceNav.module.css`. `Sidebar.css` is shared ground with #5057 — see the interaction note above.
- **`nodes.css`.** Its `.map-controls` mobile override gained the same landscape clause as the dashboard block. It stays declared *after* the base rule, per that file's #3532 ordering banner; only the media condition changed, not its position.

## Checks

- Full Vitest: `success: true`, 18,886 passed, 0 failures, 0 suite collection errors, with the PostgreSQL and MySQL containers up so the multi-backend suites ran. (An earlier full run flaked once on `DashboardMap.test.tsx` — "Unable to find a label with the text of: 3D Terrain" against an *empty* `<body>`, i.e. the component never rendered under parallel load. It passes 43/43 in isolation and the repeat full run was clean; jsdom evaluates no stylesheets, so nothing in this diff can reach it.)
- `npm run lint:ci` — no in-repo `FAIL` lines.
- `tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.server.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S6dVMHduNHsn6jNRXX25k

---

## Review follow-ups

Addressed from the automated review:

- **`.map-sidebar-toggle` was also stuck at 1000.** Same tie with Leaflet's control containers as `.map-sidebar` one rule above; raised to 1001 to match.
- **Documented why the rail-block count is pinned at two** in `dashboardMobileDrawer.test.ts`, rather than iterating whatever it finds — a third block added later is a new place for a rail rule to leak into the bar, and the author should have to come and confirm it is guarded.

Considered and deliberately not changed:

- **`MapSidebar.css`'s `@media (max-width: 768px)` full-screen sheet has no landscape clause.** Real, and the same defect class — but pre-existing, on a surface that overlaps #5054's map work, and turning a full-screen sheet on in a 390px-tall viewport is not something I want to land unvalidated at the end of this PR. Worth its own issue.
- **`.dashboard-topbar .connection-status span:not(.status-indicator) { display: none }`** would also catch the new `.status-metric-text`. That rule already hides the badge's text spans by design, and `CyclingConnectionStatus` does not render in the dashboard topbar, so behaviour is unchanged either way.
- **The run of blank lines in `Sidebar.css`'s second landscape block** is pre-existing (left by #4473's rule removals) and outside this change.
- **The drawer's `left: env(safe-area-inset-left)` versus `translateX(-100%)`** — noted as safe in practice; the review's own analysis agrees the drawer stays fully off-screen for any realistic inset.
