### PR TITLE
fix(meshcore): refresh lastHeard on telemetry round-trip, not just adverts

### DIFF
--- a/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
@@ -559,7 +559,7 @@ describe('MeshCoreRemoteTelemetryScheduler.tickOneManager', () => {
     );
   });
 
-  it('does not call upsertNode when requestNodeStatus returns no battery voltage', async () => {
+  it('does not persist batteryMv when requestNodeStatus returns no battery voltage', async () => {
     const now = 10_000_000;
     const manager = makeFakeManager({
       statusToReturn: { uptimeSecs: 500 }, // no batteryMv
@@ -581,7 +581,10 @@ describe('MeshCoreRemoteTelemetryScheduler.tickOneManager', () => {
       now: () => now,
     });
     await scheduler.tickOneManager(manager);
-    expect(upsertNode).not.toHaveBeenCalled();
+    // #5131: a status/LPP response is still a live round-trip, so lastHeard
+    // is refreshed even though there's no battery voltage to persist.
+    expect(upsertNode).toHaveBeenCalledWith({ publicKey: 'rep-a', lastHeard: now }, 'src-a');
+    expect(upsertNode).not.toHaveBeenCalledWith(expect.objectContaining({ batteryMv: expect.anything() }), 'src-a');
   });
 
   it('persists GPS position to meshcore_nodes when LPP response includes type 136', async () => {
@@ -644,7 +647,10 @@ describe('MeshCoreRemoteTelemetryScheduler.tickOneManager', () => {
       now: () => now,
     });
     await scheduler.tickOneManager(manager);
-    expect(upsertNode).not.toHaveBeenCalled();
+    // #5131: an LPP response is still a live round-trip, so lastHeard is
+    // refreshed even though the Null Island fix itself is discarded.
+    expect(upsertNode).toHaveBeenCalledWith({ publicKey: 'companion-c', lastHeard: now }, 'src-a');
+    expect(upsertNode).not.toHaveBeenCalledWith(expect.objectContaining({ latitude: expect.anything() }), 'src-a');
   });
 
   it('does not persist GPS position when LPP type 136 value lacks lat/lon fields', async () => {
@@ -670,7 +676,10 @@ describe('MeshCoreRemoteTelemetryScheduler.tickOneManager', () => {
       now: () => now,
     });
     await scheduler.tickOneManager(manager);
-    expect(upsertNode).not.toHaveBeenCalled();
+    // #5131: an LPP response is still a live round-trip, so lastHeard is
+    // refreshed even though there's no usable GPS fix to persist.
+    expect(upsertNode).toHaveBeenCalledWith({ publicKey: 'companion-d', lastHeard: now }, 'src-a');
+    expect(upsertNode).not.toHaveBeenCalledWith(expect.objectContaining({ latitude: expect.anything() }), 'src-a');
   });
 
   it('does not insert when both status and LPP are empty on a Repeater', async () => {
@@ -693,6 +702,82 @@ describe('MeshCoreRemoteTelemetryScheduler.tickOneManager', () => {
     });
     await scheduler.tickOneManager(manager);
     expect(insertSpy).not.toHaveBeenCalled();
+  });
+
+  // Regression for #5131: a node that only ever answers telemetry polls (no
+  // adverts, no messages) must still be considered "heard" — otherwise
+  // inactiveNodeNotificationService flags it as inactive despite a live
+  // round-trip minutes earlier.
+  it('persists lastHeard when a status response is received, even with no LPP records', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({
+      statusToReturn: { uptimeSecs: 500 },
+      recordsToReturn: [],
+    });
+    const upsertNode = vi.fn().mockResolvedValue(undefined);
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: {
+          getTelemetryEnabledNodes: vi.fn().mockResolvedValue([
+            makeNode({ publicKey: 'rep-e', telemetryEnabled: true, advType: 2, lastTelemetryRequestAt: null }),
+          ]),
+          markTelemetryRequested: vi.fn(),
+          upsertNode,
+        },
+        telemetry: { insertTelemetryBatch: vi.fn().mockResolvedValue(1) },
+      },
+      now: () => now,
+    });
+    await scheduler.tickOneManager(manager);
+    expect(upsertNode).toHaveBeenCalledWith({ publicKey: 'rep-e', lastHeard: now }, 'src-a');
+  });
+
+  it('persists lastHeard when LPP records are received, even with no status response', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({
+      statusToReturn: null,
+      recordsToReturn: [{ channel: 1, type: 103, value: 21.5 }],
+    });
+    const upsertNode = vi.fn().mockResolvedValue(undefined);
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: {
+          getTelemetryEnabledNodes: vi.fn().mockResolvedValue([
+            makeNode({ publicKey: 'companion-f', telemetryEnabled: true, advType: 1, lastTelemetryRequestAt: null }),
+          ]),
+          markTelemetryRequested: vi.fn(),
+          upsertNode,
+        },
+        telemetry: { insertTelemetryBatch: vi.fn().mockResolvedValue(1) },
+      },
+      now: () => now,
+    });
+    await scheduler.tickOneManager(manager);
+    expect(upsertNode).toHaveBeenCalledWith({ publicKey: 'companion-f', lastHeard: now }, 'src-a');
+  });
+
+  it('does not persist lastHeard when both status and LPP are empty', async () => {
+    const now = 10_000_000;
+    const manager = makeFakeManager({ statusToReturn: null, recordsToReturn: [] });
+    const upsertNode = vi.fn().mockResolvedValue(undefined);
+    const scheduler = new MeshCoreRemoteTelemetryScheduler({
+      registry: makeRegistry([manager]),
+      database: {
+        meshcore: {
+          getTelemetryEnabledNodes: vi.fn().mockResolvedValue([
+            makeNode({ publicKey: 'rep-g', telemetryEnabled: true, advType: 2, lastTelemetryRequestAt: null }),
+          ]),
+          markTelemetryRequested: vi.fn(),
+          upsertNode,
+        },
+        telemetry: { insertTelemetryBatch: vi.fn().mockResolvedValue(0) },
+      },
+      now: () => now,
+    });
+    await scheduler.tickOneManager(manager);
+    expect(upsertNode).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.test.ts
@@ -557,6 +557,9 @@ describe('MeshCoreRemoteTelemetryScheduler.tickOneManager', () => {
       expect.objectContaining({ publicKey: 'rep-a', batteryMv: 3700 }),
       'src-a',
     );
+    // #5131: the batteryMv write and the lastHeard write are separate
+    // upsertNode calls — confirm the latter also fires on this path.
+    expect(upsertNode).toHaveBeenCalledWith({ publicKey: 'rep-a', lastHeard: now }, 'src-a');
   });
 
   it('does not persist batteryMv when requestNodeStatus returns no battery voltage', async () => {

--- a/src/server/services/meshcoreRemoteTelemetryScheduler.ts
+++ b/src/server/services/meshcoreRemoteTelemetryScheduler.ts
@@ -433,6 +433,15 @@ export class MeshCoreRemoteTelemetryScheduler {
     const ts = this.nowFn();
     const rows: DbTelemetry[] = [];
     const sources: string[] = [];
+    // A successful status or LPP response is a live round-trip with the
+    // node, exactly as much proof of "heard" as a contact advert or a
+    // message (meshcoreManager.ts persistContact()/DM handling already
+    // bump lastHeard for those). Without this, a node that only ever
+    // responds to telemetry polls (no adverts, no messages) never refreshes
+    // meshcore_nodes.lastHeard and can be flagged as inactive by
+    // inactiveNodeNotificationService while actively answering telemetry
+    // requests. See https://github.com/Yeraze/meshmonitor/issues/5131
+    let gotResponse = false;
 
     // Path #1: SendStatusReq → StatusResponse. Works on any reachable
     // Repeater / Room Server with no login required, returns the
@@ -444,6 +453,7 @@ export class MeshCoreRemoteTelemetryScheduler {
       try {
         const status = await manager.requestNodeStatus(target.publicKey);
         if (status) {
+          gotResponse = true;
           // Device Health (#4558 follow-up): detect a reboot from the uptime
           // reading BEFORE the batch insert below, so the "prior" it reads is the
           // last tick's value. DB read only, no packet sent.
@@ -528,6 +538,7 @@ export class MeshCoreRemoteTelemetryScheduler {
 
       const records = await manager.requestRemoteTelemetry(target.publicKey);
       if (records && records.length > 0) {
+        gotResponse = true;
         const lppRows: DbTelemetry[] = [];
         for (const rec of records) {
           lppRows.push(...recordToTelemetryRows(rec, target.publicKey, nodeNum, ts));
@@ -574,6 +585,17 @@ export class MeshCoreRemoteTelemetryScheduler {
             }
           }
         }
+      }
+    }
+
+    if (gotResponse) {
+      try {
+        await this.database.meshcore.upsertNode({ publicKey: target.publicKey, lastHeard: ts }, manager.sourceId);
+      } catch (err) {
+        logger.warn(
+          `[MeshCoreRemoteTelem:${manager.sourceId}] Failed to persist lastHeard for ${keyShort}…:`,
+          err,
+        );
       }
     }
 


### PR DESCRIPTION
## Summary

- Fixes a false-positive "Inactive Node" alert for MeshCore sources: `meshcore_nodes.lastHeard` (read by both the Node Details "Last Heard" display and `inactiveNodeNotificationService`) was only refreshed by contact/advert sync (`persistContact()`) and incoming direct messages — a node that mostly answers telemetry polls, with an infrequent advert cadence, could go "inactive" by the threshold even though it was actively responding to telemetry requests.
- `MeshCoreRemoteTelemetryScheduler.requestTelemetryForNode()` now marks the target as heard (`upsertNode({ publicKey, lastHeard })`) whenever it receives a real `SendStatusReq` status response or `GetTelemetryData` LPP response, mirroring the treatment adverts and messages already get. This is a passive side-effect of a telemetry round-trip we already initiate on the scheduler's existing cadence — no new packets are sent.
- Updated three existing tests whose assertions (`upsertNode` not called when there's no battery/GPS data to persist) predated this change, and added three new tests covering the lastHeard-refresh behavior directly (status-only, LPP-only, and the empty/no-response case where it must NOT fire).

## Root cause

Traced in issue #5131: the reporter's node adverts only once or twice a day but answers remote-telemetry polls reliably. `persistContact()` and the DM handler (added for #4553) are the only two write sites for `lastHeard`; the telemetry scheduler wrote `batteryMv`/GPS but skipped `lastHeard` entirely, so a live round-trip via telemetry was invisible to "heard" tracking.

## Test plan

- [x] `npx vitest run src/server/services/meshcoreRemoteTelemetryScheduler.test.ts` — 40/40 passing
- [x] `npx vitest run src/server/services/inactiveNodeNotificationService.test.ts src/server/services/inactiveNodeNotificationService.perSource.test.ts src/db/repositories/meshcore.test.ts` — 81/81 passing
- [x] `npx tsc --noEmit -p tsconfig.server.json` — clean
- [x] `npx eslint` on both touched files — clean

Fixes #5131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012R1RV8sWmULXXdCLBcC3Ue

---
_Generated by [Claude Code](https://claude.ai/code/session_012R1RV8sWmULXXdCLBcC3Ue)_