### PR TITLE
fix(purge): scope traceroute purges, and guard the sibling that never did (#5088)

### DIFF
--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -37,6 +37,7 @@ import MapStyleManager from './MapStyleManager';
 import { useDashboardSources } from '../hooks/useDashboardData';
 import { DEFAULT_TERRARIUM_URL } from '../types/elevation';
 import { useSourceQuery } from '../hooks/useSourceQuery';
+import { useSource } from '../contexts/SourceContext';
 import {
   NODE_DISPLAY_SETTING_KEYS,
   NODE_DISPLAY_NUMERIC_DEFAULTS,
@@ -381,6 +382,10 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
   // #4412 Phase 3 WP4: scopes the Node Display GET/POST to the active source.
   // '' in mode="global" (GlobalSettingsPage renders outside a SourceProvider).
   const sourceQuery = useSourceQuery();
+  // Scope destructive purges to the source whose Danger Zone this is; null in
+  // global mode. `useSourceQuery()` returns a query string, so read the id
+  // directly rather than parsing it back out (#5088).
+  const { sourceId: purgeSourceId } = useSource();
 
   // Single draft reducer replacing the 49 `local*` mirrors (Task 5.3). Lazy-initialized once from
   // the current context/props values; category-C fields (no context/prop home) start at their
@@ -1378,7 +1383,7 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
     if (!confirmed) return;
 
     try {
-      await apiService.purgeTraceroutes();
+      await apiService.purgeTraceroutes(purgeSourceId);
       showToast(t('toast.traceroutes_purged'), 'success');
       setTimeout(() => window.location.reload(), 1500);
     } catch (error) {

--- a/src/db/repositories/traceroutes.test.ts
+++ b/src/db/repositories/traceroutes.test.ts
@@ -144,6 +144,54 @@ function runTraceroutesTests(getBackend: () => TestBackend) {
     repo = new TraceroutesRepository(backend.drizzleDb, backend.dbType);
   });
 
+  // ============ SOURCE-SCOPE GUARD (#5088) ============
+
+  /*
+   * `deleteAllTraceroutes` used to branch on `sourceId` truthiness and, when it
+   * was omitted, delete every row across every source without consulting the
+   * guard — while its sibling `deleteAllRouteSegments` threw. A caller that
+   * forgot the scope therefore wiped all traceroutes, THEN failed on the
+   * segments: an error toast on top of silent cross-source data loss, with
+   * orphaned route_segments left behind. Both must refuse the same way.
+   */
+  it('deleteAllTraceroutes refuses an omitted scope instead of wiping every source', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await expect((repo as unknown as { deleteAllTraceroutes: (s?: undefined) => Promise<number> })
+      .deleteAllTraceroutes(undefined)).rejects.toThrow(/sourceId is required/);
+  });
+
+  it('deleteAllRouteSegments refuses an omitted scope too', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await expect((repo as unknown as { deleteAllRouteSegments: (s?: undefined) => Promise<number> })
+      .deleteAllRouteSegments(undefined)).rejects.toThrow(/sourceId is required/);
+  });
+
+  it('deleteAllTraceroutes leaves other sources intact when scoped', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await repo.insertTraceroute(makeTraceroute(), 'src-a');
+    await repo.insertTraceroute(makeTraceroute(), 'src-b');
+
+    await repo.deleteAllTraceroutes('src-a');
+
+    const remaining = await repo.getAllTraceroutes(100, ALL_SOURCES);
+    expect(remaining.every(r => r.sourceId === 'src-b')).toBe(true);
+    expect(remaining.length).toBeGreaterThan(0);
+  });
+
+  it('deleteAllTraceroutes with ALL_SOURCES still clears everything', async () => {
+    const backend = getBackend();
+    if (!backend.available) return;
+    await repo.insertTraceroute(makeTraceroute(), 'src-a');
+    await repo.insertTraceroute(makeTraceroute(), 'src-b');
+
+    await repo.deleteAllTraceroutes(ALL_SOURCES);
+
+    expect(await repo.getAllTraceroutes(100, ALL_SOURCES)).toHaveLength(0);
+  });
+
   // ============ TRACEROUTES ============
 
   it('insertTraceroute / getAllTraceroutes - insert and retrieve traceroutes', async () => {

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -470,15 +470,23 @@ export class TraceroutesRepository extends BaseRepository {
   /**
    * Delete all traceroutes, optionally scoped to a single source.
    */
+  /*
+   * #5088: this used to branch on `sourceId` truthiness and, when omitted,
+   * delete every row across every source WITHOUT consulting `withSourceScope`.
+   * Its sibling `deleteAllRouteSegments` did consult the guard and threw. So a
+   * caller that forgot the scope wiped all traceroutes, then failed on the
+   * segments — the user saw an error while the data was already gone, leaving
+   * orphaned route_segments behind. Both now go through the same guard, so an
+   * omitted scope fails before deleting anything.
+   */
   async deleteAllTraceroutes(sourceId?: SourceScope): Promise<number> {
     const { traceroutes } = this.tables;
+    const scope = this.withSourceScope(traceroutes, sourceId);
     const countQuery = this.db.select({ count: count() }).from(traceroutes);
-    const result = await (sourceId
-      ? countQuery.where(eq(traceroutes.sourceId, sourceId))
-      : countQuery);
+    const result = await (scope ? countQuery.where(scope) : countQuery);
     const total = Number(result[0].count);
-    if (sourceId) {
-      await this.db.delete(traceroutes).where(eq(traceroutes.sourceId, sourceId));
+    if (scope) {
+      await this.db.delete(traceroutes).where(scope);
     } else {
       await this.db.delete(traceroutes);
     }

--- a/src/server/routes/purgeRoutes.test.ts
+++ b/src/server/routes/purgeRoutes.test.ts
@@ -4,6 +4,7 @@ import session from 'express-session';
 import request from 'supertest';
 import purgeRoutes from './purgeRoutes.js';
 import databaseService from '../../services/database.js';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 
 vi.mock('../../services/database.js', () => ({
   default: {
@@ -133,8 +134,43 @@ describe('Purge Routes', () => {
       const res = await request(app).post('/purge/traceroutes').send({});
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
-      expect(mockDb.traceroutes.deleteAllTraceroutes).toHaveBeenCalled();
-      expect(mockDb.traceroutes.deleteAllRouteSegments).toHaveBeenCalled();
+      // Asserting the ARGUMENT, not merely that it was called: the previous
+      // assertion was `toHaveBeenCalled()`, which passed while both calls
+      // omitted the scope and tripped the repository guard at runtime (#5088).
+      expect(mockDb.traceroutes.deleteAllTraceroutes).toHaveBeenCalledWith(ALL_SOURCES);
+      expect(mockDb.traceroutes.deleteAllRouteSegments).toHaveBeenCalledWith(ALL_SOURCES);
+    });
+
+    it('scopes the purge to the source when one is supplied', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      const app = createApp(adminUser.id);
+      const res = await request(app).post('/purge/traceroutes').send({ sourceId: 'src-b' });
+      expect(res.status).toBe(200);
+      expect(mockDb.traceroutes.deleteAllTraceroutes).toHaveBeenCalledWith('src-b');
+      expect(mockDb.traceroutes.deleteAllRouteSegments).toHaveBeenCalledWith('src-b');
+      expect(res.body.message).toContain('src-b');
+    });
+
+    it('never passes an omitted scope through to the repositories', async () => {
+      // The guard exists so a forgotten scope cannot silently span sources.
+      // The route must resolve it, not forward `undefined`.
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      const app = createApp(adminUser.id);
+      await request(app).post('/purge/traceroutes').send({});
+      for (const fn of [mockDb.traceroutes.deleteAllTraceroutes, mockDb.traceroutes.deleteAllRouteSegments]) {
+        expect(fn.mock.calls[0][0]).toBeDefined();
+      }
+    });
+
+    it('records the scope in the audit log', async () => {
+      mockDb.findUserByIdAsync.mockResolvedValue(adminUser);
+      mockDb.getUserPermissionSetAsync.mockResolvedValue({ resources: {}, isAdmin: true });
+      const app = createApp(adminUser.id);
+      await request(app).post('/purge/traceroutes').send({ sourceId: 'src-c' });
+      const detail = mockDb.auditLogAsync.mock.calls.at(-1)?.[3];
+      expect(JSON.parse(detail as string)).toEqual({ sourceId: 'src-c' });
     });
   });
 });

--- a/src/server/routes/purgeRoutes.ts
+++ b/src/server/routes/purgeRoutes.ts
@@ -86,18 +86,30 @@ router.post('/messages', async (req: Request, res: Response) => {
 
 router.post('/traceroutes', async (req: Request, res: Response) => {
   try {
-    await databaseService.traceroutes.deleteAllTraceroutes();
-    await databaseService.traceroutes.deleteAllRouteSegments();
+    // Mirrors /purge/nodes and /purge/telemetry: scope to the source whose
+    // Danger Zone was used, or ALL_SOURCES from the global one. Passing the
+    // scope explicitly is required — the repositories reject an omitted
+    // sourceId rather than silently spanning every source (#5088).
+    const { sourceId: purgeTraceroutesSourceId } = req.body || {};
+    const scope = purgeTraceroutesSourceId ?? ALL_SOURCES;
+
+    await databaseService.traceroutes.deleteAllTraceroutes(scope);
+    await databaseService.traceroutes.deleteAllRouteSegments(scope);
 
     void databaseService.auditLogAsync(
       req.user!.id,
       'traceroutes_purged',
       'traceroute',
-      'All traceroutes and route segments purged',
+      JSON.stringify({ sourceId: purgeTraceroutesSourceId ?? null }),
       req.ip || null
     );
 
-    res.json({ success: true, message: 'All traceroutes and route segments purged' });
+    res.json({
+      success: true,
+      message: purgeTraceroutesSourceId
+        ? `Traceroutes and route segments purged for source ${purgeTraceroutesSourceId}`
+        : 'All traceroutes and route segments purged',
+    });
   } catch (error) {
     logger.error('Error purging traceroutes:', error);
     res.status(500).json({ error: 'Failed to purge traceroutes' });

--- a/src/server/routes/tracerouteRoutes.participation.test.ts
+++ b/src/server/routes/tracerouteRoutes.participation.test.ts
@@ -6,6 +6,7 @@
  * NOT converted in this phase. See src/server/test-helpers/routeTestApp.ts.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ALL_SOURCES } from '../../db/repositories/index.js';
 import tracerouteRoutes from './tracerouteRoutes.js';
 import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
 import type { DbTraceroute } from '../../db/types.js';
@@ -46,7 +47,7 @@ describe('GET /api/traceroutes/participation/:nodeNum', () => {
     // permissions/sources, not data rows. Without this, traceroute rows
     // seeded by an earlier test (same fixed sourceA/sourceB ids) leak into a
     // later test's participation query for the same nodeNum.
-    await harness.db.traceroutes.deleteAllTraceroutes();
+    await harness.db.traceroutes.deleteAllTraceroutes(ALL_SOURCES);
     await harness.cleanup();
   });
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1337,12 +1337,14 @@ class ApiService {
     return response.json();
   }
 
-  async purgeTraceroutes() {
+  /** @param sourceId Scope the purge to one source; omit from the global Danger Zone. */
+  async purgeTraceroutes(sourceId?: string | null) {
     await this.ensureBaseUrl();
     const response = await fetch(`${this.baseUrl}/api/purge/traceroutes`, {
       method: 'POST',
       headers: this.getHeadersWithCsrf(),
       credentials: 'include',
+      body: JSON.stringify(sourceId ? { sourceId } : {}),
     });
 
     if (!response.ok) {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -3544,8 +3544,11 @@ class DatabaseService {
         await this.telemetryRepo.deleteAllTelemetry(sourceId);
       }
       if (this.traceroutesRepo) {
-        await this.traceroutesRepo.deleteAllTraceroutes(sourceId);
-        // undefined sourceId = admin global purge across every source — intentional cross-source
+        // undefined sourceId = admin global purge across every source — intentional cross-source.
+        // Both calls must resolve it: `deleteAllTraceroutes` used to accept a bare
+        // undefined and wipe every source without consulting the guard, so this line
+        // silently spanned sources while the one below it did not (#5088).
+        await this.traceroutesRepo.deleteAllTraceroutes(sourceId ?? ALL_SOURCES);
         await this.traceroutesRepo.deleteAllRouteSegments(sourceId ?? ALL_SOURCES);
       }
       if (this.neighborsRepo) {


### PR DESCRIPTION
Fixes #5088.

## The reported error, and the worse bug underneath it

`POST /purge/traceroutes` called both repository methods with no scope:

```ts
await databaseService.traceroutes.deleteAllTraceroutes();
await databaseService.traceroutes.deleteAllRouteSegments();   // <- threw
```

`deleteAllRouteSegments` runs through `withSourceScope`, which rejects an omitted `sourceId` as a deliberate data-leak guard. That produced the reported toast.

**`deleteAllTraceroutes` did not consult the guard at all.** It branched on `sourceId` truthiness and, when omitted, deleted every row across every source. So the real sequence was:

1. every source's traceroutes deleted,
2. *then* the guard threw on route segments,
3. the user saw "Error purging traceroutes" and reasonably concluded nothing had happened.

Their history was already gone, with orphaned `route_segments` left behind — and clicking again would repeat it.

## A second instance, exposed by the fix

Giving `deleteAllTraceroutes` the same guard immediately failed `purgeAllNodesAsync`, where these two lines sat adjacent:

```ts
await this.traceroutesRepo.deleteAllTraceroutes(sourceId);                 // undefined -> wiped everything
await this.traceroutesRepo.deleteAllRouteSegments(sourceId ?? ALL_SOURCES); // already correct
```

A **global** node purge had therefore been wiping traceroutes for every source with no error at all — the silent version of the same defect. Now both resolve the scope explicitly.

So there were two data-loss paths, not one:

| path | before this PR |
|---|---|
| Reset Traceroutes | wiped all sources, then errored — looked like a no-op |
| Purge Nodes (global) | wiped all sources' traceroutes silently |

## Changes

- **`traceroutes.ts`** — `deleteAllTraceroutes` uses `withSourceScope`, matching its sibling. An omitted scope now fails *before* deleting anything.
- **`purgeRoutes.ts`** — `/traceroutes` reads `{ sourceId }` and resolves `sourceId ?? ALL_SOURCES`, matching `/purge/nodes` and `/purge/telemetry`. Audit log and response message record the scope.
- **`database.ts`** — the `purgeAllNodesAsync` line above.
- **`api.ts` / `SettingsTab.tsx`** — `purgeTraceroutes(sourceId?)` sends the body; the Danger Zone passes its own source via `useSource()`, so a per-source card scopes to that source and the global one stays global.

## Why it shipped

The route test asserted `expect(...).toHaveBeenCalled()` — no arguments. It passed happily while both calls omitted the scope. It now asserts the scope argument, plus cases for the per-source path, the audit record, and that `undefined` is never forwarded to a repository.

## Verification

- New repository tests on **SQLite, PostgreSQL and MySQL**: both methods reject an omitted scope; a scoped delete leaves other sources intact; `ALL_SOURCES` still clears everything.
- With the source changes stashed, **10 assertions fail**; with them, all pass.
- Full suite: **19,179 passed, 0 failed**, with 502 PostgreSQL and 505 MySQL assertions confirmed executing (containers up, not silently skipped). Both tsconfigs clean, `lint:ci` clean.

## Note for operators

Traceroute history already destroyed by either path is not recoverable. This stops further loss; it cannot undo what has happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S6dVMHduNHsn6jNRXX25k
