### PR TITLE
fix(tcp): scope the connect timeout to its own attempt and name every teardown (#5122)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -680,7 +680,17 @@ class MeshtasticManager implements ISourceManager {
   // Buffer resets (`initConfigCache`, `preConfigChannelSnapshot`) stay as
   // separate, explicit statements at each call site — pre-refactor code
   // never bundled them into these two booleans either.
+  // Config-sync progress, for diagnosing a link that drops part-way through
+  // the initial NodeDB stream (#5122). A large NodeDB takes minutes and arrives
+  // in bursts, so "we disconnected" and "we disconnected after 120 of ~190
+  // NodeInfos, 74s in" are very different reports — and the second one is the
+  // only one that can be correlated against a packet capture.
+  private configSyncStartedAt: number | null = null;
+  private configSyncNodeInfoCount = 0;
+
   private startConfigCapture(): void {
+    this.configSyncStartedAt = Date.now();
+    this.configSyncNodeInfoCount = 0;
     this.isCapturingInitConfig = true;
     this.configCaptureComplete = false;
   }
@@ -2099,8 +2109,26 @@ class MeshtasticManager implements ISourceManager {
     }
   }
 
+  /** Seconds since the current config sync started, or 'unknown' if none is. */
+  private describeConfigSyncElapsed(): string {
+    if (this.configSyncStartedAt === null) return 'unknown elapsed time';
+    return `${Math.round((Date.now() - this.configSyncStartedAt) / 1000)}s`;
+  }
+
   private async handleDisconnected(): Promise<void> {
     logger.debug('TCP connection lost');
+
+    // Losing the link mid-sync means the whole NodeDB stream restarts from
+    // scratch on reconnect, so on a large mesh it can loop forever without ever
+    // completing. That is worth a warning with the numbers attached, not a
+    // debug line indistinguishable from an idle disconnect (#5122).
+    if (this.isCapturingInitConfig && !this.configCaptureComplete) {
+      logger.warn(
+        `⚠️ Connection lost during the initial config sync — ${this.configSyncNodeInfoCount} NodeInfo message(s) received over ${this.describeConfigSyncElapsed()}. ` +
+        'The sync restarts from the beginning on reconnect; on a large NodeDB it may never finish if this repeats. ' +
+        'Consider enabling Passive Mode for this source.'
+      );
+    }
 
     // #3962 Phase 4.2b C2: TRANSPORT_DISCONNECTED. A transport-level
     // disconnect that fires after an operator-initiated userDisconnect()
@@ -4444,6 +4472,13 @@ class MeshtasticManager implements ISourceManager {
           await this.processMyNodeInfo(parsed.data);
           break;
         case 'nodeInfo':
+          if (this.isCapturingInitConfig && !this.configCaptureComplete) {
+            this.configSyncNodeInfoCount++;
+            // Every 25th, so a 200-node sync leaves ~8 lines rather than 200.
+            if (this.configSyncNodeInfoCount % 25 === 0) {
+              logger.debug(`📇 Config sync: ${this.configSyncNodeInfoCount} NodeInfo messages in ${this.describeConfigSyncElapsed()}`);
+            }
+          }
           await this.processNodeInfoProtobuf(parsed.data);
           break;
         case 'metadata':
@@ -4753,6 +4788,8 @@ class MeshtasticManager implements ISourceManager {
             const { next, actions } = dispatch(this.#state, 'CONFIG_COMPLETE', this.buildSmContext());
             this.#state = next;
             logger.debug(`📸 Init config capture complete! Captured ${this.initConfigCache.length} messages for virtual node replay`);
+            logger.info(`✅ Config sync complete: ${this.configSyncNodeInfoCount} NodeInfo message(s) in ${this.describeConfigSyncElapsed()}`);
+            this.configSyncStartedAt = null;
 
             for (const action of actions) {
               switch (action.kind) {

--- a/src/server/tcpTransport.connectTimeout.test.ts
+++ b/src/server/tcpTransport.connectTimeout.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Connect-timeout lifetime + teardown observability (#5122).
+ *
+ * A reporter's packet capture showed MeshMonitor sending the first FIN on a
+ * healthy, mid-sync connection with nothing in the application log — no stale
+ * connection warning, no error, just a clean client-initiated close followed by
+ * a reconnect. Two properties of the old code made that shape possible:
+ *
+ *  1. The connect timeout lived in `doConnect()`'s closure and read
+ *     `this.socket` when it fired, not the socket it was armed for. Every
+ *     teardown path strips the socket's listeners (otherwise a deliberate close
+ *     looks like a lost link and triggers auto-reconnect), which removes the
+ *     very handlers that cancelled the timer — so it could outlive its own
+ *     attempt and then destroy whatever socket happened to be current.
+ *  2. Those teardown paths destroyed the socket in silence, so nothing in the
+ *     log attributed the FIN to anything.
+ *
+ * These tests drive the real `doConnect()` against a fake `net.Socket` and pin
+ * both properties: a timer can only ever kill the attempt it belongs to, and
+ * every socket we close deliberately says who closed it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const createdSockets: any[] = [];
+
+vi.mock('net', () => {
+  class FakeSocket {
+    handlers: Record<string, Array<(...a: any[]) => void>> = {};
+    setKeepAlive = vi.fn();
+    setNoDelay = vi.fn();
+    connect = vi.fn();
+    write = vi.fn();
+    destroy = vi.fn();
+    removeAllListeners = vi.fn(() => { this.handlers = {}; });
+    on = vi.fn((ev: string, fn: (...a: any[]) => void) => {
+      (this.handlers[ev] ||= []).push(fn);
+      return this;
+    });
+    once = vi.fn((ev: string, fn: (...a: any[]) => void) => {
+      (this.handlers[ev] ||= []).push(fn);
+      return this;
+    });
+    emit(ev: string, ...args: any[]) {
+      for (const fn of this.handlers[ev] ?? []) fn(...args);
+    }
+    constructor() { createdSockets.push(this); }
+  }
+  return { Socket: FakeSocket };
+});
+
+const logs = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+vi.mock('../utils/logger.js', () => ({ logger: logs }));
+
+let TcpTransport: any;
+
+const newTransport = async (connectTimeoutMs = 10_000) => {
+  const t = new TcpTransport();
+  t.setConnectTimeout(connectTimeoutMs);
+  // Never let the auto-reconnect loop open a second socket mid-test.
+  vi.spyOn(t as any, 'scheduleReconnect').mockImplementation(() => {});
+  return t;
+};
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  createdSockets.length = 0;
+  for (const fn of Object.values(logs)) fn.mockClear();
+  ({ TcpTransport } = await import('./tcpTransport.js'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('TcpTransport — connect timeout lifetime (#5122)', () => {
+  it('cancels the pending connect timeout when the attempt is torn down', async () => {
+    const t = await newTransport();
+    t.connect('node.example', 4403).catch(() => {});
+
+    // Torn down while still connecting. This is the path that used to leave a
+    // live timer behind: disconnect() strips the listeners that would have
+    // cancelled it, and never touched the timer itself.
+    t.disconnect();
+    expect((t as any).connectTimeout).toBeNull();
+
+    // A later attempt on the same transport gets its own socket...
+    t.connect('node.example', 4403).catch(() => {});
+    const second = createdSockets[1];
+    second.emit('connect');
+    expect(t.getConnectionState()).toBe(true);
+
+    // ...which the first attempt's timer must not be able to reach.
+    vi.advanceTimersByTime(120_000);
+    expect(second.destroy).not.toHaveBeenCalled();
+    expect(t.getConnectionState()).toBe(true);
+  });
+
+  it('a superseded timer never destroys the socket that replaced it', async () => {
+    const t = await newTransport();
+    t.connect('node.example', 4403).catch(() => {});
+    const first = createdSockets[0];
+
+    // doConnect() reclaims the in-flight socket and opens another. Before the
+    // fix, the first attempt's timer was still armed and read `this.socket`,
+    // so it would have destroyed this healthy replacement.
+    void (t as any).doConnect().catch(() => {});
+    const second = createdSockets[1];
+    expect(second).toBeDefined();
+    expect(second).not.toBe(first);
+    second.emit('connect');
+
+    vi.advanceTimersByTime(120_000);
+    expect(second.destroy).not.toHaveBeenCalled();
+    expect(t.getConnectionState()).toBe(true);
+  });
+
+  it('does not fire once the attempt has connected', async () => {
+    const t = await newTransport();
+    t.connect('node.example', 4403).catch(() => {});
+    const socket = createdSockets[0];
+    socket.emit('connect');
+
+    vi.advanceTimersByTime(120_000);
+
+    expect(socket.destroy).not.toHaveBeenCalled();
+    expect(t.getConnectionState()).toBe(true);
+  });
+
+  it('still destroys its own socket, loudly, when the attempt really does hang', async () => {
+    const t = await newTransport(10_000);
+    const attempt = t.connect('node.example', 4403);
+    const rejection = expect(attempt).rejects.toThrow(/Connection timeout/);
+    const socket = createdSockets[0];
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(socket.destroy).toHaveBeenCalledTimes(1);
+    // The old code destroyed the socket with no log at all.
+    expect(logs.warn.mock.calls.map((c) => String(c[0])).join('\n'))
+      .toMatch(/TCP connect to node\.example:4403 timed out after 10000ms/);
+    await rejection;
+  });
+});
+
+describe('TcpTransport — teardown says who closed the socket (#5122)', () => {
+  it('logs at info when a LIVE connection is closed deliberately', async () => {
+    const t = await newTransport();
+    t.connect('node.example', 4403).catch(() => {});
+    const socket = createdSockets[0];
+    socket.emit('connect');
+
+    t.disconnect();
+
+    // A packet capture shows a client-initiated FIN at this moment; the log has
+    // to be able to explain it, which before this change it could not.
+    expect(socket.destroy).toHaveBeenCalled();
+    const line = logs.info.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(line).toMatch(/Closing the live TCP connection to node\.example:4403/);
+    expect(line).toMatch(/disconnect\(\) was called/);
+  });
+
+  it('names the reclaim path when a new attempt takes over an existing socket', async () => {
+    const t = await newTransport();
+    t.connect('node.example', 4403).catch(() => {});
+    createdSockets[0].emit('connect');
+    logs.info.mockClear();
+
+    void (t as any).doConnect().catch(() => {});
+
+    expect(logs.info.mock.calls.map((c) => String(c[0])).join('\n'))
+      .toMatch(/reclaimed before a new connect attempt/);
+  });
+
+  it('stays at debug for a socket that was never connected', async () => {
+    const t = await newTransport();
+    t.connect('node.example', 4403).catch(() => {});
+
+    t.disconnect();
+
+    expect(createdSockets[0].destroy).toHaveBeenCalled();
+    expect(logs.info).not.toHaveBeenCalled();
+  });
+
+  it('clears the socket reference so a second teardown is a no-op', async () => {
+    const t = await newTransport();
+    t.connect('node.example', 4403).catch(() => {});
+    createdSockets[0].emit('connect');
+
+    t.disconnect();
+    t.disconnect();
+
+    expect(createdSockets[0].destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/tcpTransport.ts
+++ b/src/server/tcpTransport.ts
@@ -51,6 +51,20 @@ export class TcpTransport extends EventEmitter implements ITransport {
   private heartbeatPayloadFactory: (() => Uint8Array | Promise<Uint8Array>) | null = null;
   private heartbeatTimer: NodeJS.Timeout | null = null;
 
+  // The in-flight connect timeout, hoisted out of doConnect()'s closure.
+  //
+  // It used to be a bare local, which meant nothing outside that closure could
+  // cancel it. Every path that reclaims a socket calls removeAllListeners()
+  // first, so the 'connect'/'error'/'close' handlers that clear the timer are
+  // gone by the time the socket dies — leaving a live timer whose callback
+  // reads `this.socket`, i.e. whatever socket is current when it eventually
+  // fires. On a transport that connects again, that is a healthy, connected
+  // socket being destroyed by a stale timer, with no warning logged and an
+  // auto-reconnect scheduled right after: exactly the silent client-initiated
+  // FIN reported in #5122. Tracking it on the instance lets every teardown
+  // path cancel it.
+  private connectTimeout: NodeJS.Timeout | null = null;
+
   // Configurable TCP timing
   private connectTimeoutMs: number = 10000; // 10 second default
   private reconnectInitialDelayMs: number = 1000; // 1 second default
@@ -178,6 +192,44 @@ export class TcpTransport extends EventEmitter implements ITransport {
     return this.doConnect();
   }
 
+  private clearConnectTimeout(): void {
+    if (this.connectTimeout) {
+      clearTimeout(this.connectTimeout);
+      this.connectTimeout = null;
+    }
+  }
+
+  /**
+   * Close the current socket and say who did it.
+   *
+   * Every teardown path has to strip the socket's listeners first, otherwise
+   * the 'close' handler treats a deliberate teardown as a lost link and
+   * schedules a reconnect. The side effect was that these paths closed the
+   * socket in complete silence — no log line, no event — which is why a report
+   * like #5122 (a client-initiated FIN with nothing in the application log)
+   * could not be attributed to any particular mechanism. Routing all of them
+   * through here means every FIN we send has a reason next to it.
+   */
+  private teardownSocket(reason: string): void {
+    this.clearConnectTimeout();
+    const socket = this.socket;
+    if (!socket) return;
+    this.socket = null;
+    // `wasConnected` separates "we hung up on a live link" (which a reader of
+    // the log will want to correlate with a FIN in a packet capture) from
+    // reclaiming a socket that never came up.
+    const wasConnected = this.isConnected;
+    try {
+      socket.removeAllListeners();
+      socket.destroy();
+    } catch { /* ignore */ }
+    if (wasConnected) {
+      logger.info(`🔌 Closing the live TCP connection to ${this.config?.host}:${this.config?.port} — ${reason}`);
+    } else {
+      logger.debug(`🔌 Discarded a TCP socket that was not connected — ${reason}`);
+    }
+  }
+
   private async doConnect(): Promise<void> {
     return new Promise((resolve, reject) => {
       if (!this.config) {
@@ -194,13 +246,7 @@ export class TcpTransport extends EventEmitter implements ITransport {
       // Reclaim any pre-existing socket before opening a new one. Without this
       // a single transport could leak two live sockets at the daemon — the
       // 2:1 "Force close previous TCP connection" fingerprint from #3270.
-      if (this.socket) {
-        try {
-          this.socket.removeAllListeners();
-          this.socket.destroy();
-        } catch { /* ignore */ }
-        this.socket = null;
-      }
+      this.teardownSocket('reclaimed before a new connect attempt');
 
       this.isConnecting = true;
       logger.debug(`📡 Connecting to TCP ${this.config.host}:${this.config.port}...`);
@@ -211,16 +257,31 @@ export class TcpTransport extends EventEmitter implements ITransport {
       this.socket.setKeepAlive(true, 300000); // Keep alive every 5 minutes (app-layer health check handles dead connections)
       this.socket.setNoDelay(true); // Disable Nagle's algorithm for low latency
 
-      // Connection timeout
-      const connectTimeout = setTimeout(() => {
-        if (this.socket) {
-          this.socket.destroy();
-          reject(new Error('Connection timeout'));
+      // Connection timeout. Bound to THIS attempt's socket, not to whatever
+      // `this.socket` happens to be when it fires — a stale timer must never
+      // be able to destroy a later, healthy connection (#5122). It is also
+      // cancelled by every teardown path, so it cannot outlive its socket.
+      const attemptSocket = this.socket;
+      this.clearConnectTimeout();
+      this.connectTimeout = setTimeout(() => {
+        this.connectTimeout = null;
+        if (this.socket !== attemptSocket) {
+          // The attempt this timer belongs to is long gone. Firing here would
+          // tear down an unrelated socket.
+          logger.debug('⏱️  Ignoring a connect timeout from a superseded attempt');
+          return;
         }
+        if (!this.isConnecting) {
+          // Already connected (or already torn down) — nothing to time out.
+          return;
+        }
+        logger.warn(`⏱️  TCP connect to ${this.config?.host}:${this.config?.port} timed out after ${this.connectTimeoutMs}ms — destroying the socket`);
+        attemptSocket.destroy();
+        reject(new Error('Connection timeout'));
       }, this.connectTimeoutMs);
 
       this.socket.once('connect', () => {
-        clearTimeout(connectTimeout);
+        this.clearConnectTimeout();
         this.isConnecting = false;
         this.isConnected = true;
         this.reconnectAttempts = 0;
@@ -248,7 +309,7 @@ export class TcpTransport extends EventEmitter implements ITransport {
       });
 
       this.socket.on('error', (error: Error) => {
-        clearTimeout(connectTimeout);
+        this.clearConnectTimeout();
         logger.error('❌ TCP socket error:', error.message);
         this.emit('error', error);
 
@@ -258,7 +319,7 @@ export class TcpTransport extends EventEmitter implements ITransport {
       });
 
       this.socket.on('close', () => {
-        clearTimeout(connectTimeout);
+        this.clearConnectTimeout();
         this.isConnecting = false;
         const wasConnected = this.isConnected;
         this.isConnected = false;
@@ -328,11 +389,7 @@ export class TcpTransport extends EventEmitter implements ITransport {
     // Stop keepalive heartbeat
     this.stopHeartbeat();
 
-    if (this.socket) {
-      this.socket.removeAllListeners();
-      this.socket.destroy();
-      this.socket = null;
-    }
+    this.teardownSocket('transport.disconnect() was called');
 
     this.isConnected = false;
     this.isConnecting = false;


### PR DESCRIPTION
Addresses #5122.

## What the reporter proved

An excellent writeup with a `tcpdump` capture taken **inside** the container. It settles two things:

1. The ~10s gap before the drop is **real wire silence** — nothing in either direction between packets #313 and #314. Not a MeshMonitor logging blackout, not a processing backlog.
2. **MeshMonitor sends the first FIN.** It is a clean, client-initiated close from MeshMonitor's own ephemeral port. No RST anywhere.

And the application log around it shows no `⚠️ Stale connection detected…` line, so it is not the 5-minute idle watchdog (#2609) firing early.

## Why that combination looked impossible

I went through every path in `TcpTransport` that can close a socket:

| Path | Logs? | Emits `disconnect`? | Schedules reconnect? |
|---|---|---|---|
| `checkConnection()` stale / phantom | **WARN first** | yes | yes |
| connect timeout | nothing | yes | yes |
| `disconnect()` | nothing | **no** (listeners stripped) | no |
| `doConnect()` socket reclaim | nothing | **no** (listeners stripped) | no |

There is no ~10s inactivity timer anywhere — `MESHTASTIC_CONNECT_TIMEOUT_MS` and `MESHTASTIC_RECONNECT_INITIAL_DELAY_MS` both default to 60000, and the stale detector is 300000 on a 60s poll. The only path that closes a socket **and** leaves its handlers attached (so the log still shows `🔌 TCP connection closed` / `TCP connection lost` and a reconnect at `attempt 1`) is the connect timeout. Which brings us to a real bug.

## The bug: a connect timeout can outlive its own attempt

```js
const connectTimeout = setTimeout(() => {
  if (this.socket) {          // <-- whatever socket is CURRENT, not this attempt's
    this.socket.destroy();
    reject(new Error('Connection timeout'));
  }
}, this.connectTimeoutMs);
```

It was cancelled only by the socket's own `connect` / `error` / `close` handlers. Every teardown path calls `removeAllListeners()` before destroying the socket — it has to, or a deliberate close reads as a lost link and triggers auto-reconnect — which strips exactly those handlers. `disconnect()` clears `reconnectTimeout`, `healthCheckInterval` and `heartbeatTimer`, but the connect timeout was a closure local it could not reach.

A surviving timer then destroys **whatever socket is current when it fires**. On a transport that has since connected, that is a live socket, with its handlers intact — producing precisely the reported fingerprint: a client-initiated FIN, no warning, `🔌 TCP connection closed`, and a reconnect logged at `attempt 1` (a successful connect resets `reconnectAttempts`). It also explains an arbitrary-looking 10.38s: the delay is measured from when the *orphaned* attempt armed the timer, not from the last data packet, so it lands wherever `connectTimeoutMs` minus that attempt's age falls.

## Changes

- **The connect timeout is tracked on the instance, bound to its attempt's socket.** It refuses to act if `this.socket` is no longer the socket it was armed for, or if the attempt already connected; every teardown path cancels it; and when it does legitimately fire it now logs a warning instead of destroying the socket silently.
- **`teardownSocket(reason)`** — `disconnect()` and the `doConnect()` reclaim both route through it. It logs at **info** when the socket was actually connected ("Closing the live TCP connection to host:port — <reason>"), so a client-initiated FIN in a capture always has a line beside it naming the path that sent it, and at debug for a socket that never came up.
- **Config-sync progress logging** in `MeshtasticManager`: NodeInfo messages are counted during capture, progress logged every 25, and a **warning** with the count and elapsed time when the link is lost mid-sync — pointing at Passive Mode, because a mid-sync drop restarts the whole NodeDB stream and on a large mesh can loop without ever completing. Totals logged on completion.

## Honest status

**This does not close the issue on its own.** I could not reproduce the reported instance locally, and the timer race above is *the mechanism that fits the evidence*, not a confirmed cause — reaching it needs a teardown during the connecting window followed by another connect on the same transport instance, which is reachable but not obviously what a cold start does. What this PR does is remove that race outright and make the next report self-diagnosing: any FIN we send now has a reason logged next to it, and the log says how far the sync had got.

@ogarcia — once this ships, the lines worth grabbing from a failing cycle are `🔌 Closing the live TCP connection…` (names the path), `⏱️  TCP connect … timed out` (the connect timeout firing), and `⚠️ Connection lost during the initial config sync — N NodeInfo message(s) over Ns`.

## Mesh impact

None. No packets, no new timers, no schedulers — one existing timer is scoped more tightly and several log lines are added.

## Test plan

- [x] New `tcpTransport.connectTimeout.test.ts` (8 tests), driving the **real** `doConnect()` against a fake `net.Socket`: `disconnect()` cancels the pending timer and a later healthy socket survives it; a superseded timer never destroys the socket that replaced it; the timer does not fire once connected; it still destroys its own socket, with a warning, when an attempt genuinely hangs; and the four teardown-logging cases (live close logs at info with the reason, the reclaim path names itself, an unconnected socket stays at debug, a second teardown is a no-op).
- [x] `vitest run src/server/tcpTransport src/server/meshtasticManager.{connectionLifecycleMapping,orphanTransport,passiveMode}.test.ts`: 60 passed, 0 failed (`success: true` via the JSON reporter). The existing #3270 orphan-guard and #4692 async-write suites still pass against the reworked teardown.
- [x] `tsc --noEmit -p tsconfig.server.json` clean; `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZ871RCjD95cAu6jMfNM4