### PR TITLE
fix(meshcore): default the TCP source port to 5000, not 4403 (#5160)

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -46,3 +46,21 @@ export function isRelayRole(role: number | undefined): boolean {
 
 // Re-export HARDWARE_MODELS from the specialized utility file
 export { HARDWARE_MODELS } from '../utils/hardwareModel.js';
+/**
+ * Default TCP port for a MeshCore companion reached over the network (#5160).
+ *
+ * MeshCore's WiFi and Ethernet companion builds open their TCP server on 5000,
+ * and that is the build people actually add as a TCP source. The form used to
+ * default to 4403, which is Meshtastic's port — so every new MeshCore TCP
+ * source failed to connect until the user worked out the right number.
+ *
+ * 4403 is not arbitrary, which is why this is worth writing down: MeshCore's
+ * less common "native TCP" companion builds do listen there, and
+ * `meshcoreConfig.ts` still falls back to it for a stored config that carries
+ * no port at all. That fallback is deliberately left alone — changing it would
+ * silently repoint any existing portless source, and the form has always
+ * required a port, so it only affects sources created outside the UI.
+ *
+ * A string because it feeds `useState` and an `<input>` value directly.
+ */
+export const MESHCORE_DEFAULT_TCP_PORT = '5000';

--- a/src/pages/DashboardPage.meshcoreTcpPortDefault.test.tsx
+++ b/src/pages/DashboardPage.meshcoreTcpPortDefault.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MeshCore TCP source port default (#5160).
+ *
+ * Reported by mattch: adding a MeshCore TCP source pre-filled 4403 — the
+ * Meshtastic port — so the source failed to connect until the user worked out
+ * the right number. MeshCore's WiFi/Ethernet companion builds listen on 5000.
+ *
+ * 4403 is not a typo, which is why this is pinned rather than left to a
+ * constant nobody reads: MeshCore's less common "native TCP" builds DO use it,
+ * and `meshcoreConfig.ts` still falls back to it for a stored config with no
+ * port. The form default and that fallback deliberately differ.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import DashboardPage from './DashboardPage';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+/** A TCP source whose stored config carries no port — the edit fallback path. */
+const meshcoreSource = {
+  id: 'src-mc',
+  name: 'MC Source',
+  type: 'meshcore',
+  enabled: true,
+  config: {
+    transport: 'tcp',
+    tcpHost: 'mc.example',
+    deviceType: 'companion',
+    autoConnect: true,
+  },
+};
+
+/** Same, but with an explicit port that must survive untouched. */
+const meshcoreSourceWithPort = {
+  ...meshcoreSource,
+  id: 'src-mc-port',
+  name: 'MC Ported',
+  config: { ...meshcoreSource.config, tcpPort: 4403 },
+};
+
+vi.mock('../hooks/useDashboardData', () => ({
+  useDashboardSources: vi.fn(() => ({
+    data: [meshcoreSource, meshcoreSourceWithPort],
+    isSuccess: true,
+    isLoading: false,
+  })),
+  useSourceStatuses: vi.fn(() => new Map([['src-mc', { sourceId: 'src-mc', connected: true }]])),
+  useDashboardSourceData: vi.fn(() => ({
+    nodes: [],
+    traceroutes: [],
+    neighborInfo: [],
+    channels: [],
+    status: { sourceId: 'src-mc', connected: true },
+    isLoading: false,
+    isError: false,
+  })),
+  useDashboardUnifiedData: vi.fn(() => ({
+    nodes: [],
+    traceroutes: [],
+    neighborInfo: [],
+    channels: [],
+    status: null,
+    isLoading: false,
+    isError: false,
+  })),
+  useUnifiedStatus: vi.fn(() => ({ nodeCount: 0, connected: false })),
+  UNIFIED_SOURCE_ID: '__unified__',
+}));
+
+vi.mock('../hooks/useMapAnalysisData', () => ({
+  useMeshCoreNeighbors: vi.fn(() => ({ data: { items: [] }, isLoading: false, isError: false })),
+}));
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({
+    authStatus: {
+      authenticated: true,
+      user: {
+        id: 1,
+        username: 'admin',
+        email: null,
+        displayName: null,
+        authProvider: 'local',
+        isAdmin: true,
+        isActive: true,
+        passwordLocked: false,
+        mfaEnabled: false,
+        createdAt: 0,
+        lastLoginAt: null,
+      },
+      permissions: {} as any,
+      channelDbPermissions: {},
+      oidcEnabled: false,
+      localAuthDisabled: false,
+      anonymousDisabled: false,
+    },
+    loading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    hasPermission: vi.fn(() => true),
+    verifyMfa: vi.fn(),
+    loginWithOIDC: vi.fn(),
+    refreshAuth: vi.fn(),
+    hasChannelDbPermission: vi.fn(() => true),
+  })),
+}));
+
+vi.mock('../contexts/CsrfContext', () => ({
+  useCsrf: vi.fn(() => ({
+    csrfToken: 'test-token',
+    isLoading: false,
+    refreshToken: vi.fn(),
+    getToken: vi.fn(() => 'test-token'),
+  })),
+}));
+
+vi.mock('../contexts/SettingsContext', () => ({
+  useNodeListStyle: () => 'monochrome',
+  SettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSettings: vi.fn(() => ({
+    mapTileset: 'openstreetmap',
+    customTilesets: [],
+    defaultMapCenterLat: 30.0,
+    defaultMapCenterLon: -90.0,
+    defaultLandingPage: 'unified',
+  })),
+}));
+
+// Exposes an "Edit" button per source so the test can drive onEditSource
+// without needing the real sidebar's markup.
+vi.mock('../components/Dashboard/DashboardSidebar', () => ({
+  default: ({
+    sources,
+    onEditSource,
+    onAddSource,
+  }: {
+    sources: Array<{ id: string; name: string }>;
+    onEditSource: (id: string) => void;
+    onAddSource: () => void;
+  }) => (
+    <div data-testid="dashboard-sidebar">
+      <button type="button" onClick={onAddSource}>add-source</button>
+      {sources.map((s) => (
+        <button key={s.id} type="button" onClick={() => onEditSource(s.id)}>
+          edit-{s.name}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('../components/Dashboard/DashboardMap', () => ({
+  default: () => <div data-testid="dashboard-map" />,
+}));
+
+vi.mock('../components/LoginModal', () => ({
+  default: ({ isOpen }: { isOpen: boolean; onClose: () => void }) =>
+    (isOpen ? <div data-testid="login-modal" /> : null),
+}));
+
+vi.mock('../init', () => ({
+  appBasename: '',
+}));
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+/** The MeshCore TCP port input, found by its label. */
+const portInput = async () =>
+  (await screen.findByText('source.form.tcp_port')).parentElement!.querySelector(
+    'input[type="number"]',
+  ) as HTMLInputElement;
+
+describe('MeshCore TCP port default (#5160)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pre-fills 5000 when adding a new MeshCore TCP source', async () => {
+    // The reported bug, exactly: this used to read 4403 and the source could
+    // not connect until the user changed it by hand.
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'add-source' }));
+    fireEvent.change(await screen.findByDisplayValue('source.form.type_meshtastic'), {
+      target: { value: 'meshcore' },
+    });
+    fireEvent.change(await screen.findByDisplayValue('meshcore.form.transport_usb'), {
+      target: { value: 'tcp' },
+    });
+
+    expect((await portInput()).value).toBe('5000');
+  });
+
+  it('offers 5000 as the placeholder too', async () => {
+    // The placeholder was also 4403. Leaving it behind would have the field
+    // contradict itself the moment someone cleared it.
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'add-source' }));
+    fireEvent.change(await screen.findByDisplayValue('source.form.type_meshtastic'), {
+      target: { value: 'meshcore' },
+    });
+    fireEvent.change(await screen.findByDisplayValue('meshcore.form.transport_usb'), {
+      target: { value: 'tcp' },
+    });
+
+    expect((await portInput()).placeholder).toBe('5000');
+  });
+
+  it('falls back to 5000 when editing a source that stored no port', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'edit-MC Source' }));
+
+    expect((await portInput()).value).toBe('5000');
+  });
+
+  it('leaves an explicitly stored port alone', async () => {
+    // The guard on the fallback: a source deliberately pointed at a native-TCP
+    // build on 4403 must not be silently rewritten to 5000 by opening its form.
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'edit-MC Ported' }));
+
+    expect((await portInput()).value).toBe('4403');
+  });
+});

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -52,6 +52,7 @@ import { ToastProvider } from '../components/ToastContainer';
 import api, { ApiError } from '../services/api';
 import { logger } from '../utils/logger';
 import { appBasename } from '../init';
