### PR TITLE
fix(config): keep the GPIO Pin Usage sidebar inside the viewport (#5100)

### DIFF
--- a/src/components/ConfigurationTab.tsx
+++ b/src/components/ConfigurationTab.tsx
@@ -2750,7 +2750,32 @@ const ConfigurationTab: React.FC<ConfigurationTabProps> = ({ nodes, channels = [
           flexShrink: 0,
           alignSelf: 'flex-start',
           position: 'sticky',
-          top: '1rem',
+          /*
+           * Park below BOTH sticky things above it, not under them (#5100).
+           *
+           * `.app-header` is `position: fixed` and `.section-nav` is itself
+           * sticky at `top: var(--app-header-height)` with `z-index: 10`, so
+           * together they own the band from 0 to header+nav. A bare `top: 1rem`
+           * parked this panel at 16px — inside that band — and the chip rows
+           * drew straight over its heading. Measured at 1500x800: bar 0-60px,
+           * nav 60-192px, panel stuck at 76px. Same trap the config rail hit in
+           * #5070; see the banner on `--app-header-height` in App.css.
+           *
+           * The nav's height is published by `useSectionNavHeightVar` because
+           * it wraps: 29 chips are three rows here and fewer as the window
+           * widens. The `0px` fallback keeps the offset sane before the first
+           * measurement lands.
+           */
+          top: 'calc(var(--app-header-height) + var(--section-nav-height, 0px) + 1rem)',
+          /*
+           * The same question asked downward. With no cap, a panel taller than
+           * the space left below those two cannot fit in the viewport at all,
+           * so scrolling drags its bottom half off the screen with no way to
+           * reach it — the reported bug. Cap it and let it scroll its own
+           * content.
+           */
+          maxHeight: 'calc(100dvh - var(--app-header-height) - var(--section-nav-height, 0px) - 2rem)',
+          overflowY: 'auto',
           display: 'none' // Hidden by default, shown via media query
         }}>
           <GpioPinSummary

--- a/src/components/SectionNav.tsx
+++ b/src/components/SectionNav.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styles from './SectionNav.module.css';
+import { useSectionNavHeightVar } from '../hooks/useSectionNavHeightVar';
 
 export interface NavItem {
   id: string;
@@ -39,6 +40,11 @@ const SectionNav: React.FC<SectionNavProps> = ({ items, className }) => {
   const navRef = useRef<HTMLElement | null>(null);
   const settleUntilRef = useRef(0);
   const [activeId, setActiveId] = useState<string | null>(null);
+
+  // This nav is sticky and opaque, so a second sticky element beside it has to
+  // park below BOTH the fixed bar and this row. Its height is a function of how
+  // many chips wrap at the current width, so it gets measured (#5100).
+  useSectionNavHeightVar(navRef);
 
   // Stable dependency: callers build the `items` array inline, so it is a new
   // reference on every render and would re-arm the observer each time.

--- a/src/hooks/useSectionNavHeightVar.test.ts
+++ b/src/hooks/useSectionNavHeightVar.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * #5100: the GPIO Pin Usage sidebar is sticky beside a sticky, opaque
+ * `.section-nav`, so its offset has to clear the nav as well as the fixed bar.
+ * The nav is a wrapping chip row, so no constant describes its height and the
+ * shell measures it.
+ *
+ * jsdom has no layout, so these tests drive `publishSectionNavHeight` directly —
+ * the rounding and clear-on-zero rules are the whole of the logic, and both
+ * decide whether the panel lands under the nav or clear of it.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SECTION_NAV_HEIGHT_VAR, publishSectionNavHeight } from './useSectionNavHeightVar';
+
+describe('publishSectionNavHeight (#5100)', () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    root = document.createElement('div');
+  });
+
+  it('publishes a measured height in px', () => {
+    publishSectionNavHeight(root, 132);
+    expect(root.style.getPropertyValue(SECTION_NAV_HEIGHT_VAR)).toBe('132px');
+  });
+
+  it('rounds a fractional height UP', () => {
+    // Down-rounding leaves a sliver of the panel under the nav — the exact
+    // symptom. Device pixel ratios routinely produce fractional heights.
+    publishSectionNavHeight(root, 131.2);
+    expect(root.style.getPropertyValue(SECTION_NAV_HEIGHT_VAR)).toBe('132px');
+  });
+
+  it('clears the variable rather than publishing zero', () => {
+    // getBoundingClientRect reports 0 for a display:none element or one read
+    // before first layout. Consumers fall back to 0px, which is the same
+    // "below the header only" offset they had before this existed.
+    publishSectionNavHeight(root, 132);
+    publishSectionNavHeight(root, 0);
+    expect(root.style.getPropertyValue(SECTION_NAV_HEIGHT_VAR)).toBe('');
+  });
+
+  it('ignores a non-finite measurement', () => {
+    publishSectionNavHeight(root, 132);
+    publishSectionNavHeight(root, Number.NaN);
+    expect(root.style.getPropertyValue(SECTION_NAV_HEIGHT_VAR)).toBe('');
+  });
+
+  it('overwrites a previous value when the chip row re-wraps', () => {
+    // Widening the window drops a chip row. The panel below has to move up with
+    // it, which is the point of measuring rather than constanting.
+    publishSectionNavHeight(root, 132);
+    publishSectionNavHeight(root, 88);
+    expect(root.style.getPropertyValue(SECTION_NAV_HEIGHT_VAR)).toBe('88px');
+  });
+});

--- a/src/hooks/useSectionNavHeightVar.ts
+++ b/src/hooks/useSectionNavHeightVar.ts
@@ -1,0 +1,77 @@
+/**
+ * Publishes the sticky section-nav's REAL height as `--section-nav-height`.
+ *
+ * Sibling of `useAppHeaderHeightVar`, for the same reason and with the same
+ * shape. `.section-nav` is `position: sticky` at `top: var(--app-header-height)`
+ * (App.css), so it parks in a band directly under the fixed bar and covers
+ * anything else that tries to stick into that band — it carries `z-index: 10`.
+ *
+ * A second sticky element beside it therefore has to clear the bar AND the nav.
+ * The bar's height is measured because CSS cannot describe a `height: auto`
+ * element; the nav's height needs measuring for a different reason: it is a
+ * `flex-wrap: wrap` chip row, so its height is a function of how many chips
+ * wrap at the current width. On the Configuration tab that is 29 chips, which
+ * renders as three rows at 1500px and fewer as the window widens. No constant
+ * can be right at every width.
+ *
+ * Consumers read it with a `0px` fallback, so a surface that renders no nav —
+ * or one that mounts before this hook's first measurement — simply keeps its
+ * plain "below the header" offset.
+ *
+ * Caveat for future consumers: this is the nav's rendered height whatever shape
+ * it currently has. ConfigurationTab reshapes it into a left rail on a
+ * landscape phone (#5069), where the value is a rail's full column height and
+ * means nothing as a downward offset. Today's only consumer — the GPIO Pin
+ * Usage sidebar — is `display: none` below 1200px, so it never reads the
+ * variable in rail mode.
+ */
+import { useEffect, type RefObject } from 'react';
+
+/** The custom property "below the header AND the nav" offsets read. */
+export const SECTION_NAV_HEIGHT_VAR = '--section-nav-height';
+
+/**
+ * Writes `height` onto `root` as `--section-nav-height`, or clears it when the
+ * height is not usable so consumers fall back to `0px`.
+ *
+ * Split out from the hook so the rounding and clear-on-zero rules are testable
+ * without a live ResizeObserver, exactly as `publishAppHeaderHeight` is.
+ *
+ * Zero is not a real measurement — it is what `getBoundingClientRect` reports
+ * for a `display: none` element or one read before first layout — and pinning
+ * the offset to a stale value would be worse than the fallback.
+ */
+export function publishSectionNavHeight(root: HTMLElement, height: number): void {
+  if (!Number.isFinite(height) || height <= 0) {
+    root.style.removeProperty(SECTION_NAV_HEIGHT_VAR);
+    return;
+  }
+  // Round up, for the same reason the header does: a fractional height that
+  // rounds DOWN leaves a sliver of the consumer under the nav.
+  root.style.setProperty(SECTION_NAV_HEIGHT_VAR, `${Math.ceil(height)}px`);
+}
+
+/**
+ * Keeps `--section-nav-height` equal to `ref`'s rendered height for as long as
+ * the nav is mounted, and hands the variable back on unmount.
+ */
+export function useSectionNavHeightVar(ref: RefObject<HTMLElement | null>): void {
+  useEffect(() => {
+    const root = document.documentElement;
+    const nav = ref.current;
+    if (!nav || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(() => {
+      publishSectionNavHeight(root, nav.getBoundingClientRect().height);
+    });
+    observer.observe(nav);
+    publishSectionNavHeight(root, nav.getBoundingClientRect().height);
+
+    return () => {
+      observer.disconnect();
+      // Leaving a stale pixel value on <html> would push the next surface that
+      // mounts without a nav down by a nav's worth of empty space.
+      root.style.removeProperty(SECTION_NAV_HEIGHT_VAR);
+    };
+  }, [ref]);
+}


### PR DESCRIPTION
Closes #5100.

The GPIO Pin Usage sidebar is `position: sticky` with `top: 1rem` and no height cap. That loses on **both** ends once the page scrolls.

## Downward — the reported bug

With no `max-height`, a panel taller than the space left below the bar cannot fit in the viewport at all. Past its natural top the box drifts down with the page and its bottom half leaves the screen, with no scroll of its own to reach it. That is NullVoid's second screenshot.

## Upward — found while verifying the fix

`top: 1rem` parks the panel at 16px, which is inside the band owned by two things above it:

| Element | Position | Occupies |
|---|---|---|
| `.app-header` | `fixed`, `z-index: 10000` | 0 – 60px |
| `.section-nav` | `sticky` at `top: var(--app-header-height)`, `z-index: 10` | 60 – 192px |

Both are opaque. Measured live at 1500x800, the panel stuck at 76px and the chip rows drew straight over its "GPIO Pin Usage" heading — only the last table row was readable. Capping the height without moving the top would have left that permanently buried, so this PR fixes both.

## The fix

Park below both, and cap to what is left:

```
top:       calc(var(--app-header-height) + var(--section-nav-height, 0px) + 1rem)
maxHeight: calc(100dvh - var(--app-header-height) - var(--section-nav-height, 0px) - 2rem)
overflowY: auto
```

### Why the nav height is measured, not a constant

`.section-nav` is a `flex-wrap: wrap` chip row. Configuration renders **29** chips, which is three rows at 1500px and fewer as the window widens — no constant is right at every width.

`useSectionNavHeightVar` publishes the rendered height as `--section-nav-height`, mirroring `useAppHeaderHeightVar` from #5070 including its round-up (a fractional height rounding *down* leaves a sliver under the nav) and clear-on-zero (a `display: none` or pre-layout read returns 0) rules. `SectionNav` owns it via its existing `navRef`.

Consumers read it with a `0px` fallback and today there is exactly one consumer, so every other surface that renders a `SectionNav` is unchanged.

## Testing

**Unit:** `src/hooks/useSectionNavHeightVar.test.ts` — 5 cases covering px publish, round-up, clear-on-zero, non-finite, and re-wrap overwrite. Mirrors the existing `useAppHeaderHeightVar` suite.

**Full suite:** 19,437 tests, **0 failures**, `success: true` (109 skipped). PostgreSQL and MySQL containers were running, so the multi-backend suites really ran.

**Lint:** `lint:ci` ratchet clean (0 in-repo `FAIL` lines). `tsc --noEmit` clean.

**Live, in the dev container** at `1500x820`, Configuration tab, scrolled 9000px down:

| | Before | After |
|---|---|---|
| Panel top | 76px (under the nav, which ends at 192px) | **208px** = 60 + 132 + 16, clears the nav |
| `max-height` | none | **596px** = 820 − 60 − 132 − 32 |
| Panel bottom | ran past the viewport | **785px**, inside the 820px viewport |
| Overflow behavior | page dragged it off-screen | panel scrolls its own content |

Shrinking the viewport until the content exceeds the cap flips `scrollHeight > clientHeight` to true while the panel's bottom stays inside the viewport — the panel scrolls itself instead of running off the bottom.

Screenshot after the fix — heading and table fully visible, sitting cleanly below the chip nav, 9000px down the page:

_Screenshot sent to the maintainer to attach here (GitHub image uploads need the web UI)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZ871RCjD95cAu6jMfNM4
