### PR TITLE
chore(release): bump version to 4.16.0-rc6

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.16.0-rc5",
+  "version": "4.16.0-rc6",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.16.0-rc5",
+  "version": "4.16.0-rc6",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.16.0-rc5
-appVersion: "4.16.0-rc5"
+version: 4.16.0-rc6
+appVersion: "4.16.0-rc6"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.16.0-rc5",
+  "version": "4.16.0-rc6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.16.0-rc5",
+      "version": "4.16.0-rc6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.16.0-rc5",
+  "version": "4.16.0-rc6",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Version-only chore ahead of the v4.16.0-rc6 release.

Bumps the five files that must move together (CLAUDE.md § Versioning & Release):

| File | |
|---|---|
| `package.json` | 4.16.0-rc5 → 4.16.0-rc6 |
| `package-lock.json` | regenerated via `npm install --package-lock-only` |
| `helm/meshmonitor/Chart.yaml` | `version` **and** `appVersion` |
| `desktop/src-tauri/tauri.conf.json` | |
| `desktop/package.json` | |

Diff is 7 lines across 5 files — no code paths touched. Carries the `system-test` label because release version-bump chores always run the hardware suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZ871RCjD95cAu6jMfNM4