### PR TITLE
chore(deps): group vitest with its companions so majors travel together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,11 +29,38 @@ updates:
       - dependency-name: "maplibre-gl"
         update-types: ["version-update:semver-major"]
     groups:
+      # vitest core and its companions (@vitest/coverage-v8, @vitest/ui) pin
+      # each other EXACTLY — coverage-v8 5.0.0 declares
+      # `peerDependencies: { vitest: "5.0.0" }`. Same hazard as the
+      # codeql-action group below, in a different ecosystem.
+      #
+      # development-dependencies matched `vitest*` for minor/patch ONLY, so a
+      # major fell outside every group and Dependabot opened one PR per
+      # package: #5114 and #5107 bumped the companions to 5.0.0 with no
+      # vitest-5 PR to pair them with.
+      #
+      # That combination is not merely inconvenient, it is invisible. `.npmrc`
+      # sets legacy-peer-deps=true, so the mismatch INSTALLS without complaint,
+      # and CI does not run coverage (removed from ci.yml when it hung on Node
+      # 24; `npm run test:coverage` now runs only in release.yml). #5114 duly
+      # reported CLEAN with 13 green checks while being unmergeable in
+      # substance — the breakage would have surfaced as a failed coverage gate
+      # mid-release.
+      #
+      # Listed FIRST so it wins the match, and takes every update-type so the
+      # family always moves as one PR.
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       development-dependencies:
         patterns:
           - "@types/*"
           - "eslint*"
-          - "vitest*"
           - "@testing-library/*"
         update-types:
           - "minor"
@@ -45,6 +72,10 @@ updates:
           - "@types/*"
           - "eslint*"
           - "vitest*"
+          # `vitest*` does NOT match the scoped companions — belt and braces so
+          # a patch bump cannot fall into this catch-all if the vitest group
+          # above is ever narrowed.
+          - "@vitest/*"
           - "@testing-library/*"
         update-types:
           - "patch"


### PR DESCRIPTION
Config-only. Closes the gap that produced the two stranded Dependabot PRs, #5114 and #5107.

## What went wrong

`vitest` and its companions pin each other **exactly**:

```json
// @vitest/coverage-v8@5.0.0
"peerDependencies": { "vitest": "5.0.0", "@vitest/browser": "5.0.0" }
```

The `development-dependencies` group matched `vitest*` for **minor/patch only**, so a major fell outside every group and Dependabot opened one PR per package — #5114 (`@vitest/coverage-v8` → 5.0.0) and #5107 (`@vitest/ui` → 5.0.0), against a repo pinning `vitest@^4.1.11`, with no vitest-5 PR to pair them with.

## Why this needed a config change, not just closing two PRs

The broken combination is invisible to every gate in the repo:

| Gate | Why it misses this |
|---|---|
| npm peer resolution | `.npmrc` sets `legacy-peer-deps=true` — the mismatch **installs silently** |
| CI | Coverage was removed from `ci.yml` after `@vitest/coverage-v8` hung 30+ min on Node 24 |
| `npm run test:coverage` | Now runs **only in `release.yml`** |

So **#5114 reports CLEAN with 13 green checks** while being unmergeable in substance. The failure would have surfaced as a broken coverage gate *during a release* — and a PR that green is an easy accidental merge.

## The fix

A dedicated `vitest` group, listed **first** so it wins the match, taking **every** update-type so the family always moves as one PR:

```yaml
vitest:
  patterns:
    - "vitest"
    - "@vitest/*"
  update-types: ["major", "minor", "patch"]
```

`vitest*` is dropped from `development-dependencies` (now dead — the new group matches first) and `@vitest/*` is **added** to the `production-dependencies` excludes: `vitest*` does not match the scoped names, so without it a patch bump could fall into the `*` catch-all if this group is ever narrowed.

This is the same hazard `codeql-action` is already grouped for — sibling packages that must share a version, opened as individually-broken PRs, each needing a hand-batched replacement (#4519/#4521/#4531). Same treatment.

## Follow-up

#5114 and #5107 are being closed as superseded; Dependabot will re-raise the vitest 5 upgrade as a single grouped PR on its next run.

## Testing

YAML parses; group order verified as `vitest` → `development-dependencies` → `production-dependencies`. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc