### PR TITLE
fix(telemetry): favorite retention purge read the wrong settings namespace (#5080)

### DIFF
--- a/src/db/repositories/telemetry.favoriteRetention.multiBackend.test.ts
+++ b/src/db/repositories/telemetry.favoriteRetention.multiBackend.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Cross-dialect coverage for source-scoped favorite retention in
+ * `TelemetryRepository.deleteOldTelemetryWithFavorites` (issue #5080).
+ *
+ * The risk here is pure SQL dialect behaviour, not application logic:
+ *  - `NOT (… OR …)` over a nullable `sourceId` (three-valued logic differs in
+ *    consequence between "row deleted" and "row kept forever").
+ *  - Multiple favorite groups, each with its own cutoff, applied in sequence —
+ *    MySQL takes the count-then-delete path, SQLite/PostgreSQL use RETURNING.
+ *
+ * DDL is hand-written per dialect, matching the convention in
+ * `telemetry.cadenceAggregates.multiBackend.test.ts`.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { TelemetryRepository } from './telemetry.js';
+import { telemetrySqlite, telemetryPostgres, telemetryMysql } from '../schema/telemetry.js';
+import {
+  createSqliteBackend,
+  createPostgresBackend,
+  createMysqlBackend,
+  clearTable,
+  postgresAvailable,
+  mysqlAvailable,
+  type TestBackend,
+} from './test-utils.js';
+
+const SQLITE_CREATE = `
+  CREATE TABLE telemetry (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    nodeId TEXT NOT NULL,
+    nodeNum INTEGER NOT NULL,
+    telemetryType TEXT NOT NULL,
+    timestamp INTEGER NOT NULL,
+    value REAL NOT NULL,
+    unit TEXT,
+    createdAt INTEGER NOT NULL,
+    sourceId TEXT
+  )
+`;
+
+const POSTGRES_CREATE = `
+  DROP TABLE IF EXISTS telemetry CASCADE;
+  CREATE TABLE telemetry (
+    id SERIAL PRIMARY KEY,
+    "nodeId" TEXT NOT NULL,
+    "nodeNum" BIGINT NOT NULL,
+    "telemetryType" TEXT NOT NULL,
+    timestamp BIGINT NOT NULL,
+    value DOUBLE PRECISION NOT NULL,
+    unit TEXT,
+    "createdAt" BIGINT NOT NULL,
+    "sourceId" TEXT
+  )
+`;
+
+const MYSQL_CREATE = `
+  DROP TABLE IF EXISTS telemetry;
+  CREATE TABLE telemetry (
+    id SERIAL PRIMARY KEY,
+    nodeId VARCHAR(32) NOT NULL,
+    nodeNum BIGINT NOT NULL,
+    telemetryType VARCHAR(64) NOT NULL,
+    timestamp BIGINT NOT NULL,
+    value DOUBLE NOT NULL,
+    unit VARCHAR(32),
+    createdAt BIGINT NOT NULL,
+    sourceId VARCHAR(36)
+  )
+`;
+
+const NOW = 1_760_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+const REGULAR_CUTOFF = NOW - 7 * DAY;
+
+const NODE = '!aabbccdd';
+const NODE_NUM = 0xaabbccdd;
+
+/** One row: [nodeId, nodeNum, telemetryType, timestamp, sourceId|null]. */
+type Row = [string, number, string, number, string | null];
+
+async function insertRows(backend: TestBackend, rows: Row[]): Promise<void> {
+  const q = backend.dbType === 'postgres' ? (c: string) => `"${c}"` : (c: string) => c;
+  for (const [nodeId, nodeNum, type, ts, sourceId] of rows) {
+    await backend.exec(
+      `INSERT INTO telemetry (${q('nodeId')},${q('nodeNum')},${q('telemetryType')},timestamp,value,${q('createdAt')},${q('sourceId')}) ` +
+        `VALUES ('${nodeId}',${nodeNum},'${type}',${ts},1.0,${ts},${sourceId === null ? 'NULL' : `'${sourceId}'`})`
+    );
+  }
+}
+
+function telemetryTable(backend: TestBackend) {
+  if (backend.dbType === 'postgres') return telemetryPostgres;
+  if (backend.dbType === 'mysql') return telemetryMysql;
+  return telemetrySqlite;
+}
+
+async function remaining(
+  backend: TestBackend
+): Promise<Array<{ type: string; ts: number; sourceId: string | null }>> {
+  // Explicit column list: the hand-written DDL above is a subset of the real
+  // schema, and a bare `select()` would enumerate every schema column.
+  const t = telemetryTable(backend) as any;
+  const rows = await backend.drizzleDb
+    .select({ telemetryType: t.telemetryType, timestamp: t.timestamp, sourceId: t.sourceId })
+    .from(t);
+  return (rows as any[]).map((r) => ({
+    type: r.telemetryType,
+    ts: Number(r.timestamp),
+    sourceId: r.sourceId ?? null,
+  }));
+}
+
+function runFavoriteRetentionTests(getBackend: () => TestBackend) {
+  it('keeps a per-source favorite past the regular window and out to its own cutoff', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await insertRows(backend, [
+      [NODE, NODE_NUM, 'batteryLevel', NOW - 20 * DAY, 'src-a'], // favorited, within 30d
+      [NODE, NODE_NUM, 'batteryLevel', NOW - 40 * DAY, 'src-a'], // favorited, past 30d
+      [NODE, NODE_NUM, 'voltage', NOW - 20 * DAY, 'src-a'],      // not favorited
+      [NODE, NODE_NUM, 'batteryLevel', NOW - 1 * DAY, 'src-a'],  // recent
+    ]);
+
+    const repo = new TelemetryRepository(backend.drizzleDb, backend.dbType);
+    const result = await repo.deleteOldTelemetryWithFavorites(REGULAR_CUTOFF, NOW - 7 * DAY, [
+      {
+        sourceId: 'src-a',
+        nodeId: NODE,
+        telemetryType: 'batteryLevel',
+        cutoffTimestamp: NOW - 30 * DAY,
+      },
+    ]);
+
+    expect(result.nonFavoritesDeleted).toBe(1); // voltage
+    expect(result.favoritesDeleted).toBe(1); // the 40-day-old battery row
+
+    const rows = await remaining(backend);
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.type === 'batteryLevel')).toBe(true);
+    expect(rows.some((r) => r.ts === NOW - 20 * DAY)).toBe(true);
+  });
+
+  it('does not let one source\'s favorite protect another source\'s rows', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await insertRows(backend, [
+      [NODE, NODE_NUM, 'batteryLevel', NOW - 20 * DAY, 'src-a'], // protected
+      [NODE, NODE_NUM, 'batteryLevel', NOW - 20 * DAY, 'src-b'], // NOT protected
+    ]);
+
+    const repo = new TelemetryRepository(backend.drizzleDb, backend.dbType);
+    const result = await repo.deleteOldTelemetryWithFavorites(REGULAR_CUTOFF, NOW - 7 * DAY, [
+      {
+        sourceId: 'src-a',
+        nodeId: NODE,
+        telemetryType: 'batteryLevel',
+        cutoffTimestamp: NOW - 30 * DAY,
+      },
+    ]);
+
+    expect(result.nonFavoritesDeleted).toBe(1);
+    const rows = await remaining(backend);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sourceId).toBe('src-a');
+  });
+
+  it('applies a different cutoff per source in one pass', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await insertRows(backend, [
+      [NODE, NODE_NUM, 'batteryLevel', NOW - 20 * DAY, 'src-a'], // src-a keeps 90d → survives
+      [NODE, NODE_NUM, 'batteryLevel', NOW - 20 * DAY, 'src-b'], // src-b keeps 14d → purged
+      [NODE, NODE_NUM, 'batteryLevel', NOW - 10 * DAY, 'src-b'], // within 14d → survives
+    ]);
+
+    const repo = new TelemetryRepository(backend.drizzleDb, backend.dbType);
+    const result = await repo.deleteOldTelemetryWithFavorites(REGULAR_CUTOFF, NOW - 7 * DAY, [
+      { sourceId: 'src-a', nodeId: NODE, telemetryType: 'batteryLevel', cutoffTimestamp: NOW - 90 * DAY },
+      { sourceId: 'src-b', nodeId: NODE, telemetryType: 'batteryLevel', cutoffTimestamp: NOW - 14 * DAY },
+    ]);
+
+    expect(result.nonFavoritesDeleted).toBe(0);
+    expect(result.favoritesDeleted).toBe(1);
+
+    const rows = await remaining(backend);
+    expect(rows).toHaveLength(2);
+    expect(rows.filter((r) => r.sourceId === 'src-a')).toHaveLength(1);
+    expect(rows.filter((r) => r.sourceId === 'src-b')).toHaveLength(1);
+  });
+
+  it('does not strand legacy NULL-sourceId rows in the NOT(...) three-valued gap', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await insertRows(backend, [
+      [NODE, NODE_NUM, 'batteryLevel', NOW - 20 * DAY, null], // favorited type, legacy row
+      [NODE, NODE_NUM, 'voltage', NOW - 20 * DAY, null],      // non-favorited legacy row
+    ]);
+
+    const repo = new TelemetryRepository(backend.drizzleDb, backend.dbType);
+    const result = await repo.deleteOldTelemetryWithFavorites(REGULAR_CUTOFF, NOW - 7 * DAY, [
+      { sourceId: 'src-a', nodeId: NODE, telemetryType: 'batteryLevel', cutoffTimestamp: NOW - 30 * DAY },
+    ]);
+
+    // The non-favorited legacy row MUST be deleted — a NULL-propagating
+    // `NOT (sourceId = 'src-a' AND …)` would leave it in the table forever.
+    expect(result.nonFavoritesDeleted).toBe(1);
+    const rows = await remaining(backend);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].type).toBe('batteryLevel');
+  });
+
+  it('treats an unscoped (legacy global) favorite as matching every source', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await insertRows(backend, [
+      [NODE, NODE_NUM, 'batteryLevel', NOW - 20 * DAY, 'src-a'],
+      [NODE, NODE_NUM, 'batteryLevel', NOW - 20 * DAY, 'src-b'],
+    ]);
+
+    const repo = new TelemetryRepository(backend.drizzleDb, backend.dbType);
+    const result = await repo.deleteOldTelemetryWithFavorites(REGULAR_CUTOFF, NOW - 30 * DAY, [
+      { nodeId: NODE, telemetryType: 'batteryLevel' },
+    ]);
+
+    expect(result.nonFavoritesDeleted).toBe(0);
+    expect(result.favoritesDeleted).toBe(0);
+    expect(await remaining(backend)).toHaveLength(2);
+  });
+
+  it('never retains a favorite for less time than plain telemetry', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await insertRows(backend, [[NODE, NODE_NUM, 'batteryLevel', NOW - 3 * DAY, 'src-a']]);
+
+    const repo = new TelemetryRepository(backend.drizzleDb, backend.dbType);
+    // A favorite cutoff NEWER than the regular cutoff is nonsense; it must be
+    // clamped rather than purging inside the regular window.
+    const result = await repo.deleteOldTelemetryWithFavorites(REGULAR_CUTOFF, NOW, [
+      { sourceId: 'src-a', nodeId: NODE, telemetryType: 'batteryLevel', cutoffTimestamp: NOW },
+    ]);
+
+    expect(result.favoritesDeleted).toBe(0);
+    expect(await remaining(backend)).toHaveLength(1);
+  });
+}
+
+describe('TelemetryRepository favorite retention (#5080) - SQLite Backend', () => {
+  let backend: TestBackend;
+  beforeAll(() => {
+    backend = createSqliteBackend(SQLITE_CREATE);
+  });
+  afterAll(async () => {
+    if (backend) await backend.close();
+  });
+  beforeEach(async () => {
+    await clearTable(backend, 'telemetry');
+  });
+  runFavoriteRetentionTests(() => backend);
+
+  // The production SQLite path goes through the sync variant — same semantics,
+  // separate code path.
+  it('sync variant applies per-source cutoffs identically', async () => {
+    await insertRows(backend, [
+      [NODE, NODE_NUM, 'batteryLevel', NOW - 20 * DAY, 'src-a'],
+      [NODE, NODE_NUM, 'batteryLevel', NOW - 20 * DAY, 'src-b'],
+      [NODE, NODE_NUM, 'voltage', NOW - 20 * DAY, 'src-a'],
+    ]);
+
+    const repo = new TelemetryRepository(backend.drizzleDb, backend.dbType);
+    const result = repo.deleteOldTelemetryWithFavoritesSync(REGULAR_CUTOFF, NOW - 7 * DAY, [
+      { sourceId: 'src-a', nodeId: NODE, telemetryType: 'batteryLevel', cutoffTimestamp: NOW - 90 * DAY },
+      { sourceId: 'src-b', nodeId: NODE, telemetryType: 'batteryLevel', cutoffTimestamp: NOW - 14 * DAY },
+    ]);
+
+    expect(result.nonFavoritesDeleted).toBe(1); // voltage
+    expect(result.favoritesDeleted).toBe(1); // src-b past its 14d window
+
+    const rows = await remaining(backend);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sourceId).toBe('src-a');
+  });
+});
+
+describe.skipIf(!postgresAvailable)('TelemetryRepository favorite retention (#5080) - PostgreSQL Backend', () => {
+  let backend: TestBackend;
+  beforeAll(async () => {
+    backend = await createPostgresBackend(POSTGRES_CREATE, 'r_tel_fav_retention');
+  });
+  afterAll(async () => {
+    if (backend) await backend.close();
+  });
+  beforeEach(async () => {
+    if (!backend.available) return;
+    await clearTable(backend, 'telemetry');
+  });
+  runFavoriteRetentionTests(() => backend);
+});
+
+describe.skipIf(!mysqlAvailable)('TelemetryRepository favorite retention (#5080) - MySQL Backend', () => {
+  let backend: TestBackend;
+  beforeAll(async () => {
+    backend = await createMysqlBackend(MYSQL_CREATE, 'r_tel_fav_retention');
+  });
+  afterAll(async () => {
+    if (backend) await backend.close();
+  });
+  beforeEach(async () => {
+    if (!backend.available) return;
+    await clearTable(backend, 'telemetry');
+  });
+  runFavoriteRetentionTests(() => backend);
+});

--- a/src/db/repositories/telemetry.ts
+++ b/src/db/repositories/telemetry.ts
@@ -4,7 +4,7 @@
  * Handles all telemetry-related database operations.
  * Supports SQLite, PostgreSQL, and MySQL through Drizzle ORM.
  */
-import { eq, lt, gte, and, desc, inArray, or, not, SQL, count, sql } from 'drizzle-orm';
+import { eq, lt, gte, and, desc, inArray, isNull, or, not, SQL, count, sql } from 'drizzle-orm';
 import { ALL_SOURCES, BaseRepository, DrizzleDatabase, SourceScope } from './base.js';
 import { DatabaseType, DbTelemetry } from '../types.js';
 import { logger } from '../../utils/logger.js';
@@ -54,6 +54,24 @@ function sanitizeTelemetryTimestamp<T extends DbTelemetry>(row: T): T {
 export interface TelemetryFavorite {
   nodeId: string;
   telemetryType: string;
+  /**
+   * Source that owns this favorite (#5080). Favorites are stored per source
+   * (`source:<id>:telemetryFavorites`), so a favorite registered on source A
+   * must not protect the same (nodeId, telemetryType) rows belonging to
+   * source B. Rows with a NULL `sourceId` predate source scoping and are
+   * treated as belonging to every source, so a legacy row is never orphaned
+   * into the shorter non-favorite window.
+   *
+   * Omit for a legacy global favorites list — it then matches any source.
+   */
+  sourceId?: string;
+  /**
+   * Per-entry retention cutoff in epoch milliseconds (#5080). Rows matching
+   * this favorite that are OLDER than this are purged. Omit to use the call's
+   * `favoriteCutoffTimestamp`; set it when different sources carry different
+   * `favoriteTelemetryStorageDays` values.
+   */
+  cutoffTimestamp?: number;
 }
 
 /**
@@ -761,20 +779,63 @@ export class TelemetryRepository extends BaseRepository {
   }
 
   /**
-   * Build a SQL condition that matches any of the favorited (nodeId, telemetryType) pairs.
+   * Build a SQL condition matching one favorited (nodeId, telemetryType[, sourceId]) entry.
+   *
+   * The `sourceId` clause is deliberately `sourceId = <id> OR sourceId IS NULL`
+   * rather than a bare equality (#5080). Two reasons, both load-bearing:
+   *  - A bare `sourceId = <id>` evaluates to NULL (not FALSE) for pre-source-scoping
+   *    rows, so `NOT (…)` over it is also NULL and those rows would silently escape
+   *    the non-favorites delete forever.
+   *  - Legacy unscoped rows have no source to attribute them to, so protecting them
+   *    under any source's favorite is the safe direction: over-retention, never loss.
+   */
+  private buildFavoriteMatch(favorite: TelemetryFavorite): SQL {
+    const { telemetry } = this.tables;
+    const parts: SQL[] = [
+      eq(telemetry.nodeId, favorite.nodeId)!,
+      eq(telemetry.telemetryType, favorite.telemetryType)!,
+    ];
+    if (favorite.sourceId) {
+      parts.push(or(eq(telemetry.sourceId, favorite.sourceId), isNull(telemetry.sourceId))!);
+    }
+    return and(...parts)!;
+  }
+
+  /**
+   * Build a SQL condition that matches any of the favorited entries.
    * Returns null if favorites array is empty.
    */
-  protected buildFavoritesCondition(
-    favorites: Array<{ nodeId: string; telemetryType: string }>
-  ): SQL | null {
+  protected buildFavoritesCondition(favorites: TelemetryFavorite[]): SQL | null {
     if (favorites.length === 0) return null;
-    const { telemetry } = this.tables;
-
-    const conditions = favorites.map(f =>
-      and(eq(telemetry.nodeId, f.nodeId), eq(telemetry.telemetryType, f.telemetryType))
-    );
-
+    const conditions = favorites.map(f => this.buildFavoriteMatch(f));
     return conditions.length === 1 ? conditions[0]! : or(...conditions)!;
+  }
+
+  /**
+   * Group favorites by the cutoff timestamp that applies to them (#5080).
+   *
+   * `favoriteTelemetryStorageDays` is a per-source setting, so two sources can
+   * legitimately disagree about how long their favorites live. Each entry may
+   * carry its own `cutoffTimestamp`; entries without one fall back to the call's
+   * `favoriteCutoffTimestamp`. Every cutoff is clamped to `regularCutoffTimestamp`
+   * so a favorite can never be retained for LESS time than plain telemetry.
+   */
+  private groupFavoritesByCutoff(
+    favorites: TelemetryFavorite[],
+    favoriteCutoffTimestamp: number,
+    regularCutoffTimestamp: number
+  ): Array<{ cutoff: number; condition: SQL }> {
+    const byCutoff = new Map<number, TelemetryFavorite[]>();
+    for (const f of favorites) {
+      const cutoff = Math.min(f.cutoffTimestamp ?? favoriteCutoffTimestamp, regularCutoffTimestamp);
+      const bucket = byCutoff.get(cutoff);
+      if (bucket) bucket.push(f);
+      else byCutoff.set(cutoff, [f]);
+    }
+    return [...byCutoff.entries()].map(([cutoff, entries]) => ({
+      cutoff,
+      condition: this.buildFavoritesCondition(entries)!,
+    }));
   }
 
   /**
@@ -787,7 +848,7 @@ export class TelemetryRepository extends BaseRepository {
   async deleteOldTelemetryWithFavorites(
     regularCutoffTimestamp: number,
     favoriteCutoffTimestamp: number,
-    favorites: Array<{ nodeId: string; telemetryType: string }>
+    favorites: TelemetryFavorite[]
   ): Promise<{ nonFavoritesDeleted: number; favoritesDeleted: number }> {
     // If no favorites, just delete everything older than regularCutoff
     if (favorites.length === 0) {
@@ -795,10 +856,13 @@ export class TelemetryRepository extends BaseRepository {
       return { nonFavoritesDeleted: count, favoritesDeleted: 0 };
     }
 
-    // Validate: favoriteCutoff should be <= regularCutoff (earlier timestamp = longer retention)
-    const effectiveFavoriteCutoff = Math.min(favoriteCutoffTimestamp, regularCutoffTimestamp);
     const { telemetry } = this.tables;
-    const favoritesCondition = this.buildFavoritesCondition(favorites);
+    const favoritesCondition = this.buildFavoritesCondition(favorites)!;
+    const groups = this.groupFavoritesByCutoff(
+      favorites,
+      favoriteCutoffTimestamp,
+      regularCutoffTimestamp
+    );
 
     let nonFavoritesDeleted = 0;
     let favoritesDeleted = 0;
@@ -808,35 +872,39 @@ export class TelemetryRepository extends BaseRepository {
       const nonFavoritesCount = await this.db
         .select({ cnt: count() })
         .from(telemetry)
-        .where(and(lt(telemetry.timestamp, regularCutoffTimestamp), not(favoritesCondition!)));
+        .where(and(lt(telemetry.timestamp, regularCutoffTimestamp), not(favoritesCondition)));
       nonFavoritesDeleted = Number(nonFavoritesCount[0]?.cnt ?? 0);
 
       await this.db
         .delete(telemetry)
-        .where(and(lt(telemetry.timestamp, regularCutoffTimestamp), not(favoritesCondition!)));
+        .where(and(lt(telemetry.timestamp, regularCutoffTimestamp), not(favoritesCondition)));
 
-      const favoritesCount = await this.db
-        .select({ cnt: count() })
-        .from(telemetry)
-        .where(and(lt(telemetry.timestamp, effectiveFavoriteCutoff), favoritesCondition!));
-      favoritesDeleted = Number(favoritesCount[0]?.cnt ?? 0);
+      for (const group of groups) {
+        const favoritesCount = await this.db
+          .select({ cnt: count() })
+          .from(telemetry)
+          .where(and(lt(telemetry.timestamp, group.cutoff), group.condition));
+        favoritesDeleted += Number(favoritesCount[0]?.cnt ?? 0);
 
-      await this.db
-        .delete(telemetry)
-        .where(and(lt(telemetry.timestamp, effectiveFavoriteCutoff), favoritesCondition!));
+        await this.db
+          .delete(telemetry)
+          .where(and(lt(telemetry.timestamp, group.cutoff), group.condition));
+      }
     } else {
       // SQLite and PostgreSQL support .returning()
       const deletedNonFavorites = await (this.db as any)
         .delete(telemetry)
-        .where(and(lt(telemetry.timestamp, regularCutoffTimestamp), not(favoritesCondition!)))
+        .where(and(lt(telemetry.timestamp, regularCutoffTimestamp), not(favoritesCondition)))
         .returning({ id: telemetry.id });
       nonFavoritesDeleted = deletedNonFavorites.length;
 
-      const deletedFavorites = await (this.db as any)
-        .delete(telemetry)
-        .where(and(lt(telemetry.timestamp, effectiveFavoriteCutoff), favoritesCondition!))
-        .returning({ id: telemetry.id });
-      favoritesDeleted = deletedFavorites.length;
+      for (const group of groups) {
+        const deletedFavorites = await (this.db as any)
+          .delete(telemetry)
+          .where(and(lt(telemetry.timestamp, group.cutoff), group.condition))
+          .returning({ id: telemetry.id });
+        favoritesDeleted += deletedFavorites.length;
+      }
     }
 
     return { nonFavoritesDeleted, favoritesDeleted };
@@ -1500,6 +1568,11 @@ export class TelemetryRepository extends BaseRepository {
     const db = this.getSqliteDb();
     const { telemetry } = this.tables;
     const favoritesCondition = this.buildFavoritesCondition(favorites)!;
+    const groups = this.groupFavoritesByCutoff(
+      favorites,
+      favoriteCutoffTimestamp,
+      regularCutoffTimestamp
+    );
 
     const nonFavoritesResult = db
       .delete(telemetry)
@@ -1507,11 +1580,14 @@ export class TelemetryRepository extends BaseRepository {
       .run();
     const nonFavoritesDeleted = Number((nonFavoritesResult as any).changes ?? 0);
 
-    const favoritesResult = db
-      .delete(telemetry)
-      .where(and(lt(telemetry.timestamp, favoriteCutoffTimestamp), favoritesCondition))
-      .run();
-    const favoritesDeleted = Number((favoritesResult as any).changes ?? 0);
+    let favoritesDeleted = 0;
+    for (const group of groups) {
+      const favoritesResult = db
+        .delete(telemetry)
+        .where(and(lt(telemetry.timestamp, group.cutoff), group.condition))
+        .run();
+      favoritesDeleted += Number((favoritesResult as any).changes ?? 0);
+    }
 
     return { nonFavoritesDeleted, favoritesDeleted };
   }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -16,6 +16,7 @@ import { createRequire } from 'module';
 import { logger } from '../utils/logger.js';
 import { setDiscardInvalidPositions, parseDiscardInvalidPositions } from '../utils/positionIngestConfig.js';
 import { setNoIndexEnabled, parseNoIndexEnabled } from '../utils/robotsConfig.js';
+import { FAVORITE_STORAGE_DAYS_DEFAULT } from '../utils/telemetryRetention.js';
 import { robotsTagMiddleware } from './middleware/robotsTag.js';
 import { getSessionMiddleware } from './auth/sessionConfig.js';
 import { initializeWebSocket } from './services/webSocketService.js';
@@ -461,15 +462,21 @@ setTimeout(async () => {
 // Schedule hourly telemetry purge to keep database performant
 // Keep telemetry for 7 days (168 hours) by default
 const TELEMETRY_RETENTION_HOURS = 168; // 7 days
+// Fallback retention for FAVORITED telemetry when no namespace configures one.
+// The real window comes from each source's `favoriteTelemetryStorageDays`,
+// resolved inside purgeOldTelemetryAsync (#5080).
+const FAVORITE_TELEMETRY_DEFAULT_DAYS = FAVORITE_STORAGE_DAYS_DEFAULT;
 setInterval(async () => {
   try {
     // Long migrations (e.g. on big MySQL telemetry tables) can keep the DB
     // unready well past the first tick — wait before touching repos.
     await databaseService.waitForReady();
-    // Get favorite telemetry storage days from settings (defaults to 7 if not set)
-    const favoriteDaysStr = await databaseService.settings.getSetting('favoriteTelemetryStorageDays');
-    const favoriteDays = favoriteDaysStr ? parseInt(favoriteDaysStr) : 7;
-    const purgedCount = await databaseService.purgeOldTelemetryAsync(TELEMETRY_RETENTION_HOURS, favoriteDays);
+    // FAVORITE_TELEMETRY_DEFAULT_DAYS is only the fallback: purgeOldTelemetryAsync
+    // resolves each source's own `favoriteTelemetryStorageDays` (#5080).
+    const purgedCount = await databaseService.purgeOldTelemetryAsync(
+      TELEMETRY_RETENTION_HOURS,
+      FAVORITE_TELEMETRY_DEFAULT_DAYS
+    );
     if (purgedCount > 0) {
       logger.debug(`⏰ Hourly telemetry purge completed: removed ${purgedCount} records`);
     }
@@ -485,10 +492,10 @@ setTimeout(async () => {
     // on a large MySQL telemetry table) can run longer than this 5s delay,
     // and accessing databaseService.settings before init throws.
     await databaseService.waitForReady();
-    // Get favorite telemetry storage days from settings (defaults to 7 if not set)
-    const favoriteDaysStr = await databaseService.settings.getSetting('favoriteTelemetryStorageDays');
-    const favoriteDays = favoriteDaysStr ? parseInt(favoriteDaysStr) : 7;
-    await databaseService.purgeOldTelemetryAsync(TELEMETRY_RETENTION_HOURS, favoriteDays);
+    await databaseService.purgeOldTelemetryAsync(
+      TELEMETRY_RETENTION_HOURS,
+      FAVORITE_TELEMETRY_DEFAULT_DAYS
+    );
   } catch (error) {
     logger.error('Error during initial telemetry purge:', error);
   }

--- a/src/services/database.telemetryRetention.test.ts
+++ b/src/services/database.telemetryRetention.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Regression tests for issue #5080 — "Telemetry Dashboard shows only ~7 days of
+ * history for favorited nodes despite favoriteTelemetryStorageDays=90".
+ *
+ * The Dashboard is always rendered inside a `<SourceProvider>`, so every write it
+ * makes to `/api/settings` carries `?sourceId=<id>` and therefore lands in the
+ * per-source settings namespace (`source:<id>:telemetryFavorites`,
+ * `source:<id>:favoriteTelemetryStorageDays`). The hourly retention purge, however,
+ * read only the un-namespaced GLOBAL keys — so it saw zero favorites, fell through
+ * to `deleteOldTelemetry(now - 168h)`, and deleted every favorited chart's history
+ * older than 7 days. The chart then rendered a ~7-day X-axis no matter what
+ * "Days to view" was set to, because the older rows had already been destroyed.
+ *
+ * These tests run against the real DatabaseService singleton (:memory: SQLite under
+ * vitest) so the whole settings-read → purge path is exercised, not a mock of it.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import databaseService from './database.js';
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+const NODE = '!a1b2c3d4';
+const NODE_NUM = 0xa1b2c3d4;
+const SOURCE_ID = 'ret-source-a';
+
+/** Retention window the hourly purge job uses for non-favorited telemetry. */
+const TELEMETRY_RETENTION_HOURS = 168; // 7 days
+
+async function seedTelemetry(ageDays: number, type: string, value: number) {
+  const ts = Date.now() - ageDays * DAY;
+  await databaseService.telemetry.insertTelemetry(
+    {
+      nodeId: NODE,
+      nodeNum: NODE_NUM,
+      telemetryType: type,
+      timestamp: ts,
+      value,
+      unit: '%',
+      createdAt: ts,
+    },
+    SOURCE_ID
+  );
+}
+
+async function remainingTimestampsFor(type: string): Promise<number[]> {
+  const rows = await databaseService.getTelemetryByNodeAveragedAsync(
+    NODE,
+    Date.now() - 90 * DAY,
+    1,
+    undefined,
+    SOURCE_ID
+  );
+  return rows.filter((r) => r.telemetryType === type).map((r) => r.timestamp).sort((a, b) => a - b);
+}
+
+describe('#5080 favorite telemetry retention reads per-source settings', () => {
+  beforeEach(async () => {
+    await databaseService.waitForReady();
+    await databaseService.purgeAllTelemetryAsync();
+    await databaseService.settings.setSetting('telemetryFavorites', '');
+    await databaseService.settings.setSetting('favoriteTelemetryStorageDays', '');
+    await databaseService.settings.setSetting(`source:${SOURCE_ID}:telemetryFavorites`, '');
+    await databaseService.settings.setSetting(`source:${SOURCE_ID}:favoriteTelemetryStorageDays`, '');
+
+    // 30 days of daily battery + voltage samples for one node on one source.
+    for (let d = 0; d <= 30; d++) {
+      await seedTelemetry(d, 'batteryLevel', 100 - d);
+      await seedTelemetry(d, 'voltage', 4.0);
+    }
+  });
+
+  it('keeps favorited history for the per-source favoriteTelemetryStorageDays window', async () => {
+    // Exactly what the Dashboard writes when the user favorites a chart and sets
+    // "Favorite telemetry storage" to 30 days: both land in the SOURCE namespace.
+    await databaseService.settings.setSetting(
+      `source:${SOURCE_ID}:telemetryFavorites`,
+      JSON.stringify([{ nodeId: NODE, telemetryType: 'batteryLevel' }])
+    );
+    await databaseService.settings.setSetting(
+      `source:${SOURCE_ID}:favoriteTelemetryStorageDays`,
+      '30'
+    );
+
+    await databaseService.purgeOldTelemetryAsync(TELEMETRY_RETENTION_HOURS, 7);
+
+    const battery = await remainingTimestampsFor('batteryLevel');
+    const sevenDaysAgo = Date.now() - 7 * DAY;
+
+    // The whole point of the setting: rows older than the 7-day non-favorite
+    // window must survive out to 30 days.
+    expect(battery.filter((t) => t < sevenDaysAgo).length).toBeGreaterThan(20);
+    expect(Math.min(...battery)).toBeLessThan(Date.now() - 29 * DAY);
+
+    // Non-favorited series is still trimmed to the 7-day regular window.
+    const voltage = await remainingTimestampsFor('voltage');
+    expect(voltage.every((t) => t >= sevenDaysAgo)).toBe(true);
+  });
+
+  it('still honours a legacy global favorites list (pre-4.x installs)', async () => {
+    await databaseService.settings.setSetting(
+      'telemetryFavorites',
+      JSON.stringify([{ nodeId: NODE, telemetryType: 'batteryLevel' }])
+    );
+    await databaseService.settings.setSetting('favoriteTelemetryStorageDays', '30');
+
+    await databaseService.purgeOldTelemetryAsync(TELEMETRY_RETENTION_HOURS, 7);
+
+    const battery = await remainingTimestampsFor('batteryLevel');
+    expect(Math.min(...battery)).toBeLessThan(Date.now() - 29 * DAY);
+  });
+
+  it('purges favorited telemetry older than the per-source window', async () => {
+    await databaseService.settings.setSetting(
+      `source:${SOURCE_ID}:telemetryFavorites`,
+      JSON.stringify([{ nodeId: NODE, telemetryType: 'batteryLevel' }])
+    );
+    await databaseService.settings.setSetting(
+      `source:${SOURCE_ID}:favoriteTelemetryStorageDays`,
+      '14'
+    );
+
+    await databaseService.purgeOldTelemetryAsync(TELEMETRY_RETENTION_HOURS, 7);
+
+    const battery = await remainingTimestampsFor('batteryLevel');
+    expect(battery.every((t) => t >= Date.now() - 15 * DAY)).toBe(true);
+    expect(battery.some((t) => t < Date.now() - 7 * DAY)).toBe(true);
+  });
+
+  it('serves the full 720h window the Dashboard asks for once the data survives', async () => {
+    // The chart's X-axis is the min/max of the rows it receives, so the exact
+    // symptom in #5080 ("more points, same ~7-day span") is a data question, not
+    // a rendering one. This asserts the averaged query itself is not truncating
+    // to the newest N rows: it must return the far edge of a 30-day window.
+    await databaseService.settings.setSetting(
+      `source:${SOURCE_ID}:telemetryFavorites`,
+      JSON.stringify([{ nodeId: NODE, telemetryType: 'batteryLevel' }])
+    );
+    await databaseService.settings.setSetting(
+      `source:${SOURCE_ID}:favoriteTelemetryStorageDays`,
+      '30'
+    );
+    await databaseService.purgeOldTelemetryAsync(TELEMETRY_RETENTION_HOURS, 7);
+
+    // Exactly what GET /api/telemetry/:nodeId?hours=720 issues.
+    const hours = 720;
+    const rows = await databaseService.getTelemetryByNodeAveragedAsync(
+      NODE,
+      Date.now() - hours * HOUR,
+      undefined,
+      hours,
+      SOURCE_ID
+    );
+    const battery = rows.filter((r) => r.telemetryType === 'batteryLevel');
+    expect(battery.length).toBeGreaterThan(0);
+
+    const span = Math.max(...battery.map((r) => r.timestamp)) - Math.min(...battery.map((r) => r.timestamp));
+    expect(span).toBeGreaterThan(28 * DAY);
+  });
+
+  it('does not let one source\'s favorite protect another source\'s telemetry', async () => {
+    const OTHER = 'ret-source-b';
+    const ts = Date.now() - 20 * DAY;
+    await databaseService.telemetry.insertTelemetry(
+      {
+        nodeId: NODE,
+        nodeNum: NODE_NUM,
+        telemetryType: 'batteryLevel',
+        timestamp: ts,
+        value: 42,
+        unit: '%',
+        createdAt: ts,
+      },
+      OTHER
+    );
+
+    await databaseService.settings.setSetting(
+      `source:${SOURCE_ID}:telemetryFavorites`,
+      JSON.stringify([{ nodeId: NODE, telemetryType: 'batteryLevel' }])
+    );
+    await databaseService.settings.setSetting(
+      `source:${SOURCE_ID}:favoriteTelemetryStorageDays`,
+      '30'
+    );
+
+    await databaseService.purgeOldTelemetryAsync(TELEMETRY_RETENTION_HOURS, 7);
+
+    const otherRows = await databaseService.getTelemetryByNodeAveragedAsync(
+      NODE,
+      Date.now() - 90 * DAY,
+      1,
+      undefined,
+      OTHER
+    );
+    expect(otherRows).toHaveLength(0);
+  });
+});

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -18,6 +18,8 @@ import {
 import { validateThemeDefinition as validateTheme } from '../utils/themeValidation.js';
 import { isSourceyResource } from '../types/permission.js';
 import { computeAveragingIntervalMinutes } from '../utils/telemetryAveraging.js';
+import { buildFavoriteRetentions } from '../utils/telemetryRetention.js';
+import type { TelemetryFavorite } from '../db/repositories/telemetry.js';
 import { getMaxNodeAgeHours } from '../server/services/nodeDisplaySettings.js';
 // Drizzle ORM imports for dual-database support
 import { drizzle as drizzleSqlite } from 'drizzle-orm/better-sqlite3';
@@ -3271,85 +3273,68 @@ class DatabaseService {
   }
 
   /**
+   * Collect every favorited (nodeId, telemetryType) pair the purge must protect,
+   * from BOTH the global settings namespace and every `source:<id>:` namespace
+   * (#5080).
+   *
+   * The Dashboard always writes `telemetryFavorites` and
+   * `favoriteTelemetryStorageDays` with `?sourceId=<id>`, so reading only the
+   * global keys — as this purge used to — found nothing and deleted every
+   * favorited chart's history past the 7-day non-favorite window.
+   *
+   * One `getAllSettings()` snapshot covers both namespaces, so this costs a
+   * single query per hourly purge.
+   */
+  private async collectFavoriteRetentionsAsync(defaultDaysToKeep: number): Promise<TelemetryFavorite[]> {
+    const allSettings = await this.settings.getAllSettings();
+    return buildFavoriteRetentions(allSettings, Date.now(), defaultDaysToKeep);
+  }
+
+  /**
    * Purge old telemetry data (async version)
    */
   async purgeOldTelemetryAsync(hoursToKeep: number, favoriteDaysToKeep?: number): Promise<number> {
     const regularCutoffTime = Date.now() - (hoursToKeep * 60 * 60 * 1000);
+    const isSql = this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql';
 
-    // PostgreSQL/MySQL: Use async telemetry repository
-    if (this.drizzleDbType === 'postgres' || this.drizzleDbType === 'mysql') {
-      if (!favoriteDaysToKeep) {
-        const count = await this.telemetry.deleteOldTelemetry(regularCutoffTime);
-        logger.debug(`🧹 Purged ${count} old telemetry records (keeping last ${hoursToKeep} hours)`);
-        return count;
-      }
-
-      // Get favorites and use favorites-aware deletion
-      const favoritesStr = await this.getSettingAsync('telemetryFavorites');
-      let favorites: Array<{ nodeId: string; telemetryType: string }> = [];
-      if (favoritesStr) {
-        try {
-          favorites = JSON.parse(favoritesStr);
-        } catch (error) {
-          logger.error('Failed to parse telemetryFavorites from settings:', error);
-        }
-      }
-
-      const favoriteCutoffTime = Date.now() - (favoriteDaysToKeep * 24 * 60 * 60 * 1000);
-      const { nonFavoritesDeleted, favoritesDeleted } = await this.telemetry.deleteOldTelemetryWithFavorites(
-        regularCutoffTime,
-        favoriteCutoffTime,
-        favorites
-      );
-      const totalDeleted = nonFavoritesDeleted + favoritesDeleted;
-      logger.debug(
-        `🧹 Purged ${totalDeleted} old telemetry records ` +
-        `(${nonFavoritesDeleted} non-favorites older than ${hoursToKeep}h, ` +
-        `${favoritesDeleted} favorites older than ${favoriteDaysToKeep}d)`
-      );
-      return totalDeleted;
-    }
-
-    // SQLite: synchronous path via repository
+    // Caller explicitly opted out of favorites retention — purge everything past
+    // the regular window.
     if (!favoriteDaysToKeep) {
-      const deleted = this.telemetry.deleteOldTelemetrySync(regularCutoffTime);
+      const deleted = isSql
+        ? await this.telemetry.deleteOldTelemetry(regularCutoffTime)
+        : this.telemetry.deleteOldTelemetrySync(regularCutoffTime);
       logger.debug(`🧹 Purged ${deleted} old telemetry records (keeping last ${hoursToKeep} hours)`);
-      if (deleted > 0) this.invalidateTelemetryTypesCache();
+      if (!isSql && deleted > 0) this.invalidateTelemetryTypesCache();
       return deleted;
     }
 
-    const favoritesStr = this.getSetting('telemetryFavorites');
-    let favorites: Array<{ nodeId: string; telemetryType: string }> = [];
-    if (favoritesStr) {
-      try {
-        favorites = JSON.parse(favoritesStr);
-      } catch (error) {
-        logger.error('Failed to parse telemetryFavorites from settings:', error);
-      }
-    }
-
-    if (favorites.length === 0) {
-      const deleted = this.telemetry.deleteOldTelemetrySync(regularCutoffTime);
-      logger.debug(`🧹 Purged ${deleted} old telemetry records (keeping last ${hoursToKeep} hours, no favorites)`);
-      if (deleted > 0) this.invalidateTelemetryTypesCache();
-      return deleted;
-    }
-
+    // Each entry carries its own cutoff, resolved from that source's
+    // `favoriteTelemetryStorageDays` (falling back to global, then the caller's
+    // value). `favoriteCutoffTime` below only covers entries with no explicit
+    // cutoff, which today means none — it is the safety net, not the policy.
+    const favorites = await this.collectFavoriteRetentionsAsync(favoriteDaysToKeep);
     const favoriteCutoffTime = Date.now() - (favoriteDaysToKeep * 24 * 60 * 60 * 1000);
 
-    const { nonFavoritesDeleted, favoritesDeleted } = this.telemetry.deleteOldTelemetryWithFavoritesSync(
-      regularCutoffTime,
-      favoriteCutoffTime,
-      favorites
-    );
-    const totalDeleted = nonFavoritesDeleted + favoritesDeleted;
+    const { nonFavoritesDeleted, favoritesDeleted } = isSql
+      ? await this.telemetry.deleteOldTelemetryWithFavorites(
+          regularCutoffTime,
+          favoriteCutoffTime,
+          favorites
+        )
+      : this.telemetry.deleteOldTelemetryWithFavoritesSync(
+          regularCutoffTime,
+          favoriteCutoffTime,
+          favorites
+        );
 
+    const totalDeleted = nonFavoritesDeleted + favoritesDeleted;
     logger.debug(
       `🧹 Purged ${totalDeleted} old telemetry records ` +
       `(${nonFavoritesDeleted} non-favorites older than ${hoursToKeep}h, ` +
-      `${favoritesDeleted} favorites older than ${favoriteDaysToKeep}d)`
+      `${favoritesDeleted} of ${favorites.length} protected favorite series past their ` +
+      `per-source retention window)`
     );
-    if (totalDeleted > 0) this.invalidateTelemetryTypesCache();
+    if (!isSql && totalDeleted > 0) this.invalidateTelemetryTypesCache();
     return totalDeleted;
   }
 

--- a/src/utils/telemetryRetention.test.ts
+++ b/src/utils/telemetryRetention.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildFavoriteRetentions,
+  sourceIdFromSettingKey,
+  FAVORITE_STORAGE_DAYS_MIN,
+  FAVORITE_STORAGE_DAYS_MAX,
+} from './telemetryRetention';
+
+const NOW = 1_700_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+const favJson = (nodeId: string, telemetryType: string) =>
+  JSON.stringify([{ nodeId, telemetryType }]);
+
+describe('sourceIdFromSettingKey', () => {
+  it('extracts the source id from a per-source key', () => {
+    expect(sourceIdFromSettingKey('source:abc:telemetryFavorites', 'telemetryFavorites')).toBe('abc');
+  });
+
+  it('returns null for the global key', () => {
+    expect(sourceIdFromSettingKey('telemetryFavorites', 'telemetryFavorites')).toBeNull();
+  });
+
+  it('returns null for a different per-source key', () => {
+    expect(sourceIdFromSettingKey('source:abc:maxNodeAgeHours', 'telemetryFavorites')).toBeNull();
+  });
+
+  it('keeps a colon inside the source id intact', () => {
+    expect(
+      sourceIdFromSettingKey('source:mqtt:eu:868:telemetryFavorites', 'telemetryFavorites')
+    ).toBe('mqtt:eu:868');
+  });
+
+  it('returns null for an empty source id', () => {
+    expect(sourceIdFromSettingKey('source::telemetryFavorites', 'telemetryFavorites')).toBeNull();
+  });
+});
+
+describe('buildFavoriteRetentions (#5080)', () => {
+  it('reads favorites out of the per-source namespace', () => {
+    const retentions = buildFavoriteRetentions(
+      {
+        'source:src-a:telemetryFavorites': favJson('!aabbccdd', 'batteryLevel'),
+        'source:src-a:favoriteTelemetryStorageDays': '90',
+      },
+      NOW,
+      7
+    );
+
+    expect(retentions).toEqual([
+      {
+        sourceId: 'src-a',
+        nodeId: '!aabbccdd',
+        telemetryType: 'batteryLevel',
+        cutoffTimestamp: NOW - 90 * DAY,
+      },
+    ]);
+  });
+
+  it('gives each source its own retention window', () => {
+    const retentions = buildFavoriteRetentions(
+      {
+        'source:src-a:telemetryFavorites': favJson('!aabbccdd', 'batteryLevel'),
+        'source:src-a:favoriteTelemetryStorageDays': '90',
+        'source:src-b:telemetryFavorites': favJson('!11223344', 'voltage'),
+        'source:src-b:favoriteTelemetryStorageDays': '14',
+      },
+      NOW,
+      7
+    );
+
+    const byId = new Map(retentions.map((r) => [r.sourceId, r.cutoffTimestamp]));
+    expect(byId.get('src-a')).toBe(NOW - 90 * DAY);
+    expect(byId.get('src-b')).toBe(NOW - 14 * DAY);
+  });
+
+  it('falls back to the global storage-days value, then to the caller default', () => {
+    const withGlobal = buildFavoriteRetentions(
+      {
+        favoriteTelemetryStorageDays: '30',
+        'source:src-a:telemetryFavorites': favJson('!aabbccdd', 'batteryLevel'),
+      },
+      NOW,
+      7
+    );
+    expect(withGlobal[0].cutoffTimestamp).toBe(NOW - 30 * DAY);
+
+    const withoutGlobal = buildFavoriteRetentions(
+      { 'source:src-a:telemetryFavorites': favJson('!aabbccdd', 'batteryLevel') },
+      NOW,
+      21
+    );
+    expect(withoutGlobal[0].cutoffTimestamp).toBe(NOW - 21 * DAY);
+  });
+
+  it('keeps a legacy global favorites list, unscoped so it matches any source', () => {
+    const retentions = buildFavoriteRetentions(
+      {
+        telemetryFavorites: favJson('!aabbccdd', 'batteryLevel'),
+        favoriteTelemetryStorageDays: '45',
+      },
+      NOW,
+      7
+    );
+
+    expect(retentions).toHaveLength(1);
+    expect(retentions[0].sourceId).toBeUndefined();
+    expect(retentions[0].cutoffTimestamp).toBe(NOW - 45 * DAY);
+  });
+
+  it('clamps storage days to the range the Settings UI enforces', () => {
+    const tooBig = buildFavoriteRetentions(
+      {
+        'source:s:telemetryFavorites': favJson('!a', 'x'),
+        'source:s:favoriteTelemetryStorageDays': '3650',
+      },
+      NOW,
+      7
+    );
+    expect(tooBig[0].cutoffTimestamp).toBe(NOW - FAVORITE_STORAGE_DAYS_MAX * DAY);
+
+    const tooSmall = buildFavoriteRetentions(
+      {
+        'source:s:telemetryFavorites': favJson('!a', 'x'),
+        'source:s:favoriteTelemetryStorageDays': '0',
+      },
+      NOW,
+      7
+    );
+    expect(tooSmall[0].cutoffTimestamp).toBe(NOW - FAVORITE_STORAGE_DAYS_MIN * DAY);
+  });
+
+  it('ignores malformed or non-array favorites payloads', () => {
+    expect(
+      buildFavoriteRetentions({ 'source:s:telemetryFavorites': 'not json' }, NOW, 7)
+    ).toEqual([]);
+    expect(
+      buildFavoriteRetentions({ 'source:s:telemetryFavorites': '{"nodeId":"!a"}' }, NOW, 7)
+    ).toEqual([]);
+    expect(
+      buildFavoriteRetentions({ 'source:s:telemetryFavorites': '[{"nodeId":5}]' }, NOW, 7)
+    ).toEqual([]);
+    expect(buildFavoriteRetentions({ 'source:s:telemetryFavorites': '' }, NOW, 7)).toEqual([]);
+  });
+
+  it('ignores unrelated per-source settings keys', () => {
+    expect(
+      buildFavoriteRetentions(
+        { 'source:s:maxNodeAgeHours': '24', maxNodeAgeHours: '24' },
+        NOW,
+        7
+      )
+    ).toEqual([]);
+  });
+});

--- a/src/utils/telemetryRetention.ts
+++ b/src/utils/telemetryRetention.ts
@@ -1,0 +1,135 @@
+/**
+ * Telemetry retention helpers (issue #5080).
+ *
+ * `telemetryFavorites` and `favoriteTelemetryStorageDays` are BOTH per-source
+ * settings. The Dashboard and the Settings "Telemetry" section always render
+ * inside a `<SourceProvider>`, so every save they make carries `?sourceId=<id>`
+ * and lands under the `source:<id>:` key prefix. The hourly retention purge used
+ * to read only the un-namespaced global keys, found nothing, and therefore
+ * deleted every favorited chart's history past the 7-day non-favorite window —
+ * silently destroying the history the setting exists to preserve.
+ *
+ * This module turns one `getAllSettings()` snapshot (which contains BOTH
+ * namespaces) into the per-entry retention list the purge needs. Kept
+ * dependency-free so it can be unit-tested without a database.
+ */
+
+import type { TelemetryFavorite } from '../db/repositories/telemetry.js';
+import { logger } from './logger.js';
+
+/** Prefix used for per-source setting keys: `source:<sourceId>:<key>`. */
+const SOURCE_KEY_PREFIX = 'source:';
+
+const FAVORITES_KEY = 'telemetryFavorites';
+const STORAGE_DAYS_KEY = 'favoriteTelemetryStorageDays';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Bounds enforced by the Settings UI input (`min=7 max=90`). Applied again here
+ * because a hand-edited settings row is not validated by the UI, and a bogus
+ * value would otherwise become an unbounded retention window (or an instant
+ * purge of every favorite).
+ */
+export const FAVORITE_STORAGE_DAYS_MIN = 7;
+export const FAVORITE_STORAGE_DAYS_MAX = 90;
+
+/** Fallback when nothing valid is configured anywhere. */
+export const FAVORITE_STORAGE_DAYS_DEFAULT = 7;
+
+function clampStorageDays(raw: string | undefined, fallback: number): number {
+  const parsed = parseInt(raw ?? '', 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(FAVORITE_STORAGE_DAYS_MAX, Math.max(FAVORITE_STORAGE_DAYS_MIN, parsed));
+}
+
+/**
+ * Parse a stored `telemetryFavorites` JSON blob into (nodeId, telemetryType)
+ * pairs. Anything malformed yields an empty list — the purge must never widen
+ * or narrow retention because a settings row was corrupt.
+ */
+function parseFavorites(raw: string | undefined, label: string): Array<{ nodeId: string; telemetryType: string }> {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    logger.error(`Failed to parse ${FAVORITES_KEY} from settings (${label})`);
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return (parsed as unknown[]).filter(
+    (f): f is { nodeId: string; telemetryType: string } => {
+      if (!f || typeof f !== 'object') return false;
+      const candidate = f as Record<string, unknown>;
+      return typeof candidate.nodeId === 'string' && typeof candidate.telemetryType === 'string';
+    }
+  );
+}
+
+/**
+ * Extract the sourceId from a per-source settings key, or null if the key is
+ * not `source:<id>:<bareKey>` for the given bare key.
+ *
+ * Split from the END, never with `split(':')` — a sourceId is free to contain
+ * a colon and splitting on the first one would corrupt it.
+ */
+export function sourceIdFromSettingKey(key: string, bareKey: string): string | null {
+  const suffix = `:${bareKey}`;
+  if (!key.startsWith(SOURCE_KEY_PREFIX) || !key.endsWith(suffix)) return null;
+  const id = key.slice(SOURCE_KEY_PREFIX.length, key.length - suffix.length);
+  return id.length > 0 ? id : null;
+}
+
+/**
+ * Build the per-entry favorite retention list the telemetry purge needs, from a
+ * full settings snapshot (global keys AND `source:<id>:` keys).
+ *
+ * Resolution order for a source's retention window:
+ *   `source:<id>:favoriteTelemetryStorageDays` → global `favoriteTelemetryStorageDays`
+ *   → `defaultDays` argument → {@link FAVORITE_STORAGE_DAYS_DEFAULT}.
+ *
+ * @param allSettings - snapshot from `SettingsRepository.getAllSettings()`.
+ * @param now - epoch ms the cutoffs are measured back from.
+ * @param defaultDays - fallback retention when neither namespace configures one.
+ */
+export function buildFavoriteRetentions(
+  allSettings: Record<string, string>,
+  now: number,
+  defaultDays: number = FAVORITE_STORAGE_DAYS_DEFAULT
+): TelemetryFavorite[] {
+  const fallbackDays = clampStorageDays(undefined, defaultDays);
+  const globalDays = clampStorageDays(allSettings[STORAGE_DAYS_KEY], fallbackDays);
+
+  const retentions: TelemetryFavorite[] = [];
+
+  // Legacy / pre-4.x global favorites list. Carries no sourceId, so it protects
+  // the matching (nodeId, telemetryType) rows on every source.
+  for (const f of parseFavorites(allSettings[FAVORITES_KEY], 'global')) {
+    retentions.push({
+      nodeId: f.nodeId,
+      telemetryType: f.telemetryType,
+      cutoffTimestamp: now - globalDays * DAY_MS,
+    });
+  }
+
+  // Per-source favorites (#5080) — where every 4.x Dashboard actually writes.
+  for (const [key, value] of Object.entries(allSettings)) {
+    const sourceId = sourceIdFromSettingKey(key, FAVORITES_KEY);
+    if (!sourceId) continue;
+    const days = clampStorageDays(
+      allSettings[`${SOURCE_KEY_PREFIX}${sourceId}:${STORAGE_DAYS_KEY}`],
+      globalDays
+    );
+    for (const f of parseFavorites(value, `source ${sourceId}`)) {
+      retentions.push({
+        sourceId,
+        nodeId: f.nodeId,
+        telemetryType: f.telemetryType,
+        cutoffTimestamp: now - days * DAY_MS,
+      });
+    }
+  }
+
+  return retentions;
+}


### PR DESCRIPTION
Fixes #5080

## The bug is data loss, not a rendering problem

`telemetryFavorites` and `favoriteTelemetryStorageDays` are **per-source** settings. The Dashboard and the Settings → Telemetry section always render inside a `<SourceProvider>`, so every save they make carries `?sourceId=<id>` and lands under the `source:<id>:` key prefix (`settingsRoutes.ts`'s `scopedSettingKey`).

The hourly retention purge read only the **un-namespaced global** keys:

```ts
// src/services/database.ts (before)
const favoritesStr = await this.getSettingAsync('telemetryFavorites');  // → null on every 4.x install
```

So on any 4.x install the purge:

1. found **zero** favorites, and
2. fell through to `deleteOldTelemetry(now - 168h)`,

deleting every favorited chart's history older than **7 days** — precisely the history `favoriteTelemetryStorageDays` exists to protect. It also never saw the configured window (`server.ts` read the global `favoriteTelemetryStorageDays`, likewise absent), so the effective favorite retention was 7 days even where a stale global row existed.

The reported symptom follows directly. `Dashboard.tsx` computes `globalTimeRange` as the min/max of the rows the charts actually receive, so the X-axis spans the data, not the request. With nothing older than 7 days left in the table, raising "Days to view" widens the request (and changes the averaging bucket, hence the point count) but cannot widen the axis. **The chart was honest; the rows were gone.**

**Backends affected: all three.** The faulty settings read sits above the SQLite / PostgreSQL / MySQL branch in `purgeOldTelemetryAsync`.

The averaged-query hypotheses from triage were checked and cleared: `computeAveragingIntervalMinutes(2160)` returns 9-minute buckets and keeps the far edge, and the SQLite `LIMIT` is `~TARGET_BUCKETS × typeCount × 1.5` — an upper bound on a full window, not a newest-N truncation. A test asserts a 720h request returns a >28-day span once the data survives.

## Fix

- **`src/utils/telemetryRetention.ts` (new)** — pure helper turning one `getAllSettings()` snapshot (which already contains *both* namespaces, so this costs a single query per hourly purge) into per-entry retention specs. Each source's own `favoriteTelemetryStorageDays` wins, falling back to global → caller default. Storage days are clamped to the `7..90` range the Settings input enforces, so a hand-edited row cannot become an unbounded window or an instant purge. Source ids are split from the **end** of the key, never `split(':')`, so an id containing a colon survives.
- **`TelemetryFavorite` gains `sourceId?` and `cutoffTimestamp?`** — a favorite on source A no longer protects source B's rows, and sources with different retention windows are applied in a single pass (favorites grouped by effective cutoff).
- **`sourceId = <id> OR sourceId IS NULL`, not a bare equality.** A bare comparison makes `NOT (…)` evaluate to NULL for pre-source-scoping rows, which would leave them in the table forever. Legacy unscoped rows are also protected by any source's favorite — over-retention, never loss. Covered by a dedicated test on all three backends.
- **Favorite cutoffs clamped to the regular cutoff on the SQLite sync path too**, so a favorite is never retained for *less* time than plain telemetry (the async path already did this).
- `server.ts` no longer does its own global settings read; it passes only a fallback default.

Timestamp units: `telemetry.timestamp`, `cutoffTime` and every cutoff here are **epoch milliseconds** throughout (`Date.now() - days * 86_400_000`). No seconds/ms mixing was introduced.

## Tests

Regression test written first and **verified failing on `main`** — 3 of the 4 original cases:

```
1. keeps favorited history for the per-source favoriteTelemetryStorageDays window
   AssertionError: expected 0 to be greater than 20        ← every row past 7 days deleted
2. still honours a legacy global favorites list (pre-4.x installs)
   AssertionError: expected 1788118443475 to be less than 1786131243493
3. purges favorited telemetry older than the per-source window
   AssertionError: expected false to be true
```

- `src/services/database.telemetryRetention.test.ts` — end-to-end against the real `DatabaseService` singleton (settings read → purge → averaged read), 5 cases.
- `src/db/repositories/telemetry.favoriteRetention.multiBackend.test.ts` — source-scoped condition, per-source cutoffs, NULL-`sourceId` rows, legacy unscoped favorites, and the clamp, on **SQLite, PostgreSQL and MySQL** (plus the SQLite sync path). Uses a private fixture database via `isolationKey: 'r_tel_fav_retention'` (PR #5047 convention).
- `src/utils/telemetryRetention.test.ts` — namespace parsing, per-source day resolution, clamping, malformed payloads.

Full suite with both containers up:

```
success: true   19180 tests   0 failed   109 skipped   5297 suites   0 failed suites
PostgreSQL assertions executed: 494    MySQL assertions executed: 495
```

(109 skipped is the normal baseline, not silently-skipped backend suites — a run without the containers skips ~1,500.) `npm run lint:ci` clean, both tsconfigs typecheck.

## No screenshot

No UI change — the chart code is untouched, and the fix is a backend retention correction whose visible effect needs 30+ days of accumulated telemetry to show. Adding it here would be a picture of the same seven days.

## Note for affected users

History already destroyed by the old behaviour **is gone and cannot be recovered.** After upgrading, the favorited window refills from now on; the chart will keep showing ~7 days until enough new telemetry accumulates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S6dVMHduNHsn6jNRXX25k
