### PR TITLE
fix(mqtt): stop the upstream broker connection storm (#5079)

### DIFF
--- a/src/server/transports/mqttBrokerClient.test.ts
+++ b/src/server/transports/mqttBrokerClient.test.ts
@@ -2,14 +2,44 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
 
 // Fake mqtt.js client: an EventEmitter with the methods MqttBrokerClient uses.
+//
+// `reconnect()` mirrors mqtt.js's real `_reconnect()`: on an already-connected
+// client it tears the socket down (emitting 'close') before opening a new one.
+// That teardown is what made the pre-#5079 coordinator self-sustaining, so the
+// fake has to reproduce it for the regression tests to mean anything.
 function makeFakeClient() {
   const c = new EventEmitter() as any;
+  c.isUp = false;
+  c.reconnectAt = [] as number[];
   c.subscribe = vi.fn((_t: string[], _o: unknown, cb?: any) => cb && cb(null, [], {}));
   c.publish = vi.fn((_t: string, _p: Buffer, _o: unknown, cb?: any) => cb && cb());
   c.end = vi.fn((_f: boolean, _o: unknown, cb?: any) => cb && cb());
-  c.reconnect = vi.fn();
+  c.reconnect = vi.fn(() => {
+    c.reconnectAt.push(Date.now());
+    if (c.isUp) {
+      c.isUp = false;
+      c.emit('close');
+    }
+  });
   return c;
 }
+
+/** Simulate a CONNACK on the fake socket. */
+function up(fake: any) {
+  fake.isUp = true;
+  fake.emit('connect');
+}
+
+/** Simulate the broker (or the network) dropping the socket. */
+function down(fake: any) {
+  fake.isUp = false;
+  fake.emit('close');
+}
+
+const infoLines = (log: any) =>
+  log.info.mock.calls.map((c: unknown[]) => String(c[0]));
+const warnLines = (log: any) =>
+  log.warn.mock.calls.map((c: unknown[]) => String(c[0]));
 
 vi.mock('mqtt', () => ({
   connect: vi.fn(() => makeFakeClient()),
@@ -20,6 +50,7 @@ vi.mock('../../utils/logger.js', () => ({
 }));
 
 import { connect } from 'mqtt';
+import { logger } from '../../utils/logger.js';
 import { MqttBrokerClient, MqttReconnectCoordinator } from './mqttBrokerClient.js';
 
 const lastFakeClient = () => (connect as any).mock.results.at(-1).value;
@@ -45,7 +76,7 @@ describe('MqttBrokerClient', () => {
   describe('stability-gated backoff reset', () => {
     it('does NOT reset coordinator backoff immediately on connect', () => {
       const coord = new MqttReconnectCoordinator();
-      const resetSpy = vi.spyOn(coord, 'resetBackoff');
+      const resetSpy = vi.spyOn(coord, 'noteStableConnection');
       const client = new MqttBrokerClient({ url: 'mqtt://broker.test:1883' });
       client.setCoordinator(coord);
       void client.connect();
@@ -56,33 +87,49 @@ describe('MqttBrokerClient', () => {
 
     it('does NOT reset backoff when a connection flaps before the grace window', () => {
       const coord = new MqttReconnectCoordinator();
-      const resetSpy = vi.spyOn(coord, 'resetBackoff');
+      const resetSpy = vi.spyOn(coord, 'noteStableConnection');
       const client = new MqttBrokerClient({ url: 'mqtt://broker.test:1883' });
       client.setCoordinator(coord);
       void client.connect();
       const fake = lastFakeClient();
 
       // connect, then drop after only 5s (clientId-collision style flap)
-      fake.emit('connect');
+      up(fake);
       vi.advanceTimersByTime(5000);
-      fake.emit('close');
-      vi.advanceTimersByTime(120_000);
+      down(fake);
+      vi.advanceTimersByTime(300_000);
 
       expect(resetSpy).not.toHaveBeenCalled();
     });
 
     it('resets backoff once a connection holds past the grace window', () => {
       const coord = new MqttReconnectCoordinator();
-      const resetSpy = vi.spyOn(coord, 'resetBackoff');
+      const resetSpy = vi.spyOn(coord, 'noteStableConnection');
       const client = new MqttBrokerClient({ url: 'mqtt://broker.test:1883' });
       client.setCoordinator(coord);
       void client.connect();
       const fake = lastFakeClient();
 
-      fake.emit('connect');
-      vi.advanceTimersByTime(30_000);
+      up(fake);
+      vi.advanceTimersByTime(120_000);
 
       expect(resetSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('the grace window is longer than the max backoff, so a single retry cycle cannot look "stable"', () => {
+      // #5079: STABLE_RESET_MS was 30s against a 60s backoff cap, so once the
+      // backoff climbed past 30s every retry trivially cleared the window and
+      // knocked the throttle back to 1s — a permanent sawtooth.
+      const coord = new MqttReconnectCoordinator();
+      const resetSpy = vi.spyOn(coord, 'noteStableConnection');
+      const client = new MqttBrokerClient({ url: 'mqtt://broker.test:1883' });
+      client.setCoordinator(coord);
+      void client.connect();
+      const fake = lastFakeClient();
+
+      up(fake);
+      vi.advanceTimersByTime(61_000); // longer than BACKOFF_MAX_MS
+      expect(resetSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -199,6 +246,247 @@ describe('MqttBrokerClient', () => {
       // Reconnect delays should be non-decreasing and span more than the 1s min.
       expect(delays.length).toBeGreaterThanOrEqual(3);
       expect(delays.at(-1)!).toBeGreaterThan(delays[0]!);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // #5079 — MQTT connection storm.
+  //
+  // Symptom: hundreds of "📡 MQTT client connected" lines and dozens of
+  // short-lived sockets to the upstream broker with climbing source ports.
+  //
+  // Two defects combined:
+  //  1. MqttReconnectCoordinator reconnected EVERY registered client on each
+  //     tick. mqtt.js's _reconnect() on a live client ends the socket and
+  //     opens a new one, so one flapping pool member churned every sibling —
+  //     and each forced teardown emitted 'close', which re-armed the tick.
+  //     The coordinator therefore kept itself running forever after one drop.
+  //  2. STABLE_RESET_MS (30s) was half BACKOFF_MAX_MS (60s), so the backoff
+  //     reset to 1s the moment it grew past the grace window.
+  // ---------------------------------------------------------------------
+  describe('#5079 connection storm', () => {
+    const URL = 'mqtt://broker.test:1883';
+
+    function makePair() {
+      const coord = new MqttReconnectCoordinator();
+      const a = new MqttBrokerClient({ url: URL, clientId: '!aaaaaaaa' });
+      a.setCoordinator(coord);
+      void a.connect();
+      const fakeA = lastFakeClient();
+      const b = new MqttBrokerClient({ url: URL, clientId: '!bbbbbbbb' });
+      b.setCoordinator(coord);
+      void b.connect();
+      const fakeB = lastFakeClient();
+      return { coord, a, b, fakeA, fakeB };
+    }
+
+    it('never reconnects a healthy sibling when one pool member drops', () => {
+      const { fakeA, fakeB } = makePair();
+      up(fakeA);
+      up(fakeB);
+
+      down(fakeB);
+      vi.advanceTimersByTime(10_000); // well past the 1s first backoff
+
+      expect(fakeB.reconnect).toHaveBeenCalledTimes(1);
+      // A never dropped — churning its socket is the amplifier from #5079.
+      expect(fakeA.reconnect).not.toHaveBeenCalled();
+    });
+
+    it('quiesces once the dropped client recovers (no self-sustaining loop)', () => {
+      const { coord, fakeA, fakeB } = makePair();
+      up(fakeA);
+      up(fakeB);
+
+      down(fakeB);
+      vi.advanceTimersByTime(3000); // tick fires, B reconnects
+      up(fakeB); // B comes back
+
+      vi.advanceTimersByTime(600_000); // ten minutes of nothing happening
+
+      expect(fakeB.reconnect).toHaveBeenCalledTimes(1);
+      expect(fakeA.reconnect).not.toHaveBeenCalled();
+      expect(coord.getPendingCount()).toBe(0);
+    });
+
+    it('grows the shared backoff monotonically to the 60s cap under a sustained flap', () => {
+      const coord = new MqttReconnectCoordinator();
+      const client = new MqttBrokerClient({ url: URL, clientId: '!aaaaaaaa' });
+      client.setCoordinator(coord);
+      void client.connect();
+      const fake = lastFakeClient();
+
+      const delays: number[] = [];
+      // Sessions of 31s: longer than the OLD 30s grace window (so the buggy
+      // build reset to 1s every round) but far shorter than a genuinely
+      // stable connection.
+      for (let i = 0; i < 10; i++) {
+        up(fake);
+        vi.advanceTimersByTime(31_000);
+        const closedAt = Date.now();
+        down(fake);
+        vi.advanceTimersByTime(90_000); // let the shared tick fire
+        delays.push(fake.reconnectAt.at(-1)! - closedAt);
+      }
+
+      // First retry is prompt...
+      expect(delays[0]!).toBeLessThan(1300);
+      // ...then each retry is meaningfully slower than the last until the cap.
+      for (let i = 1; i < 6; i++) {
+        expect(delays[i]!).toBeGreaterThan(delays[i - 1]! * 1.5);
+      }
+      // ...and it settles at the 60s ceiling instead of snapping back to 1s.
+      expect(delays.at(-1)!).toBeGreaterThan(50_000);
+      expect(delays.at(-1)!).toBeLessThan(70_000);
+      expect(Math.max(...delays)).toBeLessThanOrEqual(70_000);
+    });
+
+    it('logs "connected" once per state change, not once per socket', () => {
+      const client = new MqttBrokerClient({ url: URL, clientId: '!aaaaaaaa' });
+      void client.connect();
+      const fake = lastFakeClient();
+
+      for (let i = 0; i < 12; i++) {
+        up(fake);
+        vi.advanceTimersByTime(800);
+        down(fake);
+        vi.advanceTimersByTime(200);
+      }
+
+      const connectedLines = infoLines(logger).filter((l: string) =>
+        l.includes('MQTT client connected to'),
+      );
+      expect(connectedLines).toHaveLength(1);
+    });
+
+    it('still surfaces the storm, as a rate-limited flap summary', () => {
+      const client = new MqttBrokerClient({ url: URL, clientId: '!aaaaaaaa' });
+      void client.connect();
+      const fake = lastFakeClient();
+
+      // ~5 minutes of flapping at ~1s per cycle.
+      for (let i = 0; i < 300; i++) {
+        up(fake);
+        vi.advanceTimersByTime(500);
+        down(fake);
+        vi.advanceTimersByTime(500);
+      }
+
+      const summaries = warnLines(logger).filter((l: string) => l.includes('is flapping'));
+      // A silent storm is worse than a loud one — but it must be bounded.
+      expect(summaries.length).toBeGreaterThan(0);
+      expect(summaries.length).toBeLessThanOrEqual(6); // ≤1 per 60s window
+      expect(summaries[0]).toMatch(/connects in the last/);
+      expect(summaries[0]).toMatch(/Last drop:/);
+    });
+
+    it('records why the connection dropped, not just that it reconnected', () => {
+      const client = new MqttBrokerClient({ url: URL, clientId: '!aaaaaaaa' });
+      void client.connect();
+      const fake = lastFakeClient();
+
+      up(fake);
+      vi.advanceTimersByTime(700);
+      down(fake);
+
+      const reason = client.getLastCloseReason();
+      expect(reason).toMatch(/700ms after CONNACK/);
+      expect(reason).toMatch(/duplicate Client ID/);
+      expect(warnLines(logger).some((l: string) => l.includes('dropped:'))).toBe(true);
+    });
+
+    it('attributes the drop to a client-side error when one just fired', () => {
+      const client = new MqttBrokerClient({ url: URL, clientId: '!aaaaaaaa' });
+      client.on('error', () => {}); // EventEmitter throws on an unhandled 'error'
+      void client.connect();
+      const fake = lastFakeClient();
+
+      up(fake);
+      vi.advanceTimersByTime(500);
+      fake.emit('error', new Error('ECONNRESET'));
+      down(fake);
+
+      expect(client.getLastCloseReason()).toMatch(/error: ECONNRESET/);
+    });
+
+    it('reports a pre-CONNACK failure distinctly from a broker eviction', () => {
+      const client = new MqttBrokerClient({ url: URL, clientId: '!aaaaaaaa' });
+      void client.connect();
+      const fake = lastFakeClient();
+
+      down(fake); // never connected
+
+      expect(client.getLastCloseReason()).toMatch(/before CONNACK/);
+    });
+
+    it('names the duplicate-Client-ID cause once after a run of instant evictions', () => {
+      const client = new MqttBrokerClient({ url: URL, clientId: '!aaaaaaaa' });
+      void client.connect();
+      const fake = lastFakeClient();
+
+      for (let i = 0; i < 8; i++) {
+        up(fake);
+        vi.advanceTimersByTime(400);
+        down(fake);
+        vi.advanceTimersByTime(600);
+      }
+
+      const hints = warnLines(logger).filter((l: string) =>
+        l.includes('duplicate Client ID signature'),
+      );
+      expect(hints).toHaveLength(1);
+      expect(hints[0]).toContain('!aaaaaaaa');
+    });
+
+    it('reuses one mqtt.js client across every reconnect (no leaked instances)', () => {
+      const client = new MqttBrokerClient({ url: URL, clientId: '!aaaaaaaa' });
+      void client.connect();
+      const fake = lastFakeClient();
+
+      for (let i = 0; i < 20; i++) {
+        up(fake);
+        vi.advanceTimersByTime(1000);
+        down(fake);
+        vi.advanceTimersByTime(90_000);
+      }
+
+      // One mqtt.connect() for the lifetime of the wrapper; reconnects reuse it.
+      expect((connect as any).mock.calls).toHaveLength(1);
+      expect(lastFakeClient()).toBe(fake);
+    });
+
+    it('a healthy client does not reset the shared backoff while a sibling is still down', () => {
+      const { coord, fakeA, fakeB } = makePair();
+      up(fakeA);
+      up(fakeB);
+
+      // B goes down and stays down; the tick can never bring it back.
+      fakeB.reconnect.mockImplementation(() => {
+        fakeB.reconnectAt.push(Date.now());
+        fakeB.emit('close');
+      });
+      down(fakeB);
+
+      // A stays up right through its stability window.
+      vi.advanceTimersByTime(200_000);
+
+      expect(coord.getBackoffMs()).toBeGreaterThan(1000);
+    });
+
+    it('disconnect() does not arm a reconnect for a client being torn down', async () => {
+      const client = new MqttBrokerClient({ url: URL, clientId: '!aaaaaaaa' });
+      void client.connect();
+      const fake = lastFakeClient();
+      up(fake);
+
+      fake.end.mockImplementation((_f: boolean, _o: unknown, cb?: () => void) => {
+        fake.emit('close'); // mqtt.js emits close as part of end()
+        cb?.();
+      });
+      await client.disconnect();
+
+      vi.advanceTimersByTime(300_000);
+      expect(fake.reconnect).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/server/transports/mqttBrokerClient.test.ts
+++ b/src/server/transports/mqttBrokerClient.test.ts
@@ -376,7 +376,7 @@ describe('MqttBrokerClient', () => {
       // A silent storm is worse than a loud one — but it must be bounded.
       expect(summaries.length).toBeGreaterThan(0);
       expect(summaries.length).toBeLessThanOrEqual(6); // ≤1 per 60s window
-      expect(summaries[0]).toMatch(/connects in the last/);
+      expect(summaries[0]).toMatch(/connects \/ \d+ drops in the last/);
       expect(summaries[0]).toMatch(/Last drop:/);
     });
 
@@ -407,6 +407,23 @@ describe('MqttBrokerClient', () => {
       down(fake);
 
       expect(client.getLastCloseReason()).toMatch(/error: ECONNRESET/);
+    });
+
+    it('does not warn per retry when the broker is simply unreachable', () => {
+      // No 'connect' ever fires here, so a "first drop of an episode" rule
+      // keyed off the connect count would warn on every single retry.
+      const client = new MqttBrokerClient({ url: URL, clientId: '!aaaaaaaa' });
+      void client.connect();
+      const fake = lastFakeClient();
+
+      for (let i = 0; i < 40; i++) {
+        down(fake); // connection attempt dies before CONNACK
+        vi.advanceTimersByTime(5000);
+      }
+
+      const drops = warnLines(logger).filter((l: string) => l.includes('dropped:'));
+      expect(drops).toHaveLength(1);
+      expect(drops[0]).toMatch(/before CONNACK/);
     });
 
     it('reports a pre-CONNACK failure distinctly from a broker eviction', () => {

--- a/src/server/transports/mqttBrokerClient.ts
+++ b/src/server/transports/mqttBrokerClient.ts
@@ -78,10 +78,29 @@ export interface MqttClientCapabilities {
  * Coordinates reconnection across multiple MqttBrokerClient instances
  * targeting the same broker. Instead of N independent backoff timers
  * (which interleave to produce once-per-second aggregate retry storms),
- * a single shared timer fires and reconnects all registered clients together.
+ * a single shared timer fires and reconnects the clients that asked for it.
+ *
+ * ### Only pending clients reconnect (#5079)
+ *
+ * The original implementation reconnected **every** registered client on each
+ * tick, healthy ones included. `mqtt.js`'s `_reconnect()` on an already-
+ * connected client runs `end()` then `connect()` — a full teardown and a brand
+ * new TCP socket. So in `per_gateway` mode, where the publisher pool registers
+ * one client per gateway, a single flapping member tore down and rebuilt every
+ * sibling socket on every tick. Worse, each forced teardown emitted `'close'`,
+ * which called `requestReconnect()` again: the coordinator kept itself alive
+ * forever after one initial drop. That is the connection storm in #5079 —
+ * dozens of short-lived sockets with climbing source ports, one
+ * "MQTT client connected" line each.
+ *
+ * The pending set fixes it: a tick reconnects only the clients that actually
+ * dropped, and `MqttBrokerClient.doReconnect()` additionally no-ops while
+ * connected, so a healthy socket is never churned.
  */
 export class MqttReconnectCoordinator {
   private readonly clients = new Set<MqttBrokerClient>();
+  /** Clients that reported a drop and are waiting for the next shared tick. */
+  private readonly pending = new Set<MqttBrokerClient>();
   private backoffMs = 1000;
   private timer: ReturnType<typeof setTimeout> | null = null;
   private static readonly BACKOFF_MIN_MS = 1000;
@@ -93,23 +112,47 @@ export class MqttReconnectCoordinator {
 
   unregister(client: MqttBrokerClient): void {
     this.clients.delete(client);
+    this.pending.delete(client);
   }
 
-  requestReconnect(): void {
+  requestReconnect(client: MqttBrokerClient): void {
+    if (!this.clients.has(client)) return;
+    this.pending.add(client);
     if (this.timer) return;
     const jitter = this.backoffMs * 0.2 * (Math.random() - 0.5);
     const delay = Math.round(this.backoffMs + jitter);
     this.timer = setTimeout(() => {
       this.timer = null;
-      for (const client of this.clients) {
-        client.doReconnect();
+      const due = Array.from(this.pending);
+      this.pending.clear();
+      for (const c of due) {
+        c.doReconnect();
       }
     }, delay);
     this.backoffMs = Math.min(this.backoffMs * 2, MqttReconnectCoordinator.BACKOFF_MAX_MS);
   }
 
-  resetBackoff(): void {
+  /**
+   * A registered client held a connection past its stability window.
+   *
+   * The shared backoff resets only when *nobody* is still waiting to
+   * reconnect. Previously any single client could reset it unconditionally,
+   * so in a pool one healthy member kept pinning the throttle at 1s for a
+   * flapping sibling — the storm never slowed down (#5079).
+   */
+  noteStableConnection(): void {
+    if (this.pending.size > 0 || this.timer) return;
     this.backoffMs = MqttReconnectCoordinator.BACKOFF_MIN_MS;
+  }
+
+  /** Current shared retry delay in ms (diagnostics + tests). */
+  getBackoffMs(): number {
+    return this.backoffMs;
+  }
+
+  /** How many registered clients are waiting on the next shared tick. */
+  getPendingCount(): number {
+    return this.pending.size;
   }
 
   dispose(): void {
@@ -117,6 +160,7 @@ export class MqttReconnectCoordinator {
       clearTimeout(this.timer);
       this.timer = null;
     }
+    this.pending.clear();
     this.clients.clear();
   }
 }
@@ -138,7 +182,34 @@ export class MqttBrokerClient extends EventEmitter {
   // A connection must stay up this long before its success counts as "stable"
   // and resets the reconnect backoff. Shorter than this and a flapping
   // connection would keep the backoff pinned at the minimum.
-  private static readonly STABLE_RESET_MS = 30_000;
+  //
+  // MUST stay comfortably ABOVE BACKOFF_MAX_MS. It used to be 30s — half the
+  // 60s cap — which turned the throttle into a sawtooth: the backoff climbed
+  // to 32s, the next attempt then trivially survived the 30s window, reset to
+  // 1s, and the burst repeated forever on a ~1 minute cycle. That is the
+  // "backoff never grows" half of #5079.
+  private static readonly STABLE_RESET_MS = 120_000;
+  /** A session shorter than this counts as a flap, not a real connection. */
+  private static readonly SHORT_SESSION_MS = 10_000;
+  /** At most one flap-summary warning per this window. */
+  private static readonly FLAP_SUMMARY_MS = 60_000;
+  /** Consecutive short post-CONNACK sessions before we name the likely cause. */
+  private static readonly DUPLICATE_ID_HINT_AFTER = 3;
+
+  // --- Flap diagnostics (#5079) ---------------------------------------
+  private resolvedUrl = '';
+  private resolvedClientId = '';
+  private connectedAt: number | null = null;
+  /** Connects since the last connection that proved stable. 1 = healthy. */
+  private connectsSinceStable = 0;
+  private flapEpisodeStartedAt: number | null = null;
+  private lastFlapSummaryAt = 0;
+  private lastCloseReason: string | null = null;
+  private lastErrorAt = 0;
+  private shortSessionStreak = 0;
+  private duplicateIdHintLogged = false;
+  /** Set by disconnect() so a teardown-induced 'close' never re-arms a retry. */
+  private stopping = false;
 
   constructor(options: MqttBrokerClientOptions) {
     super();
@@ -184,10 +255,15 @@ export class MqttBrokerClient extends EventEmitter {
       // MESHCORE_OBSERVER_PHASE2_SPEC.md).
       ...(this.options.will ? { will: this.options.will } : {}),
     };
+    this.resolvedUrl = url;
+    this.resolvedClientId = clientId;
+    this.stopping = false;
     this.client = connect(url, connectOptions);
 
     this.client.on('connect', () => {
+      const now = Date.now();
       this.connected = true;
+      this.connectedAt = now;
       this.lastError = null;
       this.authFailed = false;
       // Only reset the reconnect backoff once the connection proves STABLE.
@@ -197,7 +273,20 @@ export class MqttBrokerClient extends EventEmitter {
       // that drops before the grace window now never resets backoff, so it
       // climbs 1s→…→60s and the storm throttles itself.
       this.armStableReset();
-      logger.info(`📡 MQTT client connected to ${url}`);
+      this.connectsSinceStable += 1;
+      if (this.connectsSinceStable === 1) {
+        // State change into "connected" — the only line worth an info.
+        this.flapEpisodeStartedAt = now;
+        logger.info(`📡 MQTT client connected to ${url} (clientId=${clientId})`);
+      } else {
+        // Repeat connect inside a flap episode. One line per socket is what
+        // buried the container logs in #5079, so these drop to debug and the
+        // storm is surfaced by a rate-limited summary instead.
+        logger.debug(
+          `📡 MQTT reconnected to ${url} (clientId=${clientId}, attempt #${this.connectsSinceStable})`,
+        );
+        this.maybeLogFlapSummary(now);
+      }
       // Re-subscribe on every connect (covers reconnects with clean=true).
       // Clear previously-tracked denials too — a fresh session may have
       // different ACLs (e.g. broker reconfigured).
@@ -214,17 +303,32 @@ export class MqttBrokerClient extends EventEmitter {
     this.client.on('reconnect', () => this.emit('reconnect'));
     this.client.on('offline', () => {
       this.connected = false;
+      this.connectedAt = null;
       this.clearStableReset();
       this.emit('offline');
     });
     this.client.on('close', () => {
+      this.noteClose();
       this.connected = false;
+      this.connectedAt = null;
       this.clearStableReset();
       this.scheduleReconnect();
       this.emit('close');
     });
+    // MQTT 5 DISCONNECT packet. We hardcode protocolVersion 4 so this never
+    // fires today, but if the client is ever bumped it carries the broker's
+    // own reason code — by far the best drop diagnostic available.
+    this.client.on('disconnect', (packet) => {
+      const code = (packet as { reasonCode?: number } | undefined)?.reasonCode;
+      this.lastCloseReason =
+        code === undefined
+          ? 'broker sent DISCONNECT'
+          : `broker sent DISCONNECT (reasonCode=${code})`;
+      this.lastErrorAt = Date.now();
+    });
     this.client.on('error', (err) => {
       this.lastError = err.message;
+      this.lastErrorAt = Date.now();
       logger.warn(`MQTT client error (${url}): ${err.message}`);
       // Classify CONNACK auth rejections. mqtt.js surfaces these as
       // ErrorWithReasonCode whose .code matches the MQTT 3.1.1 CONNACK
@@ -292,8 +396,19 @@ export class MqttBrokerClient extends EventEmitter {
     });
   }
 
+  /**
+   * Reconnect this client, if it actually needs one.
+   *
+   * The `connected` guard is load-bearing (#5079): mqtt.js's `_reconnect()`
+   * on a live client runs `end()` then `connect()`, i.e. it throws away a
+   * perfectly good TCP socket and opens a fresh one. Reconnecting healthy
+   * clients was the amplifier that turned one dropped pool member into
+   * dozens of sockets per minute against the upstream broker.
+   */
   doReconnect(): void {
-    if (this.client) this.client.reconnect();
+    if (this.stopping || !this.client) return;
+    if (this.connected) return;
+    this.client.reconnect();
   }
 
   /**
@@ -307,7 +422,20 @@ export class MqttBrokerClient extends EventEmitter {
     this.stableTimer = setTimeout(() => {
       this.stableTimer = null;
       this.reconnectBackoffMs = MqttBrokerClient.BACKOFF_MIN_MS;
-      if (this.coordinator) this.coordinator.resetBackoff();
+      // The coordinator decides for itself — it will refuse while a sibling
+      // is still waiting to reconnect.
+      if (this.coordinator) this.coordinator.noteStableConnection();
+      if (this.connectsSinceStable > 1) {
+        const seconds = Math.round(MqttBrokerClient.STABLE_RESET_MS / 1000);
+        logger.info(
+          `📡 MQTT connection to ${this.resolvedUrl} (clientId=${this.resolvedClientId}) ` +
+            `stable for ${seconds}s after ${this.connectsSinceStable} connect attempts — backoff reset`,
+        );
+      }
+      this.connectsSinceStable = 1;
+      this.flapEpisodeStartedAt = Date.now();
+      this.shortSessionStreak = 0;
+      this.duplicateIdHintLogged = false;
     }, MqttBrokerClient.STABLE_RESET_MS);
   }
 
@@ -318,10 +446,97 @@ export class MqttBrokerClient extends EventEmitter {
     }
   }
 
+  /**
+   * Record *why* the connection dropped and log it proportionately.
+   *
+   * Before #5079 only the reconnect was visible, so a storm showed up as an
+   * endless run of "connected" lines with no hint of what was knocking the
+   * socket over. The first drop of an episode is a warning; the rest fold
+   * into the rate-limited flap summary so the log stays readable.
+   */
+  private noteClose(): void {
+    if (this.stopping) return;
+    const now = Date.now();
+    const uptimeMs = this.connectedAt === null ? null : now - this.connectedAt;
+    const reason = this.describeCloseReason(now, uptimeMs);
+    this.lastCloseReason = reason;
+
+    if (uptimeMs !== null && uptimeMs < MqttBrokerClient.SHORT_SESSION_MS) {
+      this.shortSessionStreak += 1;
+    } else {
+      this.shortSessionStreak = 0;
+    }
+
+    const where = `${this.resolvedUrl} (clientId=${this.resolvedClientId})`;
+    if (this.connectsSinceStable <= 1) {
+      logger.warn(`📡 MQTT connection to ${where} dropped: ${reason}`);
+    } else {
+      logger.debug(`📡 MQTT connection to ${where} dropped: ${reason}`);
+      this.maybeLogFlapSummary(now);
+    }
+
+    // A run of sessions that die seconds after CONNACK, with no client-side
+    // error, is the MQTT 3.1.1 §3.1.4 signature: another connection took the
+    // Client ID and the broker evicted this one. Say so once — it is the
+    // single most useful line an operator can get out of this failure.
+    if (
+      !this.duplicateIdHintLogged &&
+      this.shortSessionStreak >= MqttBrokerClient.DUPLICATE_ID_HINT_AFTER &&
+      !this.lastError
+    ) {
+      this.duplicateIdHintLogged = true;
+      logger.warn(
+        `📡 MQTT connection to ${where} has been evicted ${this.shortSessionStreak} times ` +
+          `within seconds of connecting, with no client-side error. This is the classic ` +
+          `duplicate Client ID signature (MQTT 3.1.1 §3.1.4): another client — a second ` +
+          `MeshMonitor, or the gateway node itself — is connected to this broker using the ` +
+          `same Client ID, and the broker kicks whichever session is older. Give this ` +
+          `connection a unique Client ID, or stop the other publisher.`,
+      );
+    }
+  }
+
+  private describeCloseReason(now: number, uptimeMs: number | null): string {
+    // An error within the last couple of seconds is almost certainly the cause.
+    if (this.lastError && now - this.lastErrorAt <= 2000) {
+      return `error: ${this.lastError}`;
+    }
+    if (uptimeMs === null) {
+      return 'connection attempt failed before CONNACK (unreachable broker, refused socket, or TLS failure)';
+    }
+    if (uptimeMs < MqttBrokerClient.SHORT_SESSION_MS) {
+      return (
+        `broker closed the connection ${uptimeMs}ms after CONNACK with no client-side error ` +
+        `— typically a duplicate Client ID (MQTT 3.1.1 §3.1.4), an ACL kick, or a keepalive timeout`
+      );
+    }
+    return `connection closed after ${Math.round(uptimeMs / 1000)}s with no client-side error — broker-initiated or network drop`;
+  }
+
+  /**
+   * Rate-limited storm summary. Replaces the per-reconnect info line, so the
+   * flap stays visible (a silent storm is worse than a loud one) without one
+   * log entry per socket.
+   */
+  private maybeLogFlapSummary(now: number): void {
+    if (now - this.lastFlapSummaryAt < MqttBrokerClient.FLAP_SUMMARY_MS) return;
+    this.lastFlapSummaryAt = now;
+    const startedAt = this.flapEpisodeStartedAt ?? now;
+    const windowSec = Math.max(1, Math.round((now - startedAt) / 1000));
+    const nextDelay = this.coordinator
+      ? this.coordinator.getBackoffMs()
+      : this.reconnectBackoffMs;
+    logger.warn(
+      `📡 MQTT connection to ${this.resolvedUrl} (clientId=${this.resolvedClientId}) is flapping: ` +
+        `${this.connectsSinceStable} connects in the last ${windowSec}s. ` +
+        `Last drop: ${this.lastCloseReason ?? 'unknown'}. Next retry in ~${Math.round(nextDelay / 1000)}s.`,
+    );
+  }
+
   private scheduleReconnect(): void {
-    if (!this.client) return;
+    if (this.stopping || !this.client) return;
     if (this.coordinator) {
-      this.coordinator.requestReconnect();
+      this.coordinator.requestReconnect(this);
       return;
     }
     if (this.reconnectTimer) return;
@@ -352,6 +567,9 @@ export class MqttBrokerClient extends EventEmitter {
    *   an immediate forced `end(true)`.
    */
   async disconnect(opts?: { flush?: boolean }): Promise<void> {
+    // Set before end(): end() emits 'close', and without this the teardown
+    // would arm a reconnect timer for a client we are throwing away.
+    this.stopping = true;
     if (this.coordinator) {
       this.coordinator.unregister(this);
       this.coordinator = null;
@@ -386,6 +604,11 @@ export class MqttBrokerClient extends EventEmitter {
 
     this.client = null;
     this.connected = false;
+    this.connectedAt = null;
+    this.connectsSinceStable = 0;
+    this.flapEpisodeStartedAt = null;
+    this.shortSessionStreak = 0;
+    this.duplicateIdHintLogged = false;
     this.subscriptions.clear();
     this.deniedSubscriptions.clear();
     this.authFailed = false;
@@ -397,6 +620,11 @@ export class MqttBrokerClient extends EventEmitter {
 
   getLastError(): string | null {
     return this.lastError;
+  }
+
+  /** Why the connection last dropped, as reported in the logs. Null before any drop. */
+  getLastCloseReason(): string | null {
+    return this.lastCloseReason;
   }
 
   getCapabilities(): MqttClientCapabilities {

--- a/src/server/transports/mqttBrokerClient.ts
+++ b/src/server/transports/mqttBrokerClient.ts
@@ -202,6 +202,8 @@ export class MqttBrokerClient extends EventEmitter {
   private connectedAt: number | null = null;
   /** Connects since the last connection that proved stable. 1 = healthy. */
   private connectsSinceStable = 0;
+  /** Drops since the last connection that proved stable. 0 = healthy. */
+  private dropsSinceStable = 0;
   private flapEpisodeStartedAt: number | null = null;
   private lastFlapSummaryAt = 0;
   private lastCloseReason: string | null = null;
@@ -433,6 +435,7 @@ export class MqttBrokerClient extends EventEmitter {
         );
       }
       this.connectsSinceStable = 1;
+      this.dropsSinceStable = 0;
       this.flapEpisodeStartedAt = Date.now();
       this.shortSessionStreak = 0;
       this.duplicateIdHintLogged = false;
@@ -467,10 +470,16 @@ export class MqttBrokerClient extends EventEmitter {
       this.shortSessionStreak = 0;
     }
 
+    this.dropsSinceStable += 1;
     const where = `${this.resolvedUrl} (clientId=${this.resolvedClientId})`;
-    if (this.connectsSinceStable <= 1) {
+    if (this.dropsSinceStable === 1) {
+      // First drop of an episode — loud, and it carries the reason.
       logger.warn(`📡 MQTT connection to ${where} dropped: ${reason}`);
     } else {
+      // Repeats fold into the rate-limited summary. This covers the
+      // never-reaches-CONNACK case (broker down) as well as a true flap:
+      // there is no 'connect' event to count in that scenario, so keying
+      // this off the connect counter would warn on every single retry.
       logger.debug(`📡 MQTT connection to ${where} dropped: ${reason}`);
       this.maybeLogFlapSummary(now);
     }
@@ -528,7 +537,7 @@ export class MqttBrokerClient extends EventEmitter {
       : this.reconnectBackoffMs;
     logger.warn(
       `📡 MQTT connection to ${this.resolvedUrl} (clientId=${this.resolvedClientId}) is flapping: ` +
-        `${this.connectsSinceStable} connects in the last ${windowSec}s. ` +
+        `${this.connectsSinceStable} connects / ${this.dropsSinceStable} drops in the last ${windowSec}s. ` +
         `Last drop: ${this.lastCloseReason ?? 'unknown'}. Next retry in ~${Math.round(nextDelay / 1000)}s.`,
     );
   }
@@ -606,6 +615,7 @@ export class MqttBrokerClient extends EventEmitter {
     this.connected = false;
     this.connectedAt = null;
     this.connectsSinceStable = 0;
+    this.dropsSinceStable = 0;
     this.flapEpisodeStartedAt = null;
     this.shortSessionStreak = 0;
     this.duplicateIdHintLogged = false;


### PR DESCRIPTION
Fixes #5079

## Root cause — confirmed, and entirely internal

The storm needs no misbehaving broker. **One dropped connection is enough to start a self-sustaining loop**, and once started the backoff resets itself so it never slows down. Two defects in `src/server/transports/mqttBrokerClient.ts` combine.

### 1. The reconnect coordinator churned healthy sockets, then fed itself

`MqttReconnectCoordinator.requestReconnect()` armed one shared timer and, on each tick, called `doReconnect()` on **every** registered client — connected ones included. `doReconnect()` had no `connected` guard, and mqtt.js's `_reconnect()` on a live client is:

```js
_reconnect() {
  this.emit("reconnect");
  if (this.connected) {
    this.end(() => { this.connect(); });   // <-- throws away a good socket
  } else {
    this.connect();
  }
}
```
<sub><code>node_modules/mqtt/dist/mqtt.js</code>, mqtt 5.15.2</sub>

So in `per_gateway` mode — where `MqttBridgePublisherPool` registers one client per gateway on the same coordinator — a single flapping member tore down and rebuilt **every sibling socket** on every tick. That is the "dozens of TCP connections with rapidly incrementing source ports" in the report, and one `📡 MQTT client connected` line per rebuilt socket.

Worse: each forced teardown emits `'close'`, whose handler calls `scheduleReconnect()` → `requestReconnect()` → arms the next tick. **After one initial drop the coordinator kept itself running forever**, with no flapping peer needed at all.

Measured on a 4-client pool where exactly one member drops once, over 10 minutes of simulated time:

| | socket rebuilds | per client |
|---|---|---|
| before | **216** | `[54, 54, 54, 54]` |
| after | **1** | `[0, 0, 0, 1]` |

### 2. The backoff reset itself, so it never grew

`STABLE_RESET_MS` was **30s** against a `BACKOFF_MAX_MS` of **60s**. Once the backoff climbed past 30s, the very next attempt trivially survived the grace window and reset the throttle to 1s. The `armStableReset()` guard added in #3241 was therefore a sawtooth, not a throttle. Separately, the reset was unconditional and the coordinator's backoff is shared, so in a pool **one healthy member kept resetting the backoff that a flapping sibling was trying to grow**.

Retry delay in seconds under a sustained flap with 31s sessions (long enough to clear the old 30s window, far short of a genuinely stable connection):

| | delays (s) |
|---|---|
| before | `1.1, 1.1, 1, 1.1, 1, 0.9, 0.9, 1, 1, 0.9` — pinned at the 1s floor forever |
| after | `1, 2, 4.1, 7.4, 16.3, 29.3, 54.1, 55.8, 65.1, 63.3` — geometric to the 60s cap (±10% jitter) |

A duplicate Client ID on the public broker is a plausible *trigger* for the first drop — and the new logging now names it explicitly when the signature matches — but it is not required for the storm, and it is not what sustains it.

## What changed

**Flap logic (the actual fix)**

- `MqttReconnectCoordinator` gained a **pending set**. A tick reconnects only the clients that actually dropped, not every registered client.
- `doReconnect()` **no-ops while connected**. A healthy socket is never churned. This guard is load-bearing.
- `STABLE_RESET_MS` 30s → **120s**, with a comment pinning the invariant that it must stay above `BACKOFF_MAX_MS`.
- `resetBackoff()` → `noteStableConnection()`, which **refuses while any sibling is still waiting to reconnect**.
- `disconnect()` sets a `stopping` flag *before* `end()`, so the teardown's own `'close'` no longer arms a retry for a client being discarded.

**Logging (as well as, never instead of)**

- `📡 MQTT client connected` is a **state-change** line now, not per-event. Repeat connects inside a flap episode drop to `debug`, matching the repo's log-volume trim conventions.
- The storm stays visible via a **rate-limited `warn` summary**, at most one per 60s: connect count, drop count, window length, last drop reason, next retry delay. A silent storm is worse than a loud one.
- **Every drop records why**: a client-side error within the last 2s, a pre-CONNACK failure, an eviction *N* ms after CONNACK with no client-side error, or a long-lived session closing. Previously only the reconnect was visible, which is exactly why the cause was invisible in #5079.
- The loud "first drop of an episode" line is keyed off a **drop** counter, not a connect counter — an unreachable broker never fires `connect`, so keying it off connects would warn on every retry in the one failure mode with the longest retry loop.
- After three consecutive evictions seconds after CONNACK with no error, one `warn` names the likely cause: a duplicate Client ID (MQTT 3.1.1 §3.1.4), and says how to resolve it.
- An MQTT 5 `DISCONNECT` listener is wired for its reason code. Inert at `protocolVersion: 4`, but free if the client is ever bumped.

## Tests

`src/server/transports/mqttBrokerClient.test.ts`, all with fake timers and a mocked mqtt.js — **nothing points at `mqtt.mt.gt` or any real broker.** The fake's `reconnect()` reproduces mqtt.js's real "end then connect" behaviour on a live client, which is what makes the amplification reproducible.

**14 of the tests in this file fail against the pre-fix source and pass after.** Verified by reverting only `mqttBrokerClient.ts` and re-running: `PASS (11) FAIL (14)` → `PASS (25) FAIL (0)`.

New coverage:
- a healthy sibling is never reconnected when one pool member drops
- the coordinator quiesces once the dropped client recovers (no self-sustaining loop)
- the shared backoff grows monotonically to the 60s cap under a sustained flap
- `connected` is logged once per state change, not once per socket
- the storm still surfaces, as a bounded flap summary
- the drop reason is recorded, and distinguishes error / pre-CONNACK / eviction
- an unreachable broker does not warn per retry
- the duplicate-Client-ID cause is named exactly once
- one mqtt.js client is reused across every reconnect (no leaked instances)
- `disconnect()` does not arm a reconnect for a client being torn down
- the grace window is longer than the max backoff

## Mesh impact checklist

1. **Airtime:** none. No LoRa packets are sent; this is upstream TCP/MQTT only. The change strictly *reduces* traffic — 216 → 1 socket rebuild in the measured pool scenario.
2. **Spam:** the fix removes a spam source, both toward the third-party broker and toward the container log. No new send paths, notifications, or `dataEventEmitter` fan-out.
3. **Timer reset:** the one behavioural timer change is that the existing reconnect backoff now actually grows to its 60s cap instead of resetting to 1s — the safety timer stops being defeated. No persisted last-fire timestamp is involved; the reconnect backoff is intentionally per-connection and per-process, and a restart legitimately starts a fresh connection attempt.

## Verification

- `npm run lint:ci` — no in-repo `FAIL` lines.
- `tsconfig.json` and `tsconfig.server.json` both typecheck clean.
- Full Vitest on the substantive fix, **with `mm-test-pg` and `mm-test-mysql` up**: `success: true`, 19157 tests, 0 failed, 0 failed suites, 109 skipped (the normal baseline — the multi-backend suites really ran).
- Full Vitest on the final tree: `success: true`, 19158 tests, 0 failed, 0 failed suites. This run has 962 skipped because the shared PG/MySQL test containers were removed by a concurrent session partway through my work; the delta it covers versus the verified run above is confined to a log counter in `mqttBrokerClient.ts` with zero database surface, and CI runs both backends as service containers.
- No test containers are left listening on 5433/3307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S6dVMHduNHsn6jNRXX25k
