### PR TITLE
fix(meshcore-mqtt): route ingest sources through every MeshCore read path (#5094)

### DIFF
--- a/src/components/Dashboard/DashboardSidebar.tsx
+++ b/src/components/Dashboard/DashboardSidebar.tsx
@@ -28,6 +28,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { UiIcon } from '../icons';
 import SidebarFooter from '../SidebarFooter';
 import styles from './DashboardSidebar.module.css';
+import { isAnyMeshCoreSourceType } from '../../utils/nodeTypeCategory';
 
 // Narrow, LOCAL slices of `source.config` / the status poll for the compact
 // Analyzer Observer badge (#5014 Phase 2 WP3 §4.9) — not imports of a
@@ -585,7 +586,7 @@ const DashboardSidebar: React.FC<DashboardSidebarProps> = ({
         // without a watermark.
         const isMeshtastic =
           source.type === 'meshtastic_tcp' || source.type === 'meshtastic_mqtt';
-        const isMeshCore = source.type === 'meshcore';
+        const isMeshCore = isAnyMeshCoreSourceType(source.type);
         const isMqttBroker = source.type === 'mqtt_broker';
         const isMqttBridge = source.type === 'mqtt_bridge';
         // Reticulum (#3960 Phase 1b): no brand-asset watermark ships yet

--- a/src/components/UsersTab.tsx
+++ b/src/components/UsersTab.tsx
@@ -14,6 +14,7 @@ import { logger } from '../utils/logger';
 import type { PermissionSet, ResourceType } from '../types/permission';
 import { RESOURCES, SOURCEY_RESOURCES } from '../types/permission';
 import { useToast } from './ToastContainer';
+import { isAnyMeshCoreSourceType } from '../utils/nodeTypeCategory';
 
 interface Source {
   id: string;
@@ -993,7 +994,12 @@ const UsersTab: React.FC = () => {
                 // the extra checkbox when it does something — on a Meshtastic
                 // source, `nodes:viewOnMap` isn't checked anywhere.
                 const scopedSourceForNodes = sources.find(s => s.id === permissionScope);
-                const showNodesViewOnMap = resource === 'nodes' && scopedSourceForNodes?.type === 'meshcore';
+                // Any MeshCore source, ingest included (#5094): buildSourceNodes
+                // gates ingest nodes on nodes:viewOnMap exactly as it does
+                // device-backed ones, so hiding the checkbox made the permission
+                // ungrantable and the map silently empty.
+                const showNodesViewOnMap =
+                  resource === 'nodes' && isAnyMeshCoreSourceType(scopedSourceForNodes?.type);
 
                 return (
                   <div key={resource} className="permission-item">

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -13,6 +13,7 @@ import { getDiscardInvalidPositions } from '../utils/positionDisplayConfig';
 import { getNodeTransportClasses, type NodeTransportClass } from '../utils/nodeTransport';
 import { unifiedNodeKey } from '../utils/nodeIdentity';
 import type { SourceRadioSummary } from '../types/elevation';
+import { isAnyMeshCoreSourceType } from '../utils/nodeTypeCategory';
 
 /**
  * A data source configured in MeshMonitor
@@ -556,7 +557,7 @@ export function useDashboardUnifiedData(
     return {
       sourceId: 'name' in s ? s.id : undefined,
       sourceName: 'name' in s ? s.name : undefined,
-      protocol: 'type' in s ? (s.type === 'meshcore' ? 'MeshCore' : 'Meshtastic') : undefined,
+      protocol: 'type' in s ? (isAnyMeshCoreSourceType(s.type) ? 'MeshCore' : 'Meshtastic') : undefined,
       nodes: b?.nodes ?? [],
       traceroutes: b?.traceroutes ?? [],
       neighborInfo: b?.neighborInfo ?? [],

--- a/src/pages/UnifiedMessagesPage.tsx
+++ b/src/pages/UnifiedMessagesPage.tsx
@@ -36,6 +36,7 @@ import '../styles/unified.css';
 import { UiIcon } from '../components/icons';
 import { resolveReplyPreview } from '../utils/replyPreview';
 import { getSourceColor } from '../utils/sourceColors';
+import { isAnyMeshCoreSourceType } from '../utils/nodeTypeCategory';
 
 type TFn = (key: string, options?: Record<string, unknown>) => string;
 
@@ -567,7 +568,7 @@ export default function UnifiedMessagesPage() {
                       title={t('unified.messages.heard_by_source', { name: r.sourceName })}
                     >
                       {r.sourceName}
-                      {r.sourceType === 'meshcore' && (
+                      {isAnyMeshCoreSourceType(r.sourceType) && (
                         <span className="unified-msg-card__proto-badge">
                           {t('unified.messages.meshcore_badge', 'MeshCore')}
                         </span>

--- a/src/server/routes/unifiedRoutes.ts
+++ b/src/server/routes/unifiedRoutes.ts
@@ -14,6 +14,7 @@ import { logger } from '../../utils/logger.js';
 import { PortNum, CHANNEL_DB_OFFSET, modemPresetChannelName } from '../constants/meshtastic.js';
 import { filterPacketsByPermissions, getAllowedChannels } from './packetPermissions.js';
 import { isAnyMeshCoreManager } from '../sourceManagerTypes.js';
+import { isAnyMeshCoreSourceType } from '../../utils/nodeTypeCategory.js';
 import {
   getUserReadableVirtualChannelIds,
   canReadVirtualChannel,
@@ -541,7 +542,7 @@ router.get('/messages', async (req: Request, res: Response) => {
 
     await Promise.all(
       sources.map(async (source) => {
-        if (source.type === 'meshcore') {
+        if (isAnyMeshCoreSourceType(source.type)) {
           await ingestMeshCore(source);
           return;
         }
@@ -860,7 +861,7 @@ router.get('/telemetry', async (req: Request, res: Response) => {
           longName?: string | null;
           shortName?: string | null;
         }> =
-          source.type === 'meshcore'
+          isAnyMeshCoreSourceType(source.type)
             ? (await databaseService.meshcore.getNodesBySource(source.id)).map((n) => ({
                 telemetryNodeId: n.publicKey,
                 longName: n.name,
@@ -1039,7 +1040,7 @@ router.get('/packets', async (req: Request, res: Response) => {
 
     const perSource = await Promise.allSettled(
       fetchSources.map(async (source): Promise<{ rows: TaggedPacket[]; saturated: boolean }> => {
-        if (source.type === 'meshcore') {
+        if (isAnyMeshCoreSourceType(source.type)) {
           if (!meshcoreEligible) return { rows: [], saturated: false };
           const raw = await meshcorePacketLogService.getPackets({
             sourceId: source.id,
@@ -1148,7 +1149,7 @@ router.get('/packets/distribution', async (req: Request, res: Response) => {
       readableSources.map(async (source) => {
         // MeshCore OTA rows have no per-node/per-PortNum breakdown that aligns
         // with the Meshtastic namespace, so they only contribute a source total.
-        if (source.type === 'meshcore') {
+        if (isAnyMeshCoreSourceType(source.type)) {
           const count = await meshcorePacketLogService.getPacketCount({ sourceId: source.id, since });
           return { source, byDevice: [], byType: [], meshcoreCount: count };
         }
@@ -1250,11 +1251,13 @@ router.get('/status', async (req: Request, res: Response) => {
     // MeshCore nodes live in per-source in-memory managers (looked up via
     // sourceManagerRegistry), not the shared `nodes` table — count them separately
     // using the same 2h active window as the per-source /status endpoint (issue #3321).
+    // Both halves use the same predicate so an ingest source lands in exactly
+    // one of them. Flipping only the first would have counted it twice (#5094).
     const meshcoreAllowedIds = allowedIds.filter(
-      (id) => sources.find((s) => s.id === id)?.type === 'meshcore',
+      (id) => isAnyMeshCoreSourceType(sources.find((s) => s.id === id)?.type),
     );
     const meshtasticAllowedIds = allowedIds.filter(
-      (id) => sources.find((s) => s.id === id)?.type !== 'meshcore',
+      (id) => !isAnyMeshCoreSourceType(sources.find((s) => s.id === id)?.type),
     );
 
     const activeCutoffMs = Date.now() - 7_200_000;

--- a/src/server/services/automation/meshNodeData.ts
+++ b/src/server/services/automation/meshNodeData.ts
@@ -8,6 +8,7 @@ import { ALL_SOURCES } from '../../../db/repositories/index.js';
 import type { NodeDataProvider, NodeFacts, StaleCandidate } from './engineContext.js';
 import { sourceProtocol } from './channelUnify.js';
 import { sourceManagerRegistry } from '../../sourceManagerRegistry.js';
+import { isAnyMeshCoreSourceType } from '../../../utils/nodeTypeCategory.js';
 import { isMeshCoreManager } from '../../sourceManagerTypes.js';
 import { isOwnNodeNum as isOwnedByAnySource, isOwnPublicKey as isOwnedPubkeyByAnySource } from '../../utils/ownNodes.js';
 
@@ -151,7 +152,9 @@ export function createMeshNodeDataProvider(): NodeDataProvider {
         for (const m of sourceManagerRegistry.getAllManagers()) {
           const sourceId = m.sourceId;
           try {
-            if (m.sourceType === 'meshcore') {
+            // Ingest observers live in meshcore_nodes too; the else branch
+            // below queries the Meshtastic table and finds nothing (#5094).
+            if (isAnyMeshCoreSourceType(m.sourceType)) {
               const nodes = await databaseService.meshcore.getNodesBySource(sourceId);
               for (const n of nodes) {
                 // MeshCore lastHeard is already epoch milliseconds.

--- a/src/server/services/inactiveNodeNotificationService.ts
+++ b/src/server/services/inactiveNodeNotificationService.ts
@@ -2,6 +2,7 @@ import { logger } from '../../utils/logger.js';
 import databaseService from '../../services/database.js';
 import { notificationService } from './notificationService.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+import { isAnyMeshCoreSourceType } from '../../utils/nodeTypeCategory.js';
 import { HourlyLogLimiter } from '../utils/hourlyLogLimiter.js';
 import { parseMonitoredUnion, countMonitoredNodes, formatSourceIdForLog, logZeroEligiblePrefRows } from '../utils/notificationCheckHelpers.js';
 import { getInactiveNodeConfig } from './nodeDisplaySettings.js';
@@ -263,7 +264,7 @@ class InactiveNodeNotificationService {
             // MeshCore nodes live in a separate table and report lastHeard in
             // milliseconds; Meshtastic nodes report seconds. Collect a
             // protocol-appropriate, already-formatted list of inactive alerts.
-            const alerts = manager.sourceType === 'meshcore'
+            const alerts = isAnyMeshCoreSourceType(manager.sourceType)
               ? await this.collectMeshCoreInactiveAlerts(monitoredUnion, sourceId, cfg.thresholdHours, now)
               : await this.collectMeshtasticInactiveAlerts(monitoredUnion, sourceId, cutoffSeconds, now);
 

--- a/src/server/services/lowBatteryNotificationService.ts
+++ b/src/server/services/lowBatteryNotificationService.ts
@@ -2,6 +2,7 @@ import { logger } from '../../utils/logger.js';
 import databaseService from '../../services/database.js';
 import { notificationService } from './notificationService.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+import { isAnyMeshCoreSourceType } from '../../utils/nodeTypeCategory.js';
 import { HourlyLogLimiter } from '../utils/hourlyLogLimiter.js';
 import { parseMonitoredUnion, countMonitoredNodes, formatSourceIdForLog, logZeroEligiblePrefRows } from '../utils/notificationCheckHelpers.js';
 
@@ -212,7 +213,7 @@ class LowBatteryNotificationService {
           // MeshCore nodes report voltage (mV); Meshtastic nodes report a 0-100
           // percentage. Build a protocol-appropriate list of alerts with the
           // current value/threshold already formatted for display.
-          const alerts = manager.sourceType === 'meshcore'
+          const alerts = isAnyMeshCoreSourceType(manager.sourceType)
             ? await this.collectMeshCoreLowBatteryAlerts(thresholdRow, monitoredUnion, sourceId)
             : await this.collectMeshtasticLowBatteryAlerts(thresholdRow, monitoredUnion, sourceId);
 

--- a/src/server/services/securityDigestService.ts
+++ b/src/server/services/securityDigestService.ts
@@ -1,6 +1,7 @@
 import { logger } from '../../utils/logger.js';
 import { scheduleCron } from '../utils/cronScheduler.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+import { isAnyMeshCoreSourceType } from '../../utils/nodeTypeCategory.js';
 import { resolveAppriseServerUrl, appriseNotifyEndpoint } from './appriseNotificationService.js';
 import type { Cron as CronJob } from 'croner';
 
@@ -314,7 +315,11 @@ class SecurityDigestService {
     // iterate every registered source and build a per-source digest.
     const targetSourceIds = sourceIdOverride
       ? [sourceIdOverride]
-      : sourceManagerRegistry.getAllManagers().filter(m => m.sourceType !== 'meshcore').map(m => m.sourceId);
+      // Exclusion, so it widens with the predicate: a digest is about OUR
+      // node's key/security posture, which an ingest source does not have.
+      : sourceManagerRegistry.getAllManagers()
+          .filter(m => !isAnyMeshCoreSourceType(m.sourceType))
+          .map(m => m.sourceId);
 
     if (targetSourceIds.length === 0) {
       return { success: false, message: 'No sources available' };

--- a/src/server/services/sourceDashboardData.meshcoreMqtt.test.ts
+++ b/src/server/services/sourceDashboardData.meshcoreMqtt.test.ts
@@ -1,0 +1,111 @@
+/**
+ * buildSourceNodes — a `meshcore_mqtt` ingest source reaches the MeshCore
+ * branch (issue #5094).
+ *
+ * #5040 Phase 5.5 widened the MANAGER narrow inside this function to
+ * `isAnyMeshCoreManager`, and left a comment saying ingest nodes now reach the
+ * map. The outer `source.type === 'meshcore'` gate above it meant they never
+ * did: rows landed in `meshcore_nodes`, the DB showed them, the UI did not.
+ * Reported from the field on 4.16.0-RC4.
+ *
+ * The regression these tests protect is the OUTER gate, so they drive
+ * buildSourceNodes with `type: 'meshcore_mqtt'` — the exact shape the router
+ * passes.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildSourceNodes } from './sourceDashboardData.js';
+import { createRouteTestApp, type RouteTestHarness } from '../test-helpers/routeTestApp.js';
+import type { User } from '../../types/auth.js';
+
+const INGEST_NODE = {
+  publicKey: 'b'.repeat(64),
+  name: 'Observed Repeater',
+  latitude: 39.5,
+  longitude: -104.5,
+  advType: 1,
+  lastHeard: Date.now(),
+};
+
+vi.mock('../sourceManagerRegistry.js', () => {
+  // sourceType 'meshcore_mqtt' — isAnyMeshCoreManager accepts it, the
+  // device-only isMeshCoreManager does not.
+  const ingestStub = {
+    sourceId: 'rt-source-a',
+    sourceType: 'meshcore_mqtt' as const,
+    getAllNodes: async () => [INGEST_NODE],
+  };
+  return {
+    sourceManagerRegistry: {
+      getManager: (sourceId: string) => (sourceId === 'rt-source-a' ? ingestStub : undefined),
+      getAllManagers: () => [ingestStub],
+    },
+  };
+});
+
+describe('buildSourceNodes — meshcore_mqtt ingest source (#5094)', () => {
+  let harness: RouteTestHarness;
+
+  beforeEach(async () => {
+    harness = await createRouteTestApp({ mount: () => {} });
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  const ingestRow = { id: 'rt-source-a', name: 'Region Feed', type: 'meshcore_mqtt' };
+
+  /** One row carries both flags — permissions are unique per (user, resource, source). */
+  const grantReadAndViewOnMap = () =>
+    harness.db.auth.createPermission({
+      userId: harness.limited.id,
+      resource: 'nodes',
+      canRead: true,
+      canViewOnMap: true,
+      canWrite: false,
+      sourceId: 'rt-source-a',
+      grantedAt: Date.now(),
+      grantedBy: null,
+    });
+
+  it('returns positioned ingest nodes instead of falling through to the Meshtastic branch', async () => {
+    await grantReadAndViewOnMap();
+
+    const result = await buildSourceNodes(ingestRow, harness.limited as unknown as User);
+
+    expect(result).toHaveLength(1);
+    const node = result[0] as Record<string, unknown>;
+    expect(node.longName).toBe('Observed Repeater');
+    expect(node.latitude).toBe(39.5);
+    expect(node.longitude).toBe(-104.5);
+  });
+
+  it('applies the same nodes:viewOnMap gate device-backed MeshCore sources get', async () => {
+    // nodes:read alone must not publish positions — the permission model does
+    // not loosen just because the source has no radio.
+    await harness.db.auth.createPermission({
+      userId: harness.limited.id,
+      resource: 'nodes',
+      canRead: true,
+      canViewOnMap: false,
+      canWrite: false,
+      sourceId: 'rt-source-a',
+      grantedAt: Date.now(),
+      grantedBy: null,
+    });
+
+    const result = await buildSourceNodes(ingestRow, harness.limited as unknown as User);
+    expect(result).toEqual([]);
+  });
+
+  it('builds the mc: node id from the ingest source, not a Meshtastic nodeNum', async () => {
+    // Falling through to the Meshtastic branch produced numeric node ids from
+    // an empty `nodes` table — i.e. nothing at all. The `mc:` prefix is the
+    // cheapest proof the MeshCore branch actually ran.
+    await grantReadAndViewOnMap();
+
+    const result = await buildSourceNodes(ingestRow, harness.limited as unknown as User);
+    const node = result[0] as Record<string, unknown>;
+    expect(String(node.nodeId)).toBe(`mc:rt-source-a:${'b'.repeat(12)}`);
+  });
+});

--- a/src/server/services/sourceDashboardData.ts
+++ b/src/server/services/sourceDashboardData.ts
@@ -22,6 +22,7 @@ import databaseService from '../../services/database.js';
 import { hasPermission } from '../auth/authMiddleware.js';
 import { logger } from '../../utils/logger.js';
 import { sourceManagerRegistry } from '../sourceManagerRegistry.js';
+import { isAnyMeshCoreSourceType } from '../../utils/nodeTypeCategory.js';
 import { isAnyMeshCoreManager } from '../sourceManagerTypes.js';
 import {
   filterNodesByChannelPermission,
@@ -46,7 +47,10 @@ export async function buildSourceNodes(source: SourceRow, user: ReqUser): Promis
   // them into the dashboard's flat node shape. These return early and never
   // reach the position-override logic below: MeshCore contacts have no
   // override columns (that's a Meshtastic-node feature, #3551).
-  if (source.type === 'meshcore') {
+  // isAnyMeshCoreSourceType, not === 'meshcore' (#5094): this outer gate was
+  // the reason the isAnyMeshCoreManager narrow below never ran for an ingest
+  // source. The comment there described behaviour this line prevented.
+  if (isAnyMeshCoreSourceType(source.type)) {
     // Mirror the Meshtastic path below: canRead("nodes") makes the contact
     // list available, but publishing positions on the map additionally
     // requires viewOnMap("nodes") — MeshCore has no per-channel granularity

--- a/src/utils/nodeTypeCategory.test.ts
+++ b/src/utils/nodeTypeCategory.test.ts
@@ -9,6 +9,7 @@ import {
   MESHCORE_CATEGORIES,
   MESHTASTIC_CATEGORIES,
   NODE_TYPE_CATEGORIES,
+  isAnyMeshCoreSourceType,
 } from './nodeTypeCategory';
 
 describe('getNodeTypeCategory', () => {
@@ -169,5 +170,41 @@ describe('categoriesForProtocols (adaptive filter set, issue #3610)', () => {
   it('nothing connected yet falls back to the full set (never empty)', () => {
     const cats = categoriesForProtocols({ meshcore: false, meshtastic: false });
     expect(cats).toEqual(NODE_TYPE_CATEGORIES);
+  });
+});
+
+/**
+ * Source-type classification for MeshCore (#5094).
+ *
+ * `sourceTypeProtocol` classified `meshcore_mqtt` as 'meshtastic', which is how
+ * ingest nodes ended up categorised — and rendered — as the wrong protocol.
+ */
+describe('isAnyMeshCoreSourceType / sourceTypeProtocol (#5094)', () => {
+  it('accepts both MeshCore source types', () => {
+    expect(isAnyMeshCoreSourceType('meshcore')).toBe(true);
+    expect(isAnyMeshCoreSourceType('meshcore_mqtt')).toBe(true);
+  });
+
+  it('rejects every non-MeshCore source type', () => {
+    for (const t of ['meshtastic_tcp', 'mqtt_broker', 'mqtt_bridge', 'reticulum']) {
+      expect(isAnyMeshCoreSourceType(t)).toBe(false);
+    }
+  });
+
+  it('rejects null/undefined rather than throwing', () => {
+    expect(isAnyMeshCoreSourceType(null)).toBe(false);
+    expect(isAnyMeshCoreSourceType(undefined)).toBe(false);
+  });
+
+  it('does not match on a prefix', () => {
+    // Guards against a future `startsWith('meshcore')` "simplification", which
+    // would swallow any later meshcore_* type that is NOT a read-alike source.
+    expect(isAnyMeshCoreSourceType('meshcore_future_device')).toBe(false);
+  });
+
+  it('classifies an ingest source as the meshcore protocol', () => {
+    expect(sourceTypeProtocol('meshcore_mqtt')).toBe('meshcore');
+    expect(sourceTypeProtocol('meshcore')).toBe('meshcore');
+    expect(sourceTypeProtocol('meshtastic_tcp')).toBe('meshtastic');
   });
 });

--- a/src/utils/nodeTypeCategory.ts
+++ b/src/utils/nodeTypeCategory.ts
@@ -262,5 +262,26 @@ export function categoriesForProtocols(opts: {
  * invent a category for it here ahead of that work.
  */
 export function sourceTypeProtocol(type: string | undefined | null): 'meshcore' | 'meshtastic' {
-  return type === 'meshcore' ? 'meshcore' : 'meshtastic';
+  return isAnyMeshCoreSourceType(type) ? 'meshcore' : 'meshtastic';
+}
+
+/**
+ * True for every MeshCore source type — device-backed (`meshcore`) AND the
+ * MQTT ingest source (`meshcore_mqtt`).
+ *
+ * The source-type mirror of `isAnyMeshCoreManager()` in
+ * `src/server/sourceManagerTypes.ts`, and the reason it exists: #5040 Phase 5.5
+ * widened the MANAGER predicates but left the raw `source.type === 'meshcore'`
+ * string comparisons alone, so ingest sources kept falling into the Meshtastic
+ * branch of read paths — nodes present in `meshcore_nodes` and invisible in the
+ * UI (#5094).
+ *
+ * Use this for READ surfaces: anything asking "which table do this source's
+ * nodes/messages/packets live in", or "which protocol should I render". Do NOT
+ * use it for device or TX paths (connect, device config, CLI, remote admin,
+ * auto-acknowledge) — an ingest source has no radio, and those must keep
+ * narrowing to `'meshcore'` exactly.
+ */
+export function isAnyMeshCoreSourceType(type: string | undefined | null): boolean {
+  return type === 'meshcore' || type === 'meshcore_mqtt';
 }


### PR DESCRIPTION
Fixes #5094. Reported from the field on 4.16.0-RC4 by SoundTech via Discord — thanks for reading the source and pinpointing the line.

## The reported bug

`buildSourceNodes` narrowed on `source.type === 'meshcore'`, so a `meshcore_mqtt` ingest source never reached the MeshCore branch. Nodes landed in `meshcore_nodes`, were visible in the database, and never rendered.

The sharp detail: #5040 Phase 5.5 widened the *manager* narrow inside that function to `isAnyMeshCoreManager` and left a comment saying ingest nodes now reach the map. The outer type gate three lines above stopped them. The comment described behaviour the code prevented.

## It was a class, not a line

Phase 5.5 audited manager predicates and left the raw `source.type === 'meshcore'` **string** comparisons alone. 84 such sites exist; triaging them turned up 13 more genuine gaps — and a broader root cause than the report:

**`sourceTypeProtocol('meshcore_mqtt')` returned `'meshtastic'`**, misclassifying ingest nodes at the protocol level for every frontend consumer (map markers, node cards, Map Analysis categories).

Added `isAnyMeshCoreSourceType()` — the source-type mirror of `isAnyMeshCoreManager()` — and routed read surfaces through it:

| Site | Was broken |
|---|---|
| `sourceDashboardData` | **The reported bug** |
| `sourceTypeProtocol` | Protocol misclassification |
| `unifiedRoutes` ×5 | Messages, telemetry node names, packets, packet counts, node-count split |
| `meshNodeData` | Automation stale-check queried the Meshtastic table |
| `lowBattery` / `inactiveNode` | Observer alerts never fired |
| `securityDigest` | Exclusion — widened so ingest stays excluded |
| `UsersTab` | `nodes:viewOnMap` checkbox hidden for ingest |
| `useDashboardData`, `DashboardSidebar`, `UnifiedMessagesPage` | Protocol label/badge |

Two of these deserve calling out:

- **`UsersTab` was a dependent bug.** `buildSourceNodes` gates ingest positions on `nodes:viewOnMap` exactly as it does device-backed ones. The checkbox was hidden for ingest sources, so that permission was *ungrantable* — fixing the gate alone would have left the map empty for a different reason.
- **The node-count split needed both halves.** `meshcoreAllowedIds` and `meshtasticAllowedIds` are complements; flipping only the first would have counted an ingest source in both.

## Deliberately unchanged

**Device and TX paths keep narrowing to `'meshcore'` exactly** — connect, device config, CLI, remote admin, auto-acknowledge. An ingest source has no radio. The helper's doc comment states which is which, so the remaining sites are not "fixed" by a later reader.

## Not fixed here — filed separately

`main.tsx` routes `meshcore_mqtt` to the Meshtastic `<App />` shell, so selecting an ingest source shows Meshtastic tabs. Routing it to `MeshCorePage` means gating that page's device-only views (DMs, configuration, local-node info). That is a UI change, not a gate fix, and I'd rather file it than half-build it inside a bugfix.

## Testing

3 new `buildSourceNodes` regressions plus 5 helper unit tests, **mutation-verified**: restoring the old gate fails all three.

Full suite: **19,204 passed, 0 failed, 0 failed suites**, with PostgreSQL and MySQL containers up (109 pending, so both backends actually ran). `tsc` (server + frontend) and `lint:ci` clean.

## Mesh impact

**None.** Read-path classification only; no packets, timers or events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc