### PR TITLE
fix(tcp): detect a stalled initial config sync instead of hanging (#5122 Bug B)

### DIFF
--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -688,19 +688,38 @@ class MeshtasticManager implements ISourceManager {
   private configSyncStartedAt: number | null = null;
   private configSyncNodeInfoCount = 0;
 
+  /**
+   * Mirror the capture flags onto the transport's sync-stall watchdog (#5122).
+   *
+   * These three helpers are the only writers of the capture flags, so this is
+   * the one seam where "a sync is running" is authoritative. Optional on
+   * ITransport, so non-TCP transports and test doubles simply opt out.
+   */
+  private setTransportConfigSyncActive(active: boolean): void {
+    try {
+      this.transport?.setConfigSyncActive?.(active);
+    } catch (err) {
+      // Never let a watchdog hint break the capture state machine.
+      logger.debug(`Ignoring setConfigSyncActive(${active}) failure: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
   private startConfigCapture(): void {
     this.configSyncStartedAt = Date.now();
     this.configSyncNodeInfoCount = 0;
     this.isCapturingInitConfig = true;
     this.configCaptureComplete = false;
+    this.setTransportConfigSyncActive(true);
   }
   private completeConfigCapture(): void {
     this.isCapturingInitConfig = false;
     this.configCaptureComplete = true;
+    this.setTransportConfigSyncActive(false);
   }
   private clearConfigCapture(): void {
     this.isCapturingInitConfig = false;
     this.configCaptureComplete = false;
+    this.setTransportConfigSyncActive(false);
   }
   private preserveConfigCapture(): void {
     // no-op on both flags — #3122 passive/no-VN disconnect keeps the cached

--- a/src/server/tcpTransport.configSyncStall.test.ts
+++ b/src/server/tcpTransport.configSyncStall.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Config-sync stall watchdog (#5122, Bug B).
+ *
+ * A reporter watched a node go silent part-way through the initial NodeDB sync
+ * and stay that way: no data, no error, no FIN. MeshMonitor's own state kept
+ * reporting `isConnected=true, nodeResponsive=true, configuring=true` for 70+
+ * seconds with zero reconnect attempts, until the container was killed by hand.
+ *
+ * The only liveness guard was the idle watchdog — 5 minutes by default, polled
+ * once a minute — so a stalled sync could sit undetected for the better part of
+ * five minutes. That is a distinct failure from an idle link: the peer has
+ * stopped part-way through a stream it will never resume, so waiting cannot
+ * help. These tests pin the tighter budget and, just as importantly, that it
+ * applies ONLY while a sync is running.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TcpTransport } from './tcpTransport.js';
+
+describe('TcpTransport — config-sync stall watchdog (#5122)', () => {
+  let transport: any;
+  let socket: { destroy: ReturnType<typeof vi.fn>; removeAllListeners: ReturnType<typeof vi.fn> };
+  let stale: unknown[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    transport = new TcpTransport();
+    transport.config = { host: 'node.example', port: 4403 };
+    socket = { destroy: vi.fn(), removeAllListeners: vi.fn() };
+    transport.socket = socket;
+    transport.isConnected = true;
+    transport.lastDataReceived = Date.now();
+    transport.lastMessageEmitted = Date.now();
+    stale = [];
+    transport.on('stale-connection', (info: unknown) => stale.push(info));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  /** Pretend `ms` passed with nothing arriving, then run one health check. */
+  const silentFor = (ms: number) => {
+    transport.lastDataReceived = Date.now() - ms;
+    transport.lastMessageEmitted = Date.now() - ms;
+    transport.checkConnection();
+  };
+
+  it('tears down a sync that has been silent past the 60s budget', () => {
+    transport.setConfigSyncActive(true);
+
+    silentFor(61_000);
+
+    expect(socket.destroy).toHaveBeenCalledTimes(1);
+    expect(stale).toHaveLength(1);
+    expect((stale[0] as { phase: string }).phase).toBe('config-sync');
+  });
+
+  it('tolerates the bursty pacing a large NodeDB actually has', () => {
+    // The same reporter measured ~10s of true wire silence between NodeInfo
+    // bursts on a healthy sync. A budget that trips on those would replace a
+    // rare hang with a guaranteed reconnect loop.
+    transport.setConfigSyncActive(true);
+
+    silentFor(12_000);
+    silentFor(30_000);
+    silentFor(59_000);
+
+    expect(socket.destroy).not.toHaveBeenCalled();
+    expect(stale).toEqual([]);
+  });
+
+  it('does not apply the tight budget once the sync has finished', () => {
+    // Post-sync, an idle link is normal — that is the 5-minute watchdog's job,
+    // and it must not be tightened to 60s by accident.
+    transport.setConfigSyncActive(true);
+    transport.setConfigSyncActive(false);
+
+    silentFor(120_000);
+
+    expect(socket.destroy).not.toHaveBeenCalled();
+    expect(stale).toEqual([]);
+  });
+
+  it('never applies the tight budget when no sync was ever announced', () => {
+    silentFor(120_000);
+
+    expect(socket.destroy).not.toHaveBeenCalled();
+    expect(stale).toEqual([]);
+  });
+
+  it('still lets the ordinary idle watchdog trip after the sync ends', () => {
+    transport.setConfigSyncActive(false);
+    transport.setStaleConnectionTimeout(300_000);
+
+    silentFor(301_000);
+
+    expect(socket.destroy).toHaveBeenCalledTimes(1);
+    expect((stale[0] as { phase?: string }).phase).toBeUndefined();
+  });
+
+  it('stays disabled when the operator has turned stale detection off entirely', () => {
+    // Setting the timeout to 0 is an explicit "stop policing this link". The
+    // sync watchdog rides the same health check and deliberately does not
+    // override that choice.
+    transport.setStaleConnectionTimeout(0);
+    transport.setConfigSyncActive(true);
+
+    silentFor(120_000);
+
+    expect(socket.destroy).not.toHaveBeenCalled();
+  });
+
+  it('polls fast enough that a 60s budget is not detected two minutes late', () => {
+    // A 60s budget on the default 60s poll would take up to 120s to notice.
+    transport.setConfigSyncActive(true);
+    transport.startHealthCheck();
+    const check = vi.spyOn(transport, 'checkConnection');
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(check.mock.calls.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('re-arms the health check when a sync starts on a live connection', () => {
+    transport.startHealthCheck();
+    const before = transport.healthCheckInterval;
+
+    transport.setConfigSyncActive(true);
+
+    // A new timer, so the faster cadence applies now rather than at the next
+    // minute boundary — which on a stalling sync is the whole margin.
+    expect(transport.healthCheckInterval).not.toBe(before);
+  });
+
+  it('is idempotent — repeating the same state does not churn the timer', () => {
+    transport.startHealthCheck();
+    transport.setConfigSyncActive(true);
+    const armed = transport.healthCheckInterval;
+
+    transport.setConfigSyncActive(true);
+
+    expect(transport.healthCheckInterval).toBe(armed);
+  });
+});

--- a/src/server/tcpTransport.ts
+++ b/src/server/tcpTransport.ts
@@ -31,6 +31,20 @@ export class TcpTransport extends EventEmitter implements ITransport {
   private staleConnectionTimeout: number = 300000; // 5 minutes default (in milliseconds)
   private healthCheckInterval: NodeJS.Timeout | null = null;
   private readonly HEALTH_CHECK_INTERVAL_MS = 60000; // Check every minute
+
+  // Initial-config-sync stall detection (#5122).
+  //
+  // A reporter watched a node go silent mid-sync and stay that way: no data, no
+  // error, no FIN. MeshMonitor's own state read `isConnected=true,
+  // configuring=true` for 70+ seconds with zero reconnect attempts, because the
+  // only liveness guard is the idle watchdog below — 5 minutes by default, polled
+  // once a minute. A sync that stalls is not an idle link: it will never recover
+  // on its own, and every second spent waiting is a sync that has to restart
+  // from scratch anyway. So while the manager says a sync is running, silence is
+  // policed on a much tighter budget.
+  private configSyncActive = false;
+  private readonly CONFIG_SYNC_STALL_MS = 60000; // 60s of total silence mid-sync
+  private readonly CONFIG_SYNC_CHECK_INTERVAL_MS = 15000; // poll 4x faster while syncing
   private readonly BUFFER_STALE_TIMEOUT_MS = 30000; // 30s: if buffer has data but no frames parsed, reset it
 
   // Configurable keepalive heartbeat (issues 2609 / 2616).
@@ -97,6 +111,21 @@ export class TcpTransport extends EventEmitter implements ITransport {
     }
 
     logger.debug(`⏱️  Stale connection timeout set to ${timeoutMs}ms (${Math.floor(timeoutMs / 1000 / 60)} minute(s))`);
+  }
+
+  /**
+   * Mark the initial config sync as running or finished (#5122).
+   *
+   * Re-arms the health check so the faster sync-phase cadence takes effect
+   * immediately rather than at the next minute boundary.
+   */
+  setConfigSyncActive(active: boolean): void {
+    if (this.configSyncActive === active) return;
+    this.configSyncActive = active;
+    logger.debug(`⏱️  Config-sync stall detection ${active ? 'armed' : 'disarmed'}`);
+    if (this.isConnected && this.healthCheckInterval) {
+      this.startHealthCheck();
+    }
   }
 
   /**
@@ -593,9 +622,14 @@ export class TcpTransport extends EventEmitter implements ITransport {
 
     // When heartbeat is active, check at half the heartbeat interval so we
     // detect a missed reply within ~1.5 heartbeat intervals.
-    const checkInterval = this.heartbeatIntervalMs > 0
+    const baseInterval = this.heartbeatIntervalMs > 0
       ? Math.max(5000, Math.floor(this.heartbeatIntervalMs / 2))
       : this.HEALTH_CHECK_INTERVAL_MS;
+    // A 60s stall budget polled once a minute would take up to two minutes to
+    // notice. Poll faster while syncing so detection lands close to the budget.
+    const checkInterval = this.configSyncActive
+      ? Math.min(baseInterval, this.CONFIG_SYNC_CHECK_INTERVAL_MS)
+      : baseInterval;
 
     this.healthCheckInterval = setInterval(() => {
       this.checkConnection();
@@ -697,6 +731,23 @@ export class TcpTransport extends EventEmitter implements ITransport {
 
     const now = Date.now();
     const timeSinceLastData = now - this.lastDataReceived;
+
+    // Sync-phase stall (#5122). Checked BEFORE the general idle test because its
+    // budget is much tighter — 60s versus the 5-minute default — and because a
+    // stalled sync is a distinct failure: the link is open and healthy-looking,
+    // the peer has simply stopped talking part-way through the NodeDB stream and
+    // will never resume. Reconnecting is the only way out.
+    if (this.configSyncActive && timeSinceLastData > this.CONFIG_SYNC_STALL_MS) {
+      logger.warn(
+        `⚠️  Config sync stalled: no data received for ${Math.floor(timeSinceLastData / 1000)}s ` +
+        `while the initial sync was still running (budget: ${this.CONFIG_SYNC_STALL_MS / 1000}s). Forcing reconnection...`,
+      );
+      this.emit('stale-connection', { timeSinceLastData, timeout: this.CONFIG_SYNC_STALL_MS, phase: 'config-sync' });
+      if (this.socket) {
+        this.socket.destroy();
+      }
+      return;
+    }
 
     if (timeSinceLastData > effectiveTimeoutMs) {
       const secondsSinceLastData = Math.floor(timeSinceLastData / 1000);

--- a/src/server/transports/transport.ts
+++ b/src/server/transports/transport.ts
@@ -17,4 +17,12 @@ export interface ITransport extends EventEmitter {
   send(data: Uint8Array): Promise<void>;
   getConnectionState(): boolean;
   getReconnectAttempts(): number;
+  /**
+   * Tell the transport whether the initial config sync is in progress (#5122).
+   *
+   * During that window a peer can go silent indefinitely while the link stays
+   * open, and the ordinary idle watchdog is far too slow to notice. Optional so
+   * non-TCP transports (and test doubles) need not implement it.
+   */
+  setConfigSyncActive?(active: boolean): void;
 }


### PR DESCRIPTION
Addresses **Bug B** of #5122. Bug A is #5138 — independent fixes, independently reviewable.

## The hang

From @ogarcia's run 2, one of four clean restarts:

> No further TCP activity after the last NodeInfo at 12:55:01. `getConnectionStatus` kept returning `isConnected=true, nodeResponsive=true, configuring=true` for **70+ seconds** with zero data, zero errors, zero reconnect attempts, until the container was killed manually to end the test.

They're right that this is the worse of the two failures. Bug A at least logs, flips state, and retries. Bug B leaves MeshMonitor believing everything is fine, indefinitely.

The cause is a gap in coverage rather than a broken mechanism. The only liveness guard during sync is `staleConnectionTimeout` — **5 minutes by default, polled once a minute**. Their 70s hang was nowhere near it. And because a poll cadence of 60s against a 60s budget can take 120s to notice, even a tightened threshold on the existing cadence would have been slow.

A stalled sync is a **different failure from an idle link**: the peer has stopped part-way through a stream it will never resume, so waiting cannot help. It's also strictly wasteful — the sync restarts from scratch on reconnect regardless, so every second spent hanging is a second added to recovery.

## Changes

- **`TcpTransport`** — while a sync is active, 60s of total silence trips a teardown. Checked *before* the general idle test, since its budget is much tighter. Logs a warning naming the phase and reuses the existing `stale-connection` → `socket.destroy()` → reconnect path, so recovery is the route already exercised in production.
- **Faster cadence while syncing** — the health check polls every 15s instead of 60s, so detection lands near the budget rather than up to a minute late. Reverts to the normal cadence when the sync ends.
- **`ITransport.setConfigSyncActive?()`** — optional, so non-TCP transports and test doubles opt out for free.
- **`MeshtasticManager`** — mirrors the capture flags onto the transport from `startConfigCapture` / `completeConfigCapture` / `clearConfigCapture`, which the code already documents as the *only* writers of those flags. Wrapped so a watchdog hint can never break the capture state machine.

## Why 60s

It has to clear the pacing a healthy sync actually has. The same reporter measured **~10s of true wire silence** between NodeInfo bursts on a *working* sync of the same mesh — confirmed by packet capture, not inferred from log gaps. A budget that tripped on those would trade a rare hang for a guaranteed reconnect loop, which is far worse. 60s is 6x that observed gap and still 5x faster than today's default.

## One deliberate non-behaviour

Setting `MESHTASTIC_STALE_CONNECTION_TIMEOUT=0` disables the health check entirely, and this watchdog rides that same check — so it stays off too. An operator who has said "stop policing this link" keeps that; I'd rather not have a new timer quietly override an explicit setting. Default installs get the fix.

## Mesh impact

None. No packets are sent — this only observes when data last arrived. One existing timer polls faster during a bounded window.

## Test plan

- [x] New `tcpTransport.configSyncStall.test.ts` (9 tests). Beyond the obvious trip case: it **tolerates 12s/30s/59s silences** (the healthy-pacing case that makes this safe), does not apply the tight budget after the sync ends or when no sync was announced, still lets the 5-minute idle watchdog trip afterwards, stays off when stale detection is disabled, polls ≥4x within 60s, re-arms on a live connection so the cadence change is immediate, and is idempotent so repeat calls don't churn the timer.
- [x] `vitest run src/server/tcpTransport src/server/meshtasticManager`: 917 passed, 0 failed (`success: true` via the JSON reporter).
- [x] `tsc --noEmit -p tsconfig.server.json` clean; `lint:ci` clean.

Hardware confirmation still needs @ogarcia's mesh — the hang appeared in 1 of 4 runs, so it will take a few attempts to say this caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZ871RCjD95cAu6jMfNM4