### PR TITLE
chore(release): bump to 4.16.0

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.16.0-rc6",
+  "version": "4.16.0",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.16.0-rc6",
+  "version": "4.16.0",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.16.0-rc6
-appVersion: "4.16.0-rc6"
+version: 4.16.0
+appVersion: "4.16.0"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.16.0-rc6",
+  "version": "4.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.16.0-rc6",
+      "version": "4.16.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.16.0-rc6",
+  "version": "4.16.0",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
Promotes the 4.16.0 line from **rc6 to the official release**. Six release candidates since v4.15.2; no functional change in this commit.

## Version files

All five move together, per the versioning rule:

| File | 4.16.0-rc6 → 4.16.0 |
|---|---|
| `package.json` | ✅ |
| `package-lock.json` | ✅ regenerated via `npm install --package-lock-only` |
| `helm/meshmonitor/Chart.yaml` | ✅ both `version` and `appVersion` |
| `desktop/src-tauri/tauri.conf.json` | ✅ |
| `desktop/package.json` | ✅ |

Grepped the five files afterwards for any surviving `4.16.0-rc6` — none.

## Verification

Full suite with the PostgreSQL and MySQL containers running: **19484 passed, 0 failed, 0 failed suites** (109 pending = the usual skips, not the multi-backend legs). `lint:ci` and `typecheck` clean.

Two local-environment snags worth recording, since both look like real breakage and neither is:

- **`remark-gfm` missing.** `typecheck` failed on `src/pages/PrivacyDocumentPage.tsx`. The package is a declared dependency added by the privacy-links merge (#5156), but the shared checkout's `node_modules` predated it. Resolved with `npm install`, not a code change.
- **38 failed suites on the first run**, all protobuf-related (`protobufService.*`, `protobufLoader.*`, `meshtasticProtobufService.*`, `regionCodeMapping`). The `protobufs/` submodule was uninitialised in the release worktree. `git submodule update --init --recursive` cleared all 38.

`system-test` label applied — release version bumps always get it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc
