### PR TITLE
fix(meshcore): let shared read surfaces see an MQTT ingest source, Phase 5.5 (#5040)

### DIFF
--- a/src/server/meshcoreMqttManager.readSurface.test.ts
+++ b/src/server/meshcoreMqttManager.readSurface.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Read-surface inclusion for an MQTT ingest source (#5040 Phase 5.5).
+ *
+ * Five phases added ingest paths, and every shared read surface narrowed with
+ * `isMeshCoreManager()` — which excludes this source by construction. That
+ * exclusion is correct for anything driving a radio and WRONG for anything
+ * reading data, and the failure is silent: nodes simply never appear.
+ *
+ * These pin the manager half — the methods those surfaces call. Without them a
+ * caller can narrow with `isAnyMeshCoreManager()` and still not compile, which
+ * is what kept the predicate at zero production callers.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getNodesBySource = vi.fn();
+const getRecentMessages = vi.fn();
+
+vi.mock('../services/database.js', () => ({
+  default: {
+    meshcore: {
+      getNodesBySource: (...a: unknown[]) => getNodesBySource(...a),
+      getRecentMessages: (...a: unknown[]) => getRecentMessages(...a),
+      upsertNode: vi.fn(),
+      insertMessage: vi.fn(),
+    },
+    channels: { getAllChannels: vi.fn().mockResolvedValue([]) },
+  },
+}));
+vi.mock('./services/dataEventEmitter.js', () => ({ dataEventEmitter: { emitMeshCoreMessage: vi.fn() } }));
+vi.mock('./services/meshcorePacketLogService.js', () => ({
+  default: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+}));
+
+let connected = true;
+vi.mock('./transports/mqttBrokerClient.js', () => ({
+  MqttBrokerClient: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    subscribe = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    isConnected = () => connected;
+    on() { return this; }
+    removeAllListeners() { return this; }
+  },
+}));
+
+import { MeshCoreMqttManager } from './meshcoreMqttManager.js';
+import { isAnyMeshCoreManager, isMeshCoreManager, isMeshCoreMqttManager } from './sourceManagerTypes.js';
+
+const make = () => new MeshCoreMqttManager('src-mqtt', 'Feed', {
+  brokerUrl: 'wss://b', region: 'MCO',
+});
+
+beforeEach(() => {
+  connected = true;
+  getNodesBySource.mockReset().mockResolvedValue([]);
+  getRecentMessages.mockReset().mockResolvedValue([]);
+});
+
+describe('read surface (#5040 Phase 5.5)', () => {
+  it('returns this source’s nodes, scoped by sourceId', async () => {
+    getNodesBySource.mockResolvedValue([{ publicKey: 'AA', latitude: 1, longitude: 2 }]);
+    const nodes = await make().getAllNodes();
+
+    expect(getNodesBySource).toHaveBeenCalledWith('src-mqtt');
+    expect(nodes).toHaveLength(1);
+  });
+
+  it('returns this source’s messages, scoped by sourceId', async () => {
+    getRecentMessages.mockResolvedValue([{ id: 'm1', text: 'hi' }]);
+    const msgs = await make().getRecentMessagesAsync(500);
+
+    expect(getRecentMessages).toHaveBeenCalledWith(500, 'src-mqtt');
+    expect(msgs).toHaveLength(1);
+  });
+
+  it('degrades to empty rather than throwing when the DB read fails', async () => {
+    // These feed map and search surfaces; one unreadable source must not take
+    // down a whole cross-source query.
+    getNodesBySource.mockRejectedValue(new Error('db down'));
+    getRecentMessages.mockRejectedValue(new Error('db down'));
+    const mgr = make();
+
+    await expect(mgr.getAllNodes()).resolves.toEqual([]);
+    await expect(mgr.getRecentMessagesAsync()).resolves.toEqual([]);
+  });
+
+  it('reports broker connectivity through isConnected', async () => {
+    const mgr = make();
+    expect(mgr.isConnected()).toBe(false); // not started
+    await mgr.start();
+    expect(mgr.isConnected()).toBe(true);
+    connected = false;
+    expect(mgr.isConnected()).toBe(false);
+  });
+
+  it('is included by the read predicate and excluded by the device one', () => {
+    const mgr = make();
+    // The whole point of the audit: read surfaces must use the inclusive
+    // predicate, TX surfaces the device-only one.
+    expect(isAnyMeshCoreManager(mgr)).toBe(true);
+    expect(isMeshCoreMqttManager(mgr)).toBe(true);
+    expect(isMeshCoreManager(mgr)).toBe(false);
+  });
+
+  it('satisfies the union call site without a cast', async () => {
+    // A caller that narrows with isAnyMeshCoreManager gets a union; if either
+    // member lacked getAllNodes this would not compile, which is exactly what
+    // blocked the predicate from having any production callers.
+    const mgr = make();
+    const narrowed = isAnyMeshCoreManager(mgr) ? mgr : null;
+    expect(narrowed).not.toBeNull();
+    await expect(narrowed!.getAllNodes()).resolves.toEqual([]);
+  });
+});

--- a/src/server/meshcoreMqttManager.ts
+++ b/src/server/meshcoreMqttManager.ts
@@ -53,6 +53,7 @@ import {
 import meshcorePacketLogService from './services/meshcorePacketLogService.js';
 import databaseService from '../services/database.js';
 import { decodeMeshCorePacket } from '../utils/meshcorePacketDecode.js';
+import type { MeshCoreNode, MeshCoreMessage } from './meshcoreManager.js';
 import { createHash } from 'node:crypto';
 import { ChannelCrypto } from '@michaelhart/meshcore-decoder';
 import { ALL_SOURCES } from '../db/repositories/base.js';
@@ -650,6 +651,56 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
   /** Latest status seen per observer, for the source status panel. */
   getObserverStatuses(): ReadonlyMap<string, ObserverStatusSnapshot> {
     return new Map(this.seenObserverStatus);
+  }
+
+  /**
+   * Every node this source knows, newest data from the database (#5040 Phase 5.5).
+   *
+   * The device-backed manager merges its live contact store over the DB rows;
+   * there is no contact store here, so the DB IS the whole picture — adverts
+   * (Phase 3) and observer status heartbeats (Phase 5) are the only writers.
+   *
+   * Exists so read surfaces can narrow with `isAnyMeshCoreManager()` and call
+   * this on the union without a cast. Before Phase 5.5 those surfaces narrowed
+   * device-only, which silently hid this source's nodes from the map and
+   * under-counted the unified card.
+   */
+  async getAllNodes(): Promise<MeshCoreNode[]> {
+    try {
+      return (await databaseService.meshcore.getNodesBySource(this.sourceId)) as unknown as MeshCoreNode[];
+    } catch (err) {
+      logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to read nodes:`, err);
+      return [];
+    }
+  }
+
+  /**
+   * Recent messages for this source, newest-first.
+   *
+   * Read straight from the database rather than an in-memory ring: the device
+   * manager keeps one because it receives messages as events, whereas here they
+   * arrive already persisted by the Phase 4 ingest path. Message SEARCH is the
+   * caller that matters — without this, a region feed's channel messages were
+   * stored but unsearchable.
+   */
+  async getRecentMessagesAsync(limit = 1000): Promise<MeshCoreMessage[]> {
+    try {
+      return (await databaseService.meshcore.getRecentMessages(limit, this.sourceId)) as unknown as MeshCoreMessage[];
+    } catch (err) {
+      logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to read messages:`, err);
+      return [];
+    }
+  }
+
+  /**
+   * True while the broker connection is up.
+   *
+   * Read surfaces filter on this to skip sources that are configured but not
+   * currently receiving. For this source it means "subscribed to the broker",
+   * not "has a working radio" — there is no radio.
+   */
+  isConnected(): boolean {
+    return this.client?.isConnected() ?? false;
   }
 
   getStatus(): SourceStatus {

--- a/src/server/routes/messageRoutes.test.ts
+++ b/src/server/routes/messageRoutes.test.ts
@@ -824,6 +824,51 @@ describe('Message Deletion Routes', () => {
       expect(response.body).toHaveProperty('total');
     });
 
+    it('includes an MQTT ingest source’s messages in search results (#5040 Phase 5.5)', async () => {
+      // The wiring, not the manager. Phase 5.5 exists because read surfaces
+      // narrowed device-only and silently dropped this source; a unit test on
+      // the manager cannot catch someone changing the filter predicate back.
+      const app = createApp({ id: 1, username: 'admin', isAdmin: true });
+      (databaseService as any).searchMessagesAsync = vi.fn().mockResolvedValue({ messages: [], total: 0 });
+
+      const ingestManager = {
+        sourceId: 'src-mqtt',
+        sourceType: 'meshcore_mqtt' as const,
+        isConnected: () => true,
+        getRecentMessagesAsync: vi.fn().mockResolvedValue([
+          { id: 'mqtt_1', text: 'hello from the region feed', timestamp: 5000, fromPublicKey: 'channel-0' },
+        ]),
+      };
+      registryStub.getAllManagers.mockReturnValue([ingestManager]);
+
+      const response = await request(app).get('/api/messages/search?q=region');
+
+      expect(response.status).toBe(200);
+      expect(ingestManager.getRecentMessagesAsync).toHaveBeenCalled();
+      const texts = (response.body.data ?? []).map((m: { text: string }) => m.text);
+      expect(texts).toContain('hello from the region feed');
+    });
+
+    it('skips an MQTT ingest source that is not connected', async () => {
+      const app = createApp({ id: 1, username: 'admin', isAdmin: true });
+      (databaseService as any).searchMessagesAsync = vi.fn().mockResolvedValue({ messages: [], total: 0 });
+
+      const ingestManager = {
+        sourceId: 'src-mqtt',
+        sourceType: 'meshcore_mqtt' as const,
+        isConnected: () => false,
+        getRecentMessagesAsync: vi.fn().mockResolvedValue([
+          { id: 'mqtt_1', text: 'stale region message', timestamp: 5000, fromPublicKey: 'channel-0' },
+        ]),
+      };
+      registryStub.getAllManagers.mockReturnValue([ingestManager]);
+
+      const response = await request(app).get('/api/messages/search?q=stale');
+
+      expect(response.status).toBe(200);
+      expect(ingestManager.getRecentMessagesAsync).not.toHaveBeenCalled();
+    });
+
     it('should filter by channels for non-admin user', async () => {
       const app = createApp({ id: 2, username: 'user', isAdmin: false });
       (databaseService as any).getUserPermissionSetAsync = vi.fn().mockResolvedValue({

--- a/src/server/routes/messageRoutes.ts
+++ b/src/server/routes/messageRoutes.ts
@@ -223,8 +223,17 @@ router.get('/search', async (req: Request, res: Response) => {
     }
 
     // Search MeshCore messages (in-memory filter, across every registered source)
-    const meshcoreManagers = sourceManagerRegistry.getAllManagers().filter((m): m is MeshCoreManager => isMeshCoreManager(m) && m.isConnected());
-    if ((searchScope === 'all' || searchScope === 'meshcore') && meshcoreManagers.length > 0) {
+    const allManagers = sourceManagerRegistry.getAllManagers();
+    const meshcoreManagers = allManagers.filter((m): m is MeshCoreManager => isMeshCoreManager(m) && m.isConnected());
+    // Ingest sources are resolved BEFORE the gate, and the gate counts both
+    // kinds. Nesting them inside a device-manager-only check meant an install
+    // with a region feed and no MeshCore radio got zero results — the exact
+    // silent-exclusion this phase exists to fix (#5040 Phase 5.5).
+    const ingestManagers = allManagers.filter(isMeshCoreMqttManager).filter(m => m.isConnected());
+    if (
+      (searchScope === 'all' || searchScope === 'meshcore') &&
+      (meshcoreManagers.length > 0 || ingestManagers.length > 0)
+    ) {
       const hasMeshcoreAccess = isAdmin || (accessibleChannels !== null && accessibleChannels.has(-1));
 
       if (hasMeshcoreAccess) {
@@ -234,10 +243,6 @@ router.get('/search', async (req: Request, res: Response) => {
         // Gathered separately rather than forcing one signature on both
         // (#5040 Phase 5.5): before this, a region feed's channel messages were
         // stored but never searchable.
-        const ingestManagers = sourceManagerRegistry
-          .getAllManagers()
-          .filter(isMeshCoreMqttManager)
-          .filter(m => m.isConnected());
         const ingestMessages = (
           await Promise.all(ingestManagers.map(m => m.getRecentMessagesAsync(1000)))
         ).flat();

--- a/src/server/routes/messageRoutes.ts
+++ b/src/server/routes/messageRoutes.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response } from 'express';
 import databaseService, { DbMessage } from '../../services/database.js';
 import { ALL_SOURCES } from '../../db/repositories/index.js';
-import { isMeshCoreManager, isMeshtasticManager, getPrimaryMeshtasticManager } from '../sourceManagerTypes.js';
+import { isMeshCoreManager, isMeshCoreMqttManager, isMeshtasticManager, getPrimaryMeshtasticManager } from '../sourceManagerTypes.js';
 import type { MeshCoreManager } from '../meshcoreManager.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
 import { logger } from '../../utils/logger.js';
@@ -228,7 +228,23 @@ router.get('/search', async (req: Request, res: Response) => {
       const hasMeshcoreAccess = isAdmin || (accessibleChannels !== null && accessibleChannels.has(-1));
 
       if (hasMeshcoreAccess) {
-        const allMeshcoreMessages = meshcoreManagers.flatMap(m => m.getRecentMessages(1000));
+        // Device-backed sources keep an in-memory ring and answer synchronously;
+        // an MQTT ingest source has no ring — its messages are already persisted
+        // by the Phase 4 ingest path, so it reads them back asynchronously.
+        // Gathered separately rather than forcing one signature on both
+        // (#5040 Phase 5.5): before this, a region feed's channel messages were
+        // stored but never searchable.
+        const ingestManagers = sourceManagerRegistry
+          .getAllManagers()
+          .filter(isMeshCoreMqttManager)
+          .filter(m => m.isConnected());
+        const ingestMessages = (
+          await Promise.all(ingestManagers.map(m => m.getRecentMessagesAsync(1000)))
+        ).flat();
+        const allMeshcoreMessages = [
+          ...meshcoreManagers.flatMap(m => m.getRecentMessages(1000)),
+          ...ingestMessages,
+        ];
         const filtered = allMeshcoreMessages.filter(m => {
           if (!m.text) return false;
           const textMatch = isCaseSensitive

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -13,7 +13,7 @@ import { optionalAuth } from '../auth/authMiddleware.js';
 import { logger } from '../../utils/logger.js';
 import { PortNum, CHANNEL_DB_OFFSET, modemPresetChannelName } from '../constants/meshtastic.js';
 import { filterPacketsByPermissions, getAllowedChannels } from './packetPermissions.js';
-import { isMeshCoreManager } from '../sourceManagerTypes.js';
+import { isAnyMeshCoreManager } from '../sourceManagerTypes.js';
 import {
   getUserReadableVirtualChannelIds,
   canReadVirtualChannel,
@@ -1262,7 +1262,9 @@ router.get('/status', async (req: Request, res: Response) => {
     let mcActiveNodeCount = 0;
     for (const id of meshcoreAllowedIds) {
       const _rawUni = sourceManagerRegistry.getManager(id);
-      const mcManager = _rawUni && isMeshCoreManager(_rawUni) ? _rawUni : null;
+      // isAnyMeshCoreManager (#5040 Phase 5.5): an ingest source's nodes are
+      // real nodes and must count toward the unified totals.
+      const mcManager = _rawUni && isAnyMeshCoreManager(_rawUni) ? _rawUni : null;
       if (mcManager) {
         const all = await mcManager.getAllNodes();
         mcNodeCount += all.length;

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -1269,6 +1269,10 @@ router.get('/status', async (req: Request, res: Response) => {
         const all = await mcManager.getAllNodes();
         mcNodeCount += all.length;
         const localHasLastHeard = mcManager.getLocalNode()?.lastHeard != null;
+        // The i===0 branch below only ever fires for a device-backed source:
+        // `getLocalNode()` is hardcoded null on an MQTT ingest manager (it is
+        // not a node on the mesh), so those sources fall through to the
+        // lastHeard check for every node, which is the correct reading.
         mcActiveNodeCount += all.filter((n: any, i: number) => {
           if (i === 0 && mcManager.getLocalNode() && !localHasLastHeard) return true;
           return typeof n.lastHeard === 'number' && n.lastHeard >= activeCutoffMs;

--- a/src/server/services/sourceDashboardData.meshcoreFavorite.test.ts
+++ b/src/server/services/sourceDashboardData.meshcoreFavorite.test.ts
@@ -23,6 +23,9 @@ vi.mock('../sourceManagerRegistry.js', () => ({
 
 vi.mock('../sourceManagerTypes.js', () => ({
   isMeshCoreManager: (m: unknown) => Boolean(m),
+  // buildSourceNodes narrows with the INCLUSIVE predicate since #5040 Phase
+  // 5.5, so an MQTT ingest source's advert-discovered nodes reach the map too.
+  isAnyMeshCoreManager: (m: unknown) => Boolean(m),
   isMeshtasticManager: () => false,
 }));
 

--- a/src/server/services/sourceDashboardData.ts
+++ b/src/server/services/sourceDashboardData.ts
@@ -22,7 +22,7 @@ import databaseService from '../../services/database.js';
 import { hasPermission } from '../auth/authMiddleware.js';
 import { logger } from '../../utils/logger.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
-import { isMeshCoreManager } from '../sourceManagerTypes.js';
+import { isAnyMeshCoreManager } from '../sourceManagerTypes.js';
 import {
   filterNodesByChannelPermission,
   maskNodeLocationByChannel,
@@ -58,7 +58,10 @@ export async function buildSourceNodes(source: SourceRow, user: ReqUser): Promis
     }
 
     const _raw = sourceManagerRegistry.getManager(source.id);
-    const mcManager = _raw && isMeshCoreManager(_raw) ? _raw : null;
+    // isAnyMeshCoreManager, not isMeshCoreManager (#5040 Phase 5.5): an MQTT
+    // ingest source discovers nodes from adverts and has positions for them.
+    // Narrowing device-only meant those never reached the map.
+    const mcManager = _raw && isAnyMeshCoreManager(_raw) ? _raw : null;
     const mcNodes: any[] = [];
     if (mcManager) {
       for (const n of await mcManager.getAllNodes()) {


### PR DESCRIPTION
Phase 5.5 of #5040 — the audit phase. It found **three user-visible bugs in already-merged work** rather than adding a feature.

| Surface | Bug |
|---|---|
| `sourceDashboardData.ts:61` | Phase 3's advert-discovered node positions **never reached the map** |
| `unifiedRoutes.ts:1265` | The unified card **under-counted nodes**, omitting every ingest source |
| `messageRoutes.ts:226` | Phase 4's channel messages were stored but **unsearchable** |

All three narrowed with `isMeshCoreManager()`, which excludes this source by construction. That's correct for anything driving a radio and wrong for anything reading data — and silent either way: nodes simply never appear.

## Why `isAnyMeshCoreManager()` had zero production callers

Not forgetfulness. **Switching the predicate alone would not have compiled.**

Narrowing to the union yields `MeshCoreManager | MeshCoreMqttManager`, and every read surface calls `getAllNodes()` / `getRecentMessages()` / `isConnected()` — none of which the MQTT manager implemented. So the path of least resistance at each site was to leave the narrowing device-only, and the predicate added back in Phase 1 sat unused through four more phases while the bugs accumulated behind it.

The fix is therefore **the manager's read half first, predicates second.**

That also resolves the concern raised in review on #5043 — that callers would accumulate `as MeshCoreManager` casts rather than a second guard. A cast is precisely what you reach for when the union doesn't satisfy the call. Now it does, and a test asserts the union compiles **without** one.

## Message search needed a different shape

Not a shared signature. The device manager answers synchronously from an in-memory ring; ingest messages are already persisted by the Phase 4 path, so those are gathered asynchronously and merged. Forcing one signature onto both would have meant either a fake ring here or an unnecessary async hop there.

## Mesh impact

**Zero airtime.** Read-path narrowing only. The TX-driving surfaces — the neighbours / remote-telemetry / room-sync / telemetry-poll / time-sync schedulers, the device and config routes — deliberately keep `isMeshCoreManager()` and are untouched.

## Testing

6 new tests on the manager's read half: source-scoped node and message reads, graceful degradation to empty when a DB read fails (one unreadable source must not take down a cross-source query), broker connectivity, the include/exclude predicate split, and the union compiling without a cast.

One existing mock updated — `sourceDashboardData.meshcoreFavorite.test.ts` enumerates the predicates its subject may use. Because it's a **full** mock, changing a narrowing surfaced as a missing-export error rather than passing silently; a partial mock would have hidden the change entirely.

- Full suite: **19,082 passed, 0 failed, 122 pending**, both PostgreSQL and MySQL containers up.
- Both typechecks and `lint:ci` clean.

## Remaining on the epic

Phase 6 (docs) only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc