### PR TITLE
feat(meshcore-mqtt): persist observer noise floor as telemetry (#5040)

### DIFF
--- a/docs/features/meshcore-mqtt-ingest.md
+++ b/docs/features/meshcore-mqtt-ingest.md
@@ -19,7 +19,7 @@ That is the whole point: your radio hears its own earshot, while a region feed c
 | Packet Monitor for the whole region | **Direct messages** — encrypted to their recipient, and you are not it |
 | Nodes discovered from adverts (name, role, position) | **Contacts, CLI, remote admin** — there is no device to ask |
 | Channel messages, where you hold the channel key | **Sending anything** — no radio |
-| Observer battery / uptime stats | |
+| Observer battery / uptime, and noise floor as telemetry | |
 
 The right-hand column is not a roadmap. Those are consequences of reading someone else's observations rather than operating a node, and no future phase removes them.
 
@@ -83,7 +83,13 @@ Two things adverts deliberately do **not** do:
 
 The `/status` topic carries the **publishing observer's own** battery, uptime and noise floor — not stats about nodes it overheard. Battery and uptime are stored against that observer's node row.
 
-Noise floor is decoded and shown on the source status panel but is **not stored**, since there is no column for it yet.
+Noise floor is stored as telemetry, under `mc_status_noise_floor` — the same series a device-backed MeshCore source writes, so an ingest observer graphs beside a device-backed one. It appears per observer on the **Telemetry** page.
+
+It is telemetry rather than a value on the node row because the useful question ("is this band getting more congested?") is about a trend, and a single latest reading cannot answer it. Samples are throttled to one per observer per minute — observers heartbeat every 5 minutes, so no real reading is dropped; the throttle only collapses the retained-status replay that arrives on every reconnect.
+
+::: tip Unit
+Stored as `dB` to match the existing series. Ambient RF noise is really dBm, but splitting one series across two units to correct a label would be the worse bug.
+:::
 
 A status heartbeat does **not** refresh `lastHeard`: it proves the observer can reach its broker, not that it is reachable over the air.
 

--- a/src/pages/UnifiedTelemetryPage.tsx
+++ b/src/pages/UnifiedTelemetryPage.tsx
@@ -60,6 +60,10 @@ const TYPE_LABELS: Record<string, string> = {
   numTxDropped: 'TX Drop',
   heapTotalBytes: 'Heap Total',
   heapFreeBytes: 'Heap Free',
+  // MeshCore. Other mc_* types still fall back to their raw key here; this one
+  // is labelled because an MQTT ingest source has no other telemetry surface —
+  // it has no local node, so the per-source Node Info page does not apply.
+  mc_status_noise_floor: 'Noise Floor',
   // Environment
   temperature: 'Temp',
   humidity: 'Humidity',

--- a/src/server/meshcoreMqttManager.status.test.ts
+++ b/src/server/meshcoreMqttManager.status.test.ts
@@ -6,14 +6,16 @@
  * the ones separating status from packet handling, since both ride the same
  * region topic prefix.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const upsertNode = vi.fn().mockResolvedValue(undefined);
+const insertTelemetryBatch = vi.fn().mockResolvedValue(1);
 
 vi.mock('../services/database.js', () => ({
   default: {
     meshcore: { upsertNode: (...a: unknown[]) => upsertNode(...a), insertMessage: vi.fn() },
     channels: { getAllChannels: vi.fn().mockResolvedValue([]) },
+    telemetry: { insertTelemetryBatch: (...a: unknown[]) => insertTelemetryBatch(...a) },
   },
 }));
 vi.mock('./services/dataEventEmitter.js', () => ({ dataEventEmitter: { emitMeshCoreMessage: vi.fn() } }));
@@ -59,7 +61,21 @@ async function started() {
 }
 const settle = () => new Promise(r => setTimeout(r, 0));
 
-beforeEach(() => { upsertNode.mockClear(); lastClient = null; });
+beforeEach(() => {
+  upsertNode.mockClear();
+  insertTelemetryBatch.mockClear();
+  nowMs = 1_700_000_000_000;
+  vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
+  lastClient = null;
+});
+afterEach(() => { vi.restoreAllMocks(); });
+
+/** Controls the manager's clock so the sample throttle is testable. */
+let nowMs = 1_700_000_000_000;
+
+/** The single row handed to insertTelemetryBatch on the Nth call. */
+const rowAt = (call: number) =>
+  (insertTelemetryBatch.mock.calls[call][0] as Array<Record<string, unknown>>)[0];
 
 describe('status ingest (#5040 Phase 5)', () => {
   it('subscribes to the status topic alongside packets', async () => {
@@ -209,5 +225,132 @@ describe('status ingest (#5040 Phase 5)', () => {
     lastClient!.deliver(statusTopic, { type: 'PACKET', origin_id: OBS, raw: '0500deadbeef' });
     await settle();
     expect(upsertNode).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Noise floor persistence (#5040 follow-up).
+ *
+ * Phase 5 decoded `noise_floor` and showed it live, but stored nothing, so a
+ * region feed could not answer "is this band getting more congested" — the one
+ * question the reading is for. It is written as `mc_status_noise_floor`, the
+ * series the remote-telemetry scheduler already writes for device-backed
+ * MeshCore sources, so both kinds of observer share one graph.
+ */
+describe('noise floor persistence (#5040 follow-up)', () => {
+  it('stores the reading as an mc_status_noise_floor telemetry sample', async () => {
+    await started();
+    lastClient!.deliver(statusTopic, online());
+    await settle();
+
+    expect(insertTelemetryBatch).toHaveBeenCalledTimes(1);
+    const [, sourceId] = insertTelemetryBatch.mock.calls[0];
+    expect(sourceId).toBe('src-mqtt');
+
+    const row = rowAt(0);
+    expect(row.telemetryType).toBe('mc_status_noise_floor');
+    expect(row.value).toBe(-95);
+    expect(row.nodeId).toBe(OBS);
+    // Same synthesised nodeNum every other MeshCore telemetry writer uses:
+    // low 32 bits of the pubkey, forced non-negative.
+    expect(row.nodeNum).toBe(0xaaaaaaaa & 0x7fffffff);
+  });
+
+  it('uses the same unit as the device-backed scheduler, so one series is not split', async () => {
+    await started();
+    lastClient!.deliver(statusTopic, online());
+    await settle();
+    expect(rowAt(0).unit).toBe('dB');
+  });
+
+  it('writes the node row before the sample, so the reading has a node to hang off', async () => {
+    await started();
+    lastClient!.deliver(statusTopic, online());
+    await settle();
+
+    expect(upsertNode).toHaveBeenCalled();
+    expect(insertTelemetryBatch).toHaveBeenCalled();
+    expect(upsertNode.mock.invocationCallOrder[0]).toBeLessThan(
+      insertTelemetryBatch.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('stores a reading from firmware that reports ONLY noise_floor', async () => {
+    // The Phase 5 guard returned early unless battery or uptime was present,
+    // which would have dropped this observer entirely — no node, no sample.
+    await started();
+    lastClient!.deliver(statusTopic, online({ stats: { noise_floor: -101 } }));
+    await settle();
+
+    expect(upsertNode).toHaveBeenCalledTimes(1);
+    expect(rowAt(0).value).toBe(-101);
+  });
+
+  it('drops a retained replay: a second heartbeat inside the throttle stores nothing', async () => {
+    // The broker replays each observer's retained /status on every reconnect,
+    // so a flapping socket would otherwise write a sample per reconnect.
+    await started();
+    lastClient!.deliver(statusTopic, online());
+    await settle();
+    nowMs += 5_000;
+    lastClient!.deliver(statusTopic, online({ stats: { noise_floor: -80 } }));
+    await settle();
+
+    expect(insertTelemetryBatch).toHaveBeenCalledTimes(1);
+    expect(rowAt(0).value).toBe(-95);
+  });
+
+  it('stores the next real heartbeat, which is well past the throttle', async () => {
+    await started();
+    lastClient!.deliver(statusTopic, online());
+    await settle();
+    // Observers heartbeat every 5 minutes; the throttle is 60s, so a genuine
+    // heartbeat is never the thing being dropped.
+    nowMs += 300_000;
+    lastClient!.deliver(statusTopic, online({ stats: { noise_floor: -88 } }));
+    await settle();
+
+    expect(insertTelemetryBatch).toHaveBeenCalledTimes(2);
+    expect(rowAt(1).value).toBe(-88);
+    expect(rowAt(1).timestamp).toBe(nowMs);
+  });
+
+  it('throttles per observer, not globally', async () => {
+    const other = 'BB'.repeat(32);
+    await started();
+    lastClient!.deliver(statusTopic, online());
+    await settle();
+    lastClient!.deliver(`meshcore/MCO/${other}/status`, online({ origin_id: other }));
+    await settle();
+
+    expect(insertTelemetryBatch).toHaveBeenCalledTimes(2);
+    expect(rowAt(1).nodeId).toBe(other);
+  });
+
+  it('stores nothing when the observer reports no noise floor', async () => {
+    await started();
+    lastClient!.deliver(statusTopic, online({ stats: { battery_mv: 4100 } }));
+    await settle();
+
+    expect(upsertNode).toHaveBeenCalledTimes(1);
+    expect(insertTelemetryBatch).not.toHaveBeenCalled();
+  });
+
+  it('stores nothing from an offline notice', async () => {
+    await started();
+    lastClient!.deliver(statusTopic, online({ status: 'offline' }));
+    await settle();
+    expect(insertTelemetryBatch).not.toHaveBeenCalled();
+  });
+
+  it('keeps ingesting when the telemetry write fails', async () => {
+    // A lost sample must never cost us the packet ingest on this connection.
+    insertTelemetryBatch.mockRejectedValueOnce(new Error('db down'));
+    const mgr = await started();
+    lastClient!.deliver(statusTopic, online());
+    await settle();
+
+    expect(upsertNode).toHaveBeenCalledTimes(1);
+    expect(mgr.getStatus().connected).toBe(true);
   });
 });

--- a/src/server/meshcoreMqttManager.ts
+++ b/src/server/meshcoreMqttManager.ts
@@ -51,6 +51,7 @@ import {
   type IngestedObserverPacket,
 } from './services/meshcoreMqttIngestPacket.js';
 import meshcorePacketLogService from './services/meshcorePacketLogService.js';
+import { MC_TELEMETRY_PREFIX, nodeNumFromPubkey } from './services/meshcoreTelemetryPoller.js';
 import databaseService from '../services/database.js';
 import { decodeMeshCorePacket } from '../utils/meshcorePacketDecode.js';
 import type { MeshCoreNode, MeshCoreMessage } from './meshcoreManager.js';
@@ -211,6 +212,17 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
    * so an unconditional `set()` would grow with region size forever.
    */
   private readonly seenObserverStatus = new Map<string, ObserverStatusSnapshot>();
+  /**
+   * Floor on the gap between two stored noise-floor samples for one observer.
+   *
+   * Observers heartbeat every `STATUS_REFRESH_MS` (5 minutes), so this never
+   * drops a genuine reading. It exists for the RETAINED-message path: the
+   * broker replays each observer's retained `/status` on every reconnect, so a
+   * flapping socket would otherwise write one sample per observer per
+   * reconnect. This codebase has already shipped one self-sustaining MQTT
+   * reconnect storm, so that is a real shape, not a hypothetical.
+   */
+  private static readonly MIN_NOISE_SAMPLE_MS = 60_000;
 
   constructor(sourceId: string, sourceName: string, config: MeshCoreMqttSourceConfig) {
     super();
@@ -587,11 +599,16 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
    * point as an advert, which means the observer shows up as a node on this
    * source whether or not it has also advertised.
    *
-   * Only battery and uptime are persisted. `noise_floor` decodes and is
-   * deliberately NOT stored: `meshcore_nodes` has no column for it, and adding
-   * one that nothing displays would be a dead column plus a migration. It is a
-   * genuinely useful signal for a region feed — it says how congested the band
-   * is — so it belongs with a display surface, not ahead of one.
+   * Battery and uptime are stored on the node row (current value). Noise floor
+   * is stored as a `mc_status_noise_floor` TELEMETRY row instead — the series
+   * the remote-telemetry scheduler already writes for device-backed MeshCore
+   * sources, which `TelemetryChart` already labels and `telemetryCategory`
+   * already files under `signal`. So this needs no column, no migration and no
+   * new UI, and an ingest observer graphs beside a device-backed one.
+   *
+   * Noise floor wants history rather than a current value: "how congested is
+   * this band" is a question about a trend, and a single latest reading cannot
+   * answer it. That is the same reason it is telemetry and not a node column.
    *
    * `lastHeard` is NOT touched here. A status heartbeat proves the observer is
    * talking to its BROKER, not that it is reachable on the mesh; stamping it
@@ -603,6 +620,12 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
       if (!status) return;
 
       this.stats.statusMessages++;
+
+      // Read the prior snapshot BEFORE the delete/set below overwrites it. Its
+      // `at` is what the noise-floor throttle measures against; once the new
+      // snapshot is stored the gap always reads as zero.
+      const previous = this.seenObserverStatus.get(status.originId);
+      const now = Date.now();
 
       // Enforce the cap the field comment claims. A heartbeat arrives per
       // observer per interval, and observers that go away never come back to
@@ -623,16 +646,24 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
       this.seenObserverStatus.delete(status.originId);
       this.seenObserverStatus.set(status.originId, {
         online: status.online,
-        at: Date.now(),
+        at: now,
         batteryMv: status.batteryMv,
         uptimeSecs: status.uptimeSecs,
         noiseFloor: status.noiseFloor,
       });
 
       // Nothing worth persisting on an offline notice, or from firmware that
-      // reports no stats at all.
+      // reports no stats at all. Noise floor counts as a stat: firmware that
+      // reports ONLY noise_floor still gets a node row, or its telemetry would
+      // reference a node that does not exist and show up nowhere.
       if (!status.online) return;
-      if (status.batteryMv === undefined && status.uptimeSecs === undefined) return;
+      if (
+        status.batteryMv === undefined &&
+        status.uptimeSecs === undefined &&
+        status.noiseFloor === undefined
+      ) {
+        return;
+      }
 
       await databaseService.meshcore.upsertNode(
         {
@@ -643,8 +674,62 @@ export class MeshCoreMqttManager extends EventEmitter implements ISourceManager 
         },
         this.sourceId,
       );
+
+      // Node row first, telemetry second: the sample is only reachable in the
+      // UI through its node.
+      await this.recordNoiseFloor(status.originId, status.noiseFloor, previous, now);
     } catch (err) {
       logger.debug(`[MeshCoreMqtt:${this.sourceId}] failed to handle status:`, err);
+    }
+  }
+
+  /**
+   * Store one observer's noise floor as a telemetry sample.
+   *
+   * Written as `mc_status_noise_floor` — the SAME series the remote-telemetry
+   * scheduler writes for device-backed MeshCore sources, so an ingest observer
+   * and a device-backed one land on one graph with one label and one unit.
+   *
+   * The unit is `dB`, matching that scheduler's `STATUS_FIELD_MAP`. Ambient RF
+   * noise is really dBm, and the Meshtastic-side `noiseFloor` key does say
+   * dBm — but splitting one series across two units to fix a label would be a
+   * worse bug than the label. Left as-is deliberately.
+   *
+   * A failure here is logged and swallowed: a lost telemetry sample must never
+   * cost us the packet ingest that shares this connection.
+   */
+  private async recordNoiseFloor(
+    originId: string,
+    noiseFloor: number | undefined,
+    previous: ObserverStatusSnapshot | undefined,
+    now: number,
+  ): Promise<void> {
+    if (noiseFloor === undefined || !Number.isFinite(noiseFloor)) return;
+    if (previous && now - previous.at < MeshCoreMqttManager.MIN_NOISE_SAMPLE_MS) return;
+
+    try {
+      await databaseService.telemetry.insertTelemetryBatch(
+        [
+          {
+            nodeId: originId,
+            // MeshCore has no Meshtastic nodeNum; synthesised from the pubkey
+            // exactly as every other MeshCore telemetry writer does, so the
+            // same observer gets the same number on every path.
+            nodeNum: nodeNumFromPubkey(originId),
+            telemetryType: `${MC_TELEMETRY_PREFIX}status_noise_floor`,
+            value: noiseFloor,
+            unit: 'dB',
+            timestamp: now,
+            createdAt: now,
+          },
+        ],
+        this.sourceId,
+      );
+    } catch (err) {
+      logger.debug(
+        `[MeshCoreMqtt:${this.sourceId}] failed to store noise floor for ${originId}:`,
+        err,
+      );
     }
   }
 


### PR DESCRIPTION
Follow-up to #5040. Replaces #5087, which GitHub auto-closed when its base branch (the Phase 6 docs branch) was deleted on merge — same commit, now rebased onto `main`. CI was green on it before the close.

Phase 5 decoded `noise_floor` from an observer's `/status` heartbeat and displayed it live, but stored nothing. A region feed therefore couldn't answer the question the reading exists for: *is this band getting more congested?*

## Stored as telemetry, not a column

`mc_status_noise_floor` already exists — the remote-telemetry scheduler writes it for device-backed MeshCore sources, `TelemetryChart` labels it, `telemetryCategory` files it under `signal`. Reusing that series means **no migration, no new column, no new chart component**, and an ingest observer graphs beside a device-backed one.

Telemetry rather than a value on the node row because the useful question is about a *trend*. A single latest reading can't answer it — the same reason it isn't a column.

## Three things checked before writing code

| Question | Answer |
|---|---|
| Does this fan out to automations/notifications? | **No.** `emitTelemetry` has zero callers; telemetry writes fire no events. Storage question, not a spam one. |
| Is the volume bounded? | **Yes.** Telemetry already has a 30-day retention sweep. No new knob. |
| Can anyone actually *see* the samples? | **Yes, but not where I first assumed.** |

That last one decided the design. `MeshCoreInfoView` renders from a hardcoded list with no `mc_status_*` entries, so that surface would have shown nothing. `UnifiedTelemetryPage` builds its type list dynamically from stored rows, so the series appears there per source and node. Storing data nobody can see is exactly what the original "dead column" comment objected to, so I verified the display surface rather than assuming one.

## Throttle: one sample per observer per minute

Observers heartbeat every 5 minutes (`STATUS_REFRESH_MS`), so **no genuine reading is dropped**. The throttle exists for the retained-message path: the broker replays each observer's retained `/status` on *every* reconnect, so a flapping socket would write one sample per observer per reconnect. This codebase has already shipped a self-sustaining MQTT reconnect storm, so that flood shape is history, not hypothesis.

Volume: ~288 samples per observer per day; ~7k/day for a 25-observer region.

## Latent Phase 5 bug fixed

The guard returned early unless battery **or** uptime was present, so firmware reporting only `noise_floor` was dropped entirely — no node row, no sample. The guard now includes noise floor, and the node row is written *before* the telemetry so the reading has a node to hang off.

## Deliberately unchanged

- **Unit stays `dB`**, matching the existing series. Noise floor is really dBm, but splitting one series across two units to correct a label is the worse bug. Flagged in the docs.
- **The other fifteen `mc_status_*` types** still render as raw keys on the Telemetry page. Pre-existing; widening that was beyond the ask.

## Mesh impact

**None.** No packets, no timers, no events. Read-only ingest, as the source itself is.

## Testing

10 new tests, **mutation-tested rather than trusted green**:

- Disabling the throttle → only the retained-replay test fails.
- Restoring the old early-return guard → exactly the two tests covering it fail.

Full suite: **19,154 passed, 0 failed, 0 failed suites**, with the PostgreSQL and MySQL containers up (109 pending vs 243 without them, confirming both backends ran). `tsc` and `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc