### PR TITLE
fix(tcp): retry sooner after the link drops mid-config-sync (#5122)

### DIFF
--- a/src/server/meshtasticManager.syncLossRetry.test.ts
+++ b/src/server/meshtasticManager.syncLossRetry.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the VirtualNodeServer so tests never bind a real TCP port
+const { VNConstructor } = vi.hoisted(() => ({
+  VNConstructor: vi.fn(function (this: any, _opts: any) {
+    this.start = vi.fn().mockResolvedValue(undefined);
+    this.stop = vi.fn().mockResolvedValue(undefined);
+    this.broadcastToClients = vi.fn().mockResolvedValue(undefined);
+    this.isRunning = () => true;
+    this.getClientCount = () => 0;
+  }),
+}));
+vi.mock('./virtualNodeServer.js', () => ({
+  VirtualNodeServer: VNConstructor,
+}));
+
+// Stub the TCP transport so constructing a manager never touches a real socket
+vi.mock('./tcpTransport.js', () => ({
+  TcpTransport: class {
+    connect = vi.fn().mockResolvedValue(undefined);
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    send = vi.fn().mockResolvedValue(undefined);
+    on = vi.fn();
+    off = vi.fn();
+    isConnected = () => true;
+    setStaleConnectionTimeout = vi.fn();
+    setConnectTimeout = vi.fn();
+    setReconnectTiming = vi.fn();
+  },
+}));
+
+vi.mock('../services/database.js', () => {
+  const shared = {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    settings: {
+      getSetting: vi.fn().mockResolvedValue(null),
+      setSetting: vi.fn().mockResolvedValue(undefined),
+    },
+    getAllTraceroutesForRecalculationAsync: vi.fn().mockResolvedValue([]),
+    sources: { getSource: vi.fn().mockResolvedValue(null) },
+    nodes: {
+      getNode: vi.fn().mockResolvedValue(null),
+      upsertNode: vi.fn().mockResolvedValue(undefined),
+      getActiveNodes: vi.fn().mockResolvedValue([]),
+      getAllNodes: vi.fn().mockResolvedValue([]),
+    },
+    recordTracerouteRequestAsync: vi.fn().mockResolvedValue(undefined),
+  };
+  return { default: shared, databaseService: shared };
+});
+
+vi.mock('./meshtasticProtobufService.js', () => {
+  const svc = {
+    createNodeInfo: vi.fn().mockResolvedValue(new Uint8Array()),
+    createFromRadioWithPacket: vi.fn().mockResolvedValue(new Uint8Array()),
+    getPortNumName: (n: number) => `PORT_${n}`,
+    normalizePortNum: (n: any) => (typeof n === 'number' ? n : 0),
+    processPayload: vi.fn(),
+  };
+  return { default: svc, meshtasticProtobufService: svc };
+});
+vi.mock('./services/packetLogService.js', () => ({
+  default: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+  packetLogService: { isEnabled: vi.fn().mockResolvedValue(false), logPacket: vi.fn() },
+}));
+vi.mock('./services/channelDecryptionService.js', () => ({
+  channelDecryptionService: { isEnabled: () => false, tryDecrypt: vi.fn() },
+}));
+// serverEventNotificationService is invoked from handleDisconnected
+vi.mock('./services/serverEventNotificationService.js', () => ({
+  serverEventNotificationService: {
+    notifyNodeDisconnected: vi.fn().mockResolvedValue(undefined),
+    notifyNodeConnected: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+
+import { MeshtasticManager } from './meshtasticManager.js';
+
+/**
+ * Arming the transport's mid-sync fast-retry ramp (#5122).
+ *
+ * The transport owns the ramp itself (see tcpTransport.syncLossRetry.test.ts);
+ * what the manager owns is knowing WHICH disconnects deserve it. That
+ * distinction is the whole point: `setConfigSyncActive(false)` fires on a sync
+ * that succeeded as well as one that died, so hanging the fast retry off it
+ * would shorten the backoff after perfectly healthy sessions too.
+ */
+describe('MeshtasticManager — arming the mid-sync fast retry (#5122)', () => {
+  let mgr: any;
+  let transport: {
+    noteConfigSyncLoss: ReturnType<typeof vi.fn>;
+    resetConfigSyncLossRetries: ReturnType<typeof vi.fn>;
+    setConfigSyncActive: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    mgr = new MeshtasticManager('src-1', { host: '127.0.0.1', port: 4403 }) as any;
+    transport = {
+      noteConfigSyncLoss: vi.fn(),
+      resetConfigSyncLossRetries: vi.fn(),
+      setConfigSyncActive: vi.fn(),
+    };
+    mgr.transport = transport;
+  });
+
+  it('arms the ramp when the link drops mid-sync', async () => {
+    mgr.isCapturingInitConfig = true;
+    mgr.configCaptureComplete = false;
+
+    await mgr.handleDisconnected();
+
+    expect(transport.noteConfigSyncLoss).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the backoff alone for a disconnect outside the sync', async () => {
+    // The control that keeps a powered-off node on the ordinary 60s backoff
+    // instead of collecting a SYN every three seconds at every startup.
+    mgr.isCapturingInitConfig = false;
+    mgr.configCaptureComplete = true;
+
+    await mgr.handleDisconnected();
+
+    expect(transport.noteConfigSyncLoss).not.toHaveBeenCalled();
+  });
+
+  it('resets the ramp when a sync completes', () => {
+    mgr.completeConfigCapture();
+
+    expect(transport.resetConfigSyncLossRetries).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reset the ramp when the capture is merely cleared', () => {
+    // `clearConfigCapture` runs on teardown paths where no sync finished.
+    // Resetting there would hand a failing source a fresh 3s rung every cycle.
+    mgr.clearConfigCapture();
+
+    expect(transport.resetConfigSyncLossRetries).not.toHaveBeenCalled();
+  });
+
+  it('survives a transport that implements neither hook', async () => {
+    // Both are optional on ITransport — a MeshCore/MQTT manager or a test
+    // double must not throw its way out of the disconnect path.
+    mgr.transport = { setConfigSyncActive: vi.fn() };
+    mgr.isCapturingInitConfig = true;
+    mgr.configCaptureComplete = false;
+
+    await expect(mgr.handleDisconnected()).resolves.not.toThrow();
+    expect(() => mgr.completeConfigCapture()).not.toThrow();
+  });
+});

--- a/src/server/meshtasticManager.syncLossRetry.test.ts
+++ b/src/server/meshtasticManager.syncLossRetry.test.ts
@@ -113,6 +113,19 @@ describe('MeshtasticManager — arming the mid-sync fast retry (#5122)', () => {
     expect(transport.noteConfigSyncLoss).toHaveBeenCalledTimes(1);
   });
 
+  it('does not arm once the capture has completed but not yet been cleared', async () => {
+    // The `!configCaptureComplete` half of the guard, on its own. Both flags
+    // true is a real intermediate state — the sync finished, the capture has
+    // not been torn down yet — and a disconnect there is a normal end-of-life
+    // one, not a sync that died.
+    mgr.isCapturingInitConfig = true;
+    mgr.configCaptureComplete = true;
+
+    await mgr.handleDisconnected();
+
+    expect(transport.noteConfigSyncLoss).not.toHaveBeenCalled();
+  });
+
   it('leaves the backoff alone for a disconnect outside the sync', async () => {
     // The control that keeps a powered-off node on the ordinary 60s backoff
     // instead of collecting a SYN every three seconds at every startup.

--- a/src/server/meshtasticManager.ts
+++ b/src/server/meshtasticManager.ts
@@ -718,6 +718,13 @@ class MeshtasticManager implements ISourceManager {
     this.isCapturingInitConfig = false;
     this.configCaptureComplete = true;
     this.setTransportConfigSyncActive(false);
+    // A sync that finished spends the #5122 fast-retry ladder back to the top,
+    // so it counts consecutive failures rather than lifetime ones.
+    try {
+      this.transport?.resetConfigSyncLossRetries?.();
+    } catch (err) {
+      logger.debug(`Ignoring resetConfigSyncLossRetries failure: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
   private clearConfigCapture(): void {
     this.isCapturingInitConfig = false;
@@ -2231,6 +2238,17 @@ class MeshtasticManager implements ISourceManager {
         'The sync restarts from the beginning on reconnect; on a large NodeDB it may never finish if this repeats. ' +
         'Consider enabling Passive Mode for this source.'
       );
+      // Retry sooner than the 60s default backoff (#5122). The reporter's
+      // captures show the retry after one of these completes the whole
+      // ~190-node sync in about 2s, so a minute of waiting is almost all of
+      // the user-visible outage. The transport ramps its own delay if this
+      // keeps happening, so a node that genuinely cannot finish is not
+      // hammered — see SYNC_LOSS_RETRY_LADDER_MS.
+      try {
+        this.transport?.noteConfigSyncLoss?.();
+      } catch (err) {
+        logger.debug(`Ignoring noteConfigSyncLoss failure: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
 
     // #3962 Phase 4.2b C2: TRANSPORT_DISCONNECTED. A transport-level

--- a/src/server/tcpTransport.syncLossRetry.test.ts
+++ b/src/server/tcpTransport.syncLossRetry.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Fast-retry ramp after a mid-config-sync disconnect (#5122).
+ *
+ * With #5130/#5138/#5140 in place the reporter's mesh recovers on its own, but
+ * slowly: the link dies ~11s into a ~190-node NodeDB dump, MeshMonitor waits
+ * the full `MESHTASTIC_RECONNECT_INITIAL_DELAY_MS` (60s by default), and the
+ * retry then completes the entire sync in about 2 seconds. Almost the whole
+ * ~70s outage is the wait, not the fault.
+ *
+ * Retrying fast forever would be the wrong trade, because every reconnect makes
+ * the node re-dump its whole NodeDB — the exact work that is stalling. So the
+ * delay ramps across consecutive mid-sync losses and then hands back to the
+ * ordinary backoff.
+ *
+ * These tests drive `scheduleReconnect` directly and read the delay off the
+ * scheduled timer, because the delay IS the behaviour under test — asserting
+ * that some reconnect eventually happens would pass just as well before this
+ * change.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TcpTransport } from './tcpTransport.js';
+
+describe('TcpTransport — mid-sync fast-retry ramp (#5122)', () => {
+  let transport: any;
+  let setTimeoutSpy: ReturnType<typeof vi.spyOn>;
+
+  /** Delays, in ms, of every reconnect scheduled so far. */
+  const scheduledDelays = (): number[] =>
+    setTimeoutSpy.mock.calls.map((c) => c[1] as number);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    transport = new TcpTransport();
+    transport.config = { host: 'node.example', port: 4403 };
+    transport.shouldReconnect = true;
+    // The default the reporter is running: one minute, flat.
+    transport.setReconnectTiming(60_000, 60_000);
+    setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('waits the full backoff when the sync was not the thing that broke', () => {
+    // The control. An ordinary disconnect — an unreachable node, a network
+    // blip — is not evidence that a quick retry will do any good, so it keeps
+    // the configured backoff. Without this, the ramp would turn every startup
+    // against a powered-off node into a SYN every three seconds.
+    transport.scheduleReconnect();
+
+    expect(scheduledDelays()).toEqual([60_000]);
+  });
+
+  it('retries in 3s after the link drops mid-sync', () => {
+    // The reported case: ~11s in, link dies, retry finishes the sync in ~2s.
+    transport.noteConfigSyncLoss();
+    transport.scheduleReconnect();
+
+    expect(scheduledDelays()).toEqual([3_000]);
+  });
+
+  it('ramps 3s -> 10s -> 30s across consecutive mid-sync losses', () => {
+    // A node that cannot finish its own NodeDB dump should not be asked to
+    // start over every three seconds.
+    for (let i = 0; i < 3; i++) {
+      transport.noteConfigSyncLoss();
+      transport.scheduleReconnect();
+    }
+
+    expect(scheduledDelays()).toEqual([3_000, 10_000, 30_000]);
+  });
+
+  it('hands back to the ordinary backoff once the ramp is spent', () => {
+    for (let i = 0; i < 4; i++) {
+      transport.noteConfigSyncLoss();
+      transport.scheduleReconnect();
+    }
+
+    expect(scheduledDelays()).toEqual([3_000, 10_000, 30_000, 60_000]);
+  });
+
+  it('resets the ramp when a sync actually completes', () => {
+    // The ramp counts CONSECUTIVE failures. A source that recovers on the first
+    // fast retry and hits an unrelated mid-sync loss hours later should get the
+    // quick attempt again, not resume from whatever rung it left off on.
+    transport.noteConfigSyncLoss();
+    transport.scheduleReconnect();
+    transport.noteConfigSyncLoss();
+    transport.scheduleReconnect();
+    expect(scheduledDelays()).toEqual([3_000, 10_000]);
+
+    transport.resetConfigSyncLossRetries();
+
+    transport.noteConfigSyncLoss();
+    transport.scheduleReconnect();
+    expect(scheduledDelays()).toEqual([3_000, 10_000, 3_000]);
+  });
+
+  it('does not let one mid-sync loss shorten the NEXT, unrelated disconnect', () => {
+    // The flag describes the disconnect that just happened. If it survived into
+    // the following reconnect, a single bad sync would quietly put the source on
+    // the fast path for good.
+    transport.noteConfigSyncLoss();
+    transport.scheduleReconnect();
+    transport.scheduleReconnect();
+
+    expect(scheduledDelays()).toEqual([3_000, 60_000]);
+  });
+
+  it('takes precedence over the startup-grace window', () => {
+    // Both can be armed at once on a passive-mode source. The mid-sync signal
+    // is the more specific one — it says WHY the link dropped — and its later
+    // rungs are deliberately slower than the flat grace delay, so grace must
+    // not override them and re-hammer a struggling node.
+    transport.setStartupGraceReconnect(120_000, 3_000);
+
+    for (let i = 0; i < 3; i++) {
+      transport.noteConfigSyncLoss();
+      transport.scheduleReconnect();
+    }
+
+    expect(scheduledDelays()).toEqual([3_000, 10_000, 30_000]);
+  });
+
+  it('still honours the startup-grace window for other disconnects', () => {
+    // ...and the #3122 behaviour it was added for is untouched.
+    transport.setStartupGraceReconnect(120_000, 3_000);
+
+    transport.scheduleReconnect();
+
+    expect(scheduledDelays()).toEqual([3_000]);
+  });
+
+  it('schedules nothing at all once the transport is destroyed', () => {
+    // The #3270 resurrection guard has to win over the new path too.
+    transport.destroyed = true;
+    transport.noteConfigSyncLoss();
+    transport.scheduleReconnect();
+
+    expect(scheduledDelays()).toEqual([]);
+  });
+});

--- a/src/server/tcpTransport.syncLossRetry.test.ts
+++ b/src/server/tcpTransport.syncLossRetry.test.ts
@@ -98,6 +98,27 @@ describe('TcpTransport — mid-sync fast-retry ramp (#5122)', () => {
     expect(scheduledDelays()).toEqual([3_000, 10_000, 3_000]);
   });
 
+  it('carries the ramp across an abandoned sync rather than restarting it', () => {
+    // The manager's `clearConfigCapture` (teardown paths where no sync
+    // finished) deliberately does NOT call resetConfigSyncLossRetries — only
+    // `completeConfigCapture` does. So a source that keeps dying mid-sync
+    // continues down the ramp instead of getting a fresh 3s rung each cycle.
+    //
+    // Worth stating what this does NOT affect: the ramp lives on the transport
+    // instance, and a manual disconnect/reconnect builds a new one
+    // (`teardownExistingTransport` -> `new TcpTransport()`), so an operator
+    // reconnecting by hand always starts from the top rung.
+    transport.noteConfigSyncLoss();
+    transport.scheduleReconnect();
+
+    // ...sync abandoned without completing; nothing resets the ladder...
+
+    transport.noteConfigSyncLoss();
+    transport.scheduleReconnect();
+
+    expect(scheduledDelays()).toEqual([3_000, 10_000]);
+  });
+
   it('does not let one mid-sync loss shorten the NEXT, unrelated disconnect', () => {
     // The flag describes the disconnect that just happened. If it survived into
     // the following reconnect, a single bad sync would quietly put the source on

--- a/src/server/tcpTransport.ts
+++ b/src/server/tcpTransport.ts
@@ -94,6 +94,31 @@ export class TcpTransport extends EventEmitter implements ITransport {
   private startupGraceUntil: number = 0;
   private startupGraceFastDelayMs: number = 0;
 
+  /**
+   * Fast-retry ramp after the link drops mid-config-sync (#5122).
+   *
+   * The reporter's packet captures show a node that goes silent for ~10s
+   * partway through a ~190-node NodeDB dump, flushes a backlog, then closes
+   * its own side. The retry then completes the full sync in about 2 seconds —
+   * so the recovery is cheap, and it was the 60s reconnect delay, not the
+   * failure itself, that made the mesh feel unusable.
+   *
+   * Retrying fast forever would be the wrong answer though: every reconnect
+   * makes the node re-dump its entire NodeDB, which is the very work that is
+   * stalling. So this ramps. One quick attempt catches the common case; if
+   * that also dies mid-sync, back off rather than hammer a node that has
+   * already told us twice it cannot finish.
+   *
+   * Only a *mid-sync* loss arms this. A node that is simply unreachable never
+   * starts a sync, so it keeps the ordinary backoff instead of collecting a
+   * SYN every three seconds.
+   */
+  private static readonly SYNC_LOSS_RETRY_LADDER_MS = [3_000, 10_000, 30_000];
+  /** How many rungs of the ladder this transport has spent. Reset on a sync that completes. */
+  private syncLossRetryStep = 0;
+  /** Set by `noteConfigSyncLoss()`, consumed by the next `scheduleReconnect()`. */
+  private syncLossRetryPending = false;
+
   // Protocol constants
   private readonly START1 = 0x94;
   private readonly START2 = 0xc3;
@@ -126,6 +151,30 @@ export class TcpTransport extends EventEmitter implements ITransport {
     if (this.isConnected && this.healthCheckInterval) {
       this.startHealthCheck();
     }
+  }
+
+  /**
+   * The link dropped while the initial config sync was still running (#5122).
+   *
+   * Arms one rung of the fast-retry ramp for the reconnect that is about to be
+   * scheduled. Deliberately separate from `setConfigSyncActive(false)`, which
+   * fires on a *successful* sync too — only a loss should shorten the wait.
+   */
+  noteConfigSyncLoss(): void {
+    this.syncLossRetryPending = true;
+  }
+
+  /**
+   * A config sync ran to completion — spend the ladder back to the top (#5122).
+   *
+   * Without this, a source that recovers on the first fast retry and then hits
+   * an unrelated mid-sync loss hours later would start from whatever rung it
+   * left off on. The ladder is meant to measure consecutive failures, not
+   * lifetime ones.
+   */
+  resetConfigSyncLossRetries(): void {
+    this.syncLossRetryStep = 0;
+    this.syncLossRetryPending = false;
   }
 
   /**
@@ -389,11 +438,34 @@ export class TcpTransport extends EventEmitter implements ITransport {
     // window, use the fast delay regardless of attempt count. Outside the
     // window, fall back to exponential backoff.
     const inGrace = this.startupGraceUntil > 0 && Date.now() < this.startupGraceUntil;
-    const delay = inGrace
-      ? this.startupGraceFastDelayMs
-      : Math.min(Math.pow(2, this.reconnectAttempts - 1) * this.reconnectInitialDelayMs, this.reconnectMaxDelayMs);
 
-    logger.debug(`🔄 Reconnecting in ${delay / 1000}s (attempt ${this.reconnectAttempts}${inGrace ? ', startup-grace' : ''})...`);
+    // A mid-sync loss (#5122) is the most specific signal we have about WHY the
+    // link went down, so its ramp wins over the startup grace window when both
+    // apply. The grace window stays in charge of every other early disconnect.
+    const ladder = TcpTransport.SYNC_LOSS_RETRY_LADDER_MS;
+    const useSyncLossLadder = this.syncLossRetryPending && this.syncLossRetryStep < ladder.length;
+    // Consume the flag either way: it describes the disconnect that just
+    // happened, not a standing preference, so it must not leak into the next one.
+    this.syncLossRetryPending = false;
+
+    let delay: number;
+    let label: string;
+    if (useSyncLossLadder) {
+      delay = ladder[this.syncLossRetryStep];
+      this.syncLossRetryStep++;
+      label = `, sync-loss retry ${this.syncLossRetryStep}/${ladder.length}`;
+    } else if (inGrace) {
+      delay = this.startupGraceFastDelayMs;
+      label = ', startup-grace';
+    } else {
+      delay = Math.min(
+        Math.pow(2, this.reconnectAttempts - 1) * this.reconnectInitialDelayMs,
+        this.reconnectMaxDelayMs,
+      );
+      label = '';
+    }
+
+    logger.debug(`🔄 Reconnecting in ${delay / 1000}s (attempt ${this.reconnectAttempts}${label})...`);
 
     this.reconnectTimeout = setTimeout(() => {
       this.doConnect().catch((error) => {

--- a/src/server/transports/transport.ts
+++ b/src/server/transports/transport.ts
@@ -25,4 +25,17 @@ export interface ITransport extends EventEmitter {
    * non-TCP transports (and test doubles) need not implement it.
    */
   setConfigSyncActive?(active: boolean): void;
+  /**
+   * Tell the transport the link dropped *while* the initial config sync was
+   * running (#5122), so it can retry sooner than the ordinary backoff.
+   *
+   * Separate from `setConfigSyncActive(false)`, which also fires on a sync that
+   * succeeded. Optional for the same reason as the hook above.
+   */
+  noteConfigSyncLoss?(): void;
+  /**
+   * Tell the transport a config sync ran to completion (#5122), so any
+   * fast-retry ramp armed by `noteConfigSyncLoss` resets. Optional.
+   */
+  resetConfigSyncLossRetries?(): void;
 }


### PR DESCRIPTION
Follows #5130 / #5138 / #5140 on #5122. Does **not** close it — the node-side stall is still unexplained. This fixes the recovery time, which is now most of the user-visible damage.

## What the latest report changed

@ogarcia [tested all three fixes together](https://github.com/Yeraze/meshmonitor/issues/5122#issuecomment-latest). Redaction and Bug B are confirmed fixed. Bug A reproduced anyway — and the capture is more informative than the last one:

```
#87  node → client   1436 bytes    (after 10.397s of silence, both directions)
#91  node → client   FIN,PSH,ACK   ← the NODE closes first
#93  client → node   FIN,ACK
#95  client → node   SYN           (reconnect, exactly 60.002s later)
```

Two things follow.

**The favorite deferral wasn't the root cause.** This run had no `SetFavoriteNode` in flight — none was even queued, since no locked favorite disagreed with the device. The stall happened anyway.

**The remaining stall is node-side.** Compare with the Sept 7 capture, where *MeshMonitor* sent the first FIN. That was the connect timeout #5130 fixed. Now the node hangs up on itself. Nothing left on our side is initiating it.

**But the recovery is cheap and it works.** The retry completed the full 200-node sync in 2 seconds. The outage is `11s of failure + 60s of waiting + 2s of success` — the wait is ~85% of it.

## The change

A mid-sync loss arms a fast-retry ramp on the transport:

| Consecutive mid-sync loss | Retry after |
|---|---|
| 1st | 3s |
| 2nd | 10s |
| 3rd | 30s |
| 4th+ | ordinary backoff (60s default) |

Reporter's case: **~73s → ~16s.**

### Why a ramp and not a flat fast retry

Every reconnect makes the node re-dump its entire NodeDB — the exact work that is stalling. Retrying every 3s against a node that already failed twice would be asking it to start over 40 times in two minutes. One quick attempt catches the reported case; after that, back off.

### Why only a mid-sync loss

A node that is simply unreachable — powered off, wrong IP — never starts a sync, so it keeps the ordinary backoff rather than collecting a SYN every three seconds at every startup.

This is why the hook hangs off the `isCapturingInitConfig && !configCaptureComplete` branch in `handleDisconnected` — the same condition #5140 already uses for its WARN — and **not** off `setConfigSyncActive(false)`, which also fires when a sync *succeeds*. Hanging it there would shorten the backoff after perfectly healthy sessions.

### Interaction with what's already there

- **#3122 startup grace** still governs every other early disconnect, unchanged. Where both are armed, the mid-sync ramp wins: it is the more specific signal, and its later rungs are deliberately *slower* than the flat 3s grace delay, so grace must not override them and re-hammer a struggling node.
- **#3270 destroyed-transport guard** still short-circuits before any of this.
- The ramp counts **consecutive** failures — `completeConfigCapture()` resets it, `clearConfigCapture()` deliberately does not.

Both new hooks (`noteConfigSyncLoss`, `resetConfigSyncLossRetries`) are optional on `ITransport`, so MeshCore/MQTT managers and test doubles opt out.

## Tests

`tcpTransport.syncLossRetry.test.ts` (9) drives `scheduleReconnect` and reads the delay off the scheduled timer — the delay *is* the behaviour, so asserting "a reconnect eventually happens" would pass just as well before this change. Covers the ramp, the hand-back to normal backoff, the reset, precedence over startup grace, that grace still works for other disconnects, the #3270 guard, and the control case: an ordinary disconnect still waits the full 60s.

`meshtasticManager.syncLossRetry.test.ts` (5) covers which disconnects arm it — including the control that a non-sync disconnect does not, and that a transport implementing neither hook doesn't throw.

Full suite: **18492 passed, 0 failed, 0 failed suites.** 992 pending are the PostgreSQL/MySQL container suites, which I did not run — this change touches no schema, migration, or repository code, so they aren't relevant to it.

## What this does not fix

The node-side stall. The reporter speculates about firmware 2.8.0 but flags it as a guess, and nothing in the captures ties it to a version. If it needs chasing further it will likely need firmware-level debugging rather than anything visible from the TCP client. Leaving #5122 open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc
