### PR TITLE
feat(meshcore): add the Philadelphia MeshCore 500 radio preset (#5137)

### DIFF
--- a/src/components/MeshCore/MeshCoreConfigurationView.test.tsx
+++ b/src/components/MeshCore/MeshCoreConfigurationView.test.tsx
@@ -155,3 +155,54 @@ describe('MeshCoreConfigurationView permission gating', () => {
     }
   });
 });
+
+describe('MeshCoreConfigurationView radio preset picker (#5137)', () => {
+  it('offers the Philadelphia preset and applies its parameters when chosen', () => {
+    render(<MeshCoreConfigurationView status={makeStatus()} actions={makeActions()} />);
+
+    const picker = screen.getByLabelText('meshcore.config.preset') as HTMLSelectElement;
+    expect(Array.from(picker.options).map(o => o.value)).toContain('us-philly');
+
+    fireEvent.change(picker, { target: { value: 'us-philly' } });
+
+    // 500 kHz is the whole point — it is what makes the preset FCC-compliant,
+    // and the only entry in the table that uses it.
+    expect(screen.getByLabelText('meshcore.config.frequency')).toHaveValue(902.25);
+    expect(screen.getByLabelText('meshcore.config.bandwidth')).toHaveValue('500');
+    expect(screen.getByLabelText('meshcore.config.sf')).toHaveValue('11');
+    expect(screen.getByLabelText('meshcore.config.cr')).toHaveValue('5');
+  });
+
+  it('shows the path-hash note only while the Philadelphia preset is resolved', () => {
+    render(<MeshCoreConfigurationView status={makeStatus()} actions={makeActions()} />);
+
+    expect(screen.queryByTestId('mc-cfg-preset-note')).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('meshcore.config.preset'), {
+      target: { value: 'us-philly' },
+    });
+    expect(screen.getByTestId('mc-cfg-preset-note').textContent).toMatch(/path hash/i);
+
+    // A preset with nothing extra to say must not leave the note behind.
+    fireEvent.change(screen.getByLabelText('meshcore.config.preset'), {
+      target: { value: 'us-ca' },
+    });
+    expect(screen.queryByTestId('mc-cfg-preset-note')).toBeNull();
+  });
+
+  it('shows the note for a node that already arrived on the Philadelphia parameters', () => {
+    // Keyed off the resolved preset, not the last click — a node flashed
+    // elsewhere and then connected here still needs to see the requirement.
+    render(
+      <MeshCoreConfigurationView
+        status={makeStatus({ radioFreq: 902.25, radioBw: 500, radioSf: 11, radioCr: 5 })}
+        actions={makeActions()}
+      />,
+    );
+
+    expect(
+      (screen.getByLabelText('meshcore.config.preset') as HTMLSelectElement).value,
+    ).toBe('us-philly');
+    expect(screen.getByTestId('mc-cfg-preset-note').textContent).toMatch(/path hash/i);
+  });
+});

--- a/src/components/MeshCore/MeshCoreConfigurationView.tsx
+++ b/src/components/MeshCore/MeshCoreConfigurationView.tsx
@@ -55,6 +55,13 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
 
   const presetId = useMemo(() => findPresetId(freq, bw, sf, cr), [freq, bw, sf, cr]);
 
+  // Keyed off the RESOLVED preset, not the last one clicked, so the note is
+  // also there for a node that already arrived on these parameters (#5137).
+  const presetNote = useMemo(
+    () => RADIO_PRESETS.find(p => p.id === presetId)?.note,
+    [presetId],
+  );
+
   const handlePresetChange = (id: string) => {
     if (id === 'custom') return;
     const preset = RADIO_PRESETS.find(p => p.id === id);
@@ -322,11 +329,17 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
               <option key={p.id} value={p.id}>{p.label}</option>
             ))}
           </select>
+          {presetNote && (
+            <p className="hint" data-testid="mc-cfg-preset-note">
+              <UiIcon name="info" size={14} /> {presetNote}
+            </p>
+          )}
         </div>
         <div className="form-row">
           <div>
-            <label>{t('meshcore.config.frequency', 'Frequency (MHz)')}</label>
+            <label htmlFor="mc-cfg-freq">{t('meshcore.config.frequency', 'Frequency (MHz)')}</label>
             <input
+              id="mc-cfg-freq"
               type="number"
               step="0.001"
               min={137}
@@ -337,8 +350,9 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
             />
           </div>
           <div>
-            <label>{t('meshcore.config.bandwidth', 'Bandwidth (kHz)')}</label>
+            <label htmlFor="mc-cfg-bw">{t('meshcore.config.bandwidth', 'Bandwidth (kHz)')}</label>
             <select
+              id="mc-cfg-bw"
               value={bw}
               onChange={e => setBw(parseFloat(e.target.value))}
               disabled={!connected || savingRadio}
@@ -349,8 +363,9 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
             </select>
           </div>
           <div>
-            <label>{t('meshcore.config.sf', 'Spreading Factor')}</label>
+            <label htmlFor="mc-cfg-sf">{t('meshcore.config.sf', 'Spreading Factor')}</label>
             <select
