### PR TITLE
chore(release): bump to 4.16.0-rc5

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.16.0-rc4",
+  "version": "4.16.0-rc5",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.16.0-rc4",
+  "version": "4.16.0-rc5",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.16.0-rc4
-appVersion: "4.16.0-rc4"
+version: 4.16.0-rc5
+appVersion: "4.16.0-rc5"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.16.0-rc4",
+  "version": "4.16.0-rc5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.16.0-rc4",
+      "version": "4.16.0-rc5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.16.0-rc4",
+  "version": "4.16.0-rc5",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version bump for the v4.16.0-rc5 pre-release.

All five files updated per CLAUDE.md: `package.json`, `package-lock.json` (regenerated via `npm install --package-lock-only`), `helm/meshmonitor/Chart.yaml`, `desktop/package.json`, `desktop/src-tauri/tauri.conf.json`. Verified no `4.16.0-rc4` string remains in any of them.

## What rc5 contains

Nine issues closed since rc4, plus 11 dependency bumps.

**MeshCore** — a `code=142` frame could crash the whole process via an unguarded bare reject (#5102); the pinned `meshcore.js` truncated RepeaterStats and misread Core `queue_len` (#5125); telemetry round-trips didn't refresh `lastHeard`, firing false inactive-node alerts (#5131); `meshcore_mqtt` sources were excluded from dashboard nodes (#5094) and rendered the Meshtastic shell (#5096).

**Meshtastic 2.8** — Traffic Management moved to the non-zero-enables schema; nine controls that silently did nothing on 2.8 firmware are gone (#5123).

**Infrastructure** — previously released Helm chart archives 404'd while the index still advertised them (#5119).

**UI** — chart panels overflowed the viewport in portrait (#5093); beacon offers now warn on regulator-non-compliant preset/region pairs (#5103).

Also included: #5130, which hardens the TCP connect-timeout lifetime and adds teardown attribution logging for #5122. **That issue stays open** — the fix removes a latent bug matching the reported fingerprint, but the root cause is unconfirmed.

## Test plan

- [x] `system-test` label applied — this is a version-bump release chore, which always runs the hardware suite.
- [x] Version string verified in all five files; no `rc4` residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZ871RCjD95cAu6jMfNM4