### PR TITLE
ci(release): run the coverage gate on Node 22, not Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,12 +106,35 @@ jobs:
       - name: Run all tests
         run: npm run test:run
 
+      # Node 22, NOT 24. This is the only place coverage still runs — it was
+      # removed from ci.yml when @vitest/coverage-v8 hung 30+ min on Node 24 —
+      # so a failure here blocks the whole release: build-artifacts and
+      # update-release both need this job, and skipping them leaves the
+      # published release without its source tarball.
+      #
+      # Node 24 + coverage-v8 has now bitten twice. On v4.16.0-rc6 this step
+      # failed on 24 on two consecutive runs while 22 passed the identical
+      # suite both times, with 19,361 tests passed / 0 failed, a complete
+      # coverage table, and then:
+      #
+      #   EnvironmentTeardownError: [vitest-worker]: Closing rpc while
+      #   "onUserConsoleLog" was pending
+      #   Process completed with exit code 1
+      #
+      # The gate itself is healthy — 63.94% statements against the floors in
+      # vitest.config.ts — so the answer is to run it on the runtime where it
+      # reports honestly, not to drop it. `npm run test:run` still covers Node
+      # 24 in this same matrix; only the coverage pass moves.
       - name: Generate coverage report
-        if: matrix.node-version == '24.x'
+        if: matrix.node-version == '22.x'
         run: npm run test:coverage
 
+      # Thresholds are enforced by vitest.config.ts (statements 32 overall,
+      # src/utils/** 70, src/server/** 25) — `vitest run --coverage` exits
+      # non-zero on its own if they are breached. This step is a placeholder
+      # for any additional check and must track the condition above.
       - name: Check coverage thresholds
-        if: matrix.node-version == '24.x'
+        if: matrix.node-version == '22.x'
         run: |
           echo "Checking coverage thresholds..."
           # Add coverage threshold checks here when configured


### PR DESCRIPTION
Moves the release pipeline's coverage step from Node 24 to Node 22. One condition, twice.

## Why

Node 24 + `@vitest/coverage-v8` has now blocked a release twice. On v4.16.0-rc6 the **Generate coverage report** step failed on Node 24 on two consecutive runs, while Node 22 passed the identical suite both times. Both failures were the same shape — the full run completed, the complete coverage table was emitted, and then:

```
Test Files  1246 passed | 1 skipped (1247)
      Tests  19361 passed | 109 skipped | 21 todo (19491)
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
##[error]Process completed with exit code 1
```

**Zero failed tests, and no threshold breach** — coverage came in at **63.94% statements** against the floors in `vitest.config.ts` (32 overall, `src/utils/**` 70, `src/server/**` 25). The gate is healthy and reporting a false failure.

## Why that false failure is expensive

`build-artifacts` and `update-release` both `needs:` this job, so the step failing skipped both, and **v4.16.0-rc6 published without its source tarball**.

This is also the *only* place coverage still runs — it was removed from `ci.yml` when `coverage-v8` hung 30+ min on Node 24, which is the same pathology from the other end.

## Why not just delete the step

That was the alternative, and it's the wrong trade. `vitest run --coverage` is a live gate: `vitest.config.ts` enforces those three thresholds and exits non-zero on a breach. Removing the step would delete the only enforcement of them anywhere in CI and silently un-protect `src/utils/**` at its 70% floor. If coverage genuinely isn't wanted, the honest version is to drop the thresholds from `vitest.config.ts` too — leaving them defined but unenforced reads like protection that isn't there.

## Scope

The matrix is unchanged: `npm run test:run` still runs on **both** 22 and 24. Only the coverage pass moves.

## ⚠️ This PR's CI cannot validate the change

`release.yml` triggers only on `release: [created, edited]` and `workflow_dispatch` — it does not run on pull requests. Green checks here mean the YAML is well-formed and nothing else regressed; they say nothing about the fix.

Verified locally that the YAML parses and both coverage steps now carry `matrix.node-version == '22.x'`. Local Node is v26.5.0, so a local run would not have exercised Node 22 either.

**Honest caveat:** Node 22 passed the identical suite twice *without* coverage. Coverage on Node 22 is inferred-good from the failure being Node-24-specific, not directly observed. Validate with a manual `workflow_dispatch` run after merge before trusting it on the next real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZ871RCjD95cAu6jMfNM4