+              id="mc-cfg-sf"
               value={sf}
               onChange={e => setSf(parseInt(e.target.value, 10))}
               disabled={!connected || savingRadio}
@@ -361,8 +376,9 @@ export const MeshCoreConfigurationView: React.FC<MeshCoreConfigurationViewProps>
             </select>
           </div>
           <div>
-            <label>{t('meshcore.config.cr', 'Coding Rate')}</label>
+            <label htmlFor="mc-cfg-cr">{t('meshcore.config.cr', 'Coding Rate')}</label>
             <select
+              id="mc-cfg-cr"
               value={cr}
               onChange={e => setCr(parseInt(e.target.value, 10))}
               disabled={!connected || savingRadio}

--- a/src/components/MeshCore/radioPresets.test.ts
+++ b/src/components/MeshCore/radioPresets.test.ts
@@ -1,0 +1,76 @@
+/**
+ * #5137: Philly Mesh moved the region to "MeshCore 500" on 2026-09-02 to get
+ * inside FCC 15.247(a)(2). These lock the published parameters, and guard the
+ * table-wide invariants that `findPresetId` depends on.
+ *
+ * https://phillymesh.net/2026/09/02/fcc-regulations/
+ */
+import { describe, it, expect } from 'vitest';
+import { RADIO_PRESETS, findPresetId } from './radioPresets';
+
+describe('RADIO_PRESETS', () => {
+  it('carries the Philadelphia MeshCore 500 parameters exactly as published', () => {
+    const philly = RADIO_PRESETS.find(p => p.id === 'us-philly');
+    expect(philly).toBeDefined();
+    expect({
+      freq: philly!.freq,
+      bw: philly!.bw,
+      sf: philly!.sf,
+      cr: philly!.cr,
+    }).toEqual({ freq: 902.25, bw: 500, sf: 11, cr: 5 });
+  });
+
+  it('tells the user about the 2-byte path hash the preset cannot set itself', () => {
+    // A preset only carries freq/bw/sf/cr. Philly also standardises on a
+    // 2-byte path hash, which lives in Settings — without the note a user
+    // lands on a node that looks configured and still mis-routes.
+    const philly = RADIO_PRESETS.find(p => p.id === 'us-philly');
+    expect(philly?.note).toMatch(/path hash/i);
+  });
+
+  it('has no duplicate ids', () => {
+    const ids = RADIO_PRESETS.map(p => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('adds no NEW preset that shadows another by radio parameters', () => {
+    // findPresetId resolves by value and returns the FIRST match, so a
+    // duplicate tuple makes the later preset unselectable — the picker
+    // silently jumps to its twin.
+    //
+    // One such pair already exists: 'ch' (Switzerland) is identical to
+    // 'eu-uk-narrow' at 869.618/62.5/SF8/CR8, so picking Switzerland snaps the
+    // dropdown back to EU/UK (Narrow). That predates #5137 and de-duplicating
+    // it is a call about what Swiss users should see, not a test fix — so this
+    // records it as the ONLY tolerated collision and fails on any new one.
+    const KNOWN_COLLISIONS = [['eu-uk-narrow', 'ch']];
+
+    const byTuple = new Map<string, string[]>();
+    for (const p of RADIO_PRESETS) {
+      const key = `${p.freq}|${p.bw}|${p.sf}|${p.cr}`;
+      byTuple.set(key, [...(byTuple.get(key) ?? []), p.id]);
+    }
+    const collisions = [...byTuple.values()].filter(ids => ids.length > 1);
+    expect(collisions).toEqual(KNOWN_COLLISIONS);
+  });
+});
+
+describe('findPresetId', () => {
+  it('round-trips every preset', () => {
+    // 'ch' is excluded: it is parameter-identical to the earlier
+    // 'eu-uk-narrow' and can never resolve to itself. See the collision test
+    // above for why that is recorded rather than fixed here.
+    for (const p of RADIO_PRESETS.filter(p => p.id !== 'ch')) {
+      expect(findPresetId(p.freq, p.bw, p.sf, p.cr)).toBe(p.id);
+    }
+  });
+
+  it('resolves the Philadelphia parameters to us-philly', () => {
+    expect(findPresetId(902.25, 500, 11, 5)).toBe('us-philly');
+  });
+
+  it('returns custom for parameters no preset covers', () => {
+    // Same frequency, narrower bandwidth — must NOT fall through to Philly.
+    expect(findPresetId(902.25, 250, 11, 5)).toBe('custom');
+  });
+});

--- a/src/components/MeshCore/radioPresets.ts
+++ b/src/components/MeshCore/radioPresets.ts
@@ -6,6 +6,15 @@ export interface RadioPreset {
   sf: number;
   cr: number;
   region?: string;
+  /**
+   * Anything a node needs BEYOND freq/bw/sf/cr to actually join this mesh.
+   *
+   * A preset only carries the four radio parameters, so a community that also
+   * standardises on a setting living elsewhere in the app would otherwise get
+   * a node that looks configured and still cannot talk. Shown as a hint under
+   * the preset picker (#5137).
+   */
+  note?: string;
 }
 
 export const RADIO_PRESETS: ReadonlyArray<RadioPreset> = [
@@ -25,6 +34,13 @@ export const RADIO_PRESETS: ReadonlyArray<RadioPreset> = [
   { id: 'pt868',         label: 'Portugal 868',             freq: 869.618, bw: 62.5,  sf: 7,  cr: 6 },
   { id: 'ch',            label: 'Switzerland',              freq: 869.618, bw: 62.5,  sf: 8,  cr: 8 },
   { id: 'us-ca',         label: 'USA/Canada (Recommended)', freq: 910.525, bw: 62.5,  sf: 7,  cr: 5 },
+  // Philly Mesh moved the region to "MeshCore 500" on 2026-09-02 to get inside
+  // FCC 15.247(a)(2), which wants >= 500 kHz in the 900 MHz ISM band. 902.250
+  // is chosen to sit clear of the ISM interference they measured every 250 kHz.
+  // https://phillymesh.net/2026/09/02/fcc-regulations/
+  { id: 'us-philly',     label: 'USA: Philadelphia (MeshCore 500)',
+    freq: 902.250, bw: 500, sf: 11, cr: 5,
+    note: 'Philly Mesh also standardises on a 2-byte path hash. Set "Default path hash size" to 2 bytes in Settings — this preset only carries the radio parameters.' },
   { id: 'vn-narrow',     label: 'Vietnam (Narrow)',         freq: 920.250, bw: 62.5,  sf: 8,  cr: 5 },
   { id: 'vn-depr',       label: 'Vietnam (Deprecated)',     freq: 920.250, bw: 250,   sf: 11, cr: 5 },
 ];


### PR DESCRIPTION
Closes #5137.

Philly Mesh moved the region to **MeshCore 500** on 2026-09-02 to get inside [FCC 15.247(a)(2)](https://www.ecfr.gov/current/title-47/part-15/section-15.247#p-15.247(a)(2)), which requires ≥ 500 kHz in the 900 MHz ISM band. `902.250` is chosen to sit clear of the interference they measured every 250 kHz across the band. Source: https://phillymesh.net/2026/09/02/fcc-regulations/

| | |
|---|---|
| Frequency | 902.250 MHz |
| Bandwidth | 500 kHz |
| Spreading Factor | 11 |
| Coding Rate | 4/5 |

## The preset alone isn't enough

Philly also standardises on a **2-byte path hash**, and a `RadioPreset` only carries freq/bw/sf/cr. Picking the preset and stopping would leave a node that looks configured and still mis-routes, because that setting lives in a different view — "Default path hash size" in `MeshCoreSettingsView`.

So `RadioPreset` gains an optional `note`, rendered as a hint under the picker. It's keyed off the **resolved** preset rather than the last click, so a node that arrived on these parameters already (flashed elsewhere, then connected here) sees the requirement too.

The note deliberately points at the other view instead of reaching across into it — a radio-parameter preset silently writing an unrelated setting would be worse than telling the user.

## Accessibility fix that came with it

The Frequency / Bandwidth / SF / Coding Rate fields were bare `<label>` elements with no `for` association, so they were **unlabelled for screen readers**. Now wired with `htmlFor`/`id`. This surfaced because `getByLabelText` couldn't find them from a test.

## Two findings from the new invariant tests

1. **Pre-existing collision:** `ch` (Switzerland) is parameter-identical to the earlier `eu-uk-narrow` — both `869.618 / 62.5 / SF8 / CR8`. `findPresetId` returns the first match, so **picking Switzerland snaps the dropdown back to "EU/UK (Narrow)"**. That predates this change, and de-duplicating it is a call about what Swiss users should see, not a test fix. The test records it as the *only* tolerated collision and fails on any new one; the round-trip test skips `ch` with the same rationale. **Flagging for a separate decision — not fixed here.**
2. Nothing else in the table collides, and every other preset round-trips through `findPresetId`.

## Testing

**New:** `radioPresets.test.ts` (7 cases — published parameters, the note, duplicate ids, the collision ratchet, round-trip, exact resolution, and that `902.25 @ 250 kHz` does *not* fall through to Philly) plus 3 component cases covering the picker, note show/hide, and the already-on-these-parameters path.

**Full suite:** `success: true`, 0 failures, 18,478 passed. Note: 992 skipped because the PostgreSQL/MySQL containers weren't running locally — this change touches no schema or repository code, and CI runs those backends regardless.

**Lint:** `lint:ci` ratchet clean. `tsc --noEmit` clean.

**Live, in the dev container** against the connected MC-Sandbox companion: preset present in the picker, selecting it sets `902.25 / 500 / 11 / 5` and shows the note; switching to another preset clears it. "Save radio settings" was **not** clicked — the device was not reconfigured.

_Screenshot sent to the maintainer to attach here (GitHub image uploads need the web UI)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZ871RCjD95cAu6jMfNM4
