### PR TITLE
docs: add EmComm Control script to user scripts gallery

### DIFF
--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -730,5 +730,31 @@
       "Reports per-lane wait times (General, SENTRI, NEXUS, Pedestrian, etc.)",
       "No API key or external Python packages required"
     ]
+  },
+  {
+    "name": "EmComm Control",
+    "filename": "mm_emcomm_control.py",
+    "icon": "🚨",
+    "description": "Emergency communications control for MeshMonitor supporting both LIVE real-world operations and EXERCISE/drill operations over Meshtastic and MeshCore. Provides station check-in/check-out, SITREPs, message traffic with ROUTINE/PRIORITY/IMMEDIATE precedence, operational status, exercise injects, logging, and after-action CSV exports. Designed for amateur radio EmComm, ARES/SET exercises, served agencies, and city, county/regional, and state Emergency Operations Centers (EOCs).",
+    "language": "Python",
+    "tags": ["EmComm", "Emergency Communications", "EOC", "Meshtastic", "MeshCore", "Amateur Radio", "Ham Radio", "ARES", "ARRL SET", "SITREP", "Emergency Management", "Incident Communications"],
+    "githubPath": "maxhayim/meshmonitor-emcomm-control/mm_emcomm_control.py",
+    "exampleTrigger": "EMCOMM CHECKIN {callsign} {location} {power} {role}, EMCOMM CHECKOUT {callsign}, EMCOMM SITREP {location} {status}, EMCOMM TRAFFIC {to} [ROUTINE|PRIORITY|IMMEDIATE] {text}, EMCOMM STATUS, EMCOMM HELP",
+    "requirements": [
+      "MeshMonitor with Auto Responder/User Scripts support",
+      "Python 3.9+ (no third-party packages required)",
+      "Writable /data/scripts/mm_emcomm_control_data/ for operational state and logs",
+      "Optional: legacy ^SET\\b trigger for backwards-compatible EXERCISE commands",
+      "Optional: separate mm_emcomm_panel.py browser Operator Control Panel (not required for the Auto Responder script)"
+    ],
+    "author": "maxhayim",
+    "features": [
+      "LIVE and EXERCISE/drill operating modes over Meshtastic and MeshCore",
+      "Station check-in/check-out and SITREP reporting",
+      "Message traffic with ROUTINE/PRIORITY/IMMEDIATE precedence",
+      "Operational status queries and timed exercise injects",
+      "Logging and after-action CSV exports",
+      "LIVE mode blocks simulated injects and requires explicit local activation"
+    ]
   }
 ]

--- a/docs/.vitepress/data/user-scripts.json
+++ b/docs/.vitepress/data/user-scripts.json
@@ -737,9 +737,9 @@
     "icon": "🚨",
     "description": "Emergency communications control for MeshMonitor supporting both LIVE real-world operations and EXERCISE/drill operations over Meshtastic and MeshCore. Provides station check-in/check-out, SITREPs, message traffic with ROUTINE/PRIORITY/IMMEDIATE precedence, operational status, exercise injects, logging, and after-action CSV exports. Designed for amateur radio EmComm, ARES/SET exercises, served agencies, and city, county/regional, and state Emergency Operations Centers (EOCs).",
     "language": "Python",
-    "tags": ["EmComm", "Emergency Communications", "EOC", "Meshtastic", "MeshCore", "Amateur Radio", "Ham Radio", "ARES", "ARRL SET", "SITREP", "Emergency Management", "Incident Communications"],
+    "tags": ["EmComm", "Emergency Communications", "EOC", "Ham Radio", "ARES", "SITREP"],
     "githubPath": "maxhayim/meshmonitor-emcomm-control/mm_emcomm_control.py",
-    "exampleTrigger": "EMCOMM CHECKIN {callsign} {location} {power} {role}, EMCOMM CHECKOUT {callsign}, EMCOMM SITREP {location} {status}, EMCOMM TRAFFIC {to} [ROUTINE|PRIORITY|IMMEDIATE] {text}, EMCOMM STATUS, EMCOMM HELP",
+    "exampleTrigger": "EMCOMM CHECKIN, EMCOMM CHECKOUT, EMCOMM SITREP, EMCOMM TRAFFIC, EMCOMM STATUS, EMCOMM HELP",
     "requirements": [
       "MeshMonitor with Auto Responder/User Scripts support",
       "Python 3.9+ (no third-party packages required)",


### PR DESCRIPTION
## Summary

Adds **EmComm Control** (#5165) by @maxhayim to the User Scripts Gallery — an emergency communications control script supporting both LIVE real-world operations and EXERCISE/drill operations over Meshtastic and MeshCore.

### Script Features
- Station check-in/check-out and SITREP reporting
- Message traffic with ROUTINE/PRIORITY/IMMEDIATE precedence
- Operational status queries and timed exercise injects
- Logging and after-action CSV exports
- LIVE mode blocks simulated injects and requires explicit local activation
- Optional legacy `SET` trigger support and a separate browser Operator Control Panel

The script is hosted in the author's external repo and linked via `githubPath`; no MeshMonitor code changes are required.

### Repository
https://github.com/maxhayim/meshmonitor-emcomm-control

Closes #5165

## Test plan
- [x] JSON validates (`python3 -c "import json; json.load(open('docs/.vitepress/data/user-scripts.json'))"`)
- [x] `tests/unit/UserScriptsGallery.security.test.ts` passes (52/52)
- [ ] Verify the gallery renders the new entry on the docs site
- [ ] Verify the GitHub source link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8cmiH2TmhzK1ewCVyWkYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8cmiH2TmhzK1ewCVyWkYJ)_