### PR TITLE
fix(meshcore): use theme text color for channel/room row buttons

### DIFF
--- a/src/components/MeshCore/MeshCorePage.css
+++ b/src/components/MeshCore/MeshCorePage.css
@@ -450,6 +450,7 @@
   padding: 1rem 1.25rem;
   margin: 0 0.4rem 0.5rem;
   background: var(--color-surface);
+  color: var(--color-text);
   border: 2px solid var(--color-surface-active);
   border-radius: var(--radius-xl);
   cursor: pointer;


### PR DESCRIPTION
## Summary
- `.mc-channel-row` (the card-style button used for both the MeshCore Channels list and the MeshCore Rooms list) set `background: var(--color-surface)` but never set an explicit `color`, so it fell back to the browser's default black button text instead of the theme's text color.
- In the High Contrast Dark theme (`--color-surface: #181818`), this produced near-black-on-black text, making channel/room names illegible.
- Adds `color: var(--color-text);` to `.mc-channel-row`, matching the equivalent Meshtastic `.channel-button` rule in `src/App.css` which already does this correctly.

Fixes #5071

## Test plan
- [x] Visual/code inspection confirms `.mc-channel-row-name` uses `color: inherit`, so it now correctly inherits `--color-text` instead of the browser button default.
- [ ] CI: lint, typecheck, unit tests, system tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gQnv9Mp8oZAhmUSCrCu6i

---
_Generated by [Claude Code](https://claude.ai/code/session_014gQnv9Mp8oZAhmUSCrCu6i)_