### PR TITLE
fix(meshcore): guard unhandled-rejection crash from bare library rejects

### DIFF
--- a/src/server/meshcoreNativeBackend.discovery.test.ts
+++ b/src/server/meshcoreNativeBackend.discovery.test.ts
@@ -236,6 +236,37 @@ describe('MeshCoreNativeBackend — node discovery', () => {
     expect(conn.addOrUpdateContact).not.toHaveBeenCalled();
   });
 
+  it('does not crash the process when the auto-add ack bare-rejects (#5102)', async () => {
+    const { backend, conn } = await connectedBackend();
+    const tag = 0x5a5a5a5a;
+    await backend.sendCommand('discover_nodes', { filter: 0x0c, tag });
+
+    // meshcore.js's uncorrelated global Ok/Err ack can reject
+    // addOrUpdateContact() with NO argument when a concurrent command's Err
+    // frame is misattributed to it. The discover auto-add call runs
+    // fire-and-forget (`void (async () => {...})()`), so before the fix,
+    // reading `.message` off the undefined reason threw a TypeError with no
+    // catch anywhere in the chain — a genuinely unhandled promise rejection
+    // that crashed the whole process.
+    conn.addOrUpdateContact.mockRejectedValueOnce(undefined);
+
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandledRejection);
+    try {
+      const pubkey = Uint8Array.from(Array.from({ length: 32 }, (_, i) => i + 1));
+      conn.emit('rx', buildDiscoverResp({
+        snrX4: 20, rssi: -40 & 0xff, pathLen: 0xff,
+        nodeType: AdvType.Repeater, responderSnrX4: 12, tag, pubkey,
+      }));
+      await flushAsync();
+      await flushAsync();
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+    expect(unhandled).toHaveLength(0);
+  });
+
   it('does not auto-add a prefix-only (short key) response', async () => {
     const { backend, conn, events } = await connectedBackend();
     const tag = 0x12345678;

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -407,6 +407,37 @@ describe('MeshCoreNativeBackend', () => {
     expect(resp.error).not.toBe('undefined');
   });
 
+  it('drainWaitingMessages does not crash the process when syncNextMessage bare-rejects (#5102)', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    // meshcore.js's uncorrelated global Ok/Err ack can reject syncNextMessage()
+    // with NO argument when a concurrent command's Err frame is misattributed
+    // to it (same as the `share_contact` case above). drainWaitingMessages is
+    // invoked fire-and-forget from a MsgWaiting push (`void
+    // this.drainWaitingMessages()`), so before the fix, reading `.message` off
+    // the undefined reason threw a TypeError with no catch anywhere in the
+    // chain — a genuinely unhandled promise rejection that crashed the whole
+    // process.
+    conn.syncNextMessage = () => Promise.reject(undefined);
+
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandledRejection);
+    try {
+      conn.emit(PushCodes.MsgWaiting);
+      // Flush microtasks/macrotasks so the fire-and-forget async IIFE settles.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+    expect(unhandled).toHaveLength(0);
+  });
+
   it('set_device_time resolves on Ok and forwards the epoch', async () => {
     const backend = new MeshCoreNativeBackend('src-1', {
       connectionType: 'serial',

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -40,6 +40,9 @@ const BinaryRequestTypes = { GetTelemetryData: 0x03 };
 const AdvType = { None: 0, Chat: 1, Repeater: 2, Room: 3 };
 const TxtTypes = { Plain: 0, CliData: 1, SignedPlain: 2 };
 
+/** Flush pending microtasks + setImmediate so async fire-and-forget work runs. */
+const flushAsync = () => new Promise<void>((r) => setImmediate(r));
+
 /** Mock Connection that surfaces every method the backend touches. */
 class MockConnection extends EventEmitter {
   public connectCalled = 0;
@@ -430,8 +433,8 @@ describe('MeshCoreNativeBackend', () => {
     try {
       conn.emit(PushCodes.MsgWaiting);
       // Flush microtasks/macrotasks so the fire-and-forget async IIFE settles.
-      await new Promise((r) => setImmediate(r));
-      await new Promise((r) => setImmediate(r));
+      await flushAsync();
+      await flushAsync();
     } finally {
       process.off('unhandledRejection', onUnhandledRejection);
     }

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -410,7 +410,10 @@ export class MeshCoreNativeBackend extends EventEmitter {
         this.cachedFirmwareVer = typeof info?.firmwareVer === 'number' ? info.firmwareVer : null;
       } catch (verErr) {
         this.cachedFirmwareVer = null;
-        logger.debug(`[MeshCoreNative:${this.sourceId}] deviceQuery for version failed: ${(verErr as Error).message}`);
+        // meshcore.js can reject with NO argument on an uncorrelated Err ack
+        // (#5102) — don't assume verErr is an Error.
+        const detail = verErr instanceof Error ? verErr.message : String(verErr);
+        logger.debug(`[MeshCoreNative:${this.sourceId}] deviceQuery for version failed: ${detail}`);
       }
     } catch (err) {
       // A failed connect (e.g. a SelfInfo handshake timeout right after a USB
@@ -422,8 +425,11 @@ export class MeshCoreNativeBackend extends EventEmitter {
       try {
         await this.connection?.close?.();
       } catch (closeErr) {
+        // meshcore.js can reject with NO argument on an uncorrelated Err ack
+        // (#5102) — don't assume closeErr is an Error.
+        const detail = closeErr instanceof Error ? closeErr.message : String(closeErr);
         logger.debug(
-          `[MeshCoreNative:${this.sourceId}] close after failed connect threw: ${(closeErr as Error).message}`,
+          `[MeshCoreNative:${this.sourceId}] close after failed connect threw: ${detail}`,
         );
       }
       this.connection = null;
@@ -440,7 +446,10 @@ export class MeshCoreNativeBackend extends EventEmitter {
       try {
         await this.connection.close?.();
       } catch (err) {
-        logger.debug(`[MeshCoreNative:${this.sourceId}] close threw: ${(err as Error).message}`);
+        // meshcore.js can reject with NO argument on an uncorrelated Err ack
+        // (#5102) — don't assume err is an Error.
+        const detail = err instanceof Error ? err.message : String(err);
+        logger.debug(`[MeshCoreNative:${this.sourceId}] close threw: ${detail}`);
       }
       this.connection = null;
     }
@@ -903,7 +912,12 @@ export class MeshCoreNativeBackend extends EventEmitter {
               if (existing.some((ct) => bytesToHex(ct.publicKey) === publicKey)) return;
               await c.addOrUpdateContact(publicKeyBytes, nodeType, 0, 0xff, new Uint8Array(64), '', 0, 0, 0);
             } catch (err) {
-              logger.warn(`[MeshCore:native] discover auto-add failed for ${publicKey.substring(0, 16)}…: ${(err as Error).message}`);
+              // meshcore.js's uncorrelated global Ok/Err ack can reject this
+              // promise with NO argument when a concurrent command's Err frame
+              // is misattributed to it (see the `share_contact` guard above) —
+              // don't assume `err` is an Error.
+              const detail = err instanceof Error ? err.message : err == null ? 'no ack (uncorrelated Err)' : String(err);
+              logger.warn(`[MeshCore:native] discover auto-add failed for ${publicKey.substring(0, 16)}…: ${detail}`);
             }
           })();
         }
@@ -1038,7 +1052,15 @@ export class MeshCoreNativeBackend extends EventEmitter {
         if (!next) break;
       }
     } catch (err) {
-      logger.warn(`[MeshCoreNative:${this.sourceId}] drainWaitingMessages threw: ${(err as Error).message}`);
+      // meshcore.js's uncorrelated global Ok/Err ack can reject
+      // syncNextMessage() with NO argument when a concurrent command's Err
+      // frame is misattributed to it (same as `share_contact` elsewhere in
+      // this file). This handler is invoked fire-and-forget from a
+      // `MsgWaiting` push (`void this.drainWaitingMessages()`), so letting a
+      // TypeError escape here becomes a genuinely unhandled promise
+      // rejection that crashes the whole process (#5102).
+      const detail = err instanceof Error ? err.message : err == null ? 'no ack (uncorrelated Err)' : String(err);
+      logger.warn(`[MeshCoreNative:${this.sourceId}] drainWaitingMessages threw: ${detail}`);
     } finally {
       this.drainInFlight = false;
     }
@@ -1686,9 +1708,13 @@ export class MeshCoreNativeBackend extends EventEmitter {
           } catch (writeErr) {
             // The ack may have been a foreign `Err` (cannibalised) rather than a
             // real device rejection — the read-back below is authoritative, so
-            // don't fail here.
+            // don't fail here. meshcore.js rejects with NO argument in this
+            // case (same as `share_contact` above), so don't assume
+            // `writeErr` is an Error — reading `.message` off `undefined`
+            // would throw inside this catch block (#5102).
+            const detail = writeErr instanceof Error ? writeErr.message : writeErr == null ? 'no ack (uncorrelated Err)' : String(writeErr);
             logger.debug(
-              `[MeshCore] set_out_path write ack errored for ${bytesToHex(publicKey)} (${(writeErr as Error).message}); verifying via read-back`,
+              `[MeshCore] set_out_path write ack errored for ${bytesToHex(publicKey)} (${detail}); verifying via read-back`,
             );
           }
 


### PR DESCRIPTION
## Summary

Fixes #5102 — the native MeshCore backend could crash the entire MeshMonitor process with `TypeError: Cannot read properties of undefined (reading 'message')`.

`meshcore.js`'s uncorrelated global `Ok`/`Err` ack mechanism can reject a pending promise with **no argument** when a concurrent command's `Err` frame is misattributed to it. This behavior is already documented and guarded in `meshcoreNativeBackend.ts`'s `share_contact` handler (`err instanceof Error ? err.message : ...`), but several other `catch` blocks in the same file read `(err as Error).message` unconditionally — so when `err` is `undefined`, reading `.message` off it throws a *new* `TypeError` from inside the `catch` block.

The critical instance is `drainWaitingMessages()`, which is invoked fire-and-forget (`void this.drainWaitingMessages()`) off every `MsgWaiting` push — something that happens routinely during normal mesh operation, not just during an explicit user action. With no outer `.catch`, the resulting `TypeError` became a genuinely unhandled promise rejection, which trips the app's global handler and does a graceful-shutdown-with-`exit(1)` — exactly the crash loop described in the issue. The discovery auto-add path (`addOrUpdateContact` off a `NODE_DISCOVER_RESP` push) has the identical fire-and-forget shape and the same bug.

## Changes

Applied the same defensive guard already used by `share_contact` to every other unguarded `(err as Error).message` site in `meshcoreNativeBackend.ts`:
- `drainWaitingMessages()` (the fire-and-forget `MsgWaiting` handler — primary crash site)
- discovery auto-add (fire-and-forget `NODE_DISCOVER_RESP` handler)
- `connect()`'s `deviceQuery` version probe and its failed-connect cleanup
- `disconnect()`'s `close()` call
- `set_out_path`'s write-ack debug log (lower risk — already inside a caught async op — but same unguarded pattern)

No behavior change when `err` actually is an `Error` — these are purely defensive fixes for the `undefined`/non-Error rejection case.

## Test plan

- [x] Added a regression test reproducing the exact crash: `drainWaitingMessages does not crash the process when syncNextMessage bare-rejects (#5102)` in `meshcoreNativeBackend.test.ts`, using a `process.on('unhandledRejection', ...)` listener to prove no unhandled rejection escapes.
- [x] Added an equivalent regression test for the discovery auto-add path in `meshcoreNativeBackend.discovery.test.ts`.
- [x] Verified both new tests **fail** against the pre-fix code (confirmed by reverting only the source fix and re-running) and **pass** with the fix applied.
- [x] Full Vitest suite: 625 files / 9682 tests passed, 0 failures (with git submodules initialized for the protobuf suites).
- [x] `npx tsc --noEmit -p tsconfig.server.json`: clean.
- [x] `npm run lint:ci`: clean (no new baseline violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEKNGijFrXaWyExSofDSnH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEKNGijFrXaWyExSofDSnH)_