### PR TITLE
feat(meshcore): observer device stats from the /status topic, Phase 5 (#5040)

### DIFF
--- a/src/server/meshcoreMqttManager.status.test.ts
+++ b/src/server/meshcoreMqttManager.status.test.ts
@@ -151,6 +151,59 @@ describe('status ingest (#5040 Phase 5)', () => {
     expect(upsertNode.mock.calls[0][0].noiseFloor).toBeUndefined();
   });
 
+  it('caps the observer-status map and evicts the LONGEST-UNSEEN entry', async () => {
+    // Regression for a review finding on #5076: the field comment claimed a
+    // cap that was never enforced. A heartbeat arrives per observer per
+    // interval and a departed observer never clears its own entry, so an
+    // unconditional set() grows with the region forever.
+    const mgr = await started();
+    const key = (n: number) => n.toString(16).padStart(64, '0').toUpperCase();
+
+    // Fill past the cap.
+    for (let i = 0; i < 1_005; i++) {
+      lastClient!.deliver(`meshcore/MCO/${key(i)}/status`, online({ origin_id: key(i) }));
+    }
+    await settle();
+
+    const snapshots = mgr.getObserverStatuses();
+    expect(snapshots.size).toBeLessThanOrEqual(1_000);
+    // The earliest observers were evicted; the most recent survive.
+    expect(snapshots.has(key(0))).toBe(false);
+    expect(snapshots.has(key(1_004))).toBe(true);
+  });
+
+  it('keeps a chatty observer alive rather than evicting it as stale', async () => {
+    // The eviction is longest-UNSEEN, not first-ever-seen. Without the
+    // delete-then-set, a repeat heartbeat would leave the entry at its original
+    // insertion position and the most active observer would be dropped first.
+    const mgr = await started();
+    const key = (n: number) => n.toString(16).padStart(64, '0').toUpperCase();
+
+    lastClient!.deliver(`meshcore/MCO/${key(0)}/status`, online({ origin_id: key(0) }));
+    for (let i = 1; i < 999; i++) {
+      lastClient!.deliver(`meshcore/MCO/${key(i)}/status`, online({ origin_id: key(i) }));
+    }
+    // observer 0 speaks again, right before the map overflows.
+    lastClient!.deliver(`meshcore/MCO/${key(0)}/status`, online({ origin_id: key(0) }));
+    for (let i = 999; i < 1_010; i++) {
+      lastClient!.deliver(`meshcore/MCO/${key(i)}/status`, online({ origin_id: key(i) }));
+    }
+    await settle();
+
+    const snapshots = mgr.getObserverStatuses();
+    expect(snapshots.has(key(0))).toBe(true);
+    expect(snapshots.has(key(1))).toBe(false);
+  });
+
+  it('returns a copy, so a caller cannot mutate the manager state', async () => {
+    const mgr = await started();
+    lastClient!.deliver(statusTopic, online());
+    await settle();
+
+    mgr.getObserverStatuses().clear?.();
+    expect(mgr.getObserverStatuses().size).toBe(1);
+  });
+
   it('ignores a packet body delivered on the status topic', async () => {
     await started();
     lastClient!.deliver(statusTopic, { type: 'PACKET', origin_id: OBS, raw: '0500deadbeef' });

--- a/src/server/meshcoreMqttManager.status.test.ts
+++ b/src/server/meshcoreMqttManager.status.test.ts
@@ -1,0 +1,160 @@
+/**
+ * `/status` heartbeat ingest (#5040 Phase 5).
+ *
+ * A status message describes the OBSERVER that published it — the node running
+ * the analyzer bridge — not anything it overheard. The tests that matter are
+ * the ones separating status from packet handling, since both ride the same
+ * region topic prefix.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const upsertNode = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: { upsertNode: (...a: unknown[]) => upsertNode(...a), insertMessage: vi.fn() },
+    channels: { getAllChannels: vi.fn().mockResolvedValue([]) },
+  },
+}));
+vi.mock('./services/dataEventEmitter.js', () => ({ dataEventEmitter: { emitMeshCoreMessage: vi.fn() } }));
+vi.mock('./services/meshcorePacketLogService.js', () => ({
+  default: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+}));
+
+let lastClient: FakeClient | null = null;
+class FakeClient {
+  handlers = new Map<string, (a: unknown) => void>();
+  connect = vi.fn().mockResolvedValue(undefined);
+  subscribe = vi.fn().mockResolvedValue(undefined);
+  disconnect = vi.fn().mockResolvedValue(undefined);
+  isConnected = () => true;
+  on(e: string, fn: (a: unknown) => void) { this.handlers.set(e, fn); return this; }
+  removeAllListeners() { this.handlers.clear(); return this; }
+  deliver(topic: string, b: unknown) {
+    this.handlers.get('message')?.({ topic, payload: Buffer.from(JSON.stringify(b)) });
+  }
+  deliverRaw(topic: string, raw: string) {
+    this.handlers.get('message')?.({ topic, payload: Buffer.from(raw) });
+  }
+}
+vi.mock('./transports/mqttBrokerClient.js', () => ({
+  MqttBrokerClient: class { constructor() { lastClient = new FakeClient(); return lastClient as unknown as object; } },
+}));
+
+import { MeshCoreMqttManager } from './meshcoreMqttManager.js';
+
+const OBS = 'AA'.repeat(32);
+const statusTopic = `meshcore/MCO/${OBS}/status`;
+
+const online = (over: Record<string, unknown> = {}) => ({
+  status: 'online', origin: 'BridgeNode', origin_id: OBS,
+  stats: { battery_mv: 4100, uptime_secs: 86_400, noise_floor: -95 },
+  ...over,
+});
+
+async function started() {
+  const m = new MeshCoreMqttManager('src-mqtt', 'Feed', { brokerUrl: 'wss://b', region: 'MCO' });
+  await m.start();
+  return m;
+}
+const settle = () => new Promise(r => setTimeout(r, 0));
+
+beforeEach(() => { upsertNode.mockClear(); lastClient = null; });
+
+describe('status ingest (#5040 Phase 5)', () => {
+  it('subscribes to the status topic alongside packets', async () => {
+    const mgr = await started();
+    const topics = (lastClient!.subscribe as unknown as { mock: { calls: string[][][] } }).mock.calls[0][0];
+    expect(topics).toContain('meshcore/MCO/+/packets');
+    expect(topics).toContain('meshcore/MCO/+/status');
+    expect(mgr.getStatus().connected).toBe(true);
+  });
+
+  it('records the observer’s battery and uptime against its own key', async () => {
+    const mgr = await started();
+    lastClient!.deliver(statusTopic, online());
+    await settle();
+
+    expect(upsertNode).toHaveBeenCalledTimes(1);
+    const [node, sourceId] = upsertNode.mock.calls[0];
+    expect(sourceId).toBe('src-mqtt');
+    expect(node).toMatchObject({ publicKey: OBS, name: 'BridgeNode', batteryMv: 4100, uptimeSecs: 86_400 });
+    expect(mgr.getIngestStats().statusMessages).toBe(1);
+  });
+
+  it('does NOT stamp lastHeard — a heartbeat proves broker reach, not mesh reach', async () => {
+    // Otherwise an observer whose radio is dead would look mesh-alive.
+    await started();
+    lastClient!.deliver(statusTopic, online());
+    await settle();
+    expect(upsertNode.mock.calls[0][0].lastHeard).toBeUndefined();
+  });
+
+  it('does not count status heartbeats as received packets', async () => {
+    // Both ride the same region prefix; conflating them would drift every
+    // packet counter by one per observer per heartbeat.
+    const mgr = await started();
+    lastClient!.deliver(statusTopic, online());
+    await settle();
+
+    const s = mgr.getIngestStats();
+    expect(s.statusMessages).toBe(1);
+    expect(s.received).toBe(0);
+    expect(s.rejected).toBe(0);
+  });
+
+  it('does not book a malformed status body as a rejected packet', async () => {
+    const mgr = await started();
+    lastClient!.deliverRaw(statusTopic, 'not json');
+    await settle();
+
+    expect(mgr.getIngestStats().received).toBe(0);
+    expect(mgr.getIngestStats().rejected).toBe(0);
+    expect(upsertNode).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing for an offline notice', async () => {
+    const mgr = await started();
+    lastClient!.deliver(statusTopic, online({ status: 'offline', stats: {} }));
+    await settle();
+
+    expect(upsertNode).not.toHaveBeenCalled();
+    // Still tracked, so the panel can show it went offline.
+    expect(mgr.getObserverStatuses().get(OBS)?.online).toBe(false);
+  });
+
+  it('writes nothing when firmware reports no stats', async () => {
+    await started();
+    lastClient!.deliver(statusTopic, online({ stats: {} }));
+    await settle();
+    expect(upsertNode).not.toHaveBeenCalled();
+  });
+
+  it('drops an implausible battery reading rather than storing it', async () => {
+    await started();
+    lastClient!.deliver(statusTopic, online({ stats: { battery_mv: 999_999, uptime_secs: 10 } }));
+    await settle();
+
+    const node = upsertNode.mock.calls[0][0];
+    expect(node.batteryMv).toBeUndefined();
+    expect(node.uptimeSecs).toBe(10);
+  });
+
+  it('exposes noise floor on the snapshot without persisting it', async () => {
+    // No column for it yet; decoding it now keeps the display work to a UI
+    // change rather than a migration.
+    const mgr = await started();
+    lastClient!.deliver(statusTopic, online());
+    await settle();
+
+    expect(mgr.getObserverStatuses().get(OBS)?.noiseFloor).toBe(-95);
+    expect(upsertNode.mock.calls[0][0].noiseFloor).toBeUndefined();
+  });
+
+  it('ignores a packet body delivered on the status topic', async () => {
+    await started();
+    lastClient!.deliver(statusTopic, { type: 'PACKET', origin_id: OBS, raw: '0500deadbeef' });
+    await settle();
+    expect(upsertNode).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/meshcoreMqttManager.test.ts
+++ b/src/server/meshcoreMqttManager.test.ts
@@ -127,7 +127,12 @@ describe('MeshCoreMqttManager — subscription', () => {
   it('subscribes to the region wildcard topic on start', async () => {
     await makeManager().start();
     expect(connectMock).toHaveBeenCalledTimes(1);
-    expect(subscribeMock).toHaveBeenCalledWith(['meshcore/MCO/+/packets']);
+    expect(subscribeMock).toHaveBeenCalledWith([
+      'meshcore/MCO/+/packets',
+      // Phase 5 (#5040) added the status topic to the same subscribe call —
+      // observer heartbeats ride the same region prefix as packets.
+      'meshcore/MCO/+/status',
+    ]);
   });
 
   it('is idempotent — a second start does not open a second connection', async () => {
@@ -226,7 +231,12 @@ describe('MeshCoreMqttManager — ingest', () => {
     connectMock.mockResolvedValueOnce(undefined);
     await mgr.start();
     expect(connectMock).toHaveBeenCalledTimes(2);
-    expect(subscribeMock).toHaveBeenCalledWith(['meshcore/MCO/+/packets']);
+    expect(subscribeMock).toHaveBeenCalledWith([
+      'meshcore/MCO/+/packets',
+      // Phase 5 (#5040) added the status topic to the same subscribe call —
+      // observer heartbeats ride the same region prefix as packets.
+      'meshcore/MCO/+/status',
+    ]);
   });
 
   it('tolerates stop() before start()', async () => {

--- a/src/server/meshcoreMqttManager.ts
+++ b/src/server/meshcoreMqttManager.ts
@@ -202,9 +202,12 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
   private readonly seenObservers = new Set<string>();
   private static readonly MAX_TRACKED_OBSERVERS = 1_000;
   /**
-   * Latest `/status` snapshot per observer. Bounded by the same cap — a status
-   * heartbeat arrives per observer per interval, so an unbounded map would grow
-   * with region size.
+   * Latest `/status` snapshot per observer, capped at
+   * {@link MAX_TRACKED_OBSERVERS} and evicted longest-unseen-first.
+   *
+   * The cap is enforced in `handleStatus`, not here — a heartbeat arrives per
+   * observer per interval and a departed observer never clears its own entry,
+   * so an unconditional `set()` would grow with region size forever.
    */
   private readonly seenObserverStatus = new Map<string, ObserverStatusSnapshot>();
 
@@ -599,6 +602,24 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
       if (!status) return;
 
       this.stats.statusMessages++;
+
+      // Enforce the cap the field comment claims. A heartbeat arrives per
+      // observer per interval, and observers that go away never come back to
+      // clear their entry, so an unconditional set() grows with the region
+      // forever. Evicting the LONGEST-UNSEEN entry (Map iteration is
+      // insertion-ordered, and a re-seen observer is re-inserted below) keeps
+      // the panel showing the observers that are actually active.
+      if (
+        !this.seenObserverStatus.has(status.originId) &&
+        this.seenObserverStatus.size >= MeshCoreMqttManager.MAX_TRACKED_OBSERVERS
+      ) {
+        const oldest = this.seenObserverStatus.keys().next();
+        if (!oldest.done) this.seenObserverStatus.delete(oldest.value);
+      }
+      // Delete-then-set so a repeat heartbeat moves the entry to the END of the
+      // insertion order; without it the eviction above would drop the most
+      // chatty observer rather than the most stale one.
+      this.seenObserverStatus.delete(status.originId);
       this.seenObserverStatus.set(status.originId, {
         online: status.online,
         at: Date.now(),

--- a/src/server/meshcoreMqttManager.ts
+++ b/src/server/meshcoreMqttManager.ts
@@ -45,6 +45,8 @@ import { MqttBrokerClient } from './transports/mqttBrokerClient.js';
 import {
   decodeObserverPacketMessage,
   observerPacketsSubscription,
+  observerStatusSubscription,
+  decodeObserverStatusMessage,
   observerKeyFromTopic,
   type IngestedObserverPacket,
 } from './services/meshcoreMqttIngestPacket.js';
@@ -80,6 +82,17 @@ export interface MeshCoreMqttSourceConfig {
   autoConnect?: boolean;
 }
 
+/** One observer's latest self-reported state, for the status panel. */
+export interface ObserverStatusSnapshot {
+  online: boolean;
+  /** When WE saw the heartbeat, not the publisher's clock. */
+  at: number;
+  batteryMv?: number;
+  uptimeSecs?: number;
+  /** Decoded but not persisted — see the manager's status handler. */
+  noiseFloor?: number;
+}
+
 /** Counters surfaced on the source status panel. */
 export interface MeshCoreMqttIngestStats {
   /** Messages received on the packets topic, before validation. */
@@ -94,6 +107,8 @@ export interface MeshCoreMqttIngestStats {
   advertsIngested: number;
   /** GRP_TXT frames decrypted and stored as channel messages. */
   channelMessages: number;
+  /** `/status` heartbeats decoded. Counted separately from packets. */
+  statusMessages: number;
   lastPacketAt: number | null;
   lastError: string | null;
 }
@@ -173,6 +188,7 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
     observers: 0,
     advertsIngested: 0,
     channelMessages: 0,
+    statusMessages: 0,
     lastPacketAt: null,
     lastError: null,
   };
@@ -185,6 +201,12 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
    */
   private readonly seenObservers = new Set<string>();
   private static readonly MAX_TRACKED_OBSERVERS = 1_000;
+  /**
+   * Latest `/status` snapshot per observer. Bounded by the same cap — a status
+   * heartbeat arrives per observer per interval, so an unbounded map would grow
+   * with region size.
+   */
+  private readonly seenObserverStatus = new Map<string, ObserverStatusSnapshot>();
 
   constructor(sourceId: string, sourceName: string, config: MeshCoreMqttSourceConfig) {
     super();
@@ -213,7 +235,8 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
   /** Open and subscribe. Separated so start() can roll back cleanly on failure. */
   private async openBroker(): Promise<void> {
 
-    const topic = observerPacketsSubscription(this.config.region);
+    const packetsTopic = observerPacketsSubscription(this.config.region);
+    const statusTopic = observerStatusSubscription(this.config.region);
     const client = new MqttBrokerClient({
       url: this.config.brokerUrl,
       username: this.config.username,
@@ -235,9 +258,9 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
     });
 
     await client.connect();
-    await client.subscribe([topic]);
+    await client.subscribe([packetsTopic, statusTopic]);
     logger.info(
-      `[MeshCoreMqtt:${this.sourceId}] subscribed to ${topic} on ${this.config.brokerUrl}`,
+      `[MeshCoreMqtt:${this.sourceId}] subscribed to ${packetsTopic} and ${statusTopic} on ${this.config.brokerUrl}`,
     );
   }
 
@@ -263,6 +286,16 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
    * single bad message on a busy region feed can never throw.
    */
   private handleMessage(topic: string, payload: Buffer): void {
+    // Status heartbeats ride the same region prefix as packets but are a
+    // different shape. Split on the topic suffix BEFORE any parsing or
+    // counting: the packet counters must not drift by one per observer per
+    // heartbeat, and a malformed status body must not be booked as a rejected
+    // packet.
+    if (topic.endsWith('/status')) {
+      void this.handleStatus(payload);
+      return;
+    }
+
     this.stats.received++;
     try {
       const body: unknown = JSON.parse(payload.toString('utf8'));
@@ -539,6 +572,63 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
       };
     }
     return null;
+  }
+
+  /**
+   * Record an observer's self-reported device stats (#5040 Phase 5).
+   *
+   * A `/status` message describes the OBSERVER that published it — the node
+   * running the analyzer bridge — not anything it overheard. So these stats
+   * belong to `originId` and are written through the same `upsertNode` choke
+   * point as an advert, which means the observer shows up as a node on this
+   * source whether or not it has also advertised.
+   *
+   * Only battery and uptime are persisted. `noise_floor` decodes and is
+   * deliberately NOT stored: `meshcore_nodes` has no column for it, and adding
+   * one that nothing displays would be a dead column plus a migration. It is a
+   * genuinely useful signal for a region feed — it says how congested the band
+   * is — so it belongs with a display surface, not ahead of one.
+   *
+   * `lastHeard` is NOT touched here. A status heartbeat proves the observer is
+   * talking to its BROKER, not that it is reachable on the mesh; stamping it
+   * would make an observer with a dead radio look mesh-alive.
+   */
+  private async handleStatus(payload: Buffer): Promise<void> {
+    try {
+      const status = decodeObserverStatusMessage(JSON.parse(payload.toString('utf8')));
+      if (!status) return;
+
+      this.stats.statusMessages++;
+      this.seenObserverStatus.set(status.originId, {
+        online: status.online,
+        at: Date.now(),
+        batteryMv: status.batteryMv,
+        uptimeSecs: status.uptimeSecs,
+        noiseFloor: status.noiseFloor,
+      });
+
+      // Nothing worth persisting on an offline notice, or from firmware that
+      // reports no stats at all.
+      if (!status.online) return;
+      if (status.batteryMv === undefined && status.uptimeSecs === undefined) return;
+
+      await databaseService.meshcore.upsertNode(
+        {
+          publicKey: status.originId,
+          name: status.origin !== '' ? status.origin : undefined,
+          batteryMv: status.batteryMv,
+          uptimeSecs: status.uptimeSecs,
+        },
+        this.sourceId,
+      );
+    } catch (err) {
+      logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to handle status:`, err);
+    }
+  }
+
+  /** Latest status seen per observer, for the source status panel. */
+  getObserverStatuses(): ReadonlyMap<string, ObserverStatusSnapshot> {
+    return new Map(this.seenObserverStatus);
   }
 
   getStatus(): SourceStatus {

--- a/src/server/services/meshcoreMqttIngestPacket.ts
+++ b/src/server/services/meshcoreMqttIngestPacket.ts
@@ -211,6 +211,69 @@ export function decodeObserverPacketMessage(body: unknown): IngestedObserverPack
 }
 
 /**
+ * A decoded `/status` message (#5040 Phase 5).
+ *
+ * IMPORTANT: a status message describes the OBSERVER that published it — the
+ * node running the analyzer bridge — not some arbitrary node it overheard. So
+ * these stats belong to `originId`, and nothing here says anything about the
+ * rest of the region.
+ */
+export interface IngestedObserverStatus {
+  /** Observer's public key, UPPER 64-hex. */
+  originId: string;
+  /** Observer's self-reported name. Display only. */
+  origin: string;
+  online: boolean;
+  /** Millivolts. Absent when the firmware does not report it. */
+  batteryMv?: number;
+  uptimeSecs?: number;
+  /** dBm. No column for this yet — see the manager's status handler. */
+  noiseFloor?: number;
+}
+
+/** Plausible battery range for a MeshCore node, in millivolts. */
+const BATTERY_MIN_MV = 1_000;
+const BATTERY_MAX_MV = 20_000;
+
+/**
+ * Decode one `/status`-topic message.
+ *
+ * Total: returns null rather than throwing, so a malformed status heartbeat on
+ * a busy region feed cannot break the stream. Stats are range-checked the same
+ * way packet measurements are — an out-of-range battery is not a reading.
+ */
+export function decodeObserverStatusMessage(body: unknown): IngestedObserverStatus | null {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return null;
+  const msg = body as Record<string, unknown>;
+
+  // Packet messages share the topic prefix; skip them quietly.
+  if (msg.type === 'PACKET') return null;
+  if (msg.status !== 'online' && msg.status !== 'offline') return null;
+
+  const originId = readString(msg.origin_id);
+  if (!originId || !ORIGIN_ID_RE.test(originId)) return null;
+
+  const stats = (msg.stats && typeof msg.stats === 'object' ? msg.stats : {}) as Record<string, unknown>;
+  const out: IngestedObserverStatus = {
+    originId: originId.toUpperCase(),
+    origin: readString(msg.origin) ?? '',
+    online: msg.status === 'online',
+  };
+
+  const battery = readMeasurement(stats.battery_mv, BATTERY_MIN_MV, BATTERY_MAX_MV);
+  if (battery !== undefined) out.batteryMv = battery;
+
+  // Uptime only has a floor: a node up for a year is unremarkable.
+  const uptime = readNumeric(stats.uptime_secs);
+  if (uptime !== null && uptime >= 0) out.uptimeSecs = uptime;
+
+  const noise = readMeasurement(stats.noise_floor, -200, 0);
+  if (noise !== undefined) out.noiseFloor = noise;
+
+  return out;
+}
+
+/**
  * Build the subscribe filter for a region.
  *
  * Mirrors `observerTopics()` on the publish side, with a `+` wildcard in the

--- a/src/server/services/meshcoreMqttIngestPacket.ts
+++ b/src/server/services/meshcoreMqttIngestPacket.ts
@@ -263,10 +263,15 @@ export function decodeObserverStatusMessage(body: unknown): IngestedObserverStat
   const battery = readMeasurement(stats.battery_mv, BATTERY_MIN_MV, BATTERY_MAX_MV);
   if (battery !== undefined) out.batteryMv = battery;
 
-  // Uptime only has a floor: a node up for a year is unremarkable.
+  // Uptime has a floor but no ceiling: a node up for a year is unremarkable, so
+  // there is no upper bound to check against. 0 is accepted — a node that just
+  // booted genuinely reports it.
   const uptime = readNumeric(stats.uptime_secs);
   if (uptime !== null && uptime >= 0) out.uptimeSecs = uptime;
 
+  // Ambient RF noise is negative dBm; -200 is far below any real receiver's
+  // sensitivity and 0 is the ceiling, so this rejects junk without clipping a
+  // legitimate reading from any radio.
   const noise = readMeasurement(stats.noise_floor, -200, 0);
   if (noise !== undefined) out.noiseFloor = noise;
 

--- a/src/server/services/meshcoreMqttIngestPacket.ts
+++ b/src/server/services/meshcoreMqttIngestPacket.ts
@@ -289,7 +289,11 @@ export function observerPacketsSubscription(region: string): string {
   return `meshcore/${region.trim().toUpperCase()}/+/packets`;
 }
 
-/** Same, for the status topic consumed in a later phase. */
+/**
+ * Same, for the `/status` topic — observer heartbeats carrying that node's own
+ * battery / uptime / noise-floor stats. Subscribed alongside the packets topic
+ * in the same `subscribe()` call (#5040 Phase 5).
+ */
 export function observerStatusSubscription(region: string): string {
   return `meshcore/${region.trim().toUpperCase()}/+/status`;
 }


### PR DESCRIPTION
Phase 5 of #5040. Consumes the `/status` topic — the manager has had `observerStatusSubscription()` since Phase 1 but never subscribed to it.

## What a status message actually is

**It describes the OBSERVER that published it** — the node running the analyzer bridge — not anything it overheard. So these are that node's own stats, written by its public key through the same `upsertNode` choke point as an advert. An observer therefore appears as a node on this source whether or not it has also advertised.

Worth stating plainly because the issue's phrasing ("device stats per observed node") reads the other way.

## Three decisions

**`lastHeard` is not stamped.** A heartbeat proves the observer can reach its *broker*, not that it is reachable on the *mesh*. Stamping it would make an observer with a dead radio look mesh-alive — the same class of lie as the firmware 2.8 replay bug fixed in #5038.

**Status is split off before any counting or parsing.** Status and packets share the region topic prefix. My first cut counted *after* `JSON.parse`, which would have booked a malformed status body as a **rejected packet** and drifted every packet counter by one per observer per heartbeat. Two tests pin both halves.

**`noise_floor` decodes but is not persisted.** `meshcore_nodes` has no column for it, and adding one that nothing displays is a dead column plus a migration. It is exposed on the per-observer snapshot so a UI can render it, which keeps the display work a UI change rather than a schema one.

This is a deliberate deviation from the issue's "battery / uptime / noise floor" wording — flagging it rather than quietly dropping a third of the stated scope. If you'd rather it land now, it's one nullable column plus a display.

## Validation

Battery is range-checked the way packet measurements are — an implausible reading is not a reading. Uptime has a floor only, since a node up for a year is unremarkable. An offline notice and a stats-less heartbeat both write nothing but still update the snapshot, so a panel can show that an observer went away.

## Mesh impact

**Zero airtime.** Subscribe-and-store only.

## Testing

10 new tests: subscription covers both topics, stats land against the observer's own key, `lastHeard` untouched, heartbeats not counted as packets, a malformed status body not booked as a rejected packet, offline and stats-less writes skipped, implausible battery dropped while a good uptime survives, noise floor on the snapshot but not the row, and a packet body on the status topic ignored.

Also updates two Phase 1 assertions that pinned `subscribe` to the packets topic alone — the pair is the intended behaviour now.

- Full suite: **18,924 passed, 0 failed, 122 pending**, verified with **both** PostgreSQL and MySQL containers up.
- Both typechecks and `lint:ci` clean.

One note on that number: an earlier run of this branch reported `success: true` with **975** pending because the containers had stopped — the silent-skip CLAUDE.md warns about, where ~850 multi-backend tests vanish and the headline looks identical. The 18,924 above is the run that actually covered all three backends.

## Remaining on the epic

Phase 5.5 (shared multi-source **inclusion** audit) and Phase 6 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc