### PR TITLE
fix(meshtastic): defer the favorite write-back out of the config sync (#5122 Bug A)

### DIFF
--- a/src/server/meshtasticManager.favoriteResyncDeferral.test.ts
+++ b/src/server/meshtasticManager.favoriteResyncDeferral.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the VirtualNodeServer so tests never bind a real TCP port
+const { VNConstructor } = vi.hoisted(() => ({
+  VNConstructor: vi.fn(function (this: any, _opts: any) {
+    this.start = vi.fn().mockResolvedValue(undefined);
+    this.stop = vi.fn().mockResolvedValue(undefined);
+    this.broadcastToClients = vi.fn().mockResolvedValue(undefined);
+    this.isRunning = () => true;
+    this.getClientCount = () => 0;
+  }),
+}));
+vi.mock('./virtualNodeServer.js', () => ({
+  VirtualNodeServer: VNConstructor,
+}));
+
+// Stub the TCP transport so constructing a manager never touches a real socket
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    sources: { getSource: vi.fn().mockResolvedValue(null) },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+vi.mock('./meshtasticProtobufService.js', () => {
+  const svc = {
+    createNodeInfo: vi.fn().mockResolvedValue(new Uint8Array()),
+    createFromRadioWithPacket: vi.fn().mockResolvedValue(new Uint8Array()),
+    getPortNumName: (n: number) => `PORT_${n}`,
+    normalizePortNum: (n: any) => (typeof n === 'number' ? n : 0),
+    processPayload: vi.fn(),
+  };
+  return { default: svc, meshtasticProtobufService: svc };
+});
+vi.mock('./services/packetLogService.js', () => ({
+  default: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+  packetLogService: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+}));
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: { isEnabled: () => false, tryDecrypt: vi.fn() },
+}));
+// serverEventNotificationService is invoked from handleDisconnected
+vi.mock('./services/serverEventNotificationService.js', () => ({
+  serverEventNotificationService: {
+    notifyNodeDisconnected: vi.fn().mockResolvedValue(undefined),
+    notifyNodeConnected: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+
+import { MeshtasticManager } from './meshtasticManager.js';
+
+/**
+ * Favorite write-back deferral during the initial config sync (#5122).
+ *
+ * A reporter packet-captured this: MeshMonitor sent a `SetFavoriteNode` admin
+ * packet WHILE the initial NodeDB sync was still streaming, the node stopped
+ * ACKing that exact TCP segment, the OS retransmitted it 8 times over ~10-15s
+ * with an unchanged sequence number, and the node then RST the connection. The
+ * sync restarted from scratch and, on their ~190-node mesh, never completed —
+ * reproduced in 3 of 4 clean runs. The same capture shows the identical packet
+ * flowing fine outside the sync window, so the bug is WHEN we send it.
+ *
+ * The reconciliation itself is not in question: a `favoriteLocked` node's DB
+ * value must still win immediately and locally. Only the admin write-back to
+ * the device waits for `configComplete`.
+ */
+describe('MeshtasticManager — favorite write-back deferral (#5122)', () => {
+  let mgr: any;
+  let sent: Array<{ op: 'add' | 'remove'; nodeNum: number }>;
+
+  const capturing = (on: boolean) => {
+    mgr.isCapturingInitConfig = on;
+    mgr.configCaptureComplete = !on;
+  };
+
+  beforeEach(() => {
+    mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 }) as any;
+    sent = [];
+    mgr.sendFavoriteNode = vi.fn(async (n: number) => { sent.push({ op: 'add', nodeNum: n }); });
+    mgr.sendRemoveFavoriteNode = vi.fn(async (n: number) => { sent.push({ op: 'remove', nodeNum: n }); });
+  });
+
+  it('sends nothing to the device while the config sync is still running', async () => {
+    capturing(true);
+    mgr.queueFavoriteResync(111, '!0000006f', true);
+    await Promise.resolve();
+
+    expect(sent).toEqual([]);
+    expect(mgr.pendingFavoriteResync.get(111)).toBe(true);
+  });
+
+  it('applies the deferred write-back once the sync completes', async () => {
+    capturing(true);
+    mgr.queueFavoriteResync(111, '!0000006f', true);
+    mgr.queueFavoriteResync(222, '!000000de', false);
+
+    capturing(false);
+    await mgr.flushPendingFavoriteResyncs();
+
+    expect(sent).toEqual([
+      { op: 'add', nodeNum: 111 },
+      { op: 'remove', nodeNum: 222 },
+    ]);
+    expect(mgr.pendingFavoriteResync.size).toBe(0);
+  });
+
+  it('collapses a node that flaps mid-sync into ONE write-back at its final value', async () => {
+    // The old code fired per NodeInfo. A node reported repeatedly during a
+    // large sync therefore produced a burst of admin packets — precisely the
+    // load this defers.
+    capturing(true);
+    mgr.queueFavoriteResync(111, '!0000006f', true);
+    mgr.queueFavoriteResync(111, '!0000006f', false);
+    mgr.queueFavoriteResync(111, '!0000006f', true);
+
+    capturing(false);
+    await mgr.flushPendingFavoriteResyncs();
+
+    expect(sent).toEqual([{ op: 'add', nodeNum: 111 }]);
+  });
+
+  it('sends immediately when no sync is in progress', async () => {
+    capturing(false);
+    mgr.queueFavoriteResync(111, '!0000006f', true);
+    await new Promise((r) => setImmediate(r));
+
+    expect(sent).toEqual([{ op: 'add', nodeNum: 111 }]);
+    expect(mgr.pendingFavoriteResync.size).toBe(0);
+  });
+
+  it('coalesces repeat write-backs for the same node behind a cooldown', async () => {
+    // Mirrors the ignore re-sync guard sitting directly below the call site: a
+    // device that cannot durably hold the flag would otherwise earn an admin
+    // command on every NodeInfo naming that node.
+    capturing(false);
+    await mgr.sendFavoriteResyncNow(111, '!0000006f', true);
+    await mgr.sendFavoriteResyncNow(111, '!0000006f', true);
+
+    expect(sent).toEqual([{ op: 'add', nodeNum: 111 }]);
+  });
+
+  it('does not let one node cooldown block a different node', async () => {
+    capturing(false);
+    await mgr.sendFavoriteResyncNow(111, '!0000006f', true);
+    await mgr.sendFavoriteResyncNow(222, '!000000de', true);
+
+    expect(sent).toHaveLength(2);
+  });
+
+  it('survives a send that throws, and still applies the rest of the queue', async () => {
+    capturing(true);
+    mgr.queueFavoriteResync(111, '!0000006f', true);
+    mgr.queueFavoriteResync(222, '!000000de', true);
+    mgr.sendFavoriteNode = vi.fn(async (n: number) => {
+      if (n === 111) throw new Error('device busy');
+      sent.push({ op: 'add', nodeNum: n });
+    });
+
+    capturing(false);
+    await expect(mgr.flushPendingFavoriteResyncs()).resolves.toBeUndefined();
+    expect(sent).toEqual([{ op: 'add', nodeNum: 222 }]);
+  });
+
+  it('drops queued write-backs when the sync dies mid-flight', async () => {
+    // A sync that never reaches configComplete must not carry stale intents
+    // into the next session — the device re-reports its own state on reconnect
+    // and the reconciliation runs again from there.
+    capturing(true);
+    mgr.queueFavoriteResync(111, '!0000006f', true);
+    expect(mgr.pendingFavoriteResync.size).toBe(1);
+
+    await mgr.handleDisconnected();
+
+    expect(mgr.pendingFavoriteResync.size).toBe(0);
+    expect(sent).toEqual([]);
+  });
+});

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -110,6 +110,8 @@ const SCRIPT_AUTO_RESPONDER_TIMEOUT_MS = 30_000;
 // Minimum gap between local "re-ignore" admin pushes for the same node (#2601),
 // so a device that can't durably hold the ignore doesn't trigger a command storm.
 const IGNORE_REAPPLY_COOLDOWN_MS = 60_000;
+/** Same coalescing window as the ignore re-sync, for the favorite re-sync (#5122). */
+const FAVORITE_REAPPLY_COOLDOWN_MS = 60_000;
 // Window for the {NODECOUNT}/{DIRECTCOUNT} template tokens, matching the
 // Sources panel's per-source "active" badge (issue #3388). The badge counts
 // nodes heard in the last 2h (getActiveNodeCount default, issue #2883); the
@@ -723,6 +725,78 @@ class MeshtasticManager implements ISourceManager {
     }
   }
 
+  /**
+   * Converge the device's favorite flag to ours for a `favoriteLocked` node.
+   *
+   * This used to fire inline, fire-and-forget, from `processNodeInfoProtobuf` —
+   * so on a large mesh every locked node whose device state disagreed injected
+   * an admin write INTO the initial NodeDB sync, while NodeInfo was still
+   * streaming. A reporter packet-captured the consequence (#5122): the node
+   * stops ACKing that exact segment, the OS retransmits it 8 times over
+   * ~10-15s with the same sequence number, and the node then RSTs the
+   * connection. The sync restarts from scratch and, on a ~190-node mesh, never
+   * finishes. The same capture shows this packet flowing fine outside the sync
+   * window, so the fix is when we send it, not what we send.
+   *
+   * So: during config capture, record the intent and send nothing. The DB has
+   * already been made authoritative by the caller, so nothing is lost by
+   * waiting; `flushPendingFavoriteResyncs()` drains the queue once
+   * `configComplete` lands.
+   *
+   * The cooldown mirrors the ignore re-sync directly below the call site — a
+   * device that cannot durably hold the flag would otherwise trigger an admin
+   * command on every single NodeInfo for that node.
+   */
+  private queueFavoriteResync(nodeNum: number, nodeId: string, desiredFavorite: boolean): void {
+    if (this.isCapturingInitConfig && !this.configCaptureComplete) {
+      // Map, not push: a node that flaps mid-sync collapses to its final value.
+      this.pendingFavoriteResync.set(nodeNum, desiredFavorite);
+      logger.debug(`⏸️ Deferring favorite write-back for ${nodeId} until the config sync completes (#5122)`);
+      return;
+    }
+    void this.sendFavoriteResyncNow(nodeNum, nodeId, desiredFavorite);
+  }
+
+  /** The actual admin write, cooldown-guarded. Local command — no mesh airtime. */
+  private async sendFavoriteResyncNow(nodeNum: number, nodeId: string, desiredFavorite: boolean): Promise<void> {
+    const now = Date.now();
+    const lastPush = this.favoriteReapplyCooldown.get(nodeNum) ?? 0;
+    if (now - lastPush < FAVORITE_REAPPLY_COOLDOWN_MS) {
+      logger.debug(`⏳ Favorite write-back for ${nodeId} still in cooldown — skipping`);
+      return;
+    }
+    this.favoriteReapplyCooldown.set(nodeNum, now);
+    try {
+      if (desiredFavorite) {
+        await this.sendFavoriteNode(nodeNum);
+      } else {
+        await this.sendRemoveFavoriteNode(nodeNum);
+      }
+    } catch (err) {
+      logger.warn(`⚠️ Failed to re-sync locked favorite for node ${nodeId}:`, err);
+    }
+  }
+
+  /**
+   * Drain the favorite write-backs deferred during config capture (#5122).
+   *
+   * Sends are serialised rather than fired in parallel: the whole point is to
+   * stop handing the node a burst of admin packets it may not keep up with, and
+   * firing the queue at once right after `configComplete` would recreate that in
+   * a different place. These are local admin commands to the connected node, so
+   * they cost no mesh airtime.
+   */
+  private async flushPendingFavoriteResyncs(): Promise<void> {
+    if (this.pendingFavoriteResync.size === 0) return;
+    const pending = [...this.pendingFavoriteResync.entries()];
+    this.pendingFavoriteResync.clear();
+    logger.debug(`▶️ Config sync complete — applying ${pending.length} deferred favorite write-back(s) (#5122)`);
+    for (const [nodeNum, desiredFavorite] of pending) {
+      const nodeId = `!${nodeNum.toString(16).padStart(8, '0')}`;
+      await this.sendFavoriteResyncNow(nodeNum, nodeId, desiredFavorite);
+    }
+  }
+
   private cancelConfigCompleteFallbackTimer(): void {
     if (this.configCompleteFallbackTimer) {
       clearTimeout(this.configCompleteFallbackTimer);
@@ -859,6 +933,15 @@ class MeshtasticManager implements ISourceManager {
   private remoteLocalStatsLastSentAt: Map<number, number> = new Map();
   private nodeLinkQuality: Map<number, { quality: number; lastHops: number }> = new Map(); // Track link quality per node
   private ignoreReapplyCooldown: Map<number, number> = new Map(); // nodeNum -> last local re-ignore push timestamp (#2601), coalesces bursts
+  private favoriteReapplyCooldown: Map<number, number> = new Map(); // nodeNum -> last favorite write-back timestamp (#5122), coalesces bursts
+  /**
+   * Favorite write-backs deferred until the initial config sync finishes (#5122).
+   *
+   * nodeNum -> the favorite state we want the device to converge to. A Map, so a
+   * node that flaps several times during one sync collapses to its final value
+   * and produces a single admin command on flush.
+   */
+  private pendingFavoriteResync: Map<number, boolean> = new Map();
   private remoteAdminScannerInterval: NodeJS.Timeout | null = null;
   private remoteAdminScannerIntervalMinutes: number = 0; // 0 = disabled
   private pendingRemoteAdminScans: Set<number> = new Set(); // Track nodes being scanned
@@ -2172,6 +2255,10 @@ class MeshtasticManager implements ISourceManager {
           this.localNodeInfo = null;
           this.actualDeviceConfig = null;
           this.actualModuleConfig = null;
+          // A sync that died mid-flight must not carry its deferred favorite
+          // write-backs into the next session — the device re-reports its own
+          // state on reconnect and the reconciliation runs again from there (#5122).
+          this.pendingFavoriteResync.clear();
           logger.debug('📸 Cleared device and module config cache on disconnect');
           break;
         case 'clearConfigCapture':
@@ -4820,6 +4907,9 @@ class MeshtasticManager implements ISourceManager {
                   break;
               }
             }
+            // After the action loop, so the capture flags are already flipped
+            // before any deferred admin write goes out (#5122).
+            void this.flushPendingFavoriteResyncs();
             this.assertStateConsistent();
           }
           break;
@@ -9276,19 +9366,12 @@ class MeshtasticManager implements ISourceManager {
         if (existingNode?.favoriteLocked) {
           if (existingNode.isFavorite !== nodeInfo.isFavorite) {
             logger.debug(`🔒 Node ${nodeId} favoriteLocked — preserving DB isFavorite=${existingNode.isFavorite}, re-syncing to device (device reported ${nodeInfo.isFavorite})`);
+            // The DB always wins immediately — that part is local and free.
             nodeData.isFavorite = existingNode.isFavorite;
-            // Re-push the locked favorite state to the connected device
-            void (async () => {
-              try {
-                if (existingNode.isFavorite) {
-                  await this.sendFavoriteNode(nodeNum);
-                } else {
-                  await this.sendRemoveFavoriteNode(nodeNum);
-                }
-              } catch (err) {
-                logger.warn(`⚠️ Failed to re-sync locked favorite for node ${nodeId}:`, err);
-              }
-            })();
+            // The write-back to the device is what must wait (#5122). See
+            // queueFavoriteResync: sending it mid-sync has been packet-captured
+            // wedging the node's TCP stack until it RSTs the connection.
+            this.queueFavoriteResync(nodeNum, nodeId, existingNode.isFavorite === true);
           }
         } else {
           nodeData.isFavorite = nodeInfo.isFavorite;


### PR DESCRIPTION
Addresses **Bug A** of #5122. (Bug B — the silent hang — is a separate PR.)

## The trigger is ours

@ogarcia captured this at the packet level across four clean restarts, and it reproduces in 3 of 4:

```
client writes a 45-byte packet at t=0.000
seq=991498261 retransmitted 7 more times: +0.22s, +0.21s, +0.43s, +0.86s, +1.70s, +3.47s, +6.83s
node sends RST immediately after the 8th attempt
```

Identical sequence number on every retransmission — plain OS-level TCP retransmit with standard backoff, not application backpressure (the client's receive window stays at 63000–65535 throughout). The node's TCP stack simply never ACKs that one segment, then resets. Decoding the un-ACKed payload gives the same command in both runs: a `SetFavoriteNode` admin packet.

That packet is ours, and the code sends it at the worst possible moment. `meshtasticManager.ts` reconciles `favoriteLocked` nodes inside `processNodeInfoProtobuf`:

```ts
if (existingNode?.favoriteLocked) {
  if (existingNode.isFavorite !== nodeInfo.isFavorite) {
    void (async () => { await this.sendFavoriteNode(nodeNum); })();
```

Inline, fire-and-forget, **per NodeInfo**, with no phase gate and no cooldown. So on a large mesh every locked node whose device state disagrees injects an admin write into the initial NodeDB sync while NodeInfo is still streaming.

The tell is 30 lines below it: the sibling **ignore** re-sync does the same reconciliation and *is* guarded, by `IGNORE_REAPPLY_COOLDOWN_MS` since #2601, with a comment about "a thrashing device that can't durably hold the ignore". The favorite path is that same pattern written without the guard.

Crucially, the reporter's captures also show this exact packet flowing fine mid-sync on a healthy run — ACKed normally, data continuing right after. So this is not "the packet is malformed". It is a timing interaction with whatever the node is doing during sync, and the fix is to stop competing with it.

## Changes

- **Deferral.** `queueFavoriteResync()` records the intent during config capture and sends nothing; `flushPendingFavoriteResyncs()` drains it after `configComplete`. The DB half of the reconciliation is untouched and still immediate — that is local and free. The queue is a `Map` keyed by nodeNum, so a node that flaps several times during one sync collapses to a single command at its final value.
- **Serial flush.** Draining is sequential, not `Promise.all`. Firing the whole queue at once right after `configComplete` would recreate the same burst a few seconds later.
- **Cooldown.** Per-node, matching the ignore path's 60s.
- **Cleared on disconnect.** A sync that dies mid-flight must not carry stale write-backs into the next session; the device re-reports its own state on reconnect and the reconciliation runs again from there.

## Mesh impact

None. These are local admin commands to the connected node (`destNode` is the local node) and never reach the air. The change strictly *reduces* how many are sent and moves the remainder out of the sync window. No new timers, no new schedulers.

## Test plan

- [x] New `meshtasticManager.favoriteResyncDeferral.test.ts` (8 tests): nothing is sent while capturing; the deferred writes apply after the sync; a node flapping mid-sync collapses to one command at its final value; sends go out immediately when no sync is running; the cooldown coalesces repeats for one node without blocking a different node; a throwing send does not abort the rest of the queue; and a mid-flight disconnect drops the queue. The first and fourth tests differ *only* in the capture flag, so together they pin the gate as the thing driving the behaviour.
- [x] `vitest run src/server/meshtasticManager`: 885 passed, 0 failed. `favoritesService`: 24 passed, 0 failed. (`success: true` via the JSON reporter.)
- [x] `tsc --noEmit -p tsconfig.server.json` clean; `lint:ci` clean.

Hardware confirmation still needs @ogarcia's mesh — this is the one failure mode that only shows up at ~190 nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZ871RCjD95cAu6jMfNM4