### PR TITLE
fix(dashboard): theme the MeshCore MQTT ingest inputs (#5135)

### DIFF
--- a/src/pages/DashboardPage.meshcoreMqttFieldset.test.tsx
+++ b/src/pages/DashboardPage.meshcoreMqttFieldset.test.tsx
@@ -227,6 +227,27 @@ describe('MeshCore MQTT ingest source fieldset (#5040 Phase 1)', () => {
     expect(screen.getByPlaceholderText('MCO')).toBeInTheDocument();
   });
 
+  it('themes every text input with the shared class (#5135)', () => {
+    // These rendered as unstyled native controls — white box, default border —
+    // against the app's dark modal, because the fieldset was added without
+    // `dashboard-form-input`. Nothing functional broke, so no other test
+    // noticed. Asserting on the rendered DOM rather than the source keeps this
+    // honest about what the user actually sees.
+    renderPage();
+    openAddModal();
+    selectMcMqttType();
+
+    const modal = document.querySelector('.dashboard-modal, [role="dialog"]') ?? document.body;
+    const controls = [...modal.querySelectorAll('input, select, textarea')].filter(
+      (el) => !['checkbox', 'radio'].includes((el as HTMLInputElement).type),
+    );
+    expect(controls.length).toBeGreaterThan(0);
+    const unstyled = controls.filter((el) => !el.classList.contains('dashboard-form-input'));
+    expect(
+      unstyled.map((el) => `${el.tagName.toLowerCase()}[type=${(el as HTMLInputElement).type}]`),
+    ).toEqual([]);
+  });
+
   it('states up front that the source has no radio', () => {
     // Expectation-setting matters here: a user who does not read this will file
     // "my MeshCore source has no device page" as a bug.

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -2028,6 +2028,7 @@ function DashboardInner() {
                 <label className="dashboard-form-field">
                   <span className="dashboard-form-label">{t('source.form.mc_mqtt_broker_url', 'Broker URL')}</span>
                   <input
+                    className="dashboard-form-input"
                     type="text"
                     value={formMcMqttBrokerUrl}
                     onChange={(e) => setFormMcMqttBrokerUrl(e.target.value)}
@@ -2041,6 +2042,7 @@ function DashboardInner() {
                 <label className="dashboard-form-field">
                   <span className="dashboard-form-label">{t('source.form.mc_mqtt_region', 'Region (IATA)')}</span>
                   <input
+                    className="dashboard-form-input"
                     type="text"
                     value={formMcMqttRegion}
                     onChange={(e) => setFormMcMqttRegion(e.target.value)}
@@ -2054,6 +2056,7 @@ function DashboardInner() {
                 <label className="dashboard-form-field">
                   <span className="dashboard-form-label">{t('source.form.mc_mqtt_username', 'Username (optional)')}</span>
                   <input
+                    className="dashboard-form-input"
                     type="text"
                     value={formMcMqttUsername}
                     onChange={(e) => setFormMcMqttUsername(e.target.value)}
@@ -2064,6 +2067,7 @@ function DashboardInner() {
                 <label className="dashboard-form-field">
                   <span className="dashboard-form-label">{t('source.form.mc_mqtt_password', 'Password (optional)')}</span>
                   <input
+                    className="dashboard-form-input"
                     type="password"
                     value={formMcMqttPassword}
                     onChange={(e) => setFormMcMqttPassword(e.target.value)}


### PR DESCRIPTION
Fixes #5135.

## Problem

The four text/password inputs in the **MeshCore MQTT ingest** fieldset (Broker URL, Region, Username, Password) were added without `className="dashboard-form-input"`. Without it none of the CSS variables that theme a form control apply, so the browser falls back to its native rendering — white boxes with default borders against the app's dark modal. Every other source type in the same modal styles correctly.

Visual only, no functional impact. A regression from the Phase 1 MeshCore MQTT UI (#5057), where the new fieldset was written without the shared class.

## Changes

Added the class to the four inputs.

I swept the whole file rather than trusting the reported list — checking every `<input>`/`<select>`/`<textarea>` in `DashboardPage.tsx` for the class, exempting checkboxes and radios (those are styled via their `.dashboard-form-checkbox` label). **Exactly those four came back**, so the report was complete and there's nothing else lurking in the other source types.

## Test plan

- [x] New test in `DashboardPage.meshcoreMqttFieldset.test.tsx`. It queries the **rendered modal** rather than the source text, so it asserts what the user actually sees, and it checks *every* non-checkbox control in the fieldset rather than the four by name — so the next source type added here can't reintroduce the same bug unnoticed.
- [x] **Verified the test fails without the fix**: stashed the change and re-ran — it fails naming all four (`expected [ 'input[type=text]', …(3) ] to deeply equal []`) — then restored and confirmed green. A styling test that passes both ways would be worthless.
- [x] `vitest run src/pages/DashboardPage`: 144 passed, 0 failed (`success: true` via the JSON reporter).
- [x] `tsc --noEmit` clean; `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZ871RCjD95cAu6jMfNM4