### PR TITLE
fix(survey): request the survey under /api so it reaches the API router (#5078)

### DIFF
--- a/src/components/survey/NetworkSurveyPanel.test.tsx
+++ b/src/components/survey/NetworkSurveyPanel.test.tsx
@@ -88,6 +88,21 @@ describe('NetworkSurveyPanel', () => {
     expect(get).not.toHaveBeenCalled();
   });
 
+  /*
+   * #5078: the panel requested `/sources/:id/survey` with no `/api` prefix, so
+   * the path missed the API router, fell through to the SPA catch-all, and came
+   * back as index.html with a 200. Every source on every version failed with a
+   * generic "Could not build the survey" while the server was fine. Assert the
+   * prefix, not just that a request happened.
+   */
+  it('requests the survey under /api so it reaches the API router', async () => {
+    renderPanel(survey());
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    const url = get.mock.calls[0][0] as string;
+    expect(url.startsWith('/api/')).toBe(true);
+    expect(url).toBe('/api/sources/src-a/survey?hours=24');
+  });
+
   it('states plainly that viewing it transmits nothing', async () => {
     // A panel called "survey" that quietly used airtime would be a nasty
     // surprise, and the user has no other way to tell.
@@ -137,7 +152,7 @@ describe('NetworkSurveyPanel', () => {
 
     await user.selectOptions(screen.getByTestId('survey-window'), '6');
 
-    await waitFor(() => expect(get).toHaveBeenLastCalledWith('/sources/src-a/survey?hours=6'));
+    await waitFor(() => expect(get).toHaveBeenLastCalledWith('/api/sources/src-a/survey?hours=6'));
   });
 
   it('recovers via retry after a failure', async () => {

--- a/src/components/survey/NetworkSurveyPanel.tsx
+++ b/src/components/survey/NetworkSurveyPanel.tsx
@@ -60,7 +60,7 @@ export default function NetworkSurveyPanel({
     setFailed(false);
     try {
       const res = await apiService.get<{ success: boolean; data: NetworkSurvey }>(
-        `/sources/${sourceId}/survey?hours=${hours}`,
+        `/api/sources/${sourceId}/survey?hours=${hours}`,
       );
       setSurvey(res?.data ?? null);
     } catch {

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -1314,3 +1314,58 @@ describe('ApiService.sendAdminCommand — async operation following (#4482)', ()
       .rejects.toMatchObject({ code: 'OPERATION_NOT_FOUND' });
   });
 });
+
+/*
+ * #5078: a request path missing its `/api` prefix does not 404. It falls
+ * through to the static catch-all and returns the SPA shell with a 200, so
+ * `response.json()` dies on `<!DOCTYPE` and the caller sees an opaque parse
+ * error with no hint about the real mistake. One mis-prefixed call shipped for
+ * months behind a generic "Could not build the survey".
+ */
+describe('ApiService — SPA-fallback guard (#5078)', () => {
+  beforeEach(() => {
+    (apiService as any).baseUrl = '';
+    (apiService as any).configFetched = true;
+    (apiService as any).configPromise = null;
+    mockFetch.mockClear();
+  });
+
+  it('rejects an HTML body with a message naming the endpoint', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse('<!DOCTYPE html><div id="root"></div>', true, 'text/html; charset=utf-8'),
+    );
+    await expect(apiService.get('/sources/abc/survey?hours=24'))
+      .rejects.toThrow(/\/sources\/abc\/survey/);
+  });
+
+  it('explains that the /api prefix is the likely cause', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse('<!DOCTYPE html>', true, 'text/html'),
+    );
+    await expect(apiService.get('/oops')).rejects.toThrow(/\/api prefix/);
+  });
+
+  it('still accepts a normal JSON response', async () => {
+    mockFetch.mockResolvedValueOnce(createMockResponse({ ok: true }, true, 'application/json'));
+    await expect(apiService.get('/api/thing')).resolves.toEqual({ ok: true });
+  });
+
+  it('accepts a JSON response whose content-type carries parameters', async () => {
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({ ok: true }, true, 'application/json; charset=utf-8'),
+    );
+    await expect(apiService.get('/api/thing')).resolves.toEqual({ ok: true });
+  });
+
+  it('accepts JSON served as text/plain — only HTML is the failure signal', async () => {
+    mockFetch.mockResolvedValueOnce(createMockResponse({ ok: true }, true, 'text/plain;charset=UTF-8'));
+    await expect(apiService.get('/api/thing')).resolves.toEqual({ ok: true });
+  });
+
+  it('does not reject when the server sends no content-type at all', async () => {
+    // Absent header is not evidence of an HTML body; failing here would break
+    // any endpoint that omits it.
+    mockFetch.mockResolvedValueOnce(createMockResponse({ ok: true }, true, null as any));
+    await expect(apiService.get('/api/thing')).resolves.toEqual({ ok: true });
+  });
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -364,6 +364,28 @@ class ApiService {
       });
     }
 
+    /*
+     * Guard against the SPA fallback (#5078). A request whose path misses the
+     * `/api` prefix does not 404 — it falls through to the static catch-all and
+     * returns `index.html` with a 200. `response.json()` then fails on `<!DOCTYPE`,
+     * surfacing as an opaque parse error far from the mistyped URL. Checking the
+     * content-type turns that into a message naming the offending endpoint.
+     *
+     * Deliberately narrow: it rejects `text/html` specifically, not "anything
+     * that isn't JSON". An absent header, an absent `headers` object, or a
+     * handler that returns JSON as `text/plain` are all legitimate and must
+     * pass — only the SPA shell is the failure this catches.
+     */
+    const contentType = response.headers?.get?.('content-type') || '';
+    if (contentType.includes('text/html')) {
+      throw new ApiError(
+        `Expected JSON from ${endpoint} but received HTML ("${contentType}"). ` +
+        'This usually means the request path is missing its /api prefix and was ' +
+        'served the SPA shell instead of an API response.',
+        response.status,
+      );
+    }
+
     return response.json();
   }
 


### PR DESCRIPTION
Fixes #5078.

## The bug

`NetworkSurveyPanel.tsx` requested `/sources/${sourceId}/survey?hours=${hours}` — **no `/api` prefix**.

That path does not 404. It misses the API router (mounted at `/api/sources/:id/survey`), falls through to the static catch-all, and returns `index.html` with a **200**. The client then parses the SPA shell as JSON, throws, and the panel's bare `catch {}` renders the generic `survey.failed` — "Could not build the survey".

So the server, the route and the data were always fine. The panel had simply never requested the correct path, which is why it failed for **every source on every version**, not just rc3.

Confirmed by the reporter: "Edit and Resend" on the identical request with `/api/` added returns valid JSON.

## Sweep

All 109 literal-URL `apiService` calls were checked programmatically. This was the **only** mis-prefixed one.

## Hardening

`ApiService.request()` returned `response.json()` on any 2xx without checking the content type, so an HTML body surfaced as an opaque `<!DOCTYPE` parse error far from the mistyped URL. It now throws an `ApiError` naming the endpoint and the likely missing prefix.

Deliberately **narrow**: it rejects `text/html` specifically, not "anything that isn't JSON". JSON served as `text/plain` (what `new Response(JSON.stringify(...))` produces by default), an absent `content-type`, and a response object with no `headers` at all are all legitimate and still pass. An earlier, broader version of this guard broke 24 tests across 5 unrelated suites; the narrowed form is pinned by tests for each of those cases.

## Tests

- `NetworkSurveyPanel.test.tsx`: asserts the request goes to `/api/...`.
- `api.test.ts`: five cases covering the HTML rejection, the message naming the endpoint and the prefix, and the three shapes that must **not** be rejected.
- One pre-existing assertion was updated: it asserted the buggy URL (`toHaveBeenLastCalledWith('/sources/src-a/survey?hours=6')`), so it had pinned the defect rather than the contract and passed happily while the feature was completely broken.

With the source changes stashed, **4 assertions fail**; with them, all pass.

## Verification

Full suite run locally. Zero failures in the source tree; the only failures were in stale `.claude/worktrees/*` paths belonging to other sessions, which CI never sees. Both tsconfigs clean, `lint:ci` clean.

No screenshot: the panel renders its normal survey output once the request succeeds, and reproducing the failure state requires the pre-fix build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S6dVMHduNHsn6jNRXX25k