+import { MESHCORE_DEFAULT_TCP_PORT } from '../constants';
 import { getReservedLandingPath, isReservedLandingValue } from '../utils/defaultLandingPage';
 import '../styles/dashboard.css';
 import { UiIcon } from '../components/icons';
@@ -189,7 +190,11 @@ function DashboardInner() {
   const [formMcTransport, setFormMcTransport] = useState<'usb' | 'tcp'>('usb');
   const [formMcSerialPort, setFormMcSerialPort] = useState('');
   const [formMcTcpHost, setFormMcTcpHost] = useState('');
-  const [formMcTcpPort, setFormMcTcpPort] = useState('4403');
+  // MeshCore WiFi/Ethernet companion firmware opens its TCP server on 5000
+  // (#5160). 4403 is Meshtastic's port, and also what MeshCore's less common
+  // "native TCP" companion builds use — but the WiFi/Ethernet build is what
+  // people actually add here, so it gets the default.
+  const [formMcTcpPort, setFormMcTcpPort] = useState(MESHCORE_DEFAULT_TCP_PORT);
   const [formMcDeviceType, setFormMcDeviceType] = useState<'companion' | 'repeater'>('companion');
   // MQTT broker (mqtt_broker) form state.
   const [formMqttListenPort, setFormMqttListenPort] = useState('1883');
@@ -413,7 +418,7 @@ function DashboardInner() {
     setFormMcTransport('usb');
     setFormMcSerialPort('');
     setFormMcTcpHost('');
-    setFormMcTcpPort('4403');
+    setFormMcTcpPort(MESHCORE_DEFAULT_TCP_PORT);
     setFormMcDeviceType('companion');
     setFormMqttListenPort('1883');
     setFormMqttUsername('');
@@ -577,7 +582,7 @@ function DashboardInner() {
     setFormMcTransport(mcTransport);
     setFormMcSerialPort(cfg?.serialPort ?? cfg?.port ?? '');
     setFormMcTcpHost(cfg?.tcpHost ?? '');
-    setFormMcTcpPort(cfg?.tcpPort != null ? String(cfg.tcpPort) : '4403');
+    setFormMcTcpPort(cfg?.tcpPort != null ? String(cfg.tcpPort) : MESHCORE_DEFAULT_TCP_PORT);
     setFormMcDeviceType(cfg?.deviceType === 'repeater' ? 'repeater' : 'companion');
     const link = cfg?.mqttLink as { enabled?: boolean; mqttBrokerSourceId?: string } | undefined;
     setFormMtMqttLinkBrokerId(link?.enabled && link.mqttBrokerSourceId ? link.mqttBrokerSourceId : '');
@@ -1747,7 +1752,7 @@ function DashboardInner() {
                         type="number"
                         value={formMcTcpPort}
                         onChange={(e) => setFormMcTcpPort(e.target.value)}
-                        placeholder="4403"
+                        placeholder={MESHCORE_DEFAULT_TCP_PORT}
                       />
                     </label>
                   </>

--- a/src/server/meshcoreConfig.ts
+++ b/src/server/meshcoreConfig.ts
@@ -388,6 +388,14 @@ export function meshcoreConfigFromSource(source: Source): MeshCoreConfig | null 
     return {
       connectionType: ConnectionType.TCP,
       tcpHost: cfg.tcpHost,
+      // 4403, not the 5000 the Add-Source form now defaults to (#5160). The
+      // two differ on purpose. 5000 is where MeshCore's WiFi/Ethernet
+      // companion builds listen, and that is the right thing to pre-fill for
+      // someone adding a source. This fallback only fires for a stored config
+      // with NO port at all, which the form cannot produce — it validates the
+      // field — so in practice it is reached by sources created through the
+      // API or an import. Moving it to 5000 would silently repoint those,
+      // including any that are working today against a native-TCP build.
       tcpPort: cfg.tcpPort ?? 4403,
       firmwareType,
       virtualNode,


### PR DESCRIPTION
Closes #5160. Reported by mattch on Discord.

Adding a MeshCore TCP source pre-filled `4403` — Meshtastic's port — so the source failed to connect until the user worked out the right number. MeshCore's **WiFi and Ethernet companion builds open their TCP server on 5000**, and that's the build people actually add here.

## Four sites, not three

The issue lists three `useState`/reset/fallback sites. The port input's **placeholder was also `4403`**, so fixing only the values would leave the field contradicting itself the moment someone cleared it.

The issue justified `5000` by pointing at a `placeholder="5000"` a hundred lines further down — but that one belongs to `formVnPort`, MeshMonitor's *own* Virtual Node listener ("TCP port the MeshCore mobile app connects to"), not the companion's port. The conclusion was right; the evidence wasn't.

All four now read `MESHCORE_DEFAULT_TCP_PORT` so they can't drift apart again.

## What is deliberately NOT changed

`meshcoreConfig.ts:391` still falls back to `4403` for a stored config with no port. That asymmetry is intentional:

- **4403 is a real MeshCore port**, not a stray Meshtastic value. MeshCore's less common "native TCP" companion builds listen there — which is why this repo's own `MESHCORE_VIRTUAL_NODE_DESIGN.md:253` calls it *"MeshCore's conventional companion TCP port (4403)"*.
- **The form validates the port field**, so it cannot produce a portless config. That fallback is only reachable by sources created through the API or an import — and moving it to 5000 would silently repoint any of those working today against a native-TCP build.

Both sides now carry a comment pointing at the other, so the next person who spots the mismatch finds the reasoning instead of "fixing" it.

## Tests

`DashboardPage.meshcoreTcpPortDefault.test.tsx` (4) drives the real form rather than asserting on the constant:

| Test | Why |
|---|---|
| Add a MeshCore TCP source → `5000` | the reported bug |
| Placeholder is `5000` | the site the issue missed |
| Edit a source with no stored port → `5000` | the fallback branch |
| Edit a source with `4403` → stays `4403` | **the guard** — a native-TCP source must not be rewritten just by opening its form |

Full suite: **19400 passed, 0 failed, 0 failed suites.** `lint:ci` and `typecheck` clean.

## Sources

Confirmed against MeshCore's own documentation rather than inferring from the codebase, which only ever mentions 4403:

- [Serial and Network Interfaces — MeshCore (DeepWiki)](https://deepwiki.com/ripplebiz/MeshCore/6.4-serial-and-network-interfaces) — WiFi/Ethernet companion TCP server, default 5000
- [MeshCore FAQ](https://docs.meshcore.io/faq/)
- [meshcore-cli](https://pypi.org/project/meshcore-cli/) — `--tcp` port default 5000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc
