### PR TITLE
fix(meshbeacon): refresh the module-config cache after a save (#5045)

### DIFF
--- a/.claude/agent-memory/meshtastic-expert/MEMORY.md
+++ b/.claude/agent-memory/meshtastic-expert/MEMORY.md
@@ -7,3 +7,4 @@
 - [Channel Hash Generation](reference_channel_hash_generation.md) — generateHash = xor(name) XOR xor(PSK); blank name substitutes to modem preset display name (e.g. "LongFast")
 - [StatusMessageModule broadcast gates](reference_status_message_module_broadcast_gates.md) — portnum 36; has_statusmessage flag drives BOTH 2min-vs-12h interval AND send; set path shouldReboot=false so runtime set never re-arms thread
 - [2.8 NodeNum = CRC32(public_key)](reference_nodenum_from_pubkey_2_8.md) — zlib CRC-32 over 32 raw key bytes; upgrades KEEP the 2.7 keypair, so same-pubkey+new-num = upgraded
+- [MeshBeacon broadcast_on_* deleted](reference_meshbeacon_broadcast_on_fields_removed.md) — tags 8/9/10 reserved 2026-08-28; no v2.8.0 build has them; use broadcast_targets (13)

--- a/.claude/agent-memory/meshtastic-expert/reference_meshbeacon_broadcast_on_fields_removed.md
+++ b/.claude/agent-memory/meshtastic-expert/reference_meshbeacon_broadcast_on_fields_removed.md
@@ -1,0 +1,40 @@
+---
+name: meshbeacon-broadcast-on-fields-removed
+description: MeshBeaconConfig tags 8/9/10 (broadcast_on_channel/region/preset) were deleted and reserved on 2026-08-28; all v2.8.0 firmware tags lack them — send broadcast_targets (tag 13) instead
+metadata:
+  type: reference
+---
+
+`ModuleConfig.MeshBeaconConfig` field tags **8, 9, 10** — `broadcast_on_channel`
+(ChannelSettings), `broadcast_on_region` (RegionCode), `optional broadcast_on_preset`
+(ModemPreset) — **no longer exist**. They were removed and `reserved` in protobufs
+commit `4ac5e0fc7e` "Consolidate beacon TX destinations onto broadcast_targets"
+(2026-08-28, PR meshtastic/protobufs#1048, merge `7b2464c9b8`), and in firmware by
+`7afd270f39` "Gut beacon send-as-node and consolidate TX onto broadcast_targets"
+(#11646, 2026-08-28). Tag 3 `broadcast_send_as_node` was reserved in the same wave
+(`40c405b570`).
+
+Surviving numbering (protobufs master + firmware develop + every v2.8.0 tag):
+`flags=1`, reserved 3, `broadcast_message=4`, `broadcast_offer_channel=5`,
+`broadcast_offer_region=6`, `optional broadcast_offer_preset=7`, reserved 8/9/10,
+`broadcast_interval_secs=11`, `repeated BroadcastTarget broadcast_targets=13`.
+`BroadcastTarget`: `optional preset=1`, `region=2`, reserved 3,
+`optional channel_index=4`. `ModuleConfig.mesh_beacon` oneof tag = 17;
+`AdminMessage.ModuleConfigType.MESHBEACON_CONFIG = 16`.
+
+**Why this matters:** the `broadcast_on_*` group never shipped in a tagged release
+(MeshBeacon merged 2026-07-23 via firmware #10618; first beacon-capable tags are
+`v2.8.0.7239fe8` 2026-08-29 and `v2.8.0.47db0e3` 2026-08-31 — both post-removal).
+A client built against protobufs older than 2026-08-28 that still sends fields
+9/10 hits nanopb's silent unknown-field skip: `set_module_config` decodes fine,
+`AdminModule` whole-struct-replaces `moduleConfig.mesh_beacon = beaconCfg`, and the
+values simply are not there. Symptom = "region/preset revert to UNSET, broadcast
+targets empty" with **no error and no log line**.
+
+**How to apply:** any beacon TX destination must go in `broadcast_targets` (tag 13,
+nanopb `max_count:4`). `broadcast_offer_*` (5/6/7) are unaffected — those describe
+what the beacon *advertises*, not where it transmits. `broadcast_message` is
+`max_size:101` (100 chars + NUL); overlong strings or >4 targets fail nanopb decode
+and drop the **whole** ModuleConfig silently.
+
+Related: [[reference-protobufjs-decoded-message-shape]], [[project-mt-28-tracking-state]]

--- a/src/server/meshtasticManager.meshBeaconTransmit.test.ts
+++ b/src/server/meshtasticManager.meshBeaconTransmit.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+
+/**
+ * Regression tests for issue #5045 — the MeshBeacon single-transmit settings
+ * (`Transmit Region` / `Transmit Modem Preset`, i.e. `broadcast_on_region` and
+ * `broadcast_on_preset`) read back as UNSET / "use running config" right after
+ * a save, with the Broadcast Targets list empty.
+ *
+ * Root cause: `setGenericModuleConfig` sent the admin packet but never touched
+ * `actualModuleConfig`, and `GET /api/config/current` serves that cache
+ * verbatim. Every *other* module config hid the staleness because the firmware
+ * reboots the node after `set_module_config`, which drops the TCP link and
+ * makes MeshMonitor re-download the whole config. MeshBeacon is on the
+ * firmware's no-reboot allowlist (`shouldReboot = false` in AdminModule's
+ * `mesh_beacon` case, alongside statusmessage/mqtt/serial), so nothing ever
+ * refreshed the cache and the pre-save values were served indefinitely.
+ *
+ * Confirmed against a real firmware-2.8 node: after POSTing region=US /
+ * preset=LONG_FAST the config API kept returning `broadcastOnRegion: 0` with no
+ * `broadcastOnPreset` for two solid minutes, and only a forced reconnect
+ * (which re-downloads the config) revealed that the device had persisted both
+ * values correctly all along.
+ *
+ * The cache is refreshed with *replace*, not merge, semantics because the
+ * firmware whole-struct-assigns `moduleConfig.mesh_beacon = <incoming>`: a
+ * field the client omitted is cleared on the device, so a merge would leave the
+ * cache claiming a value the node no longer holds.
+ */
+
+// Stub the TCP transport so constructing a manager never touches a real socket
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+// Prevent the constructor's async position-recalc path from touching the DB
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    sources: {
+      getSource: vi.fn().mockResolvedValue(null),
+    },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+import { MeshtasticManager } from './meshtasticManager.js';
+import protobufService from './protobufService.js';
+import { loadProtobufDefinitions, getProtobufRoot } from './protobufLoader.js';
+
+/**
+ * Enum wire values. Note the deliberate asymmetry, which is the whole trap in
+ * this area: `RegionCode.UNSET` is 0, so region 0 genuinely means "not set",
+ * while `broadcast_on_preset` is declared `optional` in the proto — it has
+ * explicit presence, and preset 0 (LONG_FAST) is a real, selectable value that
+ * a `|| null` / `?? 0` style default would erase or invent.
+ */
+const REGION_UNSET = 0;
+const REGION_US = 1;
+const PRESET_LONG_FAST = 0;
+const PRESET_MEDIUM_SLOW = 3;
+
+/**
+ * The payload `buildMeshBeaconConfigPayload` produces for the issue's repro:
+ * targets list empty, single-transmit region US, single-transmit preset
+ * LONG_FAST. `broadcastOnPreset` is included only when non-null, mirroring the
+ * builder's `optional`-field handling.
+ */
+function transmitPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    flags: 2,
+    broadcastMessage: '',
+    broadcastSendAsNode: 0,
+    broadcastOfferRegion: REGION_UNSET,
+    broadcastIntervalSecs: 3600,
+    broadcastOnRegion: REGION_US,
+    broadcastTargets: [],
+    broadcastOnPreset: PRESET_LONG_FAST,
+    ...overrides,
+  };
+}
+
+/**
+ * The shape `processConfig` stores in `actualModuleConfig` after the device's
+ * config download: a decoded `ModuleConfig.meshBeacon` message. Here it holds
+ * the pre-save state — beacon enabled, no transmit region, no transmit preset.
+ */
+function decodedMeshBeaconConfig(meshBeacon: Record<string, unknown>): any {
+  const ModuleConfig = getProtobufRoot()!.lookupType('meshtastic.ModuleConfig');
+  const encoded = ModuleConfig.encode(ModuleConfig.create({ meshBeacon })).finish();
+  return { ...(ModuleConfig.decode(encoded) as any) };
+}
+
+function makeManager(moduleConfig: any) {
+  const mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 });
+  (mgr as any).localNodeInfo = { nodeNum: 123, nodeId: '!0000007b', firmwareVersion: '2.8.0' };
+  (mgr as any).actualModuleConfig = moduleConfig;
+  // Let the admin send succeed without a socket.
+  (mgr as any).isTransportReady = () => true;
+  (mgr as any).sendLocalAdminPacket = vi.fn().mockResolvedValue(undefined);
+  return mgr;
+}
+
+/** What `GET /api/config/current` actually hands the Configuration tab. */
+function readBack(mgr: MeshtasticManager): any {
+  return JSON.parse(JSON.stringify(mgr.getCurrentConfig())).moduleConfig.meshBeacon;
+}
+
+describe('MeshBeacon single-transmit settings survive a save (#5045)', () => {
+  beforeAll(async () => {
+    await loadProtobufDefinitions();
+  });
+
+  it('serves the just-saved transmit region and preset, not the pre-save values', async () => {
+    const mgr = makeManager(decodedMeshBeaconConfig({ flags: 2, broadcastIntervalSecs: 3600 }));
+
+    // Pre-condition: the device had neither field set.
+    expect(readBack(mgr).broadcastOnRegion).toBe(REGION_UNSET);
+    expect(readBack(mgr).broadcastOnPreset).toBeUndefined();
+
+    await mgr.setGenericModuleConfig('meshbeacon', transmitPayload());
+
+    const wire = readBack(mgr);
+    expect(wire.broadcastOnRegion).toBe(REGION_US);
+    // Preset 0 is LONG_FAST, a real selection — it must come back as 0, not be
+    // dropped as if it were an absent `optional` field.
+    expect(wire.broadcastOnPreset).toBe(PRESET_LONG_FAST);
+    expect(typeof wire.broadcastOnRegion).toBe('number');
+    expect(typeof wire.broadcastOnPreset).toBe('number');
+  });
+
+  it('keeps an empty broadcast targets list empty', async () => {
+    const mgr = makeManager(decodedMeshBeaconConfig({ flags: 2 }));
+    await mgr.setGenericModuleConfig('meshbeacon', transmitPayload());
+    expect(readBack(mgr).broadcastTargets).toEqual([]);
+  });
+
+  it('clears an optional preset the user reset to "use running config"', async () => {
+    // The device whole-struct-replaces, so omitting `broadcast_on_preset`
+    // clears it there; a merging cache would keep serving the old preset.
+    const mgr = makeManager(
+      decodedMeshBeaconConfig({ flags: 2, broadcastOnRegion: REGION_US, broadcastOnPreset: PRESET_MEDIUM_SLOW }),
+    );
+    expect(readBack(mgr).broadcastOnPreset).toBe(PRESET_MEDIUM_SLOW);
+
+    const { broadcastOnPreset: _omitted, ...withoutPreset } = transmitPayload();
+    await mgr.setGenericModuleConfig('meshbeacon', withoutPreset);
+
+    const wire = readBack(mgr);
+    expect(wire.broadcastOnPreset).toBeUndefined();
+    expect(wire.broadcastOnRegion).toBe(REGION_US);
+  });
+
+  it('leaves the cache alone when the send fails', async () => {
+    const mgr = makeManager(decodedMeshBeaconConfig({ flags: 2 }));
+    (mgr as any).sendLocalAdminPacket = vi.fn().mockRejectedValue(new Error('transmit disabled'));
+
+    await expect(mgr.setGenericModuleConfig('meshbeacon', transmitPayload())).rejects.toThrow();
+    expect(readBack(mgr).broadcastOnRegion).toBe(REGION_UNSET);
+  });
+
+  it('refreshes other module sections too, without disturbing their siblings', async () => {
+    const mgr = makeManager({ serial: { enabled: false, baud: 0 }, telemetry: { deviceUpdateInterval: 900 } });
+    await mgr.setGenericModuleConfig('serial', { enabled: true, baud: 5, echo: false });
+
+    const wire = JSON.parse(JSON.stringify(mgr.getCurrentConfig())).moduleConfig;
+    expect(wire.serial).toEqual({ enabled: true, baud: 5, echo: false });
+    expect(wire.telemetry.deviceUpdateInterval).toBe(900);
+  });
+});
+
+describe('MeshBeacon transmit fields on the wire (#5045)', () => {
+  beforeAll(async () => {
+    await loadProtobufDefinitions();
+  });
+
+  /**
+   * Asserts the protocol, not our implementation: `broadcast_on_region` is a
+   * plain proto3 enum (tag 9) and `broadcast_on_preset` is `optional` (tag 10),
+   * so an explicit preset 0 must appear on the wire while an omitted one must
+   * not — that is what lets the device tell "LONG_FAST" apart from "use the
+   * running config".
+   */
+  function decodeSetModuleConfig(config: Record<string, unknown>): any {
+    const encoded = protobufService.createSetModuleConfigMessageGeneric('meshbeacon', config, new Uint8Array());
+    const AdminMessage = getProtobufRoot()!.lookupType('meshtastic.AdminMessage');
+    return (AdminMessage.decode(encoded) as any).setModuleConfig.meshBeacon;
+  }
+
+  it('encodes an explicit LONG_FAST preset and a US region', () => {
+    const beacon = decodeSetModuleConfig(transmitPayload());
+    expect(beacon.broadcastOnRegion).toBe(REGION_US);
+    expect(Object.prototype.hasOwnProperty.call(beacon, 'broadcastOnPreset')).toBe(true);
+    expect(beacon.broadcastOnPreset).toBe(PRESET_LONG_FAST);
+  });
+
+  it('omits the preset entirely when the user chose "use running config"', () => {
+    const { broadcastOnPreset: _omitted, ...withoutPreset } = transmitPayload();
+    const beacon = decodeSetModuleConfig(withoutPreset);
+    expect(Object.prototype.hasOwnProperty.call(beacon, 'broadcastOnPreset')).toBe(false);
+    expect(beacon.broadcastOnRegion).toBe(REGION_US);
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -14279,15 +14279,25 @@ class MeshtasticManager implements ISourceManager {
   /**
    * Update cached module config section after a successful admin command.
    * Mirrors `updateCachedDeviceConfig` above but for `actualModuleConfig`.
+   *
+   * `mode: 'replace'` drops the previous section instead of merging into it,
+   * which is what the firmware does: `AdminModule` whole-struct-assigns
+   * `moduleConfig.<section> = <incoming>`, so a field the client left out is
+   * cleared on the device. Merging would leave the cache claiming a value the
+   * node no longer holds — for MeshBeacon that means an `optional`
+   * `broadcast_on_preset` the user reset to "use running config" would survive
+   * as its old preset number (#5045).
    */
-  updateCachedModuleConfig(section: string, values: Record<string, any>): void {
+  updateCachedModuleConfig(section: string, values: Record<string, any>, mode: 'merge' | 'replace' = 'merge'): void {
     if (!this.actualModuleConfig) {
       this.actualModuleConfig = {};
     }
-    this.actualModuleConfig[section] = {
-      ...this.actualModuleConfig[section],
-      ...values
-    };
+    this.actualModuleConfig[section] = mode === 'replace'
+      ? { ...values }
+      : {
+        ...this.actualModuleConfig[section],
+        ...values
+      };
   }
 
   // ── Narrow accessors for RemoteAdminService (#3962 Phase 4.2a PR5 §4e) ──

--- a/src/server/services/deviceAdminService.ts
+++ b/src/server/services/deviceAdminService.ts
@@ -43,6 +43,7 @@
 import type { MeshtasticManager } from '../meshtasticManager.js';
 import databaseService from '../../services/database.js';
 import protobufService from '../protobufService.js';
+import { MODULE_FIELD_BY_ID } from '../constants/configTypes.js';
 import { calculateLoRaFrequency } from '../../utils/loraFrequency.js';
 import { logger } from '../../utils/logger.js';
 
@@ -360,6 +361,30 @@ export class DeviceAdminService {
 
       await this.mgr.sendLocalAdminPacket(adminPacket);
       logger.debug(`⚙️ Sent set_${moduleType}_config admin message`);
+
+      // Refresh the cached section (#5045). `GET /api/config/current` serves
+      // `actualModuleConfig` verbatim, and nothing else writes it outside the
+      // device's config download — so without this the Configuration tab keeps
+      // rendering the pre-save values every time it remounts.
+      //
+      // Most module saves hid that: the firmware reboots after
+      // `set_module_config`, MeshMonitor's link drops, and the reconnect
+      // re-downloads the whole config. MeshBeacon is on the firmware's
+      // no-reboot allowlist (`shouldReboot = false`, alongside
+      // statusmessage/mqtt/serial), so its stale cache never got corrected.
+      //
+      // Replace rather than merge, mirroring the device's whole-struct assign:
+      // a field the client omitted — an `optional` preset the user reset to
+      // "use running config", say — is cleared on the node, so the cache must
+      // drop it too. Optimistic by design: where the firmware clamps a value
+      // (the MeshBeacon 3600 s interval floor) the cache shows what we asked
+      // for until the next config download; the UI already warns about that
+      // floor next to the input.
+      const cacheKey = MODULE_FIELD_BY_ID[moduleType];
+      if (cacheKey) {
+        this.mgr.updateCachedModuleConfig(cacheKey, config, 'replace');
+        logger.debug(`⚙️ Updated actualModuleConfig.${cacheKey} cache`);
+      }
     } catch (error) {
       logger.error(`❌ Error sending ${moduleType} config:`, error);
       throw error;


### PR DESCRIPTION
Fixes #5045

## Root cause

`GET /api/config/current` hands the Configuration tab `MeshtasticManager.actualModuleConfig` verbatim. Outside the device's own config download, the only thing that ever wrote that cache was `setTelemetryConfig`. `setGenericModuleConfig` — the path every module save on the Configuration tab takes — sent the admin packet and returned without touching it, so the tab re-read the **pre-save** values every time it remounted.

Every other module save hid this. The firmware reboots the node after `set_module_config`, MeshMonitor's TCP link drops, and the reconnect re-downloads the whole config, which repairs the cache within seconds. MeshBeacon is on the firmware's **no-reboot allowlist** — `AdminModule`'s `mesh_beacon` case explicitly sets `shouldReboot = false`, alongside statusmessage/mqtt/serial — so nothing ever corrected its cache and the stale values were served indefinitely.

That is why **both** fields revert, not just the preset: the whole cached `meshBeacon` sub-message is the pre-save one. Nothing about `broadcast_on_region` (a plain proto3 enum, `UNSET = 0`) or `broadcast_on_preset` (`optional`, where `0` is a genuine LONG_FAST) is mishandled — the read path and the encoder were both already correct.

## Evidence

**Confirmed against real hardware** — a connected firmware `2.8.0.eb6df1c` node:

1. `POST /api/config/module/meshbeacon` with `broadcastOnRegion: 1` (US) and `broadcastOnPreset: 0` (LONG_FAST) → `success: true`.
2. `GET /api/config/current` returned `broadcastOnRegion: 0` and no `broadcastOnPreset` — immediately, and still at t+120 s.
3. `POST /api/connection/reconnect` (forces a config re-download) → the same endpoint returned `broadcastOnRegion: 1, broadcastOnPreset: 0`. **The device had persisted both values correctly the whole time.**
4. Clearing the fields again reproduced it in the opposite direction: the API kept reporting US/LONG_FAST after the device had dropped them, until another reconnect. The rig has been restored to its original state.

The write path was ruled out with a decode, not an assumption: `createSetModuleConfigMessageGeneric` produces `…48 01 50 00…` — tag 9 varint 1 and tag 10 varint 0 — so fields 9 and 10 really are on the wire, and protobufjs honours the `optional` field's explicit presence (an omitted preset produces no tag 10 at all).

## The fix

`setGenericModuleConfig` now refreshes the cached section after a successful send, with **replace** rather than merge semantics — mirroring the firmware, which whole-struct-assigns `moduleConfig.<section> = <incoming>`. A field the client omitted is cleared on the device, so a merge would leave the cache claiming an `optional` preset the user had just reset to "use running config".

The cache update is optimistic. Where the firmware clamps a value (the MeshBeacon 3600 s interval floor) it shows what we asked for until the next config download; the UI already warns about that floor next to the input, and the previous behaviour — showing a value from before the save — was not more truthful.

## Tests

New `src/server/meshtasticManager.meshBeaconTransmit.test.ts`, 7 tests. **3 of them fail on `main`** and pass with the fix:

- `serves the just-saved transmit region and preset, not the pre-save values` — `AssertionError: expected +0 to be 1`
- `clears an optional preset the user reset to "use running config"` — `AssertionError: expected 3 to be undefined`
- `refreshes other module sections too, without disturbing their siblings` — `expected { enabled: false, baud: +0 } to deeply equal { enabled: true, baud: 5, echo: false }`

The two wire-encoding tests assert the *protocol* — that an explicit LONG_FAST (`0`) is emitted on tag 10 while "use running config" emits nothing — and pass both before and after, which is what pins the bug to the cache rather than the encoder.

Full suite: 19,036 tests, 0 failed, 0 failed suites, 109 skipped, with PostgreSQL and MySQL containers up. `lint:ci` clean, both tsconfigs typecheck.

## Mesh impact

None. No packet is sent, scheduled, or retried that was not sent before — the change is a single in-memory cache write after an admin packet MeshMonitor already sent.

## Separate follow-up worth opening

While confirming the protocol, the firmware research turned up an **independent** problem that this PR does not address, because fixing it is a feature-sized change and a product decision:

`broadcast_on_channel` (8), `broadcast_on_region` (9) and `broadcast_on_preset` (10) were **removed from `meshtastic/protobufs` and from the firmware on 2026-08-28** (protobufs PR #1048 / firmware PR #11646), consolidated onto `repeated BroadcastTarget broadcast_targets = 13`; the tags are now `reserved`. Both tagged 2.8.0 builds (`v2.8.0.7239fe8`, `v2.8.0.47db0e3`) post-date the removal. MeshMonitor's `protobufs` submodule is pinned at `6ceceae4` (2026-07-29), which still has the old fields — so on any firmware built after 2026-08-28 we emit tags 9 and 10, nanopb skips them as unknown, and the values silently vanish. The node used to verify this PR is a develop build from inside the five-week window where the fields existed, which is why the round trip worked there.

Moving the single-transmit UI onto `broadcast_targets` also drops a capability — `broadcast_on_channel` embedded a free-form `ChannelSettings` (name + PSK), while a target's `channel_index` references a slot that must already exist on the node — so it needs a UI decision, not just a submodule bump. The beacon proto is also still churning (firmware PR #11662, open, moves `broadcast_offer_channel` next). Details are captured in `.claude/agent-memory/meshtastic-expert/reference_meshbeacon_broadcast_on_fields_removed.md` in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S6dVMHduNHsn6jNRXX25k
