### PR TITLE
fix(ci): drop the runner's Chrome apt source before the security scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,14 @@ jobs:
           sudo apt-get install -y wget apt-transport-https gnupg lsb-release
           wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
           echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          # The runner image ships a Google Chrome apt source that neither scan
+          # job needs. `apt-get update` refreshes every configured source, so
+          # when that repo serves an index whose hash disagrees with its
+          # Release file, apt exits 100 and takes this step down with it —
+          # before Trivy is ever installed, so the job fails with no SARIF and
+          # no finding. Dropping the source keeps the failure surface to the
+          # repos we actually asked for.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
           sudo apt-get install -y trivy
 
@@ -254,6 +262,11 @@ jobs:
       - name: Install & update ClamAV
         run: |
           set -e
+          # Same reason as the Trivy job above: drop the runner's Chrome apt
+          # source so a bad index hash upstream cannot fail this step. `set -e`
+          # makes it fatal here immediately, so ClamAV never runs and the job
+          # reports a failure it never actually scanned for.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
           sudo apt-get install -y clamav clamav-freshclam
           sudo systemctl stop clamav-freshclam || true


### PR DESCRIPTION
`Security Scan` and `ClamAV Scan` are failing on every PR, and **neither failure is a finding.**

## What is happening

Both jobs run `sudo apt-get update`, which refreshes *every* apt source configured on the runner image — including the pre-installed Google Chrome repo that neither job has any use for. That repo is currently serving an index whose hash disagrees with its Release file:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
##[error]Process completed with exit code 100.
```

Exit 100 is apt, not a scanner verdict.

## Why it matters more than a normal flake

The failure lands **before either tool installs**, so the jobs report failure having scanned nothing:

- ClamAV: `##[warning]No files were found with the provided path: clamav.log`
- Trivy: `##[error]Path does not exist: trivy-results.sarif`

A red X meaning *"apt could not reach Google"* is visually identical to a red X meaning *"we found malware"*. That's the worst property a security check can have — it trains people to wave the scans through.

## The change

Remove the Chrome source before `apt-get update` in both jobs, narrowing the refresh to the repos these jobs actually asked for (Ubuntu's own, plus Trivy's). Nothing here consumes Chrome.

## Verified, not assumed

I reran the failed jobs once and got a **byte-identical** failure at the same URL, so this is a persistent upstream mirror problem rather than a flake worth retrying. Bounded the retries there instead of spinning.

Every other job on the affected PR passed: Test Suite 22.x/24.x/25.x, Build Check, Docker Build, Documentation Build, CodeQL, Trivy, claude-review.

## Provenance

Found while working #5160. Its PR (#5163) is green on everything else and blocked solely by this. Kept separate deliberately — unrelated CI infrastructure, and this unblocks every other open PR too, not just that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc
