### PR TITLE
fix(meshcore): decode RepeaterStats/Core stats fields dropped by the pinned library (#5125)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#148527002ee49b7a6977b01b925182f4a8dc515f",
+        "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#bd710fccbe56e86258c37a3d0e4ddcc905d1ec2c",
         "@maplibre/maplibre-gl-leaflet": "^0.1.4",
         "@michaelhart/meshcore-decoder": "^0.3.0",
         "@tanstack/react-query": "^5.102.8",
@@ -3070,7 +3070,7 @@
     },
     "node_modules/@liamcottle/meshcore.js": {
       "version": "1.13.0",
-      "resolved": "git+ssh://git@github.com/Yeraze/meshcore.js.git#148527002ee49b7a6977b01b925182f4a8dc515f",
+      "resolved": "git+ssh://git@github.com/Yeraze/meshcore.js.git#bd710fccbe56e86258c37a3d0e4ddcc905d1ec2c",
       "integrity": "sha512-3SQTR8pR+3k9AQxNgn1e+myozm7+df/UYVWZ5Cs5GrVd4F2M4v0E76pAC/Nd7O5szfY0ET9RcMXycbTqJHH/tg==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#148527002ee49b7a6977b01b925182f4a8dc515f",
+    "@liamcottle/meshcore.js": "github:Yeraze/meshcore.js#bd710fccbe56e86258c37a3d0e4ddcc905d1ec2c",
     "@maplibre/maplibre-gl-leaflet": "^0.1.4",
     "@michaelhart/meshcore-decoder": "^0.3.0",
     "@tanstack/react-query": "^5.102.8",

--- a/src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx
+++ b/src/components/MeshCore/MeshCoreRemoteStatsPanel.tsx
@@ -122,7 +122,9 @@ export const MeshCoreRemoteStatsPanel: React.FC<Props> = ({
               <StatField label={t('meshcore.remoteStats.last_snr', 'Last SNR')} value={formatSnr(status.lastSnr)} />
               <StatField label={t('meshcore.remoteStats.noise_floor', 'Noise floor')} value={formatRssi(status.noiseFloor)} />
               <StatField label={t('meshcore.remoteStats.air_time', 'Air time')} value={formatAirTime(status.airTimeSecs)} />
+              <StatField label={t('meshcore.remoteStats.rx_air_time', 'RX air time')} value={formatAirTime(status.rxAirTimeSecs)} />
               <StatField label={t('meshcore.remoteStats.errors', 'Error Events')} value={formatNumber(status.errors)} />
+              <StatField label={t('meshcore.remoteStats.recv_errors', 'Receive errors')} value={formatNumber(status.recvErrors)} />
 
               <div className="mrs-section">
                 <h5>{t('meshcore.remoteStats.rx', 'Received')}</h5>

--- a/src/components/MeshCore/hooks/useMeshCore.ts
+++ b/src/components/MeshCore/hooks/useMeshCore.ts
@@ -415,6 +415,10 @@ export interface MeshCoreRemoteStatus {
   errors?: number;
   directDups?: number;
   floodDups?: number;
+  /** Total receive air time in seconds. Repeater firmware >= v1.8 only (#5125). */
+  rxAirTimeSecs?: number;
+  /** RadioLib CRC/receive error count. Repeater firmware >= v1.12 only (#5125). */
+  recvErrors?: number;
   txPower?: number;
   radioFreq?: number;
   radioBw?: number;

--- a/src/components/TelemetryChart.tsx
+++ b/src/components/TelemetryChart.tsx
@@ -239,6 +239,8 @@ const TELEMETRY_LABELS: Record<string, string> = {
   mc_status_errors: 'Errors',
   mc_status_direct_dups: 'Duplicates (Direct)',
   mc_status_flood_dups: 'Duplicates (Flood)',
+  mc_status_rx_air_time_secs: 'RX Air Time',
+  mc_status_recv_errors: 'Receive Errors',
   // Local-node poller types (meshcoreTelemetryPoller) — shorter names than
   // the remote-status path above; both can appear in the telemetry store.
   mc_queue_len: 'Queue Length',

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -703,6 +703,10 @@ export interface MeshCoreStatus {
   errors?: number;
   directDups?: number;
   floodDups?: number;
+  /** Total receive air time in seconds. Repeater firmware >= v1.8 only. */
+  rxAirTimeSecs?: number;
+  /** RadioLib CRC/receive error count. Repeater firmware >= v1.12 only. */
+  recvErrors?: number;
 
   // Companion-only fields (radio config etc.). Kept on the interface for
   // backwards compatibility with callers that ask Companion targets for status.
@@ -5370,6 +5374,8 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
           errors: d.errors,
           directDups: d.direct_dups,
           floodDups: d.flood_dups,
+          rxAirTimeSecs: d.rx_air_time_secs,
+          recvErrors: d.recv_errors,
           txPower: d.tx_power,
           radioFreq: d.radio_freq,
           radioBw: d.radio_bw,

--- a/src/server/meshcoreNativeBackend.test.ts
+++ b/src/server/meshcoreNativeBackend.test.ts
@@ -63,7 +63,7 @@ class MockConnection extends EventEmitter {
   public deviceTimeResponse: { epochSecs: number } | null = { epochSecs: 1700000000 };
   public statsResponse: any = {
     type: StatsTypes.Core,
-    data: { batteryMilliVolts: 4100, uptimeSecs: 12345, queueLen: 0 },
+    data: { batteryMilliVolts: 4100, uptimeSecs: 12345, errors: 7, queueLen: 3 },
   };
   public deviceQueryResponse: any = {
     firmwareVer: 4,
@@ -841,7 +841,76 @@ describe('MeshCoreNativeBackend', () => {
     await backend.connect();
     const resp = await backend.sendCommand('get_stats', { type: 'core' });
     expect(resp.success).toBe(true);
-    expect(resp.data).toEqual({ battery_mv: 4100, uptime_secs: 12345, queue_len: 0 });
+    // `errors` sits between uptime and queue_len in the Core stats payload.
+    // The pinned meshcore.js used to skip it, so queue_len read the low byte
+    // of errors and `errors` never surfaced at all (#5125).
+    expect(resp.data).toEqual({ battery_mv: 4100, uptime_secs: 12345, errors: 7, queue_len: 3 });
+  });
+
+  it('core stats survive a device that omits errors/queue_len (#5125)', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    // meshcore.js reports a short payload's trailing fields as null.
+    conn.statsResponse = {
+      type: StatsTypes.Core,
+      data: { batteryMilliVolts: 4100, uptimeSecs: 12345, errors: null, queueLen: null },
+    };
+    const resp = await backend.sendCommand('get_stats', { type: 'core' });
+    expect(resp.success).toBe(true);
+    expect(resp.data).toEqual({ battery_mv: 4100, uptime_secs: 12345, errors: undefined, queue_len: undefined });
+  });
+
+  it('get_status forwards the trailing RepeaterStats counters (#5125)', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    conn.contactsResponse = [{ publicKey: Uint8Array.from(Array.from({ length: 32 }, (_, i) => i + 1)) }];
+    // firmware >= v1.8 appends total_rx_air_time_secs; >= v1.12 appends
+    // n_recv_errors. meshcore.js only decodes them from upstream PR #37 on.
+    conn.statusResolveValue = {
+      batt_milli_volts: 4000,
+      total_up_time_secs: 999,
+      total_air_time_secs: 120,
+      total_rx_air_time_secs: 456,
+      n_recv_errors: 12,
+    };
+    const pubkeyHex = Array.from({ length: 32 }, (_, i) => (i + 1).toString(16).padStart(2, '0')).join('');
+    const resp = await backend.sendCommand('get_status', { public_key: pubkeyHex });
+    expect(resp.success).toBe(true);
+    expect(resp.data).toMatchObject({
+      air_time_secs: 120,
+      rx_air_time_secs: 456,
+      recv_errors: 12,
+    });
+  });
+
+  it('get_status leaves the trailing counters undefined on pre-v1.8 firmware (#5125)', async () => {
+    const backend = new MeshCoreNativeBackend('src-1', {
+      connectionType: 'serial',
+      serialPort: '/dev/ttyUSB0',
+    });
+    await backend.connect();
+    const conn = lastInstanceRef.current as MockConnection;
+    conn.contactsResponse = [{ publicKey: Uint8Array.from(Array.from({ length: 32 }, (_, i) => i + 1)) }];
+    // Short payload — meshcore.js reports the absent trailing fields as null.
+    conn.statusResolveValue = {
+      batt_milli_volts: 4000,
+      total_up_time_secs: 999,
+      total_rx_air_time_secs: null,
+      n_recv_errors: null,
+    };
+    const pubkeyHex = Array.from({ length: 32 }, (_, i) => (i + 1).toString(16).padStart(2, '0')).join('');
+    const resp = await backend.sendCommand('get_status', { public_key: pubkeyHex });
+    expect(resp.success).toBe(true);
+    expect(resp.data.rx_air_time_secs).toBeUndefined();
+    expect(resp.data.recv_errors).toBeUndefined();
   });
 
   it('maps get_device_time to { time }', async () => {

--- a/src/server/meshcoreNativeBackend.ts
+++ b/src/server/meshcoreNativeBackend.ts
@@ -1988,6 +1988,13 @@ export class MeshCoreNativeBackend extends EventEmitter {
           errors: stats?.err_events,
           direct_dups: stats?.n_direct_dups,
           flood_dups: stats?.n_flood_dups,
+          // RepeaterStats grew two trailing counters after the original 48-byte
+          // layout: total_rx_air_time_secs (firmware v1.8) and n_recv_errors
+          // (v1.12). meshcore.js only started decoding them in upstream PR #37
+          // (#5125); both read back `null` from older firmware that stops the
+          // payload short, so normalise that to `undefined` for the bridge shape.
+          rx_air_time_secs: stats?.total_rx_air_time_secs ?? undefined,
+          recv_errors: stats?.n_recv_errors ?? undefined,
           tx_power: undefined,
           radio_freq: undefined,
           radio_bw: undefined,
@@ -2325,7 +2332,11 @@ export class MeshCoreNativeBackend extends EventEmitter {
       return {
         battery_mv: data.batteryMilliVolts,
         uptime_secs: data.uptimeSecs,
-        queue_len: data.queueLen,
+        // `errors` sits between uptime and queue_len on the wire. meshcore.js
+        // used to skip it, which made queue_len read the low byte of errors —
+        // wrong on any device reporting non-zero errors (#5125).
+        errors: data.errors ?? undefined,
+        queue_len: data.queueLen ?? undefined,
       };
     }
     if (type === 'radio') {

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
@@ -732,6 +732,26 @@ describe('statusToTelemetryRows', () => {
     expect(rows.every((r) => r.nodeId === 'pk' && r.nodeNum === 99 && r.timestamp === 1_700_000_000)).toBe(true);
   });
 
+  it('maps the RepeaterStats counters added by firmware v1.8 / v1.12 (#5125)', () => {
+    const rows = statusToTelemetryRows(
+      { rxAirTimeSecs: 456, recvErrors: 12 },
+      'pk',
+      1,
+      1_700_000_000,
+    );
+    const byType = new Map(rows.map((r) => [r.telemetryType, r]));
+    expect(byType.get('mc_status_rx_air_time_secs')?.value).toBe(456);
+    expect(byType.get('mc_status_rx_air_time_secs')?.unit).toBe('s');
+    expect(byType.get('mc_status_recv_errors')?.value).toBe(12);
+  });
+
+  it('emits no rows for the new counters on firmware that never sends them (#5125)', () => {
+    const rows = statusToTelemetryRows({ batteryMv: 3700 }, 'pk', 1, 0);
+    const types = rows.map((r) => r.telemetryType);
+    expect(types).not.toContain('mc_status_rx_air_time_secs');
+    expect(types).not.toContain('mc_status_recv_errors');
+  });
+
   it('skips undefined fields rather than emitting NaN rows', () => {
     const rows = statusToTelemetryRows({ batteryMv: 3700 }, 'pk', 1, 0);
     expect(rows).toHaveLength(1);

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.ts
@@ -262,6 +262,11 @@ export const STATUS_FIELD_MAP: readonly StatusFieldDef[] = [
   { source: 'errors', telemetryType: 'errors' },
   { source: 'directDups', telemetryType: 'direct_dups' },
   { source: 'floodDups', telemetryType: 'flood_dups' },
+  // Added to RepeaterStats by firmware v1.8 / v1.12 respectively; only decoded
+  // by meshcore.js from upstream PR #37 onwards (#5125). Absent on older
+  // firmware, in which case statusToTelemetryRows skips the row.
+  { source: 'rxAirTimeSecs', telemetryType: 'rx_air_time_secs', unit: 's' },
+  { source: 'recvErrors', telemetryType: 'recv_errors' },
 ];
 
 export function statusToTelemetryRows(

--- a/src/utils/telemetryCategory.ts
+++ b/src/utils/telemetryCategory.ts
@@ -149,6 +149,8 @@ const TYPE_CATEGORY: Record<string, TelemetryCategory> = {
   mc_status_errors: 'network',
   mc_status_direct_dups: 'network',
   mc_status_flood_dups: 'network',
+  mc_status_rx_air_time_secs: 'network',
+  mc_status_recv_errors: 'network',
   mc_tx_duty_pct: 'network',
   mc_rx_duty_pct: 'network',
   mc_pkt_sent_rate: 'network',


### PR DESCRIPTION
Fixes #5125.

## Problem

The pinned `@liamcottle/meshcore.js` fork (`Yeraze/meshcore.js@1485270`, 2026-08-25) predates upstream [PR #37](https://github.com/meshcore-dev/meshcore.js/pull/37), so two decoder bugs were live:

1. **`getStatus()` truncated RepeaterStats at 48 bytes.** Firmware grew the payload twice — `total_rx_air_time_secs` (v1.8) and `n_recv_errors` (v1.12) — and both were silently dropped. Neither value reached the Remote Stats panel, the Telemetry page, or telemetry history for any repeater/room server on modern firmware.
2. **`onStatsResponse()` read `queueLen` from the wrong byte for `STATS_TYPE_CORE`.** The payload is `battery_mv:u16, uptime_secs:u32, errors:u16, queue_len:u8`; the library skipped `errors`, so the value stored and displayed as Companion queue depth was the low byte of `errors` — wrong on any device reporting non-zero errors.

## Changes

**Library repin.** `Yeraze/meshcore.js@bd710fc` — cherry-picks upstream `1c3240a` onto the existing `fix/4922-serial-lock-and-await-open` branch (a rebase onto upstream `master` was not viable: 1.14/1.15 changed the `sendCommandSendRawData` signature and removed `pingRepeaterZeroHop`). Adds one commit on top of the cherry-pick that guards both Core reads with `getRemainingBytesCount()`, so a short payload from older firmware degrades to `null` instead of throwing a `RangeError` out of `BufferReader`.

**MeshMonitor plumbing** for the two new counters:
- `meshcoreNativeBackend.ts` — `get_status` forwards `rx_air_time_secs` / `recv_errors`; `statsResponseToBridgeShape('core')` now forwards `errors` and the corrected `queue_len`. Library `null`s normalise to `undefined` so downstream `!== undefined` guards keep skipping absent fields.
- `meshcoreManager.ts` — `MeshCoreStatus` gains `rxAirTimeSecs` / `recvErrors`; `requestNodeStatus` maps them.
- `meshcoreRemoteTelemetryScheduler.ts` — `STATUS_FIELD_MAP` emits `mc_status_rx_air_time_secs` (unit `s`) and `mc_status_recv_errors`.
- `telemetryCategory.ts` / `TelemetryChart.tsx` — categorise and label the new series.
- `MeshCoreRemoteStatsPanel.tsx` + `useMeshCore.ts` — two new stat fields ("RX air time", "Receive errors").

Companion Core stats get the fix for free: `getStatsCore()` already mapped `d.errors`, which was never populated before, so `mc_errors` starts working and `mc_queue_len` becomes correct.

## Mesh impact

None. No new packets, timers, or schedulers — this only changes how bytes already on the wire are decoded. The existing remote-telemetry poll cadence is unchanged.

## Test plan

- [x] New: `get_status` forwards the trailing counters, and leaves them `undefined` on pre-v1.8 firmware that reports them as `null`.
- [x] New: Core stats bridge shape carries `errors` and the corrected `queue_len`, and survives a device that omits both.
- [x] New: `statusToTelemetryRows` emits the two new telemetry types with the right units, and emits nothing for them when the firmware never sends them.
- [x] Updated the existing `maps get_stats to snake_case bridge shape` expectation (mock core stats now carry a distinct `errors` and `queueLen` so a regression to the old off-by-two read fails the test).
- [x] `vitest run` on both touched suites: 113 passed, 0 failed (`success: true` via the JSON reporter).
- [x] `tsc --noEmit` clean for both the app and server projects; `lint:ci` clean.

Hardware verification of the two new panel fields against a repeater on firmware ≥ v1.12 still needs a real device — CI cannot cover that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZ871RCjD95cAu6jMfNM4