### PR TITLE
fix(telemetry): stop chart panels overflowing the viewport in portrait (#5093)

### DIFF
--- a/src/components/TelemetryGraphs.css
+++ b/src/components/TelemetryGraphs.css
@@ -86,6 +86,19 @@
   border: 1px solid var(--color-surface-hover);
   border-radius: var(--radius-lg);
   padding: 15px;
+  /*
+   * #5093: a grid item defaults to `min-width: auto`, so it refuses to shrink
+   * below its content's min-content width. These cards therefore sized to their
+   * own contents (measured 307-502px) rather than to the track, and anything
+   * wider than the viewport spilled off the right edge in portrait. Landscape
+   * hid it because ~852px accommodates even the widest card.
+   *
+   * Note the mobile `grid-template-columns: 1fr` below does NOT prevent this:
+   * `1fr` is shorthand for `minmax(auto, 1fr)`, and that `auto` floor is exactly
+   * the min-content size we need to escape. The floor has to be zeroed, either
+   * here or as `minmax(0, 1fr)` on the track.
+   */
+  min-width: 0;
 }
 
 .graph-header {
@@ -103,7 +116,21 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: calc(100% - 60px); /* Reserve space for favorite and menu buttons */
+  /*
+   * #5093: this used to reserve a fixed `max-width: calc(100% - 60px)` for
+   * "the favorite and menu buttons". That was true when there were two of
+   * them; a TelemetryGraphs header now carries up to six controls — the
+   * 3-button mode-toggle group (~ / gauge / #), solar, CSV export, favorite
+   * and the ⋯ menu — which measure ~182px. The title therefore claimed 122px
+   * more than was left, pushing the controls past the right edge in portrait.
+   *
+   * Sizing by flex instead of a magic number self-corrects however many
+   * controls a given header renders. `min-width: 0` is what lets the title
+   * actually shrink: a flex item's default `min-width: auto` floors it at
+   * min-content, and `text-overflow: ellipsis` never engages above that floor.
+   */
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .graph-actions {
@@ -111,6 +138,8 @@
   align-items: center;
   gap: 4px;
   position: relative;
+  /* Never squeeze the controls — the title gives way instead (#5093). */
+  flex: 0 0 auto;
 }
 
 .favorite-btn,
@@ -303,7 +332,9 @@
 
 @media (max-width: 768px) {
   .graphs-grid {
-    grid-template-columns: 1fr;
+    /* `minmax(0, 1fr)`, not `1fr` — see the min-width note on .graph-container
+       (#5093). Bare `1fr` keeps a min-content floor and still overflows. */
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .telemetry-graphs {

--- a/src/components/TelemetryGraphs.layout.test.ts
+++ b/src/components/TelemetryGraphs.layout.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Chart panel layout in narrow portrait viewports (#5093).
+ *
+ * On a phone in portrait, the chart cards on the Node Info page ran off the
+ * right edge — the plotted line spilled past the viewport and the header
+ * controls were clipped — while landscape looked fine. Two independent
+ * min-content floors caused it, and each has a non-obvious fix that is very
+ * easy to "tidy up" back into the broken form:
+ *
+ *   1. A grid item defaults to `min-width: auto`, so `.graph-container` sized
+ *      to its own contents rather than the track. Writing the mobile track as
+ *      bare `1fr` does NOT help: `1fr` means `minmax(auto, 1fr)`, and that
+ *      `auto` floor is the very thing being escaped.
+ *   2. `.graph-title` reserved a fixed `calc(100% - 60px)` for "the favorite
+ *      and menu buttons". A TelemetryGraphs header now renders up to six
+ *      controls (~182px), so the title over-claimed and pushed them off-screen.
+ *
+ * This is a pure-CSS fix with no JS behaviour to assert, so the stylesheet is
+ * checked directly — the same approach BeaconOffersPanel.test.tsx uses to guard
+ * its own CSS module. Rendering cannot cover it: jsdom has no layout engine, so
+ * a reintroduced min-content floor would still "pass" a render test.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Comments are stripped first: these rules are heavily commented, and the
+// comments quote the very declarations being asserted absent (e.g. the old
+// `max-width: calc(...)`), which would otherwise match.
+const css = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'TelemetryGraphs.css'),
+  'utf8',
+).replace(/\/\*[\s\S]*?\*\//g, '');
+
+/** Body of the first rule whose selector list contains `selector`. */
+const ruleBody = (selector: string, from = 0): string => {
+  const re = new RegExp(`(^|\\})[^{}]*\\${selector}\\b[^{}]*\\{([^}]*)\\}`, 'm');
+  const match = re.exec(css.slice(from));
+  expect(match, `rule for ${selector} not found`).not.toBeNull();
+  return match![2];
+};
+
+describe('TelemetryGraphs.css — narrow-viewport overflow (#5093)', () => {
+  it('lets .graph-container shrink below its content width', () => {
+    // Without this a card sizes to min-content (measured 307-502px) and any
+    // card wider than the viewport spills off the right edge in portrait.
+    expect(ruleBody('.graph-container')).toMatch(/min-width:\s*0/);
+  });
+
+  it('zeroes the mobile grid track floor with minmax(0, 1fr), not bare 1fr', () => {
+    const mobile = css.slice(css.indexOf('@media (max-width: 768px)'));
+    const grid = /\.graphs-grid\s*\{([^}]*)\}/.exec(mobile);
+    expect(grid, '.graphs-grid override missing from the mobile media query').not.toBeNull();
+    expect(grid![1]).toMatch(/grid-template-columns:\s*minmax\(\s*0\s*,\s*1fr\s*\)/);
+    // `1fr` on its own is `minmax(auto, 1fr)` and reintroduces the floor.
+    expect(grid![1]).not.toMatch(/grid-template-columns:\s*1fr\s*;/);
+  });
+
+  it('sizes .graph-title by flex rather than reserving a fixed pixel budget', () => {
+    const title = ruleBody('.graph-title');
+    // A hard-coded reservation cannot track how many controls a header renders,
+    // which is what pushed them off-screen once the mode-toggle group landed.
+    expect(title).not.toMatch(/max-width:\s*calc\(/);
+    expect(title).toMatch(/flex:\s*1\s+1\s+auto/);
+    // Required for `text-overflow: ellipsis` to engage — a flex item's default
+    // `min-width: auto` floors it at min-content and the title never truncates.
+    expect(title).toMatch(/min-width:\s*0/);
+    expect(title).toMatch(/text-overflow:\s*ellipsis/);
+  });
+
+  it('keeps .graph-actions at its natural width so the title gives way instead', () => {
+    expect(ruleBody('.graph-actions')).toMatch(/flex:\s*0\s+0\s+auto/);
+  });
+});


### PR DESCRIPTION
Fixes #5093.

## Problem

On a phone in portrait, the chart cards on the Node Info page run off the right edge — the plotted line spills past the viewport and the header controls are clipped — while landscape looks fine.

Two **independent** min-content floors held the cards wider than the screen. Fixing either alone leaves the bug.

**1. The card could not shrink below its own contents.** A grid item defaults to `min-width: auto`, so `.graph-container` sized to its content rather than to the track. The mobile override didn't save it, because it was written as bare `1fr` — which is `minmax(auto, 1fr)`, and that `auto` floor is precisely what needed escaping. That subtlety is why the mobile query *looked* correct.

**2. The title over-claimed the header.** `.graph-title` reserved `max-width: calc(100% - 60px)` "for the favorite and menu buttons". True when there were two of them. A TelemetryGraphs header now renders up to **six** — the 3-button mode-toggle group (`~` / gauge / `#`), solar, CSV export, favorite, and the `⋯` menu, measuring **206px**. The title therefore claimed ~146px more than was left and pushed the controls off-screen.

## Changes

- `.graph-container` → `min-width: 0`; mobile track → `minmax(0, 1fr)`.
- `.graph-title` → `flex: 1 1 auto; min-width: 0`, dropping the fixed reservation. Sizing by flex self-corrects however many controls a given header renders, instead of encoding a count that goes stale the next time a button is added. The `min-width: 0` is also what lets the already-present `text-overflow: ellipsis` engage at all.
- `.graph-actions` → `flex: 0 0 auto`, so the title gives way rather than the controls.

`TelemetryGraphs.css` is the single source for these classes — `PacketRateGraphs`, `LinkQualityGraph` and `SmartHopsGraphs` all import it and nothing else redefines them — so this covers every chart panel, not just the two named in the report.

## Verification

Measured in Chrome at **390×844** against the **built** stylesheet served by the dev container, toggling only the pre-fix declarations:

| Panel | Before | After |
|---|---|---|
| Air Utilization (TX) (%) | card **397px**, page overflows **17px** | card 370px, no overflow |
| Active Nodes (MeshMonitor) | card **444px**, page overflows **64px**, controls clipped **48px** | card 370px, no overflow, all controls visible |

Both are the panels named in the report. `444px < 852px` is exactly why rotating to landscape hid it.

Screenshots (before: the ★ and ⋯ buttons are entirely off-screen and the charts run past the right edge; after: cards fit, the title ellipsizes to `Active Nodes (M…`, all seven controls visible) are attached in the session.

## Test plan

- [x] New `TelemetryGraphs.layout.test.ts` — asserts the stylesheet directly, the same approach `BeaconOffersPanel.test.tsx` uses for its CSS module. **jsdom has no layout engine**, so a render test cannot catch a reintroduced min-content floor; this guards the four declarations that matter, including that the mobile track is `minmax(0, 1fr)` and *not* bare `1fr`, and that `.graph-title` has no `max-width: calc(...)`. CSS comments are stripped before matching — they quote the very declarations asserted absent.
- [x] `vitest run` over the layout test plus the four chart suites: 44 passed, 0 failed (`success: true` via the JSON reporter).
- [x] `tsc --noEmit` clean; `lint:ci` clean.
- [x] Deployed to the dev container and confirmed the built bundle carries `min-width:0`, `flex:auto`/`min-width:0` on the title, `flex:none` on the actions, and `@media (width<=768px){.graphs-grid{grid-template-columns:minmax(0,1fr)}}` — i.e. the fix survives the lightningcss minifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZ871RCjD95cAu6jMfNM4