### PR TITLE
feat(beacons): warn on regulator-non-compliant preset/region in received offers (#5103)

### DIFF
--- a/src/components/beacons/BeaconOffersPanel.module.css
+++ b/src/components/beacons/BeaconOffersPanel.module.css
@@ -80,6 +80,23 @@
   color: var(--color-text-muted);
 }
 
+/* Regulator-compliance warning (#5103). Same visual language as the
+   amateur-band alert on the LoRa config section, so a user reads them as the
+   same class of "this is legal advice, not a control". */
+.beaconOfferWarning {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.35rem;
+  margin: 0.35rem 0 0;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--color-warning);
+  border-radius: 4px;
+  background-color: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  color: var(--color-warning);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
 .beaconOfferActions {
   display: flex;
   gap: 0.5rem;

--- a/src/components/beacons/BeaconOffersPanel.test.tsx
+++ b/src/components/beacons/BeaconOffersPanel.test.tsx
@@ -173,6 +173,26 @@ describe('BeaconOffersPanel', () => {
     expect(screen.getByText(/Advertises a mesh/i)).toBeTruthy();
     expect(screen.queryByText(/switch preset/i)).toBeNull();
   });
+
+  it('warns about a non-compliant advertised region/preset without blocking the join (#5103)', async () => {
+    // Long Fast in the US: fits the band, so the firmware legality check is
+    // happy, but FCC §15.247 needs 500 kHz. Warning-only — the join button
+    // must still be there.
+    renderPanel([offer({ offerRegion: 1, offerPreset: 0 })]);
+    await screen.findByTestId(`beacon-offer-${NODE}`);
+
+    const warning = screen.getByTestId('beacon-offer-compliance');
+    expect(warning.textContent).toMatch(/not compliant in/i);
+    expect(warning.textContent).toContain('LONG_TURBO');
+    expect(warning.getAttribute('role')).toBe('alert');
+    expect(screen.queryByTestId('beacon-offer-reason')).toBeNull();
+  });
+
+  it('shows no compliance warning for a compliant region/preset (#5103)', async () => {
+    renderPanel([offer({ offerRegion: 1, offerPreset: 9 })]); // US / LONG_TURBO
+    await screen.findByTestId(`beacon-offer-${NODE}`);
+    expect(screen.queryByTestId('beacon-offer-compliance')).toBeNull();
+  });
 });
 
 describe('stylesheet', () => {

--- a/src/components/beacons/BeaconOffersPanel.tsx
+++ b/src/components/beacons/BeaconOffersPanel.tsx
@@ -170,6 +170,20 @@ export default function BeaconOffersPanel({
                   rewrite the radio's LoRa config, which this card does not do. */}
               {verdict.presetNote && <p className={styles.beaconOfferNote}>{verdict.presetNote}</p>}
 
+              {/* Regulator-compliance warning for the advertised region/preset
+                  (#5103). Warning-only, like the amateur-band notice on the
+                  local LoRa config — it describes the neighbour's mesh and
+                  never gates the join. */}
+              {verdict.complianceNote && (
+                <p
+                  role="alert"
+                  className={styles.beaconOfferWarning}
+                  data-testid="beacon-offer-compliance"
+                >
+                  <UiIcon name="alert" /> {verdict.complianceNote}
+                </p>
+              )}
+
               {/* Decision 2: say why, rather than hiding the offer. */}
               {!verdict.actionable && (
                 <p className={styles.beaconOfferReason} data-testid="beacon-offer-reason">

--- a/src/components/beacons/beaconOfferActionability.test.ts
+++ b/src/components/beacons/beaconOfferActionability.test.ts
@@ -90,4 +90,63 @@ describe('assessBeaconOffer', () => {
       expect(assessBeaconOffer(joinable).presetNote).toBeUndefined();
     });
   });
+  // --- Regulator-compliance warning (#5103) ---
+
+  it('warns that Long Fast is not compliant in the US and names Long Turbo', () => {
+    // The combination the official Meshtastic clients now flag. It PASSES the
+    // firmware bandwidth-fits-the-band check, so only the compliance table
+    // catches it — that is the whole point of the second check.
+    const r = assessBeaconOffer({ ...joinable, offerRegion: 1, offerPreset: 0 });
+    expect(isPresetLegalForRegion(1, 0)).toBe(true);
+    expect(r.complianceNote).toMatch(/not compliant in/i);
+    expect(r.complianceNote).toContain('LONG_FAST');
+    expect(r.complianceNote).toContain('250 kHz');
+    expect(r.complianceNote).toContain('LONG_TURBO');
+  });
+
+  it('never blocks the join on a compliance warning', () => {
+    // Region/preset are context about the neighbour's mesh; joining a channel
+    // does not touch this node's LoRa config, so a warning must not gate it.
+    const r = assessBeaconOffer({ ...joinable, offerRegion: 1, offerPreset: 0 });
+    expect(r.actionable).toBe(true);
+  });
+
+  it('still reports the compliance warning on an un-actionable offer', () => {
+    const r = assessBeaconOffer({ offerChannelName: null, offerRegion: 1, offerPreset: 0 });
+    expect(r.actionable).toBe(false);
+    expect(r.complianceNote).toMatch(/not compliant in/i);
+  });
+
+  it('does not warn about a US preset that meets the 500 kHz floor', () => {
+    for (const preset of [8, 9, 16]) { // SHORT_TURBO, LONG_TURBO, MEDIUM_TURBO
+      expect(assessBeaconOffer({ ...joinable, offerRegion: 1, offerPreset: preset }).complianceNote)
+        .toBeUndefined();
+    }
+  });
+
+  it('is default-open: a region with no confirmed rule produces no warning', () => {
+    // EU_868 with a 125 kHz preset — narrow, but no ETSI rule is encoded, and
+    // guessing one would put a false legal claim in front of the user.
+    expect(assessBeaconOffer({ ...joinable, offerRegion: 3, offerPreset: 1 }).complianceNote)
+      .toBeUndefined();
+    // An unknown region code likewise.
+    expect(assessBeaconOffer({ ...joinable, offerRegion: 250, offerPreset: 0 }).complianceNote)
+      .toBeUndefined();
+  });
+
+  it('needs both a region and a preset before it judges anything', () => {
+    // offer_region UNSET (0) normalises to falsy; offer_preset 0 is LONG_FAST,
+    // a real value — so the guards are deliberately asymmetric.
+    expect(assessBeaconOffer({ ...joinable, offerPreset: 0 }).complianceNote).toBeUndefined();
+    expect(assessBeaconOffer({ ...joinable, offerRegion: 1 }).complianceNote).toBeUndefined();
+    expect(assessBeaconOffer({ ...joinable, offerRegion: 0, offerPreset: 0 }).complianceNote).toBeUndefined();
+  });
+
+  it('keeps the compliance warning separate from the plain preset note', () => {
+    // They are rendered differently (warning box vs muted line), so a caller
+    // must be able to tell them apart.
+    const r = assessBeaconOffer({ ...joinable, offerRegion: 1, offerPreset: 0 });
+    expect(r.presetNote).toMatch(/Advertises a mesh on/);
+    expect(r.presetNote).not.toMatch(/not compliant/i);
+  });
 });

--- a/src/components/beacons/beaconOfferActionability.ts
+++ b/src/components/beacons/beaconOfferActionability.ts
@@ -19,6 +19,7 @@
  * neither gates or drives the accept.
  */
 import {
+  getRegionComplianceWarning,
   isPresetLegalForRegion,
   MODEM_PRESET_OPTIONS,
   REGION_OPTIONS,
@@ -49,6 +50,17 @@ export interface OfferActionability {
    * not touch LoRa config.
    */
   presetNote?: string;
+  /**
+   * Regulator-compliance warning for the advertised (region, preset) pair —
+   * a combination that fits the band but that the region's regulator does not
+   * permit, e.g. Long Fast in the US (#5103).
+   *
+   * Kept separate from `presetNote` rather than appended to it so the card can
+   * style it as a warning, matching the amateur-radio warning on the local LoRa
+   * config. Like `presetNote`, it never gates the join: it describes the
+   * neighbour's mesh, not anything this node is about to do.
+   */
+  complianceNote?: string;
 }
 
 export function presetName(preset: number | null | undefined): string {
@@ -75,6 +87,22 @@ function hasPreset(offer: BeaconOfferLike): boolean {
   return offer.offerPreset != null;
 }
 
+/**
+ * Warning for a (region, preset) pair that fits the band but that the region's
+ * regulator does not permit (#5103). Independent of `isPresetLegalForRegion`,
+ * which only answers the firmware's bandwidth-fits-the-span question — Long
+ * Fast in the US passes that and is still non-compliant.
+ *
+ * Only produced when the offer carries BOTH a region and a preset: a rule is
+ * per-region, and there is nothing to judge without the preset.
+ */
+function buildComplianceNote(offer: BeaconOfferLike): string | undefined {
+  if (!hasRegion(offer) || !hasPreset(offer)) return undefined;
+  const warning = getRegionComplianceWarning(offer.offerRegion!, offer.offerPreset!);
+  if (!warning) return undefined;
+  return `${presetName(offer.offerPreset)}'s ${warning.bandwidthKHz} kHz bandwidth is not compliant in ${regionName(offer.offerRegion)} — ${warning.rationale}. ${warning.recommendedPresetName} is the recommended preset there.`;
+}
+
 function buildPresetNote(offer: BeaconOfferLike): string | undefined {
   if (!hasRegion(offer) && !hasPreset(offer)) return undefined;
 
@@ -90,6 +118,7 @@ function buildPresetNote(offer: BeaconOfferLike): string | undefined {
 
 export function assessBeaconOffer(offer: BeaconOfferLike): OfferActionability {
   const presetNote = buildPresetNote(offer);
+  const complianceNote = buildComplianceNote(offer);
   const channelName = offer.offerChannelName?.trim();
 
   if (!channelName) {
@@ -99,7 +128,7 @@ export function assessBeaconOffer(offer: BeaconOfferLike): OfferActionability {
     const reason = presetNote
       ? 'This beacon advertises a mesh but offers no channel to join, so there is nothing to apply automatically.'
       : 'This beacon carries no network offer — it is text only.';
-    return { actionable: false, reason, presetNote };
+    return { actionable: false, reason, presetNote, complianceNote };
   }
 
   if (!offer.hasChannelKey) {
@@ -107,8 +136,9 @@ export function assessBeaconOffer(offer: BeaconOfferLike): OfferActionability {
       actionable: false,
       reason: `The beacon names a channel ("${channelName}") but did not include its key, so joining it would produce a channel that cannot decrypt anything.`,
       presetNote,
+      complianceNote,
     };
   }
 
-  return { actionable: true, presetNote };
+  return { actionable: true, presetNote, complianceNote };
 }

--- a/src/components/configuration/LoRaConfigSection.test.tsx
+++ b/src/components/configuration/LoRaConfigSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { MODEM_PRESET_OPTIONS, FEM_LNA_MODE_OPTIONS, AMATEUR_RADIO_REGIONS, isAmateurRadioRegion, REGION_MAP } from './constants';
+import { MODEM_PRESET_OPTIONS, FEM_LNA_MODE_OPTIONS, AMATEUR_RADIO_REGIONS, isAmateurRadioRegion, REGION_MAP, REGION_COMPLIANCE_RULES, getRegionComplianceWarning, isPresetLegalForRegion } from './constants';
 
 /**
  * LoRaConfigSection Tests
@@ -237,6 +237,43 @@ describe('LoRaConfigSection', () => {
 
       expect(config.usePreset).toBe(true);
       expect(config).toHaveProperty('modemPreset');
+    });
+  });
+  describe('Region regulator compliance (#5103)', () => {
+    it('flags Long Fast in the US even though it passes the bandwidth fit-check', () => {
+      // The two checks answer different questions. If this ever starts failing
+      // because isPresetLegalForRegion went false, the compliance table is no
+      // longer the thing catching this case and the warning may be duplicated.
+      expect(isPresetLegalForRegion(1, 0)).toBe(true);
+      const w = getRegionComplianceWarning(1, 0);
+      expect(w).not.toBeNull();
+      expect(w!.bandwidthKHz).toBe(250);
+      expect(w!.minBandwidthKHz).toBe(500);
+      expect(w!.recommendedPresetName).toBe('LONG_TURBO');
+    });
+
+    it('clears every US preset at or above the 500 kHz floor', () => {
+      for (const preset of [8, 9, 16]) { // SHORT_TURBO, LONG_TURBO, MEDIUM_TURBO
+        expect(getRegionComplianceWarning(1, preset), `preset ${preset}`).toBeNull();
+      }
+    });
+
+    it('is default-open — no rule, no warning', () => {
+      expect(getRegionComplianceWarning(3, 1)).toBeNull();   // EU_868, 125 kHz
+      expect(getRegionComplianceWarning(250, 0)).toBeNull(); // unknown region
+      expect(getRegionComplianceWarning(null, 0)).toBeNull();
+      expect(getRegionComplianceWarning(1, null)).toBeNull();
+    });
+
+    it('recommends a preset that itself satisfies the rule it is recommended for', () => {
+      // A table entry pointing at a preset that also fails the floor would send
+      // the user straight back to the same warning.
+      for (const [region, rule] of Object.entries(REGION_COMPLIANCE_RULES)) {
+        expect(
+          getRegionComplianceWarning(Number(region), rule.recommendedPreset),
+          `region ${region} recommends preset ${rule.recommendedPreset}`,
+        ).toBeNull();
+      }
     });
   });
 });

--- a/src/components/configuration/constants.ts
+++ b/src/components/configuration/constants.ts
@@ -323,6 +323,77 @@ export function isPresetLegalForRegion(
   return spanMHz >= bandwidthMHz - 1e-9;
 }
 
+// --- Region -> regulator compliance guidance (issue #5103) ---
+//
+// This is NOT the same question as `isPresetLegalForRegion` above. That one
+// mirrors the firmware's fit-check: "does this preset's bandwidth physically
+// fit inside the region's frequency span?" A combination can pass that check
+// and still be **non-compliant with the region's regulator** — the case the
+// official Meshtastic clients now warn about for Long Fast in the US.
+//
+// US: FCC §15.247(a)(2) permits digital modulation in 902-928 MHz only when the
+// 6 dB bandwidth is at least 500 kHz. Long Fast is 250 kHz, so it clears the
+// 26 MHz band span by a mile and is still outside the rule; Long Turbo (500 kHz)
+// is the compliant equivalent, which is why the mobile app recommends it.
+//
+// As with the legality table, no protobuf field carries any of this — it is
+// client-side guidance. Coverage is deliberately thin and **default-open**: a
+// region with no entry produces no warning at all. Add an entry only where the
+// regulator guidance is confirmed, or where the upstream apps already flag it.
+
+export interface RegionComplianceRule {
+  /** Regulator's minimum occupied bandwidth, in kHz. */
+  minBandwidthKHz: number;
+  /** Preset to suggest instead — must itself satisfy the rule. */
+  recommendedPreset: number;
+  /** Why the rule exists, in one clause, for the user-facing warning. */
+  rationale: string;
+}
+
+export const REGION_COMPLIANCE_RULES: Record<number, RegionComplianceRule> = {
+  1: {
+    minBandwidthKHz: 500,
+    recommendedPreset: 9, // LONG_TURBO
+    rationale: 'FCC §15.247 allows digital modulation in the 902-928 MHz band only at 500 kHz of bandwidth or more',
+  },
+};
+
+export interface RegionComplianceWarning {
+  /** Bandwidth the offered preset actually uses, in kHz. */
+  bandwidthKHz: number;
+  /** Regulator minimum this fails. */
+  minBandwidthKHz: number;
+  rationale: string;
+  /** Protobuf name of the suggested preset, e.g. `LONG_TURBO`. */
+  recommendedPresetName: string;
+}
+
+/**
+ * Regulator-compliance check for a (region, preset) pair.
+ *
+ * Returns null — no warning — for an unknown region, a region with no rule, a
+ * null region or preset, or a preset that satisfies the rule. Never throws and
+ * never blocks anything: this is advisory only.
+ */
+export function getRegionComplianceWarning(
+  region: number | null | undefined,
+  preset: number | null | undefined
+): RegionComplianceWarning | null {
+  if (region == null || preset == null) return null;
+  const rule = REGION_COMPLIANCE_RULES[region];
+  if (!rule) return null;
+  const info = REGION_FREQ_INFO[region];
+  const bandwidthKHz = getPresetBandwidthKHz(preset, !!info?.wideLora);
+  if (bandwidthKHz >= rule.minBandwidthKHz) return null;
+  const recommended = MODEM_PRESET_OPTIONS.find((o) => o.value === rule.recommendedPreset);
+  return {
+    bandwidthKHz,
+    minBandwidthKHz: rule.minBandwidthKHz,
+    rationale: rule.rationale,
+    recommendedPresetName: recommended?.name ?? `preset ${rule.recommendedPreset}`,
+  };
+}
+
 /**
  * Returns the subset of MODEM_PRESET_OPTIONS that are legal for `region`.
  * `currentPreset`, when supplied, is always retained even if it is illegal, so


### PR DESCRIPTION
Closes #5103.

## Problem

A received MeshBeacon can advertise a `(offer_region, offer_preset)` pair that is technically valid LoRa but **not permitted by that country's regulator**. MeshMonitor already flagged two problem classes:

- bandwidth doesn't fit the region's frequency span — `buildPresetNote` / `isPresetLegalForRegion`
- amateur-radio region selected locally — `isAmateurRadioRegion`

The third class was missing. **Long Fast in the US** is the canonical case: 250 kHz sits comfortably inside the 26 MHz 902-928 band, so the firmware's fit-check passes and MeshMonitor said nothing — while FCC §15.247 requires a 6 dB bandwidth of at least 500 kHz for digital modulation there. The official Meshtastic clients now warn about exactly this pairing and recommend Long Turbo.

## Changes

**`configuration/constants.ts`** — a per-region compliance table living next to the existing legality logic, so the local LoRa config picker can share it in the follow-up the issue describes:

```ts
REGION_COMPLIANCE_RULES: Record<number, { minBandwidthKHz, recommendedPreset, rationale }>
getRegionComplianceWarning(region, preset): RegionComplianceWarning | null
```

Only the US entry ships. Coverage is deliberately thin and **default-open** — a region with no confirmed rule produces no warning, because a guessed rule would put a false legal claim in front of the user.

**`beaconOfferActionability.ts`** — `assessBeaconOffer` gains `complianceNote`, kept as its own field rather than appended to `presetNote` so the card can style it as a warning instead of muted context. Produced only when the offer carries both a region and a preset (the `offer_region` UNSET-is-0 vs `offer_preset` explicit-presence asymmetry is preserved).

**`BeaconOffersPanel`** — renders it in the same `--color-warning` box the amateur-band notice uses, with `role="alert"`. **It never gates the join**: joining a channel does not touch LoRa config, so region/preset stay context about the neighbour's mesh, exactly as #4723 decided. No "apply this preset" action is offered.

## Mesh impact

None. This renders data already received; no packets, timers, or schedulers.

## Test plan

- [x] `beaconOfferActionability.test.ts` (+7): US/Long Fast warns and names Long Turbo; the offer stays actionable; the warning still appears on an un-actionable offer; the three ≥500 kHz US presets are silent; EU_868 and an unknown region code stay silent (default-open); region-only and preset-only offers judge nothing; `presetNote` never absorbs the warning text. One test asserts `isPresetLegalForRegion(1, 0) === true` first, so if the fit-check ever starts catching this case the duplication is visible.
- [x] `BeaconOffersPanel.test.tsx` (+2): the warning renders with `role="alert"` and no blocking reason alongside it; a compliant pair renders no warning. The existing stylesheet cross-check test already covers the new `.beaconOfferWarning` class.
- [x] `LoRaConfigSection.test.tsx` (+4): table-level coverage, including a guard that every rule's `recommendedPreset` itself satisfies the rule it is recommended for — otherwise the suggestion would send the user straight back to the same warning.
- [x] `vitest run src/components/beacons src/components/configuration/LoRaConfigSection.test.tsx`: 61 passed, 0 failed (`success: true` via the JSON reporter).
- [x] `tsc --noEmit` clean; `lint:ci` clean.

Screenshot of the warning on a beacon card to follow once the branch is deployed to the dev container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZ871RCjD95cAu6jMfNM4