### PR TITLE
feat(map): make route segments respect Show RF / UDP / MQTT (#5097)

### DIFF
--- a/src/components/Dashboard/DashboardMap.test.tsx
+++ b/src/components/Dashboard/DashboardMap.test.tsx
@@ -32,6 +32,30 @@ const mocks = vi.hoisted(() => ({
   terrainCaps: { enabled: false, terrainTiles: false, isLoading: false },
   rendered3DNodes: [] as unknown[][],
   geoJsonLayers: [] as Array<{ id: string; name: string; visible: boolean; style: { color: string } }>,
+  // #5097: the Show RF / UDP / MQTT toggles have to vary per test to exercise
+  // the route-segment transport filter. Defaults match what the static mock
+  // used before, so every pre-existing test is unaffected.
+  mapContext: {
+    showPaths: false,
+    showRoute: false,
+    showRfNodes: true,
+    showUdpNodes: true,
+    showMqttNodes: true,
+  },
+  // Segments handed to the shared TraceroutePathsLayer on the last render.
+  tracerouteSegments: [] as Array<{ fromNodeNum: number; toNodeNum: number; isMqtt: boolean }>,
+}));
+
+// #5097: DashboardMap builds its own per-record traceroute segments (it renders
+// individual traceroutes rather than aggregating by node pair, so it cannot
+// share `useTraceroutePaths`). Stub the shared layer to capture what it is
+// handed — that list IS the filter's output. No pre-existing test renders
+// traceroutes (`defaultProps.traceroutes` is empty), so this affects nothing else.
+vi.mock('../map/layers/TraceroutePathsLayer', () => ({
+  TraceroutePathsLayer: ({ segments }: { segments: Array<{ fromNodeNum: number; toNodeNum: number; isMqtt: boolean }> }) => {
+    mocks.tracerouteSegments = segments;
+    return <div data-testid="traceroute-paths-layer" data-count={segments.length} />;
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -115,17 +139,17 @@ vi.mock('react-leaflet', () => ({
 // filtering doesn't drop existing fixture nodes), traceroute/accuracy off.
 vi.mock('../../contexts/MapContext', () => ({
   useMapContext: () => ({
-    showPaths: false,
+    showPaths: mocks.mapContext.showPaths,
     setShowPaths: vi.fn(),
-    showRoute: false,
+    showRoute: mocks.mapContext.showRoute,
     setShowRoute: vi.fn(),
     showAccuracyRegions: false,
     setShowAccuracyRegions: vi.fn(),
-    showRfNodes: true,
+    showRfNodes: mocks.mapContext.showRfNodes,
     setShowRfNodes: vi.fn(),
-    showUdpNodes: true,
+    showUdpNodes: mocks.mapContext.showUdpNodes,
     setShowUdpNodes: vi.fn(),
-    showMqttNodes: true,
+    showMqttNodes: mocks.mapContext.showMqttNodes,
     setShowMqttNodes: vi.fn(),
     showNeighborInfo: true,
     setShowNeighborInfo: vi.fn(),
@@ -354,6 +378,15 @@ describe('DashboardMap', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    // #5097: back to the pre-existing defaults for every test that doesn't opt in.
+    mocks.mapContext = {
+      showPaths: false,
+      showRoute: false,
+      showRfNodes: true,
+      showUdpNodes: true,
+      showMqttNodes: true,
+    };
+    mocks.tracerouteSegments = [];
     // Reset the shared settings mock to "no Default Map Center configured".
     mocks.settings.mapPinStyle = 'official';
     mocks.settings.overlayColors = darkOverlayColors;
@@ -956,5 +989,85 @@ describe('DashboardMap', () => {
     rerender(<DashboardMap {...defaultProps} sourceId="src-a" nodes={[nodeWithPosition]} />);
     expect(screen.queryByTestId('map-3d-view')).not.toBeInTheDocument();
     expect(screen.getByTestId('map-container')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #5097 — Show RF / UDP / MQTT on route segments
+// ---------------------------------------------------------------------------
+// DashboardMap builds its own per-record traceroute segments rather than going
+// through `useTraceroutePaths` (it renders individual traceroutes; the Nodes map
+// aggregates them by node pair). That means the transport filter is wired up in
+// two places, and these tests cover the Dashboard's copy — the hook's copy is
+// covered by useTraceroutePaths.transportFilter.test.tsx.
+describe('DashboardMap — route segment transport filter (#5097)', () => {
+  const TX_LORA = 1;
+  const TX_MQTT = 5;
+  const TX_MULTICAST_UDP = 6;
+  const RAW_SENTINEL = -128; // INT8_MIN; /4 == the firmware unknown-SNR sentinel
+  const RAW_GOOD = 40; // 10 dB
+
+  const trNodes = [
+    { nodeNum: 100, user: { id: '!64', shortName: 'A', longName: 'A' }, position: { latitude: 35.0, longitude: -80.0 }, hopsAway: 1, role: 1, lastHeard: recent },
+    { nodeNum: 200, user: { id: '!c8', shortName: 'B', longName: 'B' }, position: { latitude: 35.2, longitude: -80.2 }, hopsAway: 1, role: 1, lastHeard: recent },
+  ];
+
+  /** One direct traceroute 100 <-> 200, carrying a record transport. */
+  function trace(transportMechanism: number | null, snrRaw = RAW_GOOD) {
+    return {
+      id: 1,
+      sourceId: 'src-a',
+      fromNodeNum: 100,
+      toNodeNum: 200,
+      route: '[]',
+      routeBack: '[]',
+      snrTowards: JSON.stringify([snrRaw]),
+      snrBack: JSON.stringify([snrRaw]),
+      transportMechanism,
+      // Milliseconds, unlike the `recent` node fixture above, which is a
+      // `lastHeard` value in SECONDS. DashboardMap compares a traceroute's
+      // timestamp against `Date.now() - maxAge`, so a seconds value reads as
+      // 1970 and the row is dropped by the age filter before any transport
+      // filtering happens — which would make every assertion here vacuous.
+      timestamp: Date.now(),
+      createdAt: Date.now(),
+    };
+  }
+
+  function renderWith(traceroutes: unknown[]) {
+    mocks.mapContext.showPaths = true;
+    render(<DashboardMap {...defaultProps} sourceId="src-a" nodes={trNodes} traceroutes={traceroutes} />);
+    return mocks.tracerouteSegments;
+  }
+
+  it('draws the segments when every toggle is on', () => {
+    // A positive control for the four negative assertions below: without it,
+    // an empty `segments` for any reason (age filter, unresolved positions)
+    // would make every "is filtered out" test pass vacuously.
+    expect(renderWith([trace(TX_MULTICAST_UDP)]).length).toBeGreaterThan(0);
+  });
+
+  it('hides a UDP-delivered traceroute when Show UDP is off', () => {
+    mocks.mapContext.showUdpNodes = false;
+    expect(renderWith([trace(TX_MULTICAST_UDP)])).toHaveLength(0);
+  });
+
+  it('hides an MQTT-delivered traceroute when Show MQTT is off', () => {
+    mocks.mapContext.showMqttNodes = false;
+    expect(renderWith([trace(TX_MQTT)])).toHaveLength(0);
+  });
+
+  it('keeps a pre-migration traceroute, which reads as RF', () => {
+    // Upgrade safety on the Dashboard too: NULL must not mean "hidden".
+    mocks.mapContext.showMqttNodes = false;
+    mocks.mapContext.showUdpNodes = false;
+    expect(renderWith([trace(null)]).length).toBeGreaterThan(0);
+  });
+
+  it('hides a sentinel hop of an RF traceroute when Show MQTT is off', () => {
+    // Per-hop beats per-record: the traceroute arrived over LoRa, but the hop
+    // itself carries the firmware unknown-SNR sentinel.
+    mocks.mapContext.showMqttNodes = false;
+    expect(renderWith([trace(TX_LORA, RAW_SENTINEL)])).toHaveLength(0);
   });
 });

--- a/src/components/Dashboard/DashboardMap.tsx
+++ b/src/components/Dashboard/DashboardMap.tsx
@@ -45,6 +45,12 @@ import {
 import { getSourceColor, resolveSourceColor } from '../../utils/sourceColors';
 import { getOwnNodePositions } from '../../utils/ownNodePositions';
 import { nodePassesTransportFilter } from '../../utils/nodeTransport';
+import {
+  hopTransportClass,
+  segmentPassesTransportFilter,
+  tracerouteTransportClass,
+  transportFilterIsInert,
+} from '../../utils/tracerouteTransport';
 import { shouldDiscardPosition } from '../../utils/nullIsland';
 import { getDiscardInvalidPositions } from '../../utils/positionDisplayConfig';
 import { effectiveMapMaxAgeHours } from '../../utils/mapAge';
@@ -570,6 +576,15 @@ export default function DashboardMap({
   // traceroute's own key is prefixed onto the util's per-hop key
   // (`"forward:123-456"`) since multiple traceroute records can repeat the
   // same node pair and the util itself only decomposes one record at a time.
+  // #5097 — memoized so `tracerouteRenderSegments` can list it as a dependency
+  // without rebuilding every segment on each render.
+  const transportFlags = useMemo(
+    () => ({ showRfNodes, showUdpNodes, showMqttNodes }),
+    [showRfNodes, showUdpNodes, showMqttNodes],
+  );
+  // All three on means the filter can remove nothing — skip the per-hop work.
+  const transportFilterActive = !transportFilterIsInert(transportFlags);
+
   const tracerouteRenderSegments = useMemo<TracerouteRenderSegment[]>(() => {
     if (!showPaths && !showRoute) return [];
     // Map Features age slider (#3322): hide traceroutes/route segments older
@@ -602,12 +617,23 @@ export default function DashboardMap({
         },
         { resolvePosition },
       );
+      // #5097 — Show RF / UDP / MQTT. One traceroute per iteration, so a hop's
+      // class is this record's transport unless the hop's own unknown-SNR
+      // sentinel says MQTT. Same rule the neighbor links above use, and the
+      // same rule `useTraceroutePaths` applies on the Nodes map.
+      const recordClass = tracerouteTransportClass(tr);
       for (const seg of decomposed) {
+        if (
+          transportFilterActive &&
+          !segmentPassesTransportFilter([hopTransportClass(recordClass, seg.isMqtt)], transportFlags)
+        ) {
+          continue;
+        }
         segs.push({ ...seg, key: `${keyPrefix}-${seg.key}` });
       }
     }
     return segs;
-  }, [traceroutes, positionByNodeNum, showPaths, showRoute, effectiveMaxAge]);
+  }, [traceroutes, positionByNodeNum, showPaths, showRoute, effectiveMaxAge, transportFilterActive, transportFlags]);
 
   const hasNodes = nodesWithPosition.length > 0;
 

--- a/src/components/MapAnalysis/layers/TraceroutePathsLayer.tsx
+++ b/src/components/MapAnalysis/layers/TraceroutePathsLayer.tsx
@@ -125,6 +125,19 @@ export default function TraceroutePathsLayer() {
   const selectedSourceId =
     selected?.type === 'node' ? selected.sourceId ?? null : null;
 
+  // #5097 — the same Show RF / UDP / MQTT pills that already filter the node
+  // markers (`useAnalysisNodes`) now filter these hops too, so the two layers
+  // agree about what a disabled transport means. Memoised because the analysis
+  // hook lists it as a dependency.
+  const transportFlags = useMemo(
+    () => ({
+      showRfNodes: config.transports.rf,
+      showUdpNodes: config.transports.udp,
+      showMqttNodes: config.transports.mqtt,
+    }),
+    [config.transports],
+  );
+
   const { segments } = useTracerouteAnalysis({
     traceroutes: items as TracerouteAnalysisInput[],
     positionByKey,
@@ -133,6 +146,7 @@ export default function TraceroutePathsLayer() {
     options,
     visibleNodeNums,
     timeWindow,
+    transportFlags,
   });
 
   // Arrows are only drawn in the directional (node-selected) view to keep the

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -178,6 +178,7 @@ import {
   runMigration158Mysql,
 } from '../server/migrations/158_meshcore_packet_log_observer.js';
 import { migration as nodeIdentityMergesMigration, runMigration159Postgres, runMigration159Mysql } from '../server/migrations/159_node_identity_merges.js';
+import { migration as tracerouteTransportMechanismMigration, runMigration160Postgres, runMigration160Mysql } from '../server/migrations/160_traceroute_transport_mechanism.js';
 
 // ============================================================================
 // Registry
@@ -2573,4 +2574,22 @@ registry.register({
   sqlite: (db) => nodeIdentityMergesMigration.up(db),
   postgres: (client) => runMigration159Postgres(client),
   mysql: (pool) => runMigration159Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 160: `traceroutes.transportMechanism` (#5097) — which transport
+// carried the traceroute, so the map's Show RF / UDP / MQTT toggles can filter
+// route segments the way they already filter markers and neighbor links. NULL
+// on legacy rows (the transport was never recorded and cannot be recovered);
+// readers fall back to 'rf' so historical traceroutes stay visible.
+// Idempotent across SQLite / PostgreSQL / MySQL.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 160,
+  name: 'traceroute_transport_mechanism',
+  settingsKey: 'migration_160_traceroute_transport_mechanism',
+  sqlite: (db) => tracerouteTransportMechanismMigration.up(db),
+  postgres: (client) => runMigration160Postgres(client),
+  mysql: (pool) => runMigration160Mysql(pool),
 });

--- a/src/db/repositories/traceroutes.test.ts
+++ b/src/db/repositories/traceroutes.test.ts
@@ -38,6 +38,7 @@ const POSTGRES_CREATE = `
     "routePositions" TEXT,
     channel INTEGER,
     "packetId" BIGINT,
+    "transportMechanism" INTEGER,
     timestamp BIGINT NOT NULL,
     "createdAt" BIGINT NOT NULL,
     "sourceId" TEXT
@@ -77,6 +78,7 @@ const MYSQL_CREATE = `
     routePositions TEXT,
     channel INT,
     packetId BIGINT,
+    transportMechanism INT,
     timestamp BIGINT NOT NULL,
     createdAt BIGINT NOT NULL,
     sourceId VARCHAR(36)
@@ -351,6 +353,69 @@ function runTraceroutesTests(getBackend: () => TestBackend) {
     const all = await repo.getAllTraceroutes(100, ALL_SOURCES);
     expect(all.length).toBe(1);
     expect(Number(all[0].packetId)).toBe(packetId);
+  });
+
+  it('transportMechanism (#5097) - persists on insert and is returned', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    const now = Date.now();
+    // 6 = MULTICAST_UDP. Stored so the map's Show RF / UDP / MQTT toggles can
+    // filter this traceroute's route segments.
+    await repo.insertTraceroute(makeTraceroute({ timestamp: now, createdAt: now, transportMechanism: 6 }));
+
+    const all = await repo.getAllTraceroutes(100, ALL_SOURCES);
+    expect(all.length).toBe(1);
+    expect(Number(all[0].transportMechanism)).toBe(6);
+  });
+
+  it('transportMechanism (#5097) - null when the caller supplies none', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    const now = Date.now();
+    await repo.insertTraceroute(makeTraceroute({ timestamp: now, createdAt: now }));
+
+    const all = await repo.getAllTraceroutes(100, ALL_SOURCES);
+    // Readers resolve null to 'rf' so pre-migration rows stay on the map — see
+    // utils/tracerouteTransport.ts.
+    expect(all[0].transportMechanism ?? null).toBeNull();
+  });
+
+  it('transportMechanism (#5097) - the RESPONSE stamps it, not the pending request', async () => {
+    const backend = getBackend();
+    if (!backend.available) {
+      console.log(`⚠ Skipped: ${backend.skipReason}`);
+      return;
+    }
+
+    const now = Date.now();
+    // The pending row is written when WE send the request, so it has no
+    // transport; the response is the packet that actually crossed the mesh.
+    await repo.insertTraceroute(makeTraceroute({ timestamp: now, createdAt: now }));
+    const pending = await repo.findPendingTraceroute(1001, 2002, now - 60000);
+    expect(pending).not.toBeNull();
+
+    await repo.updateTracerouteResponse(
+      pending!.id,
+      '1001,3003,2002',
+      '2002,3003,1001',
+      '10.5,8.2',
+      '9.1,7.3',
+      now + 5000,
+      3_500_000_124,
+      5, // MQTT
+    );
+
+    const all = await repo.getAllTraceroutes(100, ALL_SOURCES);
+    expect(all.length).toBe(1);
+    expect(Number(all[0].transportMechanism)).toBe(5);
   });
 
   it('getTraceroutesByNodes - filter by from/to (bidirectional)', async () => {

--- a/src/db/repositories/traceroutes.ts
+++ b/src/db/repositories/traceroutes.ts
@@ -36,6 +36,7 @@ export class TraceroutesRepository extends BaseRepository {
       routePositions: tracerouteData.routePositions ?? null,
       channel: tracerouteData.channel ?? null,
       packetId: tracerouteData.packetId ?? null,
+      transportMechanism: tracerouteData.transportMechanism ?? null,
       timestamp: tracerouteData.timestamp,
       createdAt: tracerouteData.createdAt,
     };
@@ -72,12 +73,17 @@ export class TraceroutesRepository extends BaseRepository {
   /**
    * Update a pending traceroute with response data
    */
-  async updateTracerouteResponse(id: number, route: string | null, routeBack: string | null, snrTowards: string | null, snrBack: string | null, timestamp: number, packetId?: number | null): Promise<void> {
+  async updateTracerouteResponse(id: number, route: string | null, routeBack: string | null, snrTowards: string | null, snrBack: string | null, timestamp: number, packetId?: number | null, transportMechanism?: number | null): Promise<void> {
     const { traceroutes } = this.tables;
     const set: any = { route, routeBack, snrTowards, snrBack, timestamp };
     // Only overwrite packetId when the response carries one — preserves any id
     // already stored on the pending row if this update doesn't supply it.
     if (packetId !== undefined) set.packetId = packetId;
+    // #5097: the pending row was written when WE sent the request, so it
+    // carries no transport. The response is the packet that actually crossed
+    // the mesh, so its mechanism is the one the map should filter on. Same
+    // "only when supplied" rule as packetId.
+    if (transportMechanism !== undefined) set.transportMechanism = transportMechanism;
     await this.db
       .update(traceroutes)
       .set(set)
@@ -605,6 +611,9 @@ export class TraceroutesRepository extends BaseRepository {
             snrTowards: tracerouteData.snrTowards || null,
             snrBack: tracerouteData.snrBack || null,
             packetId: tracerouteData.packetId ?? null,
+            // #5097 — see updateTracerouteResponse for why the response's
+            // mechanism, not the pending request's, is the one stored.
+            transportMechanism: tracerouteData.transportMechanism ?? null,
             timestamp: tracerouteData.timestamp,
           })
           .where(eq(traceroutes.id, id))
@@ -620,6 +629,7 @@ export class TraceroutesRepository extends BaseRepository {
           snrTowards: tracerouteData.snrTowards || null,
           snrBack: tracerouteData.snrBack || null,
           packetId: tracerouteData.packetId ?? null,
+          transportMechanism: tracerouteData.transportMechanism ?? null,
           timestamp: tracerouteData.timestamp,
           createdAt: tracerouteData.createdAt,
           sourceId: sourceId ?? null,

--- a/src/db/schema/traceroutes.ts
+++ b/src/db/schema/traceroutes.ts
@@ -21,6 +21,7 @@ export const traceroutesSqlite = sqliteTable('traceroutes', {
   routePositions: text('routePositions'), // JSON: { nodeNum: { lat, lng, alt? } } position snapshot at traceroute time
   channel: integer('channel'), // Mesh channel this traceroute was received on (null = unknown/pre-migration)
   packetId: integer('packetId'), // Originating Meshtastic packet id (null = pre-migration). Enables cross-source correlation (#3623)
+  transportMechanism: integer('transportMechanism'), // meshtastic.MeshPacket.TransportMechanism of the packet that carried the route (null = pre-migration -> treated as RF). Drives the map's Show RF/UDP/MQTT filter for route segments (#5097)
   timestamp: integer('timestamp').notNull(),
   createdAt: integer('createdAt').notNull(),
   // Source association (nullable — NULL = legacy default source)
@@ -59,6 +60,7 @@ export const traceroutesPostgres = pgTable('traceroutes', {
   routePositions: pgText('routePositions'), // JSON: { nodeNum: { lat, lng, alt? } } position snapshot at traceroute time
   channel: pgInteger('channel'), // Mesh channel this traceroute was received on (null = unknown/pre-migration)
   packetId: pgBigint('packetId', { mode: 'number' }), // Originating Meshtastic packet id (null = pre-migration). Enables cross-source correlation (#3623)
+  transportMechanism: pgInteger('transportMechanism'), // see SQLite definition (#5097)
   timestamp: pgBigint('timestamp', { mode: 'number' }).notNull(),
   createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
   // Source association (nullable — NULL = legacy default source)
@@ -97,6 +99,7 @@ export const traceroutesMysql = mysqlTable('traceroutes', {
   routePositions: myText('routePositions'), // JSON: { nodeNum: { lat, lng, alt? } } position snapshot at traceroute time
   channel: myInt('channel'), // Mesh channel this traceroute was received on (null = unknown/pre-migration)
   packetId: myBigint('packetId', { mode: 'number' }), // Originating Meshtastic packet id (null = pre-migration). Enables cross-source correlation (#3623)
+  transportMechanism: myInt('transportMechanism'), // see SQLite definition (#5097)
   timestamp: myBigint('timestamp', { mode: 'number' }).notNull(),
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
   // Source association (nullable — NULL = legacy default source)

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -215,6 +215,14 @@ export interface DbTraceroute {
   routePositions?: string | null;
   channel?: number | null;
   packetId?: number | null;
+  /**
+   * `meshtastic.MeshPacket.TransportMechanism` of the packet that carried the
+   * route data (#5097). NULL on every pre-migration-160 row and on any packet
+   * that reported no mechanism — read it through `classifyNodeTransport`,
+   * which falls back to `'rf'`, so legacy traceroutes stay visible under the
+   * map's default toggles.
+   */
+  transportMechanism?: number | null;
   timestamp: number;
   createdAt: number;
 }

--- a/src/hooks/usePoll.ts
+++ b/src/hooks/usePoll.ts
@@ -118,6 +118,13 @@ export interface PollTraceroute {
   snrTowards: string;
   snrBack: string;
   routePositions?: string; // JSON: { [nodeNum]: { lat, lng, alt? } } - position snapshot at traceroute time
+  /**
+   * `MeshPacket.TransportMechanism` of the packet that carried this route
+   * (#5097, migration 160). Null on pre-migration rows; readers resolve that to
+   * `'rf'` via `utils/tracerouteTransport.ts`. Drives the Show RF / UDP / MQTT
+   * filter on the Dashboard and Map Analysis route-segment layers.
+   */
+  transportMechanism?: number | null;
   timestamp: number;
   createdAt: number;
   hopCount: number;

--- a/src/hooks/useSourceView.ts
+++ b/src/hooks/useSourceView.ts
@@ -676,10 +676,12 @@ export function useSourceView(params: UseSourceViewParams) {
       snrBack: tr.snrBack,
       timestamp: tr.timestamp,
       createdAt: tr.createdAt,
+      // #5097 — drives the Show RF / UDP / MQTT filter on route segments.
+      transportMechanism: tr.transportMechanism,
     }));
   }, [
     traceroutes
-      .map(tr => `${tr.fromNodeNum}-${tr.toNodeNum}-${tr.route}-${tr.routeBack}-${tr.timestamp || tr.createdAt}`)
+      .map(tr => `${tr.fromNodeNum}-${tr.toNodeNum}-${tr.route}-${tr.routeBack}-${tr.timestamp || tr.createdAt}-${tr.transportMechanism ?? ''}`)
       .join(','),
   ]);
 
@@ -719,6 +721,14 @@ export function useSourceView(params: UseSourceViewParams) {
     return new Set(visibleNodes.map(n => n.nodeNum));
   }, [processedNodes, showRfNodes, showUdpNodes, showMqttNodes, showIncompleteNodes, showEstimatedPositions, nodesWithEstimatedPosition, effectiveMapMaxAge]);
 
+  // #5097 — memoized so the identity is stable; `useTraceroutePaths` lists it
+  // as a memo dependency, and a fresh object each render would rebuild every
+  // segment on the map.
+  const transportFlags = useMemo(
+    () => ({ showRfNodes, showUdpNodes, showMqttNodes }),
+    [showRfNodes, showUdpNodes, showMqttNodes],
+  );
+
   const { traceroutePathsElements, selectedNodeTraceroute, tracerouteNodeNums, tracerouteBounds } = useTraceroutePaths({
     showPaths,
     showRoute,
@@ -732,6 +742,7 @@ export function useSourceView(params: UseSourceViewParams) {
     callbacks: tracerouteCallbacks,
     visibleNodeNums,
     mapZoom,
+    transportFlags,
   });
 
   return {

--- a/src/hooks/useTracerouteAnalysis.test.ts
+++ b/src/hooks/useTracerouteAnalysis.test.ts
@@ -281,3 +281,79 @@ describe('analyzeTraceroutes', () => {
     expect(segments).toHaveLength(0);
   });
 });
+
+describe('analyzeTraceroutes — Show RF / UDP / MQTT (#5097)', () => {
+  const ALL_ON = { showRfNodes: true, showUdpNodes: true, showMqttNodes: true };
+  const RAW_SENTINEL = -128; // INT8_MIN; /4 == UNKNOWN_SNR_SENTINEL
+  const RAW_GOOD = 20; // 5 dB
+
+  /** Same fixture as `directTrace`, plus a record transport. */
+  function tracedOver(mechanism: number | null, snrRaw = RAW_GOOD): TracerouteAnalysisInput {
+    return { ...directTrace(1, [snrRaw], [snrRaw]), transportMechanism: mechanism };
+  }
+
+  it('filters nothing when no flags are supplied', () => {
+    // Map Analysis without the pills wired must behave exactly as before.
+    const { segments } = analyzeTraceroutes(
+      makeParams({ traceroutes: [tracedOver(6)], selectedNodeNum: REQ, selectedSourceId: 's1' }),
+    );
+    expect(segments.length).toBeGreaterThan(0);
+  });
+
+  it('drops a UDP-delivered traceroute when Show UDP is off', () => {
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [tracedOver(6)], // MULTICAST_UDP
+        selectedNodeNum: REQ,
+        selectedSourceId: 's1',
+        transportFlags: { ...ALL_ON, showUdpNodes: false },
+      }),
+    );
+    expect(segments).toHaveLength(0);
+  });
+
+  it('keeps a pre-migration traceroute, which reads as RF', () => {
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [tracedOver(null)],
+        selectedNodeNum: REQ,
+        selectedSourceId: 's1',
+        transportFlags: { ...ALL_ON, showUdpNodes: false, showMqttNodes: false },
+      }),
+    );
+    expect(segments.length).toBeGreaterThan(0);
+  });
+
+  it('drops a sentinel hop of an RF traceroute when Show MQTT is off', () => {
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [tracedOver(1, RAW_SENTINEL)], // LORA record, sentinel hops
+        selectedNodeNum: REQ,
+        selectedSourceId: 's1',
+        transportFlags: { ...ALL_ON, showMqttNodes: false },
+      }),
+    );
+    expect(segments).toHaveLength(0);
+  });
+
+  it('keeps a hop that merely reports no SNR at all', () => {
+    // The deliberate divergence from `isMqtt`/colouring: a MISSING sample is
+    // coloured unknown but must not be hidden behind the MQTT toggle, or hops
+    // from pre-snr-array firmware would vanish.
+    const noSnr: TracerouteAnalysisInput = {
+      ...directTrace(2, [], []),
+      routeBack: '[]',
+      snrBack: '[0]', // non-empty so the #2051 return-path guard passes
+      transportMechanism: 1,
+    };
+    const { segments } = analyzeTraceroutes(
+      makeParams({
+        traceroutes: [noSnr],
+        selectedNodeNum: REQ,
+        selectedSourceId: 's1',
+        transportFlags: { ...ALL_ON, showMqttNodes: false },
+      }),
+    );
+    expect(segments.length).toBeGreaterThan(0);
+  });
+});

--- a/src/hooks/useTracerouteAnalysis.ts
+++ b/src/hooks/useTracerouteAnalysis.ts
@@ -4,6 +4,13 @@ import { useMemo } from 'react';
 // tests) don't have to pull in mapHelpers.tsx's leaflet/react-leaflet
 // imports just for the sentinel.
 import { isUnknownSnr, hasReturnPath } from '../utils/tracerouteSegments';
+import {
+  hopTransportClass,
+  segmentPassesTransportFilter,
+  tracerouteTransportClass,
+  transportFilterIsInert,
+  type TransportFilterFlags,
+} from '../utils/tracerouteTransport';
 
 /**
  * Traceroute analysis for the Map Analysis view (issue #3399).
@@ -40,6 +47,11 @@ export interface TracerouteAnalysisInput {
   snrTowards?: string | null;
   snrBack?: string | null;
   timestamp?: number;
+  /**
+   * `MeshPacket.TransportMechanism` of the packet that carried this route
+   * (#5097, migration 160). Absent/null resolves to `'rf'`.
+   */
+  transportMechanism?: number | null;
 }
 
 export interface TracerouteAnalysisOptions {
@@ -59,6 +71,12 @@ export interface AnalyzeParams {
   /** When set (search active), segments touching a node outside this set are dropped. */
   visibleNodeNums?: Set<number> | null;
   timeWindow?: { startMs?: number; endMs?: number } | null;
+  /**
+   * Map Analysis' Show RF / UDP / MQTT pills (#5097). A hop is dropped when the
+   * transport it was observed over is switched off — the same rule the Nodes
+   * map applies in `useTraceroutePaths`. Omit to filter nothing.
+   */
+  transportFlags?: TransportFilterFlags | null;
 }
 
 export interface AnalyzedSegment {
@@ -192,7 +210,11 @@ export function analyzeTraceroutes(params: AnalyzeParams): AnalyzeResult {
     options,
     visibleNodeNums,
     timeWindow,
+    transportFlags,
   } = params;
+
+  // #5097 — all three toggles on means the filter can remove nothing.
+  const transportFilterActive = !!transportFlags && !transportFilterIsInert(transportFlags);
 
   // "focus" = a node is selected AND the focus toggle is on. Only then do we
   // scope to / classify relative to that node; otherwise links render globally.
@@ -228,6 +250,9 @@ export function analyzeTraceroutes(params: AnalyzeParams): AnalyzeResult {
   // 2. Aggregate directed hops.
   const acc = new Map<string, Accum>();
   for (const tr of rows) {
+    // #5097 — how this traceroute reached us; each hop inherits it unless the
+    // hop's own unknown-SNR sentinel says MQTT.
+    const recordTransportClass = tracerouteTransportClass(tr);
     for (const seg of segmentsForTraceroute(tr)) {
       if (INVALID_NODE_NUMS.has(seg.from) || INVALID_NODE_NUMS.has(seg.to)) continue;
       if (seg.from === seg.to) continue;
@@ -239,6 +264,16 @@ export function analyzeTraceroutes(params: AnalyzeParams): AnalyzeResult {
       // Search filter: both endpoints must be visible.
       if (visibleNodeNums) {
         if (!visibleNodeNums.has(seg.from) || !visibleNodeNums.has(seg.to)) continue;
+      }
+      // #5097 — Show RF / UDP / MQTT. Note this asks for an EXPLICIT sentinel,
+      // where `hasUnknown` below also counts a missing SNR sample. Deliberate:
+      // `hasUnknown` drives colour, and colouring a no-data hop as unknown is
+      // honest, but HIDING one behind the MQTT toggle would remove hops that
+      // simply came from pre-snr-array firmware.
+      if (transportFilterActive && transportFlags) {
+        const hopIsMqtt = seg.snr !== undefined && isUnknownSnr(seg.snr);
+        const cls = hopTransportClass(recordTransportClass, hopIsMqtt);
+        if (!segmentPassesTransportFilter([cls], transportFlags)) continue;
       }
 
       const key = aggregateKey(seg);
@@ -351,6 +386,7 @@ export function useTracerouteAnalysis(params: AnalyzeParams): AnalyzeResult {
     options,
     visibleNodeNums,
     timeWindow,
+    transportFlags,
   } = params;
   return useMemo(
     () =>
@@ -362,6 +398,7 @@ export function useTracerouteAnalysis(params: AnalyzeParams): AnalyzeResult {
         options,
         visibleNodeNums,
         timeWindow,
+        transportFlags,
       }),
     [
       traceroutes,
@@ -371,6 +408,7 @@ export function useTracerouteAnalysis(params: AnalyzeParams): AnalyzeResult {
       options,
       visibleNodeNums,
       timeWindow,
+      transportFlags,
     ],
   );
 }

--- a/src/hooks/useTraceroutePaths.transportFilter.test.tsx
+++ b/src/hooks/useTraceroutePaths.transportFilter.test.tsx
@@ -184,6 +184,38 @@ describe('useTraceroutePaths — Show RF / UDP / MQTT on route segments (#5097)'
     expect(basePairs(params)).toContain('100-300');
   });
 
+  it('keys segments numerically, so a mixed-width node pair still matches', () => {
+    // Review point on #5097: the pair key used a bare `.sort()`, which orders
+    // lexicographically — [9, 100] becomes "100-9". Every site was wrong the
+    // same way so nothing broke, but a new site using a numeric sort would have
+    // silently missed the accumulated transport classes and rendered a segment
+    // the toggle should have removed. Node 9 vs 100 is the smallest pair that
+    // distinguishes the two orderings.
+    const params = baseParams({
+      nodesPositionDigest: [
+        { nodeNum: 9, position: { latitude: 40.0, longitude: -75.0 }, user: { id: '!9', longName: 'S', shortName: 'S' } },
+        { nodeNum: 100, position: { latitude: 40.2, longitude: -75.2 }, user: { id: '!64', longName: 'A', shortName: 'A' } },
+      ],
+      traceroutesDigest: [
+        traceroute({
+          fromNodeNum: 9,
+          toNodeNum: 100,
+          fromNodeId: '!9',
+          toNodeId: '!64',
+          route: '[]',
+          routeBack: '[]',
+          snrTowards: '[40]',
+          snrBack: '[40]',
+          transportMechanism: TX_MQTT,
+        }),
+      ],
+      transportFlags: { ...ALL_ON, showMqttNodes: false },
+    });
+    // If the filter looked the pair up under a differently-ordered key it would
+    // find no classes, fall through to "no evidence", and draw the segment.
+    expect(basePairs(params)).toEqual([]);
+  });
+
   it('applies the same rule to the selected traceroute layer', () => {
     // "Show Traceroute" is a separate memo with its own render path; a fix that
     // only reached the aggregated layer would leave this one unfiltered.

--- a/src/hooks/useTraceroutePaths.transportFilter.test.tsx
+++ b/src/hooks/useTraceroutePaths.transportFilter.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * Show RF / UDP / MQTT filtering of route segments (#5097).
+ *
+ * These render the real hook and read the segments it hands to
+ * `TraceroutePathsLayer`, rather than re-implementing the predicate in the
+ * test. The predicate itself is covered in `utils/tracerouteTransport.test.ts`;
+ * what needs proving here is that the hook actually applies it, on both layers,
+ * with the right class for each hop — which a re-implementation cannot show.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+  useTraceroutePaths,
+  type NodePositionDigest,
+  type TracerouteDigest,
+  type ThemeColors,
+  type UseTraceroutePathsParams,
+} from './useTraceroutePaths';
+import { TX_LORA, TX_MQTT, TX_MULTICAST_UDP } from '../utils/nodeTransport';
+import { UNKNOWN_SNR_SENTINEL } from '../utils/tracerouteSegments';
+
+/** Raw (un-scaled) SNR that decodes to the firmware unknown-hop sentinel. */
+const RAW_SENTINEL = UNKNOWN_SNR_SENTINEL * 4; // -128, i.e. INT8_MIN
+const RAW_GOOD = 40; // 10 dB
+
+const NODES: NodePositionDigest[] = [
+  { nodeNum: 100, position: { latitude: 40.0, longitude: -75.0 }, user: { id: '!64', longName: 'A', shortName: 'A' } },
+  { nodeNum: 200, position: { latitude: 40.2, longitude: -75.2 }, user: { id: '!c8', longName: 'B', shortName: 'B' } },
+  { nodeNum: 300, position: { latitude: 40.1, longitude: -75.1 }, user: { id: '!12c', longName: 'C', shortName: 'C' } },
+];
+
+const THEME: ThemeColors = {
+  accentAlt: '#111', error: '#f00', accent: '#0f0',
+  tracerouteForward: '#00f', tracerouteReturn: '#f0f',
+} as ThemeColors;
+
+/**
+ * A traceroute 100 -> 300 -> 200 (and back). `snrTowards`/`snrBack` are raw
+ * firmware values; the hook scales by 4 internally.
+ */
+function traceroute(over: Partial<TracerouteDigest> = {}): TracerouteDigest {
+  return {
+    fromNodeNum: 100,
+    toNodeNum: 200,
+    fromNodeId: '!64',
+    toNodeId: '!c8',
+    route: '[300]',
+    routeBack: '[300]',
+    snrTowards: JSON.stringify([RAW_GOOD, RAW_GOOD]),
+    snrBack: JSON.stringify([RAW_GOOD, RAW_GOOD]),
+    timestamp: Date.now(),
+    ...over,
+  };
+}
+
+function baseParams(over: Partial<UseTraceroutePathsParams> = {}): UseTraceroutePathsParams {
+  return {
+    showPaths: true,
+    showRoute: false,
+    selectedNodeId: null,
+    currentNodeId: '!64',
+    nodesPositionDigest: NODES,
+    traceroutesDigest: [traceroute()],
+    distanceUnit: 'km',
+    maxNodeAgeHours: 0, // 0 = "never" — keep every traceroute regardless of age
+    themeColors: THEME,
+    callbacks: { onSelectNode: () => {}, onSelectRouteSegment: () => {} },
+    ...over,
+  };
+}
+
+/** Node-pair keys of the segments the base ("Show Route Segments") layer drew. */
+function basePairs(params: UseTraceroutePathsParams): string[] {
+  const { result } = renderHook(() => useTraceroutePaths(params));
+  const layer = result.current.traceroutePathsElements?.[0];
+  if (!layer) return [];
+  // Reading the layer's props is the point: the segments it was handed ARE the
+  // filter's output.
+  const segments = (layer as any).props.segments as Array<{ fromNodeNum: number; toNodeNum: number }>;
+  return segments.map(s => [s.fromNodeNum, s.toNodeNum].sort((a, b) => a - b).join('-'));
+}
+
+/** Node-pair keys of the segments the selected-traceroute layer drew. */
+function selectedPairs(params: UseTraceroutePathsParams): string[] {
+  const { result } = renderHook(() => useTraceroutePaths(params));
+  const layers = result.current.selectedNodeTraceroute;
+  if (!layers) return [];
+  return layers.flatMap(layer =>
+    ((layer as any).props.segments ?? []).map((s: { fromNodeNum: number; toNodeNum: number }) =>
+      [s.fromNodeNum, s.toNodeNum].sort((a, b) => a - b).join('-'),
+    ),
+  );
+}
+
+const ALL_ON = { showRfNodes: true, showUdpNodes: true, showMqttNodes: true };
+
+describe('useTraceroutePaths — Show RF / UDP / MQTT on route segments (#5097)', () => {
+  it('draws every segment when no transport flags are supplied', () => {
+    // The compatibility guarantee: a caller with no toggles filters nothing.
+    expect(new Set(basePairs(baseParams()))).toEqual(new Set(['100-300', '200-300']));
+  });
+
+  it('draws every segment when all three toggles are on', () => {
+    expect(new Set(basePairs(baseParams({ transportFlags: ALL_ON })))).toEqual(
+      new Set(['100-300', '200-300']),
+    );
+  });
+
+  it('hides a UDP-delivered traceroute when Show UDP is off', () => {
+    // The half of the request that could not be built before migration 160:
+    // nothing on the row said UDP, so nothing could filter on it.
+    const params = baseParams({
+      traceroutesDigest: [traceroute({ transportMechanism: TX_MULTICAST_UDP })],
+      transportFlags: { ...ALL_ON, showUdpNodes: false },
+    });
+    expect(basePairs(params)).toEqual([]);
+  });
+
+  it('keeps a UDP-delivered traceroute while Show UDP is on', () => {
+    const params = baseParams({
+      traceroutesDigest: [traceroute({ transportMechanism: TX_MULTICAST_UDP })],
+      transportFlags: { ...ALL_ON, showRfNodes: false, showMqttNodes: false },
+    });
+    expect(new Set(basePairs(params))).toEqual(new Set(['100-300', '200-300']));
+  });
+
+  it('hides an MQTT-delivered traceroute when Show MQTT is off', () => {
+    const params = baseParams({
+      traceroutesDigest: [traceroute({ transportMechanism: TX_MQTT })],
+      transportFlags: { ...ALL_ON, showMqttNodes: false },
+    });
+    expect(basePairs(params)).toEqual([]);
+  });
+
+  it('treats a pre-migration traceroute (no mechanism) as RF', () => {
+    // Upgrade safety: historical rows carry NULL and must not vanish.
+    const params = baseParams({
+      traceroutesDigest: [traceroute({ transportMechanism: null })],
+      transportFlags: { ...ALL_ON, showMqttNodes: false, showUdpNodes: false },
+    });
+    expect(new Set(basePairs(params))).toEqual(new Set(['100-300', '200-300']));
+
+    const rfOff = baseParams({
+      traceroutesDigest: [traceroute({ transportMechanism: null })],
+      transportFlags: { ...ALL_ON, showRfNodes: false },
+    });
+    expect(basePairs(rfOff)).toEqual([]);
+  });
+
+  it('drops only the sentinel hop of an RF traceroute when Show MQTT is off', () => {
+    // Per-hop, not per-record: hop 100->300 carries the firmware unknown-SNR
+    // sentinel, so it is an MQTT hop even though the traceroute reached us over
+    // RF. Its sibling 300->200 is real RF and stays. This is the requester's
+    // "segments that relied on mqtt are filtered" in its sharpest form.
+    const params = baseParams({
+      traceroutesDigest: [
+        traceroute({
+          transportMechanism: TX_LORA,
+          snrTowards: JSON.stringify([RAW_SENTINEL, RAW_GOOD]),
+          snrBack: JSON.stringify([RAW_GOOD, RAW_SENTINEL]),
+        }),
+      ],
+      transportFlags: { ...ALL_ON, showMqttNodes: false },
+    });
+    // Forward hop 0 (100->300) and return hop 1 (300->100) are both the 100-300
+    // pair and both sentinel, so that pair is MQTT-only and drops.
+    expect(new Set(basePairs(params))).toEqual(new Set(['200-300']));
+  });
+
+  it('keeps a link one traceroute saw over RF even when another saw it over MQTT', () => {
+    // The additive-across-records half. The 100-300 pair is contributed twice:
+    // once by an MQTT traceroute, once by an RF one. RF evidence is real, so
+    // turning MQTT off must not erase the link.
+    const params = baseParams({
+      traceroutesDigest: [
+        traceroute({ fromNodeNum: 100, toNodeNum: 300, route: '[]', routeBack: '[]', transportMechanism: TX_MQTT, snrTowards: '[40]', snrBack: '[40]' }),
+        traceroute({ fromNodeNum: 100, toNodeNum: 300, fromNodeId: '!64', toNodeId: '!12c', route: '[]', routeBack: '[]', transportMechanism: TX_LORA, snrTowards: '[40]', snrBack: '[40]', timestamp: Date.now() + 1000 }),
+      ],
+      transportFlags: { ...ALL_ON, showMqttNodes: false },
+    });
+    expect(basePairs(params)).toContain('100-300');
+  });
+
+  it('applies the same rule to the selected traceroute layer', () => {
+    // "Show Traceroute" is a separate memo with its own render path; a fix that
+    // only reached the aggregated layer would leave this one unfiltered.
+    const shown = baseParams({
+      showPaths: false,
+      showRoute: true,
+      selectedNodeId: '!c8',
+      traceroutesDigest: [traceroute({ transportMechanism: TX_MULTICAST_UDP })],
+      transportFlags: ALL_ON,
+    });
+    expect(selectedPairs(shown).length).toBeGreaterThan(0);
+
+    const hidden = { ...shown, transportFlags: { ...ALL_ON, showUdpNodes: false } };
+    expect(selectedPairs(hidden)).toEqual([]);
+  });
+});

--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -259,6 +259,19 @@ const BROADCAST_ADDR = 4294967295;
  */
 const FALLBACK_SNR_COLORS: SnrColorScale = darkOverlayColors.snrColors;
 
+/**
+ * Canonical key for an unordered node pair — the same string for A→B and B→A.
+ *
+ * The numeric comparator is deliberate. `Array.prototype.sort()` with no
+ * comparator sorts lexicographically, so `[9, 100]` orders as `[100, 9]`. Every
+ * call site here used the bare `.sort()`, so the keys agreed with each other and
+ * nothing was broken — but "correct only because every site is wrong the same
+ * way" is a trap for the next person to add a site. Routing all of them through
+ * one helper removes the coupling. (Raised in review on #5097.)
+ */
+const nodePairKey = (a: number, b: number): string =>
+  [a, b].sort((x, y) => x - y).join('-');
+
 // `isValidRouteNode` (reserved/broadcast node-number filtering) is imported
 // from `tracerouteSegments.ts` — that's the single home; see its doc comment.
 // #1862 snapshot parsing + snapshot-then-live position resolution likewise go
@@ -345,7 +358,7 @@ export function useTraceroutePaths({
     const tracerouteMap = new Map<string, TracerouteDigest>();
     recentTraceroutes.forEach(tr => {
       // Create a bidirectional key (same for A→B and B→A)
-      const key = [tr.fromNodeNum, tr.toNodeNum].sort().join('-');
+      const key = nodePairKey(tr.fromNodeNum, tr.toNodeNum);
       const existing = tracerouteMap.get(key);
       const timestamp = tr.timestamp || tr.createdAt || 0;
       const existingTimestamp = existing?.timestamp || existing?.createdAt || 0;
@@ -410,7 +423,7 @@ export function useTraceroutePaths({
         for (let i = 0; i < forwardPositions.length - 1; i++) {
           const from = forwardPositions[i];
           const to = forwardPositions[i + 1];
-          const segmentKey = [from.nodeNum, to.nodeNum].sort().join('-');
+          const segmentKey = nodePairKey(from.nodeNum, to.nodeNum);
 
           segmentUsage.set(segmentKey, (segmentUsage.get(segmentKey) || 0) + 1);
 
@@ -464,7 +477,7 @@ export function useTraceroutePaths({
         for (let i = 0; i < backPositions.length - 1; i++) {
           const from = backPositions[i];
           const to = backPositions[i + 1];
-          const segmentKey = [from.nodeNum, to.nodeNum].sort().join('-');
+          const segmentKey = nodePairKey(from.nodeNum, to.nodeNum);
 
           segmentUsage.set(segmentKey, (segmentUsage.get(segmentKey) || 0) + 1);
 
@@ -516,7 +529,7 @@ export function useTraceroutePaths({
     // the SNR averaging below.
     if (transportFilterActive && transportFlags) {
       filteredSegments = filteredSegments.filter(segment => {
-        const segKey = segment.nodeNums.slice().sort().join('-');
+        const segKey = nodePairKey(segment.nodeNums[0], segment.nodeNums[1]);
         return segmentPassesTransportFilter(
           segmentTransportClasses.get(segKey) ?? [],
           transportFlags,
@@ -528,7 +541,7 @@ export function useTraceroutePaths({
     if (mapZoom !== undefined && mapZoom < 8) {
       // Regional view: only show segments with good or medium SNR (filter out poor/unknown)
       filteredSegments = filteredSegments.filter(segment => {
-        const segKey = segment.nodeNums.slice().sort().join('-');
+        const segKey = nodePairKey(segment.nodeNums[0], segment.nodeNums[1]);
         const snrData = segmentSNRs.get(segKey);
         if (!snrData || snrData.length === 0) return false; // Hide unknown segments at low zoom
         const rfSnrs = snrData.filter(d => !isUnknownSnr(d.snr)).map(d => d.snr);
@@ -543,7 +556,7 @@ export function useTraceroutePaths({
     // popup/className below can read them straight off `seg` instead of a
     // side-table lookup.
     const renderSegments: TracerouteRenderSegment[] = filteredSegments.map(segment => {
-      const segmentKey = segment.nodeNums.slice().sort().join('-');
+      const segmentKey = nodePairKey(segment.nodeNums[0], segment.nodeNums[1]);
       const usage = segmentUsage.get(segmentKey) || 1;
       // A segment is MQTT/IP only when the firmware reported the unknown-SNR
       // sentinel for that specific hop (issue #2931). Don't infer from
@@ -585,7 +598,7 @@ export function useTraceroutePaths({
     const renderBasePopup = (seg: TracerouteRenderSegment): React.ReactNode => {
       const nodeNum1 = seg.fromNodeNum;
       const nodeNum2 = seg.toNodeNum;
-      const segmentKey = [nodeNum1, nodeNum2].sort().join('-');
+      const segmentKey = nodePairKey(nodeNum1, nodeNum2);
       const usage = segmentUsage.get(segmentKey) || 1;
       const node1 = nodeByNum.get(nodeNum1);
       const node2 = nodeByNum.get(nodeNum2);

--- a/src/hooks/useTraceroutePaths.tsx
+++ b/src/hooks/useTraceroutePaths.tsx
@@ -31,6 +31,14 @@ import { TraceroutePathsLayer } from '../components/map/layers/TraceroutePathsLa
 import { darkOverlayColors } from '../config/overlayColors';
 import { logger } from '../utils/logger';
 import type { DistanceUnit } from '../contexts/SettingsContext';
+import {
+  hopTransportClass,
+  segmentPassesTransportFilter,
+  tracerouteTransportClass,
+  transportFilterIsInert,
+  type NodeTransportClass,
+  type TransportFilterFlags,
+} from '../utils/tracerouteTransport';
 
 /** Small component for route segment SNR chart with time-of-day / chronological toggle */
 function SegmentSnrChart({ chartData }: {
@@ -166,6 +174,12 @@ export interface TracerouteDigest {
   routePositions?: string; // JSON: { [nodeNum]: { lat, lng, alt? } } - position snapshot at traceroute time
   timestamp?: number;
   createdAt?: number;
+  /**
+   * `MeshPacket.TransportMechanism` of the packet that carried this route
+   * (#5097, migration 160). Absent/null on pre-migration rows and resolves to
+   * `'rf'` — see `utils/tracerouteTransport.ts`.
+   */
+  transportMechanism?: number | null;
 }
 
 /**
@@ -210,6 +224,14 @@ export interface UseTraceroutePathsParams {
   visibleNodeNums?: Set<number>;
   /** Current map zoom level - controls detail filtering */
   mapZoom?: number;
+  /**
+   * The map's Show RF / UDP / MQTT toggles (#5097). A hop is drawn only when a
+   * transport it was observed over is enabled — see
+   * `utils/tracerouteTransport.ts` for how a hop's class is decided. Omit to
+   * disable transport filtering entirely (every segment renders), which is
+   * what callers that have no toggles should do.
+   */
+  transportFlags?: TransportFilterFlags;
 }
 
 /**
@@ -259,7 +281,12 @@ export function useTraceroutePaths({
   callbacks,
   visibleNodeNums,
   mapZoom,
+  transportFlags,
 }: UseTraceroutePathsParams): UseTraceroutePathsResult {
+  // #5097. Absent flags, or all three on, means the filter cannot remove
+  // anything — skip the per-segment bookkeeping entirely on a map that may
+  // carry hundreds of segments.
+  const transportFilterActive = !!transportFlags && !transportFilterIsInert(transportFlags);
   // Shared live-node position map for the #1862 snapshot-then-live fallback,
   // built via the shared `buildLiveNodePositionMap` (also fixes the
   // lat/lng===0 falsy-zero bug on the live side, not just the snapshot side).
@@ -283,6 +310,20 @@ export function useTraceroutePaths({
     const segmentSNRs = new Map<string, Array<{ snr: number; timestamp: number }>>();
     // Track segments that have MQTT/unknown hops (SNR sentinel indicates MQTT gateway or unknown)
     const segmentHasMqtt = new Map<string, boolean>();
+    // #5097 — every transport class this segment has been observed over, across
+    // all contributing traceroutes. Union, not last-wins: a link seen over RF by
+    // one traceroute and MQTT by another is genuinely both, and stays on the map
+    // while either toggle is on. Only populated when the filter can actually
+    // remove something (see `transportFilterActive`).
+    const segmentTransportClasses = new Map<string, Set<NodeTransportClass>>();
+    const noteTransportClass = (segmentKey: string, cls: NodeTransportClass): void => {
+      let set = segmentTransportClasses.get(segmentKey);
+      if (!set) {
+        set = new Set<NodeTransportClass>();
+        segmentTransportClasses.set(segmentKey, set);
+      }
+      set.add(cls);
+    };
     // Track most recent timestamp per segment for temporal fade
     const segmentLatestTimestamp = new Map<string, number>();
     const segmentsList: Array<{
@@ -343,6 +384,9 @@ export function useTraceroutePaths({
         const snrForward =
           tr.snrTowards && tr.snrTowards !== 'null' && tr.snrTowards !== '' ? JSON.parse(tr.snrTowards) : [];
         const timestamp = tr.timestamp || tr.createdAt || Date.now();
+        // #5097 — how THIS traceroute reached us. Each hop inherits it unless
+        // the hop's own unknown-SNR sentinel says MQTT.
+        const recordTransportClass = tracerouteTransportClass(tr);
 
         // #1862 — snapshot positions via the shared util (fixes a
         // lat/lng===0 truthy-check bug in the old per-consumer copy).
@@ -380,6 +424,13 @@ export function useTraceroutePaths({
             if (isUnknownSnr(snrValue)) {
               segmentHasMqtt.set(segmentKey, true);
             }
+          }
+
+          if (transportFilterActive) {
+            // The sentinel is only knowable when this hop reported an SNR; with
+            // none, the record's own transport is the best evidence there is.
+            const hopIsMqtt = snrForward[i] !== undefined && isUnknownSnr(snrForward[i] / 4);
+            noteTransportClass(segmentKey, hopTransportClass(recordTransportClass, hopIsMqtt));
           }
 
           // Track most recent timestamp for temporal fade
@@ -429,6 +480,11 @@ export function useTraceroutePaths({
             }
           }
 
+          if (transportFilterActive) {
+            const hopIsMqtt = snrBack[i] !== undefined && isUnknownSnr(snrBack[i] / 4);
+            noteTransportClass(segmentKey, hopTransportClass(recordTransportClass, hopIsMqtt));
+          }
+
           // Track most recent timestamp for temporal fade
           const existingTsBack = segmentLatestTimestamp.get(segmentKey) || 0;
           if (timestamp > existingTsBack) {
@@ -454,6 +510,19 @@ export function useTraceroutePaths({
           return visibleNodeNums.has(nodeNum1) && visibleNodeNums.has(nodeNum2);
         })
       : segmentsList;
+
+    // #5097 — Show RF / UDP / MQTT. Applied after the endpoint-visibility pass
+    // and before the zoom-adaptive one, so a segment removed here never reaches
+    // the SNR averaging below.
+    if (transportFilterActive && transportFlags) {
+      filteredSegments = filteredSegments.filter(segment => {
+        const segKey = segment.nodeNums.slice().sort().join('-');
+        return segmentPassesTransportFilter(
+          segmentTransportClasses.get(segKey) ?? [],
+          transportFlags,
+        );
+      });
+    }
 
     // Zoom-adaptive filtering: at low zoom levels, only show stronger segments
     if (mapZoom !== undefined && mapZoom < 8) {
@@ -729,7 +798,7 @@ export function useTraceroutePaths({
         segmentClassName={baseSegmentClassName}
       />,
     ];
-  }, [showPaths, traceroutesDigest, nodesPositionDigest, distanceUnit, maxNodeAgeHours, themeColors.snrColors, themeColors.mqttSegment, themeColors.faint, callbacks, visibleNodeNums, mapZoom, liveNodePositions]);
+  }, [showPaths, traceroutesDigest, nodesPositionDigest, distanceUnit, maxNodeAgeHours, themeColors.snrColors, themeColors.mqttSegment, themeColors.faint, callbacks, visibleNodeNums, mapZoom, liveNodePositions, transportFilterActive, transportFlags]);
 
   // Separate memoization for selected node traceroute (showRoute)
   // This can change independently without re-rendering the base map markers
@@ -758,7 +827,7 @@ export function useTraceroutePaths({
       // forward and return legs are gated independently: `route` gates the
       // forward leg, `hasReturnPath` gates the return leg (#2051) — a
       // traceroute can render one leg without the other.
-      const segments = decomposeTraceroute(
+      const decomposed = decomposeTraceroute(
         {
           fromNodeNum: selectedTrace.fromNodeNum,
           toNodeNum: selectedTrace.toNodeNum,
@@ -771,6 +840,21 @@ export function useTraceroutePaths({
         },
         { resolvePosition }
       );
+
+      // #5097 — Show RF / UDP / MQTT. One record, so each hop's class is the
+      // record's transport unless the hop's own unknown-SNR sentinel says MQTT.
+      // Hops removed here leave a gap in the drawn path on purpose: the map is
+      // meant to show what the enabled transports alone can account for, and
+      // bridging the gap would draw a link the user asked not to see.
+      const segments =
+        transportFilterActive && transportFlags
+          ? decomposed.filter(seg =>
+              segmentPassesTransportFilter(
+                [hopTransportClass(tracerouteTransportClass(selectedTrace), seg.isMqtt)],
+                transportFlags,
+              ),
+            )
+          : decomposed;
 
       if (segments.length === 0) return null;
 
@@ -866,7 +950,7 @@ export function useTraceroutePaths({
       logger.error('Error rendering selected node traceroute:', error);
       return null;
     }
-  }, [showRoute, selectedNodeId, traceroutesDigest, nodesPositionDigest, currentNodeId, distanceUnit, themeColors.error, themeColors.accent, themeColors.tracerouteForward, themeColors.tracerouteReturn, themeColors.snrColors, liveNodePositions]);
+  }, [showRoute, selectedNodeId, traceroutesDigest, nodesPositionDigest, currentNodeId, distanceUnit, themeColors.error, themeColors.accent, themeColors.tracerouteForward, themeColors.tracerouteReturn, themeColors.snrColors, liveNodePositions, transportFilterActive, transportFlags]);
 
   // Compute the set of node numbers involved in the selected traceroute.
   // Used for filtering map markers to only show nodes in the active

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -8666,6 +8666,14 @@ class MeshtasticManager implements ISourceManager {
         routePositions: JSON.stringify(routePositions),
         channel: channelIndex >= 0 ? channelIndex : null,
         packetId: meshPacket.id != null ? Number(meshPacket.id) : null,
+        // #5097 — which transport carried this traceroute, so the map's
+        // Show RF / UDP / MQTT toggles can filter its route segments. This is
+        // per-RECORD, and it has to be: the traceroute protobuf carries no
+        // per-hop transport field, and the only per-hop signal (the unknown-SNR
+        // sentinel) says nothing about UDP. Same resolver the node rows use, so
+        // a bridge packet with no explicit mechanism still classifies MQTT via
+        // the legacy `viaMqtt` flag.
+        transportMechanism: resolveRadioPacketTransport(meshPacket),
         timestamp: timestamp,
         createdAt: Date.now()
       };

--- a/src/server/migrations/160_traceroute_transport_mechanism.pgmysql.test.ts
+++ b/src/server/migrations/160_traceroute_transport_mechanism.pgmysql.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Migration 160 — PostgreSQL / MySQL container behaviour (#5097).
+ *
+ * The repository suites build their fixture from the Drizzle definitions, so
+ * they cannot catch a migration whose `ALTER TABLE` disagrees with the schema.
+ * Here the consequence of a mismatch is quiet: every traceroute insert would
+ * either fail or drop `transportMechanism` on the floor, and the map's Show RF
+ * / UDP / MQTT toggles would silently classify every route segment as RF —
+ * looking exactly like the bug this migration exists to fix.
+ *
+ * So: create the table as it stood BEFORE this migration, run the real
+ * migration, then write and read through the real Drizzle table object (which
+ * now includes the column).
+ *
+ * **Isolation.** Own PostgreSQL schema, own MySQL database. `traceroutes` is a
+ * fixture table in several other suites, and two suites creating/dropping the
+ * same name in one test database is an active race (CLAUDE.md Multi-Database).
+ *
+ * A silent skip still reports `success: true`; confirm coverage via
+ * `numPendingTests` in the JSON reporter.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import mysql from 'mysql2/promise';
+import { drizzle as drizzlePostgres } from 'drizzle-orm/node-postgres';
+import { drizzle as drizzleMysql } from 'drizzle-orm/mysql2';
+import { eq } from 'drizzle-orm';
+import * as schema from '../../db/schema/index.js';
+import { traceroutesPostgres, traceroutesMysql } from '../../db/schema/traceroutes.js';
+import { runMigration160Postgres, runMigration160Mysql } from './160_traceroute_transport_mechanism.js';
+import { postgresAvailable, mysqlAvailable } from '../../db/repositories/test-utils.js';
+
+const { Pool: PgPool } = pg;
+
+const PG_SCHEMA = 'tr_migration_160';
+const MYSQL_DB = 'meshmonitor_test_tr_160';
+
+/**
+ * `traceroutes` as it existed at migration 159 — no `transportMechanism`, and
+ * no FK to `nodes` (irrelevant to the column under test, and requiring the
+ * whole nodes table here would just couple this suite to an unrelated schema).
+ */
+const PRE_MIGRATION_PG = `
+  CREATE TABLE traceroutes (
+    id SERIAL PRIMARY KEY,
+    "fromNodeNum" BIGINT NOT NULL,
+    "toNodeNum" BIGINT NOT NULL,
+    "fromNodeId" TEXT NOT NULL,
+    "toNodeId" TEXT NOT NULL,
+    route TEXT,
+    "routeBack" TEXT,
+    "snrTowards" TEXT,
+    "snrBack" TEXT,
+    "routePositions" TEXT,
+    channel INTEGER,
+    "packetId" BIGINT,
+    timestamp BIGINT NOT NULL,
+    "createdAt" BIGINT NOT NULL,
+    "sourceId" TEXT
+  )`;
+
+const PRE_MIGRATION_MYSQL = `
+  CREATE TABLE traceroutes (
+    id SERIAL PRIMARY KEY,
+    fromNodeNum BIGINT NOT NULL,
+    toNodeNum BIGINT NOT NULL,
+    fromNodeId TEXT NOT NULL,
+    toNodeId TEXT NOT NULL,
+    route TEXT,
+    routeBack TEXT,
+    snrTowards TEXT,
+    snrBack TEXT,
+    routePositions TEXT,
+    channel INT,
+    packetId BIGINT,
+    timestamp BIGINT NOT NULL,
+    createdAt BIGINT NOT NULL,
+    sourceId VARCHAR(36)
+  )`;
+
+const BASE_ROW = {
+  fromNodeNum: 0xfedcba98, // unsigned 32-bit, above signed INTEGER's ceiling
+  toNodeNum: 0x11223344,
+  fromNodeId: '!fedcba98',
+  toNodeId: '!11223344',
+  route: '[300]',
+  routeBack: '[300]',
+  snrTowards: '[40,40]',
+  snrBack: '[40,40]',
+  routePositions: null,
+  channel: 0,
+  packetId: 987654321,
+  timestamp: 1_800_000_000_000,
+  createdAt: 1_800_000_000_000,
+  sourceId: 'src-a',
+};
+
+/** MULTICAST_UDP — the value that could not be stored before this migration. */
+const UDP = 6;
+
+describe.skipIf(!postgresAvailable)('migration 160 — PostgreSQL (container)', () => {
+  let pool: InstanceType<typeof PgPool>;
+  let db: ReturnType<typeof drizzlePostgres>;
+
+  beforeAll(async () => {
+    const admin = new PgPool({
+      host: 'localhost', port: 5433, user: 'test', password: 'test', database: 'meshmonitor_test',
+    });
+    await admin.query(`DROP SCHEMA IF EXISTS ${PG_SCHEMA} CASCADE`);
+    await admin.query(`CREATE SCHEMA ${PG_SCHEMA}`);
+    await admin.end();
+
+    pool = new PgPool({
+      host: 'localhost', port: 5433, user: 'test', password: 'test', database: 'meshmonitor_test',
+      options: `-c search_path=${PG_SCHEMA}`,
+    });
+    await pool.query(PRE_MIGRATION_PG);
+    db = drizzlePostgres(pool, { schema });
+  }, 30_000);
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS ${PG_SCHEMA} CASCADE`);
+      await pool.end();
+    }
+  });
+
+  it('adds a column the Drizzle schema can round-trip, and runs twice safely', async () => {
+    const client = await pool.connect();
+    try {
+      await runMigration160Postgres(client);
+      // The ledger normally runs a migration once, but a crash between the
+      // migration and its ledger write re-runs it — idempotency is mandatory.
+      await expect(runMigration160Postgres(client)).resolves.toBeUndefined();
+    } finally {
+      client.release();
+    }
+
+    await db.insert(traceroutesPostgres).values({ ...BASE_ROW, transportMechanism: UDP });
+    const [row] = await db
+      .select()
+      .from(traceroutesPostgres)
+      .where(eq(traceroutesPostgres.packetId, BASE_ROW.packetId));
+
+    expect(row.transportMechanism).toBe(UDP);
+    expect(Number(row.fromNodeNum)).toBe(BASE_ROW.fromNodeNum);
+  });
+
+  it('leaves the column NULL for a row that supplies none', async () => {
+    // The upgrade path: readers resolve NULL to 'rf', so historical traceroutes
+    // stay visible. A NOT NULL / DEFAULT here would have been wrong — it would
+    // assert a transport nobody recorded.
+    await db.insert(traceroutesPostgres).values({ ...BASE_ROW, packetId: 111 });
+    const [row] = await db
+      .select()
+      .from(traceroutesPostgres)
+      .where(eq(traceroutesPostgres.packetId, 111));
+
+    expect(row.transportMechanism).toBeNull();
+  });
+});
+
+describe.skipIf(!mysqlAvailable)('migration 160 — MySQL (container)', () => {
+  let pool: mysql.Pool;
+  let db: ReturnType<typeof drizzleMysql>;
+
+  beforeAll(async () => {
+    const admin = mysql.createPool({
+      host: 'localhost', port: 3307, user: 'root', password: 'root', connectionLimit: 1,
+    });
+    await admin.query(`DROP DATABASE IF EXISTS \`${MYSQL_DB}\``);
+    await admin.query(`CREATE DATABASE \`${MYSQL_DB}\``);
+    await admin.query(`GRANT ALL ON \`${MYSQL_DB}\`.* TO 'test'@'%'`);
+    await admin.query('FLUSH PRIVILEGES');
+    await admin.end();
+
+    pool = mysql.createPool({
+      host: 'localhost', port: 3307, user: 'test', password: 'test', database: MYSQL_DB, connectionLimit: 5,
+    });
+    await pool.query(PRE_MIGRATION_MYSQL);
+    db = drizzleMysql(pool, { schema, mode: 'default' });
+  }, 30_000);
+
+  afterAll(async () => {
+    if (pool) await pool.end();
+    const admin = mysql.createPool({
+      host: 'localhost', port: 3307, user: 'root', password: 'root', connectionLimit: 1,
+    });
+    await admin.query(`DROP DATABASE IF EXISTS \`${MYSQL_DB}\``);
+    await admin.end();
+  });
+
+  it('adds a column the Drizzle schema can round-trip, and runs twice safely', async () => {
+    await runMigration160Mysql(pool);
+    await expect(runMigration160Mysql(pool)).resolves.toBeUndefined();
+
+    await db.insert(traceroutesMysql).values({ ...BASE_ROW, transportMechanism: UDP });
+    const [row] = await db
+      .select()
+      .from(traceroutesMysql)
+      .where(eq(traceroutesMysql.packetId, BASE_ROW.packetId));
+
+    expect(row.transportMechanism).toBe(UDP);
+    expect(Number(row.fromNodeNum)).toBe(BASE_ROW.fromNodeNum);
+  });
+
+  it('leaves the column NULL for a row that supplies none', async () => {
+    await db.insert(traceroutesMysql).values({ ...BASE_ROW, packetId: 111 });
+    const [row] = await db
+      .select()
+      .from(traceroutesMysql)
+      .where(eq(traceroutesMysql.packetId, 111));
+
+    expect(row.transportMechanism).toBeNull();
+  });
+});

--- a/src/server/migrations/160_traceroute_transport_mechanism.ts
+++ b/src/server/migrations/160_traceroute_transport_mechanism.ts
@@ -1,0 +1,64 @@
+/**
+ * Migration 160: `traceroutes.transportMechanism` (#5097).
+ *
+ * The map's Show RF / Show UDP / Show MQTT toggles filtered node markers and
+ * neighbor links but not traceroute route segments, because nothing on the
+ * traceroute row said which transport carried it. The traceroute protobuf has
+ * no per-hop transport field either — the only per-hop signal is the firmware's
+ * unknown-SNR sentinel, which marks an MQTT hop and says nothing about UDP.
+ *
+ *   transportMechanism  INTEGER  `meshtastic.MeshPacket.TransportMechanism` of
+ *                                the packet that carried the route data:
+ *                                1 LORA · 5 MQTT · 6 MULTICAST_UDP (and the
+ *                                LORA_ALT / INTERNAL / API values in between).
+ *
+ * NULL is the right backfill and there is nothing better available: the
+ * transport of a traceroute received before this migration was never recorded
+ * anywhere, so it cannot be reconstructed. Readers run NULL through
+ * `classifyNodeTransport`, which falls back to `'rf'` — the pre-existing map
+ * behaviour, so every historical traceroute stays visible under the default
+ * toggles rather than vanishing on upgrade.
+ *
+ * No index: the column is never a query predicate. Filtering happens in the
+ * renderer, on rows already fetched by timestamp for the map's age window.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL.
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+import {
+  addColumnIfMissing,
+  addColumnIfMissingPostgres,
+  addColumnIfMissingMysql,
+} from './helpers.js';
+
+const LABEL = 'Migration 160';
+const TABLE = 'traceroutes';
+const COLUMN = 'transportMechanism';
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (db: Database): void => {
+    logger.info(`${LABEL} (SQLite): adding ${TABLE}.${COLUMN}...`);
+    addColumnIfMissing(db, TABLE, COLUMN, `${COLUMN} INTEGER`);
+  },
+
+  down: (_db: Database): void => {
+    logger.debug(`${LABEL} down: not implemented (column drops are destructive)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration160Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): adding ${TABLE}.${COLUMN}...`);
+  await addColumnIfMissingPostgres(client, TABLE, COLUMN, `"${COLUMN}" INTEGER`);
+}
+
+// ============ MySQL ============
+
+export async function runMigration160Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): adding ${TABLE}.${COLUMN}...`);
+  await addColumnIfMissingMysql(pool, TABLE, COLUMN, `${COLUMN} INT`);
+}

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -261,6 +261,13 @@ export interface DbTraceroute {
   routePositions?: string;
   /** Originating Meshtastic packet id (null/undefined = not captured). Enables cross-source correlation (#3623). */
   packetId?: number | null;
+  /**
+   * `MeshPacket.TransportMechanism` of the packet that carried the route
+   * (#5097, migration 160). Null/undefined on pre-migration rows and resolves
+   * to `'rf'` through `classifyNodeTransport`, so historical traceroutes stay
+   * visible under the map's default Show RF / UDP / MQTT toggles.
+   */
+  transportMechanism?: number | null;
   timestamp: number;
   createdAt: number;
 }
@@ -2213,7 +2220,8 @@ class DatabaseService {
               tracerouteData.snrTowards || null,
               tracerouteData.snrBack || null,
               tracerouteData.timestamp,
-              tracerouteData.packetId ?? null
+              tracerouteData.packetId ?? null,
+              tracerouteData.transportMechanism ?? null
             );
           } else {
             // Insert new traceroute

--- a/src/utils/tracerouteTransport.test.ts
+++ b/src/utils/tracerouteTransport.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for traceroute hop transport classification (#5097).
+ *
+ * The rules under test are the ones that decide whether a route segment
+ * disappears when a user turns off Show MQTT or Show UDP. Two of them are
+ * counter-intuitive enough to be worth pinning:
+ *
+ *   1. Within a hop, the per-hop MQTT sentinel BEATS the record's transport.
+ *      Additive here would keep exactly the segments the toggle exists to
+ *      remove.
+ *   2. Across records, the union IS additive. A link one traceroute saw over
+ *      RF is an RF link, whatever a second traceroute travelled over.
+ *
+ * They look contradictory and are not — see the module doc.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  hopTransportClass,
+  segmentPassesTransportFilter,
+  tracerouteTransportClass,
+  transportFilterIsInert,
+  type NodeTransportClass,
+} from './tracerouteTransport';
+import { TX_LORA, TX_LORA_ALT2, TX_MQTT, TX_MULTICAST_UDP, TX_API, TX_INTERNAL } from './nodeTransport';
+
+const ALL_ON = { showRfNodes: true, showUdpNodes: true, showMqttNodes: true };
+const RF_ONLY = { showRfNodes: true, showUdpNodes: false, showMqttNodes: false };
+const NONE = { showRfNodes: false, showUdpNodes: false, showMqttNodes: false };
+
+describe('tracerouteTransportClass', () => {
+  it('maps the mechanism enum onto the three filter classes', () => {
+    expect(tracerouteTransportClass({ transportMechanism: TX_LORA })).toBe('rf');
+    expect(tracerouteTransportClass({ transportMechanism: TX_LORA_ALT2 })).toBe('rf');
+    expect(tracerouteTransportClass({ transportMechanism: TX_MQTT })).toBe('mqtt');
+    expect(tracerouteTransportClass({ transportMechanism: TX_MULTICAST_UDP })).toBe('udp');
+  });
+
+  it('treats a pre-migration row as RF, not as hidden', () => {
+    // The load-bearing case on upgrade: migration 160 backfills NULL because
+    // the transport was never recorded and cannot be recovered. If NULL meant
+    // "no class", every historical traceroute would vanish from the map the
+    // moment the user upgraded — a far worse outcome than showing them.
+    expect(tracerouteTransportClass({ transportMechanism: null })).toBe('rf');
+    expect(tracerouteTransportClass({})).toBe('rf');
+    expect(tracerouteTransportClass(null)).toBe('rf');
+    expect(tracerouteTransportClass(undefined)).toBe('rf');
+  });
+
+  it('honours the legacy viaMqtt flag when the enum is absent or ambiguous', () => {
+    // INTERNAL (0) and an unset scalar are indistinguishable on the wire, so
+    // the boolean is the only signal left for a bridge row written before the
+    // mechanism existed.
+    expect(tracerouteTransportClass({ viaMqtt: true })).toBe('mqtt');
+    expect(tracerouteTransportClass({ transportMechanism: TX_INTERNAL, viaMqtt: true })).toBe('mqtt');
+    expect(tracerouteTransportClass({ transportMechanism: TX_API, viaMqtt: true })).toBe('mqtt');
+    // An explicit mechanism still wins over a stale boolean.
+    expect(tracerouteTransportClass({ transportMechanism: TX_LORA, viaMqtt: true })).toBe('rf');
+  });
+});
+
+describe('hopTransportClass', () => {
+  it('lets the per-hop MQTT sentinel override the record transport', () => {
+    // NullVoid's ask in one assertion: a hop that relied on MQTT is an MQTT
+    // hop, even though the traceroute reporting it arrived over RF.
+    expect(hopTransportClass('rf', true)).toBe('mqtt');
+    expect(hopTransportClass('udp', true)).toBe('mqtt');
+  });
+
+  it('inherits the record transport when the sentinel did not fire', () => {
+    expect(hopTransportClass('rf', false)).toBe('rf');
+    expect(hopTransportClass('udp', false)).toBe('udp');
+    expect(hopTransportClass('mqtt', false)).toBe('mqtt');
+  });
+});
+
+describe('segmentPassesTransportFilter', () => {
+  it('shows a segment when any observed transport is enabled', () => {
+    expect(segmentPassesTransportFilter(['rf'], RF_ONLY)).toBe(true);
+    expect(segmentPassesTransportFilter(['mqtt'], RF_ONLY)).toBe(false);
+    expect(segmentPassesTransportFilter(['udp'], RF_ONLY)).toBe(false);
+  });
+
+  it('keeps a link that any one traceroute observed over an enabled transport', () => {
+    // The additive-across-records half. Turning MQTT off must not erase a link
+    // an RF traceroute independently confirmed.
+    expect(segmentPassesTransportFilter(['rf', 'mqtt'], RF_ONLY)).toBe(true);
+    expect(segmentPassesTransportFilter(['udp', 'mqtt'], RF_ONLY)).toBe(false);
+  });
+
+  it('hides everything when every toggle is off', () => {
+    for (const c of ['rf', 'udp', 'mqtt'] as NodeTransportClass[]) {
+      expect(segmentPassesTransportFilter([c], NONE)).toBe(false);
+    }
+  });
+
+  it('shows a segment with no transport evidence at all', () => {
+    // Not the same as "hide": a segment we know nothing about is not one the
+    // user asked to hide, and returning false would make it unreachable under
+    // every combination of toggles.
+    expect(segmentPassesTransportFilter([], NONE)).toBe(true);
+    expect(segmentPassesTransportFilter([], RF_ONLY)).toBe(true);
+  });
+
+  it('accepts a Set, which is how the aggregated layer accumulates classes', () => {
+    expect(segmentPassesTransportFilter(new Set<NodeTransportClass>(['mqtt']), RF_ONLY)).toBe(false);
+    expect(segmentPassesTransportFilter(new Set<NodeTransportClass>(['mqtt', 'rf']), RF_ONLY)).toBe(true);
+  });
+});
+
+describe('transportFilterIsInert', () => {
+  it('is inert only when all three toggles are on', () => {
+    // Callers use this to skip per-segment bookkeeping on maps with hundreds of
+    // segments, so a false negative here is a real render cost.
+    expect(transportFilterIsInert(ALL_ON)).toBe(true);
+    expect(transportFilterIsInert(RF_ONLY)).toBe(false);
+    expect(transportFilterIsInert({ ...ALL_ON, showMqttNodes: false })).toBe(false);
+    expect(transportFilterIsInert({ ...ALL_ON, showUdpNodes: false })).toBe(false);
+    expect(transportFilterIsInert({ ...ALL_ON, showRfNodes: false })).toBe(false);
+  });
+});

--- a/src/utils/tracerouteTransport.ts
+++ b/src/utils/tracerouteTransport.ts
@@ -1,0 +1,130 @@
+/**
+ * Transport classification for rendered traceroute hops (#5097).
+ *
+ * The map's Show RF / Show UDP / Show MQTT toggles filtered node markers
+ * (`nodePassesTransportFilter`) and neighbor links (#3223), but route segments
+ * rendered regardless. NullVoid's ask: "have route segments respect the mqtt
+ * and udp flag — if either of these are off, route segments that relied on
+ * mqtt or udp are filtered from the map."
+ *
+ * ## What the data actually supports
+ *
+ * There are exactly two transport signals on a traceroute, at different
+ * granularities:
+ *
+ *   - **Per-record** — `traceroutes.transportMechanism` (migration 160): the
+ *     `MeshPacket.TransportMechanism` of the packet that carried the route
+ *     data to us. NULL on pre-migration rows, which `classifyNodeTransport`
+ *     resolves to `'rf'` so historical traceroutes stay visible by default.
+ *
+ *   - **Per-hop** — the firmware's unknown-SNR sentinel (`isMqtt` on a
+ *     `TracerouteRenderSegment`, #2931). It says nothing whatsoever about UDP,
+ *     and it is not *only* an MQTT marker: `TraceRouteModule::insertUnknownHops`
+ *     writes it for an MQTT-bridged leg, a decrypt failure, a relay-role node,
+ *     or pre-snr-array firmware alike. Treating it as MQTT is nonetheless the
+ *     right call here, for two reasons. It is what the map already tells the
+ *     user — these hops render in the MQTT colour and dash style today — and
+ *     under the reading the request came from ("show me what the RF mesh alone
+ *     can show me"), a hop whose SNR the firmware could not fill in is not an
+ *     RF-confirmed hop either way.
+ *
+ * The traceroute protobuf carries no per-hop transport field, so there is no
+ * third option and no way to recover UDP at hop granularity. Hence:
+ *
+ *   hop class = sentinel ? 'mqtt' : the record's own transport class
+ *
+ * The sentinel WINS over the record. That ordering is the requester's ask: a
+ * hop that relied on MQTT drops out when Show MQTT is off, even though the
+ * traceroute reporting it reached us over RF. Treating the two as additive
+ * would keep exactly the segments the toggle is meant to remove.
+ *
+ * ## Across records
+ *
+ * The aggregated layer ("Show Route Segments") collapses many traceroutes onto
+ * one line per node pair, so a segment can carry several hop classes. There
+ * the union IS additive, matching `nodePassesTransportFilter`: a link observed
+ * over RF by one traceroute and over MQTT by another stays on the map while
+ * Show RF is on, because the RF observation is real evidence for that link.
+ * Additive-across-records and sentinel-wins-within-a-hop are not in tension —
+ * they answer different questions ("was this link ever seen over RF?" vs
+ * "did this particular hop rely on MQTT?").
+ *
+ * For single-record layers (the selected traceroute, the Dashboard's per-record
+ * segments) the union has one member and this collapses to the same rule the
+ * neighbor links use.
+ */
+import { classifyNodeTransport, type NodeTransportClass } from './nodeTransport.js';
+
+export type { NodeTransportClass };
+
+/** The transport toggles, as the map contexts spell them. */
+export interface TransportFilterFlags {
+  showRfNodes: boolean;
+  showUdpNodes: boolean;
+  showMqttNodes: boolean;
+}
+
+/** The subset of a traceroute row this module reads. */
+export interface TracerouteTransportFields {
+  transportMechanism?: number | null;
+  /** Legacy fallback, for rows/digests that carry the boolean but not the enum. */
+  viaMqtt?: boolean | null;
+}
+
+/**
+ * Transport class of the traceroute record itself — how the route data reached
+ * us. NULL/absent `transportMechanism` resolves to `'rf'` (see module doc).
+ */
+export function tracerouteTransportClass(
+  traceroute: TracerouteTransportFields | null | undefined,
+): NodeTransportClass {
+  return classifyNodeTransport({
+    transportMechanism: traceroute?.transportMechanism,
+    viaMqtt: traceroute?.viaMqtt,
+  });
+}
+
+/**
+ * Transport class of one rendered hop. The per-hop MQTT sentinel overrides the
+ * record's own transport — see the module doc for why that ordering is the
+ * whole point.
+ */
+export function hopTransportClass(
+  recordClass: NodeTransportClass,
+  hopIsMqtt: boolean,
+): NodeTransportClass {
+  return hopIsMqtt ? 'mqtt' : recordClass;
+}
+
+/**
+ * Whether a segment should be drawn, given every transport class observed for
+ * it. Additive across classes, like `nodePassesTransportFilter`.
+ *
+ * An empty class set returns `true` rather than `false`: a segment with no
+ * transport evidence at all is not a segment the user asked to hide, and
+ * returning false would make it invisible under every combination of toggles.
+ */
+export function segmentPassesTransportFilter(
+  classes: Iterable<NodeTransportClass>,
+  flags: TransportFilterFlags,
+): boolean {
+  let sawAny = false;
+  for (const c of classes) {
+    sawAny = true;
+    switch (c) {
+      case 'mqtt': if (flags.showMqttNodes) return true; break;
+      case 'udp':  if (flags.showUdpNodes) return true; break;
+      case 'rf':   if (flags.showRfNodes) return true; break;
+    }
+  }
+  return !sawAny;
+}
+
+/**
+ * True when the toggles are all on — i.e. the filter cannot remove anything.
+ * Callers use this to skip the per-segment work entirely, which is the common
+ * case on a map with hundreds of segments.
+ */
+export function transportFilterIsInert(flags: TransportFilterFlags): boolean {
+  return flags.showRfNodes && flags.showUdpNodes && flags.showMqttNodes;
+}


### PR DESCRIPTION
Closes #5097.

Requested by NullVoid in Discord: *"have route segments respect the mqtt and udp flag — if either of these are off, route segments that relied on mqtt or udp are filtered from the map."* The toggles already filtered node markers and, since #3223, neighbor links; traceroute route segments rendered regardless.

## Why this needed a schema change

Neighbor links were easy because `neighborInfo` rows carry a backend `transportClass`. Traceroutes carry nothing of the sort. The only transport signal on one was the firmware's unknown-SNR sentinel, which is per-hop, says nothing about UDP, and is **not even exclusively MQTT** — `TraceRouteModule::insertUnknownHops` also writes it for a decrypt failure, a relay-role node, or pre-snr-array firmware. The traceroute protobuf has no per-hop transport field, so there was no third option: **UDP could not be filtered at all without storing something new.**

**Migration 160** adds `traceroutes.transportMechanism` — the `MeshPacket.TransportMechanism` of the packet that carried the route data — stamped at ingest via the same `resolveRadioPacketTransport` the node rows use.

- **NULL on every pre-migration row**, because the transport was never recorded and cannot be reconstructed. Readers resolve NULL to `'rf'` through `classifyNodeTransport`, so historical traceroutes stay visible under the default toggles instead of vanishing on upgrade. A `NOT NULL DEFAULT` would have asserted a transport nobody recorded.
- **The response stamps the column, not the pending request row.** The pending row is written when *we* send the request and has no transport; the response is the packet that actually crossed the mesh.

## The rule

New `src/utils/tracerouteTransport.ts` owns it, and the module doc explains the two halves that look contradictory and aren't:

```
hop class = sentinel ? 'mqtt' : the record's own transport class
```

**Within a hop, the sentinel wins.** That ordering *is* the request: a hop that relied on MQTT drops out when Show MQTT is off, even though the traceroute reporting it arrived over RF. Additive there would keep exactly the segments the toggle exists to remove.

**Across records, the union is additive**, matching `nodePassesTransportFilter`: a link one traceroute saw over RF stays on the map while Show RF is on, whatever a second traceroute travelled over. RF evidence for a link is real evidence. The two rules answer different questions — *"was this link ever seen over RF?"* vs *"did this particular hop rely on MQTT?"*.

Hops removed leave a **gap** rather than joining across; bridging would draw a link the user asked not to see.

## Surfaces

Applied everywhere route segments render, so the toggles mean the same thing on every map:

| Surface | Where |
|---|---|
| Nodes map, aggregated ("Show Route Segments") | `useTraceroutePaths` base memo |
| Nodes map, selected ("Show Traceroute") | `useTraceroutePaths` selected memo |
| Dashboard map | `DashboardMap.tsx` |
| Map Analysis | `useTracerouteAnalysis`, driven by the pills that already filter its node markers |

All four skip the per-segment work entirely when all three toggles are on (`transportFilterIsInert`).

## ⚠️ Note on defaults

`showMqttNodes` and `showUdpNodes` both default to **false** (`MapContext.tsx:121,125`). So on a default map this **removes segments that render today** — every segment carrying the unknown-SNR sentinel (currently drawn dashed in the MQTT colour) and every segment from a traceroute delivered over MQTT or UDP. That is the requested behaviour and it matches how node markers already behave, but it is a visible change on upgrade, not an opt-in. Flagging it because it will read as "the map lost route segments" to anyone who doesn't connect it to the toggles.

## Tests

- `utils/tracerouteTransport.test.ts` (11) — the classification rules, including the pre-migration-NULL-is-RF case and both halves of the sentinel-vs-union asymmetry.
- `hooks/useTraceroutePaths.transportFilter.test.tsx` (9) — renders the **real hook** and reads the segments it hands the layer, rather than re-implementing the predicate. Covers both memos, including "drops only the sentinel hop of an RF traceroute".
- `hooks/useTracerouteAnalysis.test.ts` (+5) — the Map Analysis path, including the deliberate divergence where a *missing* SNR sample is coloured unknown but **not** hidden (hiding it would remove hops from pre-snr-array firmware).
- `db/repositories/traceroutes.test.ts` (+3 × 3 backends) — round-trip, NULL default, and the response-stamps-it case. The hand-written PG/MySQL `CREATE TABLE` blocks in that file gained the column too; without that, every `select()` in those legs would have failed (the #4250 trap).
- `migrations/160_*.pgmysql.test.ts` (4) — the migration's `ALTER` and the Drizzle schema agree, and it runs twice safely.

**Full suite: 19340 passed, 0 failed, 0 failed suites**, with the PostgreSQL and MySQL containers running (109 pending, down from 982 without them — the multi-backend legs genuinely ran). `npm run lint:ci` and `npm run typecheck` clean.

## Live verification

Deployed to the dev container and confirmed in the browser:

- `migration_160_traceroute_transport_mechanism: completed` in settings — the migration ran on a real upgraded SQLite database.
- `GET /api/traceroutes/recent` now returns `transportMechanism` on every row; all 317 existing rows are `null`, exactly the documented pre-migration state.
- Toggling Show RF / Show MQTT on the Nodes map re-filters segments with no console errors and no rendering regressions.

**Not verified on live hardware:** the ingest stamp writing a non-null value. This install has `tracerouteIntervalMinutes: 0` (auto-traceroute disabled), so no new traceroute arrived during testing, and I did not fire a manual one — that puts packets on the user's mesh, which is their call. The write path is covered by the repository round-trip tests on all three backends, and uses the same `resolveRadioPacketTransport` helper the node rows already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc
