### PR TITLE
feat(meshcore): channel messages from an MQTT region feed, Phase 4 (#5040)

### DIFF
--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -1305,12 +1305,26 @@ export class MeshCoreRepository extends BaseRepository {
    * Insert a message. `sourceId` is required so every row in
    * `meshcore_messages` is stamped with its owning source.
    */
-  async insertMessage(message: DbMeshCoreMessage, sourceId: string): Promise<void> {
+  /**
+   * Insert a message, ignoring a duplicate id.
+   *
+   * Returns TRUE only when a row was actually written. That return value is
+   * load-bearing (#5040 Phase 4): callers gate their `dataEventEmitter` emit on
+   * it, so a message the same source receives twice fires notifications and
+   * automations exactly once. Mirrors `MessagesRepository.insertMessage`, which
+   * has used this shape since the Meshtastic MQTT path had the same problem.
+   *
+   * The device path passes a random id and so always inserts, unchanged. The
+   * MQTT ingest path passes a CONTENT-derived id, so the same frame relayed by
+   * many observers collapses to one row here rather than N.
+   */
+  async insertMessage(message: DbMeshCoreMessage, sourceId: string): Promise<boolean> {
     if (!sourceId) {
       throw new Error('MeshCoreRepository.insertMessage requires a sourceId');
     }
     const { meshcoreMessages } = this.tables;
-    await this.db.insert(meshcoreMessages).values({ ...message, sourceId });
+    const result = await this.insertIgnore(meshcoreMessages, { ...message, sourceId });
+    return this.getAffectedRows(result) > 0;
   }
 
   /**

--- a/src/db/repositories/meshcore.ts
+++ b/src/db/repositories/meshcore.ts
@@ -1302,11 +1302,10 @@ export class MeshCoreRepository extends BaseRepository {
   }
 
   /**
-   * Insert a message. `sourceId` is required so every row in
-   * `meshcore_messages` is stamped with its owning source.
-   */
-  /**
    * Insert a message, ignoring a duplicate id.
+   *
+   * `sourceId` is required so every row in `meshcore_messages` is stamped with
+   * its owning source.
    *
    * Returns TRUE only when a row was actually written. That return value is
    * load-bearing (#5040 Phase 4): callers gate their `dataEventEmitter` emit on

--- a/src/server/meshcoreMqttManager.channel.test.ts
+++ b/src/server/meshcoreMqttManager.channel.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Channel-message ingest for an MQTT region feed (#5040 Phase 4).
+ *
+ * The behaviour that matters is duplicate collapse. A region feed relays the
+ * same channel message once per observer that heard it, so without a
+ * content-derived id twenty observers would mean twenty rows in the message
+ * list AND twenty notifications / automation triggers.
+ *
+ * The design mirrors the Meshtastic messages table: content-derived id
+ * including sourceId + insert-or-ignore, with the emit gated on whether a row
+ * was actually written.
+ */
+import { describe, it, expect } from 'vitest';
+import { channelMessageId, pskToHex } from './meshcoreMqttManager.js';
+
+describe('channelMessageId', () => {
+  it('is stable for the same message — so N observers collapse to one row', () => {
+    const a = channelMessageId('src-1', 'a3', 1_700_000_000, 'hello mesh');
+    const b = channelMessageId('src-1', 'a3', 1_700_000_000, 'hello mesh');
+    expect(a).toBe(b);
+  });
+
+  it('differs per source — a copy your own radio heard keeps its own row', () => {
+    const mqtt = channelMessageId('src-mqtt', 'a3', 1_700_000_000, 'hello');
+    const device = channelMessageId('src-device', 'a3', 1_700_000_000, 'hello');
+    expect(mqtt).not.toBe(device);
+  });
+
+  it('separates different text, timestamps, and channels', () => {
+    const base = channelMessageId('s', 'a3', 100, 'x');
+    expect(base).not.toBe(channelMessageId('s', 'a3', 100, 'y'));
+    expect(base).not.toBe(channelMessageId('s', 'a3', 101, 'x'));
+    expect(base).not.toBe(channelMessageId('s', 'b4', 100, 'x'));
+  });
+
+  it('does not collide when text and timestamp are swapped around the separator', () => {
+    // A naive `${ts}${text}` concat would make these identical.
+    expect(channelMessageId('s', 'a3', 1, '23hello')).not.toBe(
+      channelMessageId('s', 'a3', 12, '3hello'),
+    );
+  });
+
+  it('is namespaced so it cannot collide with a device-path random id', () => {
+    expect(channelMessageId('s', 'a3', 1, 'x').startsWith('mqtt_s_')).toBe(true);
+  });
+});
+
+describe('pskToHex', () => {
+  it('passes hex through, lowercased', () => {
+    expect(pskToHex('AABBCC')).toBe('aabbcc');
+  });
+
+  it('converts the base64 form channels are stored in', () => {
+    const hex = pskToHex(Buffer.from('0123456789abcdef', 'hex').toString('base64'));
+    expect(hex).toBe('0123456789abcdef');
+  });
+
+  it('returns null for absent or unusable values rather than throwing', () => {
+    expect(pskToHex(null)).toBeNull();
+    expect(pskToHex(undefined)).toBeNull();
+    expect(pskToHex('')).toBeNull();
+  });
+
+  it('treats an odd-length hex-looking string as base64, not hex', () => {
+    // 'abc' is hex-ish but cannot be bytes; falling through to base64 is the
+    // safe reading, and a wrong key simply fails the channel-hash match.
+    expect(pskToHex('abc')).not.toBe('abc');
+  });
+});

--- a/src/server/meshcoreMqttManager.channelIngest.test.ts
+++ b/src/server/meshcoreMqttManager.channelIngest.test.ts
@@ -1,0 +1,195 @@
+/**
+ * End-to-end channel-message ingest (#5040 Phase 4).
+ *
+ * Builds a GENUINELY ENCRYPTED GRP_TXT frame — AES-128-ECB with the 2-byte
+ * HMAC-SHA256 prefix MeshCore uses — so the whole path runs for real: frame
+ * parse, channel-hash key selection, decrypt, id derivation, insert-or-ignore,
+ * and the gated event emit. Stubbing the decrypt would leave the part most
+ * likely to be wrong untested.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHmac, createCipheriv } from 'node:crypto';
+import { ChannelCrypto } from '@michaelhart/meshcore-decoder';
+
+const insertMessage = vi.fn().mockResolvedValue(true);
+const getAllChannels = vi.fn();
+const emitMeshCoreMessage = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      insertMessage: (...a: unknown[]) => insertMessage(...a),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+    },
+    channels: { getAllChannels: (...a: unknown[]) => getAllChannels(...a) },
+  },
+}));
+vi.mock('./services/dataEventEmitter.js', () => ({
+  dataEventEmitter: { emitMeshCoreMessage: (...a: unknown[]) => emitMeshCoreMessage(...a) },
+}));
+vi.mock('./services/meshcorePacketLogService.js', () => ({
+  default: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+}));
+
+let lastClient: FakeClient | null = null;
+class FakeClient {
+  handlers = new Map<string, (a: unknown) => void>();
+  connect = vi.fn().mockResolvedValue(undefined);
+  subscribe = vi.fn().mockResolvedValue(undefined);
+  disconnect = vi.fn().mockResolvedValue(undefined);
+  isConnected = () => true;
+  on(e: string, fn: (a: unknown) => void) { this.handlers.set(e, fn); return this; }
+  removeAllListeners() { this.handlers.clear(); return this; }
+  deliver(topic: string, b: unknown) {
+    this.handlers.get('message')?.({ topic, payload: Buffer.from(JSON.stringify(b)) });
+  }
+}
+vi.mock('./transports/mqttBrokerClient.js', () => ({
+  MqttBrokerClient: class { constructor() { lastClient = new FakeClient(); return lastClient as unknown as object; } },
+}));
+
+import { MeshCoreMqttManager } from './meshcoreMqttManager.js';
+
+const SECRET_HEX = '0123456789abcdef0123456789abcdef'; // 16 bytes
+const SECRET_B64 = Buffer.from(SECRET_HEX, 'hex').toString('base64');
+const OBSERVER_A = 'AA'.repeat(32);
+const OBSERVER_B = 'BB'.repeat(32);
+
+/** Encrypt exactly as MeshCore does, so the shipping decrypt accepts it. */
+function encryptChannelBody(timestampSec: number, body: string): { macHex: string; ctHex: string } {
+  const text = Buffer.from(body, 'utf8');
+  const plain = Buffer.alloc(5 + text.length);
+  plain.writeUInt32LE(timestampSec, 0);
+  plain[4] = 0; // flags
+  text.copy(plain, 5);
+  // AES-ECB with NoPadding needs a block multiple.
+  const padded = Buffer.alloc(Math.ceil(plain.length / 16) * 16);
+  plain.copy(padded);
+
+  const cipher = createCipheriv('aes-128-ecb', Buffer.from(SECRET_HEX, 'hex'), null);
+  cipher.setAutoPadding(false);
+  const ct = Buffer.concat([cipher.update(padded), cipher.final()]);
+
+  // MAC: HMAC-SHA256 over the ciphertext, keyed with the 16-byte secret
+  // zero-padded to 32 — first two bytes.
+  const key32 = Buffer.alloc(32);
+  Buffer.from(SECRET_HEX, 'hex').copy(key32);
+  const mac = createHmac('sha256', key32).update(ct).digest();
+  return { macHex: mac.subarray(0, 2).toString('hex'), ctHex: ct.toString('hex') };
+}
+
+/** header | path_len | channel_hash | mac(2) | ciphertext */
+function grpTxtFrame(timestampSec: number, body: string): string {
+  const { macHex, ctHex } = encryptChannelBody(timestampSec, body);
+  const hash = ChannelCrypto.calculateChannelHash(SECRET_HEX);
+  const header = ((5 & 0x0f) << 2) | 1; // payload GRP_TXT(5), route FLOOD(1)
+  return header.toString(16).padStart(2, '0') + '00' + hash + macHex + ctHex;
+}
+
+const msg = (raw: string, observer = OBSERVER_A) => ({
+  type: 'PACKET', origin: 'Obs', origin_id: observer, raw, SNR: '-5', RSSI: '-88',
+});
+
+async function started() {
+  const m = new MeshCoreMqttManager('src-mqtt', 'Feed', { brokerUrl: 'wss://b', region: 'MCO' });
+  await m.start();
+  return m;
+}
+const settle = () => new Promise(r => setTimeout(r, 0));
+
+beforeEach(() => {
+  insertMessage.mockClear().mockResolvedValue(true);
+  emitMeshCoreMessage.mockClear();
+  getAllChannels.mockResolvedValue([{ id: 0, name: 'Public', psk: SECRET_B64 }]);
+  lastClient = null;
+});
+
+describe('channel message ingest (#5040 Phase 4)', () => {
+  it('decrypts a real GRP_TXT frame and stores it', async () => {
+    const mgr = await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER_A}/packets`,
+      msg(grpTxtFrame(1_700_000_000, 'Alice: hello mesh')));
+    await settle();
+
+    expect(insertMessage).toHaveBeenCalledTimes(1);
+    const [row, sourceId] = insertMessage.mock.calls[0];
+    expect(sourceId).toBe('src-mqtt');
+    expect(row).toMatchObject({ text: 'hello mesh', fromName: 'Alice', messageType: 'channel' });
+    // Sender's timestamp, not ingest time.
+    expect(row.timestamp).toBe(1_700_000_000_000);
+    expect(mgr.getIngestStats().channelMessages).toBe(1);
+  });
+
+  it('gives two observers of the SAME message one id — so it collapses to one row', async () => {
+    await started();
+    const frame = grpTxtFrame(1_700_000_000, 'Alice: same message');
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER_A}/packets`, msg(frame, OBSERVER_A));
+    await settle();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER_B}/packets`, msg(frame, OBSERVER_B));
+    await settle();
+
+    expect(insertMessage).toHaveBeenCalledTimes(2);
+    expect(insertMessage.mock.calls[0][0].id).toBe(insertMessage.mock.calls[1][0].id);
+  });
+
+  it('emits ONCE even when many observers relay the message', async () => {
+    // The whole point: without the insert-or-ignore gate, twenty observers
+    // would mean twenty notifications and twenty automation triggers.
+    insertMessage.mockResolvedValueOnce(true).mockResolvedValue(false);
+    const mgr = await started();
+    const frame = grpTxtFrame(1_700_000_000, 'Alice: broadcast');
+
+    for (const obs of [OBSERVER_A, OBSERVER_B, OBSERVER_A]) {
+      lastClient!.deliver(`meshcore/MCO/${obs}/packets`, msg(frame, obs));
+      await settle();
+    }
+
+    expect(insertMessage).toHaveBeenCalledTimes(3);
+    expect(emitMeshCoreMessage).toHaveBeenCalledTimes(1);
+    expect(mgr.getIngestStats().channelMessages).toBe(1);
+  });
+
+  it('keeps a message with no "Sender: " prefix verbatim', async () => {
+    await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER_A}/packets`,
+      msg(grpTxtFrame(1_700_000_000, 'no prefix here')));
+    await settle();
+
+    expect(insertMessage.mock.calls[0][0]).toMatchObject({
+      text: 'no prefix here', fromName: null,
+    });
+  });
+
+  it('ignores a channel we hold no key for, without erroring', async () => {
+    // The common case on a region feed: most traffic is for channels we are
+    // not in, and that must not log or throw per packet.
+    getAllChannels.mockResolvedValue([
+      { id: 0, name: 'Other', psk: Buffer.from('ff'.repeat(16), 'hex').toString('base64') },
+    ]);
+    const mgr = await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER_A}/packets`,
+      msg(grpTxtFrame(1_700_000_000, 'Alice: secret')));
+    await settle();
+
+    expect(insertMessage).not.toHaveBeenCalled();
+    expect(mgr.getIngestStats().channelMessages).toBe(0);
+  });
+
+  it('reads channel keys across ALL sources, since an ingest source holds none', async () => {
+    await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER_A}/packets`,
+      msg(grpTxtFrame(1_700_000_000, 'Alice: x')));
+    await settle();
+
+    expect(getAllChannels).toHaveBeenCalled();
+    // Called with the ALL_SOURCES sentinel, not this source's id.
+    expect(getAllChannels.mock.calls[0][0]).not.toBe('src-mqtt');
+  });
+
+  it('ignores non-GRP_TXT frames', async () => {
+    await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER_A}/packets`, msg('0500deadbeef'));
+    await settle();
+    expect(insertMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/meshcoreMqttManager.channelIngest.test.ts
+++ b/src/server/meshcoreMqttManager.channelIngest.test.ts
@@ -52,11 +52,18 @@ import { MeshCoreMqttManager } from './meshcoreMqttManager.js';
 
 const SECRET_HEX = '0123456789abcdef0123456789abcdef'; // 16 bytes
 const SECRET_B64 = Buffer.from(SECRET_HEX, 'hex').toString('base64');
+/** A second, distinct channel key so channel ROUTING can be proven. */
+const SECRET3_HEX = 'fedcba9876543210fedcba9876543210';
+const SECRET3_B64 = Buffer.from(SECRET3_HEX, 'hex').toString('base64');
 const OBSERVER_A = 'AA'.repeat(32);
 const OBSERVER_B = 'BB'.repeat(32);
 
 /** Encrypt exactly as MeshCore does, so the shipping decrypt accepts it. */
-function encryptChannelBody(timestampSec: number, body: string): { macHex: string; ctHex: string } {
+function encryptChannelBody(
+  timestampSec: number,
+  body: string,
+  secretHex: string = SECRET_HEX,
+): { macHex: string; ctHex: string } {
   const text = Buffer.from(body, 'utf8');
   const plain = Buffer.alloc(5 + text.length);
   plain.writeUInt32LE(timestampSec, 0);
@@ -66,22 +73,22 @@ function encryptChannelBody(timestampSec: number, body: string): { macHex: strin
   const padded = Buffer.alloc(Math.ceil(plain.length / 16) * 16);
   plain.copy(padded);
 
-  const cipher = createCipheriv('aes-128-ecb', Buffer.from(SECRET_HEX, 'hex'), null);
+  const cipher = createCipheriv('aes-128-ecb', Buffer.from(secretHex, 'hex'), null);
   cipher.setAutoPadding(false);
   const ct = Buffer.concat([cipher.update(padded), cipher.final()]);
 
   // MAC: HMAC-SHA256 over the ciphertext, keyed with the 16-byte secret
   // zero-padded to 32 — first two bytes.
   const key32 = Buffer.alloc(32);
-  Buffer.from(SECRET_HEX, 'hex').copy(key32);
+  Buffer.from(secretHex, 'hex').copy(key32);
   const mac = createHmac('sha256', key32).update(ct).digest();
   return { macHex: mac.subarray(0, 2).toString('hex'), ctHex: ct.toString('hex') };
 }
 
 /** header | path_len | channel_hash | mac(2) | ciphertext */
-function grpTxtFrame(timestampSec: number, body: string): string {
-  const { macHex, ctHex } = encryptChannelBody(timestampSec, body);
-  const hash = ChannelCrypto.calculateChannelHash(SECRET_HEX);
+function grpTxtFrame(timestampSec: number, body: string, secretHex: string = SECRET_HEX): string {
+  const { macHex, ctHex } = encryptChannelBody(timestampSec, body, secretHex);
+  const hash = ChannelCrypto.calculateChannelHash(secretHex);
   const header = ((5 & 0x0f) << 2) | 1; // payload GRP_TXT(5), route FLOOD(1)
   return header.toString(16).padStart(2, '0') + '00' + hash + macHex + ctHex;
 }
@@ -149,15 +156,49 @@ describe('channel message ingest (#5040 Phase 4)', () => {
     expect(mgr.getIngestStats().channelMessages).toBe(1);
   });
 
+  it('files the message under the channel that decrypted it, not channel 0', async () => {
+    // Regression for a bug caught in review on #5063. An empty fromPublicKey
+    // does not simply hide these rows — it falls through
+    // channelWhereClause(0)'s legacy "null recipient, non-channel sender"
+    // branch, so EVERY ingested message would have filed under channel 0
+    // whichever channel it actually came from. Silent mis-filing, not absence.
+    getAllChannels.mockResolvedValue([
+      { id: 0, name: 'Public', psk: SECRET_B64 },
+      { id: 3, name: 'Gauntlet', psk: SECRET3_B64 },
+    ]);
+    await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER_A}/packets`,
+      msg(grpTxtFrame(1_700_000_000, 'Alice: on three', SECRET3_HEX)));
+    await settle();
+
+    expect(insertMessage).toHaveBeenCalledTimes(1);
+    expect(insertMessage.mock.calls[0][0].fromPublicKey).toBe('channel-3');
+  });
+
+  it('still files a channel-0 message under channel 0', async () => {
+    getAllChannels.mockResolvedValue([
+      { id: 0, name: 'Public', psk: SECRET_B64 },
+      { id: 3, name: 'Gauntlet', psk: SECRET3_B64 },
+    ]);
+    await started();
+    lastClient!.deliver(`meshcore/MCO/${OBSERVER_A}/packets`,
+      msg(grpTxtFrame(1_700_000_000, 'Alice: on zero')));
+    await settle();
+
+    expect(insertMessage.mock.calls[0][0].fromPublicKey).toBe('channel-0');
+  });
+
   it('keeps a message with no "Sender: " prefix verbatim', async () => {
     await started();
     lastClient!.deliver(`meshcore/MCO/${OBSERVER_A}/packets`,
       msg(grpTxtFrame(1_700_000_000, 'no prefix here')));
     await settle();
 
-    expect(insertMessage.mock.calls[0][0]).toMatchObject({
-      text: 'no prefix here', fromName: null,
-    });
+    // undefined, not null: one object is both inserted and emitted, and the
+    // event's MeshCoreMessage type declares `fromName?: string`.
+    const row = insertMessage.mock.calls[0][0];
+    expect(row.text).toBe('no prefix here');
+    expect(row.fromName).toBeUndefined();
   });
 
   it('ignores a channel we hold no key for, without erroring', async () => {

--- a/src/server/meshcoreMqttManager.channelIngest.test.ts
+++ b/src/server/meshcoreMqttManager.channelIngest.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createHmac, createCipheriv } from 'node:crypto';
 import { ChannelCrypto } from '@michaelhart/meshcore-decoder';
+import { ALL_SOURCES } from '../db/repositories/base.js';
 
 const insertMessage = vi.fn().mockResolvedValue(true);
 const getAllChannels = vi.fn();
@@ -223,8 +224,10 @@ describe('channel message ingest (#5040 Phase 4)', () => {
     await settle();
 
     expect(getAllChannels).toHaveBeenCalled();
-    // Called with the ALL_SOURCES sentinel, not this source's id.
-    expect(getAllChannels.mock.calls[0][0]).not.toBe('src-mqtt');
+    // Assert the ALL_SOURCES sentinel POSITIVELY: a negative check would still
+    // pass if a regression passed some third value that is neither this source
+    // nor the sentinel.
+    expect(getAllChannels.mock.calls[0][0]).toBe(ALL_SOURCES);
   });
 
   it('ignores non-GRP_TXT frames', async () => {

--- a/src/server/meshcoreMqttManager.ts
+++ b/src/server/meshcoreMqttManager.ts
@@ -99,14 +99,6 @@ export interface MeshCoreMqttIngestStats {
 }
 
 /**
- * Convert an ADVERT's self-reported unix-seconds timestamp into a `lastHeard`
- * milliseconds value, or `undefined` when it carries none.
- *
- * Clamped to now: the value comes from an untrusted publisher, so a future
- * claim is either a forgery or a node with a bad clock, and both would corrupt
- * every "last heard" ordering that reads this column.
- */
-/**
  * Content-derived message id for a channel message ingested over MQTT
  * (#5040 Phase 4).
  *
@@ -152,6 +144,14 @@ export function pskToHex(psk: string | null | undefined): string | null {
   }
 }
 
+/**
+ * Convert an ADVERT's self-reported unix-seconds timestamp into a `lastHeard`
+ * milliseconds value, or `undefined` when it carries none.
+ *
+ * Clamped to now: the value comes from an untrusted publisher, so a future
+ * claim is either a forgery or a node with a bad clock, and both would corrupt
+ * every "last heard" ordering that reads this column.
+ */
 export function advertLastHeardMs(timestampSec: number, nowMs: number = Date.now()): number | undefined {
   if (!Number.isFinite(timestampSec) || timestampSec <= 0) return undefined;
   return Math.min(timestampSec * 1000, nowMs);
@@ -456,6 +456,21 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
       // Sender's own timestamp, not ingest time — every observer's copy of one
       // message must agree, and a delayed relay must not re-date it (the same
       // rule Phase 3 applies to lastHeard).
+      // The row's timestamp falls back to ingest time when the sender has no
+      // clock, but the ID deliberately keeps the raw 0.
+      //
+      // Those diverge on purpose. Every observer of one transmission must
+      // derive the SAME id, and ingest time differs per observer — so the id
+      // can only use what is on the wire. The cost is a real limitation worth
+      // stating: for a CLOCK-LESS sender, two separate transmissions of
+      // identical text on one channel are indistinguishable, and the second
+      // collapses into the first.
+      //
+      // That is inherent, not a gap to close. MeshCore encrypts
+      // `timestamp | flags | text` with AES-ECB, so with a zero timestamp both
+      // transmissions are byte-identical on the wire; nothing separates them
+      // except reception time, and using that would break the multi-observer
+      // collapse this id exists for.
       const timestampMs = plain.timestampSec > 0 ? plain.timestampSec * 1000 : Date.now();
       const id = channelMessageId(this.sourceId, group.channelHash, plain.timestampSec, plain.text);
 

--- a/src/server/meshcoreMqttManager.ts
+++ b/src/server/meshcoreMqttManager.ts
@@ -51,6 +51,10 @@ import {
 import meshcorePacketLogService from './services/meshcorePacketLogService.js';
 import databaseService from '../services/database.js';
 import { decodeMeshCorePacket } from '../utils/meshcorePacketDecode.js';
+import { createHash } from 'node:crypto';
+import { ChannelCrypto } from '@michaelhart/meshcore-decoder';
+import { ALL_SOURCES } from '../db/repositories/base.js';
+import { dataEventEmitter } from './services/dataEventEmitter.js';
 import { logger } from '../utils/logger.js';
 
 /** Persisted `sources.config` shape for a `meshcore_mqtt` source. */
@@ -88,6 +92,8 @@ export interface MeshCoreMqttIngestStats {
   observers: number;
   /** ADVERT frames turned into node create/updates. */
   advertsIngested: number;
+  /** GRP_TXT frames decrypted and stored as channel messages. */
+  channelMessages: number;
   lastPacketAt: number | null;
   lastError: string | null;
 }
@@ -100,6 +106,52 @@ export interface MeshCoreMqttIngestStats {
  * claim is either a forgery or a node with a bad clock, and both would corrupt
  * every "last heard" ordering that reads this column.
  */
+/**
+ * Content-derived message id for a channel message ingested over MQTT
+ * (#5040 Phase 4).
+ *
+ * Includes `sourceId` so a copy your own radio heard keeps its own row under
+ * its own source — the two are different observations and the UI labels them —
+ * while every observer relaying the SAME frame on THIS source collapses to one
+ * id and therefore one row.
+ *
+ * Keyed on (channel, sender timestamp, text) rather than the raw frame: two
+ * observers can report the same message with different hop paths and signal
+ * metadata, so the raw bytes differ while the message does not.
+ */
+/** The shape `ChannelCrypto.decryptGroupTextMessage` returns in `data`. */
+interface ChannelPlaintext {
+  timestamp?: number;
+  flags?: number;
+  sender?: string;
+  message?: string;
+}
+
+export function channelMessageId(
+  sourceId: string,
+  channelHash: string,
+  timestampSec: number,
+  text: string,
+): string {
+  const digest = createHash('sha256')
+    .update(`${channelHash}\u0000${timestampSec}\u0000${text}`)
+    .digest('hex')
+    .slice(0, 24);
+  return `mqtt_${sourceId}_${digest}`;
+}
+
+/** Base64 or hex channel secret -> lowercase hex, or null when unusable. */
+export function pskToHex(psk: string | null | undefined): string | null {
+  if (!psk) return null;
+  if (/^[0-9a-fA-F]+$/.test(psk) && psk.length % 2 === 0) return psk.toLowerCase();
+  try {
+    const buf = Buffer.from(psk, 'base64');
+    return buf.length > 0 ? buf.toString('hex') : null;
+  } catch {
+    return null;
+  }
+}
+
 export function advertLastHeardMs(timestampSec: number, nowMs: number = Date.now()): number | undefined {
   if (!Number.isFinite(timestampSec) || timestampSec <= 0) return undefined;
   return Math.min(timestampSec * 1000, nowMs);
@@ -120,6 +172,7 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
     rejected: 0,
     observers: 0,
     advertsIngested: 0,
+    channelMessages: 0,
     lastPacketAt: null,
     lastError: null,
   };
@@ -249,6 +302,7 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
       this.emit('ota_packet', decoded.event);
       void this.persistPacket(decoded);
       void this.ingestAdvert(decoded);
+      void this.ingestChannelMessage(decoded);
     } catch (err) {
       this.stats.rejected++;
       logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to handle message:`, err);
@@ -363,6 +417,106 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
     } catch (err) {
       logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to ingest advert:`, err);
     }
+  }
+
+  /**
+   * Decrypt a GRP_TXT (channel) frame and store it as a message (#5040 Phase 4).
+   *
+   * ## Channel keys are read across ALL sources
+   *
+   * An ingest source has no device and therefore no channels of its own — the
+   * PSKs a user holds live on their device source. Reading every source's
+   * channels is the only way this works without asking them to duplicate keys
+   * onto a radio-less source, and it matches the codebase's existing
+   * cross-source exception: CLAUDE.md names decryption keys as the canonical
+   * "global by design" case (the Meshtastic `channel_database` does the same).
+   *
+   * Keys are selected by channel hash rather than brute-forced: the frame's
+   * first payload byte is `SHA256(secret)[0]`, so at most a couple of
+   * candidates are ever tried per frame.
+   *
+   * ## Duplicates collapse at the id, not at read time
+   *
+   * The id is CONTENT-derived and includes `sourceId`, so the same frame
+   * relayed by twenty observers writes ONE row, while a copy your own radio
+   * heard keeps its own row under its own source (source-labelled in the UI).
+   * `insertMessage` returns whether it actually wrote, and the event emit is
+   * gated on that — otherwise twenty observers would mean twenty notifications
+   * and twenty automation triggers.
+   */
+  private async ingestChannelMessage(decoded: IngestedObserverPacket): Promise<void> {
+    try {
+      const packet = decodeMeshCorePacket(decoded.event.raw_hex);
+      const group = packet?.payload?.groupText;
+      if (!group) return;
+
+      const plain = await this.decryptGroupText(group);
+      if (!plain) return;
+
+      // Sender's own timestamp, not ingest time — every observer's copy of one
+      // message must agree, and a delayed relay must not re-date it (the same
+      // rule Phase 3 applies to lastHeard).
+      const timestampMs = plain.timestampSec > 0 ? plain.timestampSec * 1000 : Date.now();
+      const id = channelMessageId(this.sourceId, group.channelHash, plain.timestampSec, plain.text);
+
+      const inserted = await databaseService.meshcore.insertMessage(
+        {
+          id,
+          fromPublicKey: '',
+          fromName: plain.senderName,
+          text: plain.text,
+          timestamp: timestampMs,
+          messageType: 'channel',
+          snr: decoded.event.snr ?? null,
+          rssi: decoded.event.rssi ?? null,
+          createdAt: Date.now(),
+        },
+        this.sourceId,
+      );
+
+      if (!inserted) return; // A different observer's copy already landed.
+      this.stats.channelMessages++;
+      dataEventEmitter.emitMeshCoreMessage(
+        { id, text: plain.text, timestamp: timestampMs } as never,
+        this.sourceId,
+      );
+    } catch (err) {
+      logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to ingest channel message:`, err);
+    }
+  }
+
+  /**
+   * Try every known channel key whose hash matches the frame's.
+   *
+   * Returns null when we hold no matching key — the overwhelmingly common case
+   * on a region feed, where most traffic belongs to channels we are not in.
+   * That is not an error and must not be logged per packet.
+   */
+  private async decryptGroupText(
+    group: { channelHash: string; cipherMacHex: string; ciphertextHex: string },
+  ): Promise<{ text: string; senderName: string | null; timestampSec: number } | null> {
+    const channels = await databaseService.channels.getAllChannels(ALL_SOURCES);
+    for (const ch of channels) {
+      const secretHex = pskToHex(ch.psk);
+      if (!secretHex) continue;
+      if (ChannelCrypto.calculateChannelHash(secretHex) !== group.channelHash) continue;
+
+      const res = ChannelCrypto.decryptGroupTextMessage(
+        group.ciphertextHex,
+        group.cipherMacHex,
+        secretHex,
+      );
+      // The library already splits the plaintext into timestamp / flags /
+      // sender / message, so there is no second parser to keep in step.
+      const data = res?.success ? (res.data as ChannelPlaintext | undefined) : undefined;
+      if (!data || typeof data.message !== 'string' || data.message === '') continue;
+      return {
+        text: data.message,
+        senderName: typeof data.sender === 'string' && data.sender !== '' ? data.sender : null,
+        timestampSec: typeof data.timestamp === 'number' ? data.timestamp : 0,
+      };
+    }
+    return null;
   }
 
   getStatus(): SourceStatus {

--- a/src/server/meshcoreMqttManager.ts
+++ b/src/server/meshcoreMqttManager.ts
@@ -459,27 +459,30 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
       const timestampMs = plain.timestampSec > 0 ? plain.timestampSec * 1000 : Date.now();
       const id = channelMessageId(this.sourceId, group.channelHash, plain.timestampSec, plain.text);
 
-      const inserted = await databaseService.meshcore.insertMessage(
-        {
+      const row = {
           id,
-          fromPublicKey: '',
-          fromName: plain.senderName,
+          // 'channel-N' is how this table encodes channel membership; the
+          // channel queries match on it. An empty value here would fall through
+          // channelWhereClause(0)'s legacy "null recipient, non-channel sender"
+          // branch and file EVERY ingested message under channel 0, whichever
+          // channel it actually came from.
+          fromPublicKey: `channel-${plain.channelIdx}`,
+          // undefined, not null: the DB column is nullable but the event's
+          // MeshCoreMessage type is `fromName?: string`, and one object has to
+          // satisfy both — it is inserted and emitted unchanged.
+          fromName: plain.senderName ?? undefined,
           text: plain.text,
           timestamp: timestampMs,
           messageType: 'channel',
-          snr: decoded.event.snr ?? null,
-          rssi: decoded.event.rssi ?? null,
+          snr: decoded.event.snr ?? undefined,
+          rssi: decoded.event.rssi ?? undefined,
           createdAt: Date.now(),
-        },
-        this.sourceId,
-      );
+      };
 
+      const inserted = await databaseService.meshcore.insertMessage(row, this.sourceId);
       if (!inserted) return; // A different observer's copy already landed.
       this.stats.channelMessages++;
-      dataEventEmitter.emitMeshCoreMessage(
-        { id, text: plain.text, timestamp: timestampMs } as never,
-        this.sourceId,
-      );
+      dataEventEmitter.emitMeshCoreMessage(row, this.sourceId);
     } catch (err) {
       logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to ingest channel message:`, err);
     }
@@ -494,7 +497,7 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
    */
   private async decryptGroupText(
     group: { channelHash: string; cipherMacHex: string; ciphertextHex: string },
-  ): Promise<{ text: string; senderName: string | null; timestampSec: number } | null> {
+  ): Promise<{ text: string; senderName: string | null; timestampSec: number; channelIdx: number } | null> {
     const channels = await databaseService.channels.getAllChannels(ALL_SOURCES);
     for (const ch of channels) {
       const secretHex = pskToHex(ch.psk);
@@ -514,6 +517,10 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
         text: data.message,
         senderName: typeof data.sender === 'string' && data.sender !== '' ? data.sender : null,
         timestampSec: typeof data.timestamp === 'number' ? data.timestamp : 0,
+        // The row id of the key that decrypted it IS the channel index — the
+        // only way to know which channel a frame belongs to, since the wire
+        // carries a hash rather than an index.
+        channelIdx: Number(ch.id),
       };
     }
     return null;

--- a/src/utils/meshcorePacketDecode.ts
+++ b/src/utils/meshcorePacketDecode.ts
@@ -99,6 +99,28 @@ export interface DecodedAdvert {
   appDataHex?: string;
 }
 
+/**
+ * GRP_TXT (channel message) plaintext framing (#5040 Phase 4).
+ *
+ * A channel message is NOT laid out like the other encrypted types. The generic
+ * branch reads byte 0 as `destHash` and byte 1 as `srcHash`, but for GRP_TXT:
+ *
+ *   byte 0      channel hash  (first byte of SHA256(channel secret))
+ *   bytes 1..2  cipher MAC    (2 bytes)
+ *   bytes 3..   ciphertext
+ *
+ * So byte 1 is half a MAC, not a source hash, and `encryptedHex` from the
+ * generic branch starts one byte too early to feed a decrypt. Decoding it
+ * properly here keeps ONE decoder for both the packet monitor and the ingest
+ * path rather than re-slicing raw bytes at the call site.
+ */
+export interface DecodedGroupText {
+  /** Selects the channel: matches `ChannelCrypto.calculateChannelHash(secret)`. */
+  channelHash: string;
+  cipherMacHex: string;
+  ciphertextHex: string;
+}
+
 export interface DecodedMeshCorePacket {
   header: {
     raw: number;
@@ -120,6 +142,8 @@ export interface DecodedMeshCorePacket {
     sizeBytes: number;
     hex: string;
     advert?: DecodedAdvert;
+    /** Present for GRP_TXT (0x05) only — see DecodedGroupText. */
+    groupText?: DecodedGroupText;
     message?: { destHash: string; srcHash: string; encryptedHex: string };
     ack?: { ackCodeHex: string };
   };
@@ -229,6 +253,26 @@ export function decodeMeshCorePacket(rawHex: string | null | undefined): Decoded
   } else if (payloadType === 0x03) {
     // ACK — entire payload is the ack code.
     payload.ack = { ackCodeHex: bytesToHex(payloadBytes) };
+  } else if (payloadType === 0x05) {
+    // GRP_TXT: channel_hash(1) | cipher_mac(2) | ciphertext(rest).
+    if (payloadBytes.length >= 4) {
+      payload.groupText = {
+        channelHash: payloadBytes[0].toString(16).padStart(2, '0'),
+        cipherMacHex: bytesToHex(payloadBytes.subarray(1, 3)),
+        ciphertextHex: bytesToHex(payloadBytes.subarray(3)),
+      };
+    } else {
+      errors.push('GRP_TXT payload too short to decode');
+    }
+    // Also fill the generic shape so the monitor's existing rendering is
+    // unchanged; only the new `groupText` field is layout-correct for decrypt.
+    if (payloadBytes.length >= 2) {
+      payload.message = {
+        destHash: payloadBytes[0].toString(16).padStart(2, '0'),
+        srcHash: payloadBytes[1].toString(16).padStart(2, '0'),
+        encryptedHex: bytesToHex(payloadBytes.subarray(2)),
+      };
+    }
   } else if (ENCRYPTED_MSG_TYPES.has(payloadType)) {
     // Plaintext (dest_hash, src_hash) prefix; the rest is encrypted.
     if (payloadBytes.length >= 2) {


### PR DESCRIPTION
Phase 4 of #5040. Decrypts GRP_TXT frames off a region feed using the channel keys the user already holds, and stores them as MeshCore messages.

## Mirrors the Meshtastic messages design rather than inventing one

Per direction on the epic. That table already solved this exact problem when its MQTT path landed: **content-derived id including `sourceId`** + **insert-or-ignore** + **gating the event emit on whether a row was actually written**.

Three properties fall out for free:

| | |
|---|---|
| Twenty observers relay one message | **One row** — they all derive the same id |
| Your radio *also* heard it | **Both rows kept**, different `sourceId`, UI labels each |
| Notifications / automations | Fire **once**, not twenty times |

**That last one is why this could not be fixed at read time.** Every insert emits `dataEventEmitter.emitMeshCoreMessage`, which fans out to Apprise, push, and the automation engine — so N observers would mean N notifications regardless of how the message list deduped afterwards. Gating on the insert-or-ignore return is the fix, and Meshtastic already does it that way.

`MeshCoreRepository.insertMessage` now uses `insertIgnore` and returns whether it wrote, matching `MessagesRepository.insertMessage`. The device path passes a random id and so always inserts, unchanged.

## Decoder: GRP_TXT needs its own shape

A channel message is **not** laid out like the other encrypted types:

```
byte 0      channel hash   (SHA256(secret)[0])
bytes 1..2  cipher MAC     (2 bytes)
bytes 3..   ciphertext
```

The generic branch reads byte 0 as `destHash` and byte 1 as `srcHash`, so its `encryptedHex` starts one byte early and cannot be fed to a decrypt. `DecodedGroupText` keeps **one** decoder serving both the packet monitor and ingest, rather than re-slicing raw bytes at the call site. The existing generic fields are still populated, so the monitor's rendering is untouched.

## Channel keys are read across all sources

An ingest source has no device and therefore no channels of its own — the PSKs live on the user's device source. Requiring them to be duplicated onto a radio-less source would make the feature useless out of the box.

CLAUDE.md names decryption keys as **the** canonical cross-source-by-design exception (the Meshtastic `channel_database` behaves identically), so this follows existing precedent rather than creating a new one.

Keys are selected **by channel hash**, not brute-forced: the frame's first payload byte is `SHA256(secret)[0]`, so at most a couple of candidates are tried per frame. The overwhelmingly common "a channel we don't hold" case stays silent rather than logging per packet.

## Mesh impact

**Zero airtime.** Decrypt-and-store only; this source cannot transmit. The notification fan-out is explicitly bounded to one event per distinct message — see above.

## Testing

16 tests. The end-to-end ones **encrypt frames for real** — AES-128-ECB plus the 2-byte HMAC-SHA256 prefix, mirroring MeshCore's algorithm — because the library only decrypts. Stubbing the decrypt would have left the likeliest-wrong part of the path untested.

Covered: real-frame decrypt and store, id stability across observers, id separation across sources, **emit-once under repeated relay**, the no-`Sender:`-prefix case, a channel we hold no key for (silent, no error), keys read cross-source, non-GRP_TXT ignored, and id-collision edges around the timestamp/text separator.

- Full suite with PostgreSQL and MySQL up: **18,805 passed, 0 failed, 0 failed suites**.
- Both typechecks and `lint:ci` clean.

## Remaining on the epic

Phase 5 (status-topic device stats), Phase 5.5 (shared multi-source **inclusion** audit), Phase 6 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc