### PR TITLE
fix(admin): stamp the security load gate from the per-section load too (#5077)

### DIFF
--- a/src/components/AdminCommandsTab.tsx
+++ b/src/components/AdminCommandsTab.tsx
@@ -17,7 +17,7 @@ import { getHardwareModelName, getRoleName } from '../utils/nodeHelpers';
 import { DeviceConfigurationSection } from './admin-commands/DeviceConfigurationSection';
 import AutoFavoriteManagementSection from './admin-commands/AutoFavoriteManagementSection';
 import { ModuleConfigurationSection } from './admin-commands/ModuleConfigurationSection';
-import { useAdminCommandsState, buildMeshBeaconConfigPayload, parseMeshBeaconConfig } from './admin-commands/useAdminCommandsState';
+import { useAdminCommandsState, buildMeshBeaconConfigPayload, parseMeshBeaconConfig, buildSecurityConfigUpdates } from './admin-commands/useAdminCommandsState';
 import {
   DEFAULT_PUBLIC_PSK,
   PUBLIC_CHANNEL_PRECISION_MAX_BITS,
@@ -589,25 +589,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
       await new Promise(resolve => setTimeout(resolve, 200));
 
       await loadConfig('security', 5, (result) => {
-        const config = result.config;
-        if (config.adminKeys !== undefined) {
-          const keys = config.adminKeys.length === 0 ? [''] : (config.adminKeys.length < 3 ? [...config.adminKeys, ''] : config.adminKeys.slice(0, 3));
-          setSecurityConfig({ adminKeys: keys });
-        }
-        const securityUpdates: any = {};
-        if (config.isManaged !== undefined) securityUpdates.isManaged = config.isManaged;
-        if (config.serialEnabled !== undefined) securityUpdates.serialEnabled = config.serialEnabled;
-        if (config.debugLogApiEnabled !== undefined) securityUpdates.debugLogApiEnabled = config.debugLogApiEnabled;
-        if (config.adminChannelEnabled !== undefined) securityUpdates.adminChannelEnabled = config.adminChannelEnabled;
-
-        // #4736: stamp WHICH node these values came from. Save is gated on this
-        // matching the current selection, so the admin keys and flags being
-        // written are always the ones the user actually saw for that node.
-        securityUpdates.loadedForNodeNum = selectedNodeNum;
-
-        if (Object.keys(securityUpdates).length > 0) {
-          setSecurityConfig(securityUpdates);
-        }
+        applyLoadedSecurityConfig(result.config, selectedNodeNum);
       });
       await new Promise(resolve => setTimeout(resolve, 200));
 
@@ -977,6 +959,20 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
   };
 
   // Individual section load handlers
+  /*
+   * #5077: the security payload is applied from two places — the "load all"
+   * sequence and the per-section Load button. They were near-identical copies,
+   * and the #4736 `loadedForNodeNum` stamp was added to the first one only. The
+   * per-section load therefore populated the fields but left the Save gate
+   * closed forever, so a remote node's security config could be edited and
+   * never saved. One applier, so the two paths cannot drift again.
+   */
+  const applyLoadedSecurityConfig = useCallback((config: any, forNodeNum: number | null) => {
+    const { adminKeys, updates } = buildSecurityConfigUpdates(config, forNodeNum);
+    if (adminKeys) setSecurityConfig({ adminKeys });
+    setSecurityConfig(updates);
+  }, [setSecurityConfig]);
+
   const handleLoadSingleConfig = async (configType: string) => {
     if (selectedNodeNum === null) {
       showToast(t('admin_commands.please_select_node'), 'error');
@@ -1149,18 +1145,7 @@ const AdminCommandsTab: React.FC<AdminCommandsTabProps> = ({ nodes, currentNodeI
                 });
                 break;
               case 'security':
-                if (config.adminKeys !== undefined) {
-                  const keys = config.adminKeys.length === 0 ? [''] : (config.adminKeys.length < 3 ? [...config.adminKeys, ''] : config.adminKeys.slice(0, 3));
-                  setSecurityConfig({ adminKeys: keys });
-                }
-                const securityUpdates: Record<string, unknown> = {};
-                if (config.isManaged !== undefined) securityUpdates.isManaged = config.isManaged;
-                if (config.serialEnabled !== undefined) securityUpdates.serialEnabled = config.serialEnabled;
-                if (config.debugLogApiEnabled !== undefined) securityUpdates.debugLogApiEnabled = config.debugLogApiEnabled;
-                if (config.adminChannelEnabled !== undefined) securityUpdates.adminChannelEnabled = config.adminChannelEnabled;
-                if (Object.keys(securityUpdates).length > 0) {
-                  setSecurityConfig(securityUpdates);
-                }
+                applyLoadedSecurityConfig(config, selectedNodeNum);
                 break;
               case 'bluetooth':
                 setBluetoothConfig({

--- a/src/components/admin-commands/securityConfigUpdates.test.ts
+++ b/src/components/admin-commands/securityConfigUpdates.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Security-config load gate (#5077, extends #4736).
+ *
+ * The Save Security Config button is gated on `loadedForNodeNum` matching the
+ * selected node. The payload used to be applied from two near-identical inline
+ * copies — the "load all" sequence and the per-section Load button — and only
+ * the first stamped the gate. A per-section load therefore showed the node's
+ * security config and left Save disabled forever.
+ *
+ * These pin the property that actually matters: the stamp does not depend on
+ * how many fields the device sent.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildSecurityConfigUpdates } from './useAdminCommandsState';
+
+describe('buildSecurityConfigUpdates (#5077)', () => {
+  it('stamps loadedForNodeNum so the Save gate opens', () => {
+    const { updates } = buildSecurityConfigUpdates({ isManaged: true }, 42);
+    expect(updates.loadedForNodeNum).toBe(42);
+  });
+
+  it('stamps it even when the device reported no recognised fields', () => {
+    // The regression: an empty payload previously produced no stamp, so Save
+    // stayed disabled. The gate records which node the values came from — a
+    // fact about the load, not about the field count.
+    const { updates } = buildSecurityConfigUpdates({}, 42);
+    expect(updates.loadedForNodeNum).toBe(42);
+  });
+
+  it('stamps it when every flag is false — falsy is not absent', () => {
+    const { updates } = buildSecurityConfigUpdates(
+      { isManaged: false, serialEnabled: false, debugLogApiEnabled: false, adminChannelEnabled: false },
+      7,
+    );
+    expect(updates).toMatchObject({
+      isManaged: false,
+      serialEnabled: false,
+      debugLogApiEnabled: false,
+      adminChannelEnabled: false,
+      loadedForNodeNum: 7,
+    });
+  });
+
+  it('carries a null node through rather than dropping the key', () => {
+    const { updates } = buildSecurityConfigUpdates({ isManaged: true }, null);
+    expect('loadedForNodeNum' in updates).toBe(true);
+    expect(updates.loadedForNodeNum).toBeNull();
+  });
+
+  it('omits flags the device did not send, so they keep their current value', () => {
+    const { updates } = buildSecurityConfigUpdates({ isManaged: true }, 1);
+    expect('serialEnabled' in updates).toBe(false);
+    expect('adminChannelEnabled' in updates).toBe(false);
+  });
+
+  it('pads an empty admin-key list to one blank input', () => {
+    const { adminKeys } = buildSecurityConfigUpdates({ adminKeys: [] }, 1);
+    expect(adminKeys).toEqual(['']);
+  });
+
+  it('pads a short admin-key list with a blank slot', () => {
+    const { adminKeys } = buildSecurityConfigUpdates({ adminKeys: ['a', 'b'] }, 1);
+    expect(adminKeys).toEqual(['a', 'b', '']);
+  });
+
+  it('caps admin keys at the firmware maximum of three', () => {
+    const { adminKeys } = buildSecurityConfigUpdates({ adminKeys: ['a', 'b', 'c', 'd'] }, 1);
+    expect(adminKeys).toEqual(['a', 'b', 'c']);
+  });
+
+  it('leaves adminKeys undefined when the device sent none', () => {
+    const { adminKeys } = buildSecurityConfigUpdates({ isManaged: true }, 1);
+    expect(adminKeys).toBeUndefined();
+  });
+});

--- a/src/components/admin-commands/useAdminCommandsState.ts
+++ b/src/components/admin-commands/useAdminCommandsState.ts
@@ -721,6 +721,44 @@ function adminCommandsReducer(state: AdminCommandsState, action: AdminCommandsAc
  * Hook to manage admin commands state with useReducer
  * Consolidates 50+ useState calls into organized state management
  */
+/**
+ * Build the security-config state updates from a loaded remote config.
+ *
+ * Extracted in #5077. The payload was applied from two places — the "load all"
+ * sequence and the per-section Load button — as near-identical inline copies.
+ * The #4736 `loadedForNodeNum` stamp was added to the first only, so a
+ * per-section security load populated the fields while leaving the Save gate
+ * closed: the config could be edited and never saved to the node.
+ *
+ * `loadedForNodeNum` is ALWAYS stamped, including when the device reported no
+ * recognised fields. The gate answers "which node did the values on screen come
+ * from", which is a fact about the load, not about how many fields it carried.
+ *
+ * @param config    Decoded security config from the admin response.
+ * @param forNodeNum The node the values were loaded from; stamped onto the gate.
+ * @returns `adminKeys` when present (applied separately), and the flag updates.
+ */
+export function buildSecurityConfigUpdates(
+  config: Record<string, unknown>,
+  forNodeNum: number | null,
+): { adminKeys?: string[]; updates: Record<string, unknown> } {
+  const result: { adminKeys?: string[]; updates: Record<string, unknown> } = { updates: {} };
+
+  if (Array.isArray(config.adminKeys)) {
+    const keys = config.adminKeys as string[];
+    result.adminKeys = keys.length === 0
+      ? ['']
+      : (keys.length < 3 ? [...keys, ''] : keys.slice(0, 3));
+  }
+
+  for (const field of ['isManaged', 'serialEnabled', 'debugLogApiEnabled', 'adminChannelEnabled'] as const) {
+    if (config[field] !== undefined) result.updates[field] = config[field];
+  }
+
+  result.updates.loadedForNodeNum = forNodeNum;
+  return result;
+}
+
 export function useAdminCommandsState() {
   const [state, dispatch] = useReducer(adminCommandsReducer, initialState);
 


### PR DESCRIPTION
Fixes #5077.

## Root cause — not what the issue suspected

The issue suspected the stamp was being swallowed by

```ts
if (Object.keys(securityUpdates).length > 0) { setSecurityConfig(securityUpdates); }
```

It was not. In the "load all" sequence the stamp is assigned **before** that check, so the object always has at least one key and the guard always passes. That path worked correctly.

**There are two security-load paths, and only one was ever fixed.** `handleLoadSingleConfig`'s `case 'security'` — the per-section **Load** button — is a near-identical copy of the load-all block that **never assigned `loadedForNodeNum` at all**. #4736 added the stamp to the first copy only.

So loading Security via the per-section button populated every field on screen and left the Save gate closed permanently: exactly the reported "loads successfully, Save never enables".

## Fix

Rather than paste the missing line into the second copy, the payload logic moves into a pure `buildSecurityConfigUpdates()` in `useAdminCommandsState.ts`, beside the existing `buildMeshBeaconConfigPayload`, and both paths call it.

Two near-identical copies drifting apart is the actual defect here — one applier makes that impossible, and it gives the behaviour a unit-testable seam that the 3,000-line component did not have.

`loadedForNodeNum` is now **always** stamped, including for a payload carrying no recognised fields. The gate answers "which node did the values on screen come from" — a fact about the load, not about how many fields it happened to contain.

## Tests

New `securityConfigUpdates.test.ts` (9 cases) pins the properties that matter rather than the shape of the code:

- the stamp is present when fields are returned, when **none** are, and when every flag is `false` (falsy is not absent);
- a `null` node keeps the key rather than dropping it;
- flags the device did not send are omitted, so they retain their current value;
- admin-key padding/capping to the firmware maximum of three.

**On regression evidence:** I cannot offer a stash-and-rerun failure for this one, and would rather say so than imply otherwise. The builder did not previously exist, and the old per-section block contained no `loadedForNodeNum` assignment anywhere — the proof is the removed code in the diff, not a red test.

## Verification

Full suite: **19,198 passed, 0 failed, 0 failing suites**, with 502 PostgreSQL and 505 MySQL assertions confirmed executing. Frontend tsconfig clean, `lint:ci` clean.

No screenshot: the visible change is a button's enabled state, which needs a live remote-admin node over the mesh to reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S6dVMHduNHsn6jNRXX25k
