### PR TITLE
fix(meshcore): cancel in-flight Auto-Pathfinding runs on stop/reconnect

### DIFF
--- a/src/server/meshcoreManager.autoPathfindingRunCancellation.test.ts
+++ b/src/server/meshcoreManager.autoPathfindingRunCancellation.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression test for #5170: MeshCore Auto-Pathfinding in-flight runs were
+ * never cancelled, so every reconnect stacked another concurrent run.
+ *
+ * Root cause: `startAutoPathfinding()` calls `stopAutoPathfinding()`, which
+ * bumps `autoPathfindingGeneration` and clears the jitter/interval timer
+ * handles, but an `executeRun()` already iterating its target list has no
+ * way to observe that. Its loop only checked `!this.connected` and spent
+ * almost all its time inside the per-target `await setTimeout(intervalMs)`
+ * sleep. If a reconnect completed within one sleep — which with
+ * auto-reconnect it nearly always does — the stale run woke back up, saw
+ * `connected === true` again, and kept firing requests alongside the new
+ * run the reconnect had just started. #4435 (fix for #4434) stopped
+ * overlapping *timer installation*; this fixes overlapping *runs*.
+ *
+ * The fix has `executeRun()` capture `myGeneration` (already in its closure
+ * from `startAutoPathfinding()`) and bail out — once before starting, and
+ * once per loop iteration (which covers immediately after the inter-target
+ * sleep, since that's where control returns to next) — whenever
+ * `myGeneration !== this.autoPathfindingGeneration`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MeshCoreManager, MeshCoreDeviceType } from './meshcoreManager.js';
+import { logger } from '../utils/logger.js';
+import databaseService from '../services/database.js';
+
+function mockPathfindingSettings() {
+  return vi.spyOn(databaseService.settings, 'getSettingForSource').mockImplementation(
+    async (_sourceId: string | null | undefined, key: string) => {
+      switch (key) {
+        case 'meshcoreAutoPathfindingEnabled':
+          return 'true';
+        case 'meshcoreAutoPathfindingPathDiscoveryEnabled':
+          return 'true';
+        case 'meshcoreAutoPathfindingNeighborsEnabled':
+          return 'false';
+        case 'meshcoreAutoPathfindingIntervalMinutes':
+          return '3';
+        case 'meshcoreAutoPathfindingRepeatHours':
+          return '1';
+        default:
+          return null;
+      }
+    }
+  );
+}
+
+function makeCompanionContacts(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    publicKey: `pubkey-${i}`,
+    advName: `Companion ${i}`,
+    name: `Companion ${i}`,
+    advType: MeshCoreDeviceType.COMPANION,
+  }));
+}
+
+describe('MeshCoreManager Auto-Pathfinding run cancellation (#5170)', () => {
+  beforeEach(() => {
+    vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+    // Deterministic jitter: initialJitterMs = Math.random() * maxJitterMs.
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    vi.spyOn(databaseService, 'getMeshcorePathfindingFilterSettingsAsync').mockResolvedValue({
+      enabled: false, targetKeys: [], contactsEnabled: false, regexEnabled: false, nameRegex: '.*',
+      lastHeardEnabled: false, lastHeardHours: 168, hopsEnabled: false, hopsMin: 0, hopsMax: 10,
+      signalEnabled: false, rssiMin: -200, snrMin: -100,
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('stopAutoPathfinding() mid-loop (e.g. disabling the feature) stops the run at its next target, not just its timers', async () => {
+    const m = new MeshCoreManager('test-source');
+    mockPathfindingSettings();
+    (m as any).connected = true;
+    (m as any).canTransmit = vi.fn().mockReturnValue(true);
+    (m as any).getContacts = vi.fn().mockReturnValue(makeCompanionContacts(5));
+    const discoverContactPath = vi.fn().mockResolvedValue(true);
+    (m as any).discoverContactPath = discoverContactPath;
+
+    await m.startAutoPathfinding();
+    // Fire the jitter timeout (0ms) to start the first run and install the
+    // recurring interval.
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The run has just sent target 0 and is now asleep for intervalMs
+    // (3 minutes) before target 1.
+    expect(discoverContactPath).toHaveBeenCalledTimes(1);
+
+    // Disabling Auto-Pathfinding in the UI (or a source teardown) calls
+    // stopAutoPathfinding() — it clears the jitter/interval timer handles,
+    // but before the fix had no way to reach the sleep this run is
+    // currently parked in.
+    m.stopAutoPathfinding();
+
+    // Wake that sleep. Before the fix the loop only checked
+    // `this.connected`, still true, and would send target 1. After the
+    // fix it must observe the bumped generation and stop.
+    await vi.advanceTimersByTimeAsync(3 * 60 * 1000);
+
+    expect(discoverContactPath).toHaveBeenCalledTimes(1);
+  });
+
+  it('a reconnect racing the inter-target sleep leaves only the new run sending — the stale run never reaches its next target', async () => {
+    const m = new MeshCoreManager('test-source');
+    mockPathfindingSettings();
+    (m as any).connected = true;
+    (m as any).canTransmit = vi.fn().mockReturnValue(true);
+    // A reconnect can refresh the contact list, so give the two runs
+    // disjoint target sets — this lets the assertions tell which run a
+    // given call came from regardless of timer firing order.
+    const getContacts = vi.fn()
+      .mockReturnValueOnce(makeCompanionContacts(5))
+      .mockReturnValue(makeCompanionContacts(5).map(c => ({ ...c, publicKey: `new-${c.publicKey}` })));
+    (m as any).getContacts = getContacts;
+    const discoverContactPath = vi.fn().mockResolvedValue(true);
+    (m as any).discoverContactPath = discoverContactPath;
+
+    await m.startAutoPathfinding();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(discoverContactPath).toHaveBeenCalledWith('pubkey-0');
+    expect(discoverContactPath).toHaveBeenCalledTimes(1);
+
+    // Reconnect completes while the first run is still asleep between
+    // targets — connect() calls startAutoPathfinding() again, unawaited,
+    // exactly as it does in production.
+    void m.startAutoPathfinding();
+    await vi.advanceTimersByTimeAsync(0);
+    // The new run has sent its own target 0 by now.
+    expect(discoverContactPath).toHaveBeenCalledWith('new-pubkey-0');
+
+    // Wake both runs' inter-target sleeps. Before the fix the stale run
+    // would still see this.connected === true and send its target 1
+    // ('pubkey-1') on top of whatever the new run does, stacking runs on
+    // every reconnect. After the fix it observes the generation bump and
+    // stops instead.
+    await vi.advanceTimersByTimeAsync(3 * 60 * 1000);
+    expect(discoverContactPath).not.toHaveBeenCalledWith('pubkey-1');
+  });
+
+  it('a superseded run does not start a fresh pass over targets at all', async () => {
+    const m = new MeshCoreManager('test-source');
+    mockPathfindingSettings();
+    (m as any).connected = true;
+    (m as any).canTransmit = vi.fn().mockReturnValue(true);
+    (m as any).getContacts = vi.fn().mockReturnValue(makeCompanionContacts(3));
+    const discoverContactPath = vi.fn().mockResolvedValue(true);
+    (m as any).discoverContactPath = discoverContactPath;
+
+    await m.startAutoPathfinding();
+    // Bump the generation before the jitter timeout fires (e.g. a
+    // disconnect racing the still-pending jitter delay).
+    m.stopAutoPathfinding();
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+    expect(discoverContactPath).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/meshcoreManager.autoPathfindingRunCancellation.test.ts
+++ b/src/server/meshcoreManager.autoPathfindingRunCancellation.test.ts
@@ -142,6 +142,9 @@ describe('MeshCoreManager Auto-Pathfinding run cancellation (#5170)', () => {
     // stops instead.
     await vi.advanceTimersByTimeAsync(3 * 60 * 1000);
     expect(discoverContactPath).not.toHaveBeenCalledWith('pubkey-1');
+    // The new run is unaffected by the stale run's cancellation — it
+    // continues on to its own next target.
+    expect(discoverContactPath).toHaveBeenCalledWith('new-pubkey-1');
   });
 
   it('a superseded run does not start a fresh pass over targets at all', async () => {
@@ -160,5 +163,8 @@ describe('MeshCoreManager Auto-Pathfinding run cancellation (#5170)', () => {
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
 
     expect(discoverContactPath).not.toHaveBeenCalled();
+    // A superseded run must not advance the "last completed run" timestamp
+    // either — only a run that actually finishes its target list should.
+    expect((m as any).autoPathfindingLastRunAt).toBe(0);
   });
 });

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -7141,6 +7141,14 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
     logger.info(`[MeshCore:${this.sourceId}] Auto-pathfinding: starting (pathDiscovery=${pathDiscoveryEnabled}, neighbors=${neighborsEnabled}, interval=${intervalMinutes}m, repeat=${repeatHours}h, jitter=${Math.round(initialJitterMs / 1000)}s)`);
 
     const executeRun = async () => {
+      // #5170: a stale run from a superseded generation (e.g. the old run
+      // from before a reconnect) must not start a fresh pass over the
+      // target list — checked again inside the loop below since this only
+      // guards entry, not a run already iterating targets.
+      if (myGeneration !== this.autoPathfindingGeneration) {
+        logger.debug(`[MeshCore:${this.sourceId}] Auto-pathfinding: run superseded before start, skipping`);
+        return;
+      }
       // Receive-only (#4547): loop entry — before any guarded primitive.
       if (!this.canTransmit()) {
         logger.debug(`⏭️ [MeshCore:${this.sourceId}] Auto-pathfinding: Skipping - receive-only mode`);
@@ -7185,6 +7193,16 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
 
       for (let i = 0; i < targets.length; i++) {
         if (!this.connected) break;
+        // #5170: re-checked per-target (and immediately after the
+        // inter-target sleep below, since that's where this run spends
+        // almost all its time) — a reconnect bumps the generation via
+        // stopAutoPathfinding()+startAutoPathfinding(), and this stale run
+        // must stop promptly instead of continuing to fire requests
+        // alongside the new run that reconnect just started.
+        if (myGeneration !== this.autoPathfindingGeneration) {
+          logger.debug(`[MeshCore:${this.sourceId}] Auto-pathfinding: run superseded mid-loop, stopping`);
+          break;
+        }
         // Receive-only (#4547): re-checked per-target — the loop awaits
         // between targets, so the flag can flip mid-run.
         if (!this.canTransmit()) {


### PR DESCRIPTION
## Summary
- Fixes #5170 — MeshCore Auto-Pathfinding never cancelled an in-flight `executeRun()`. Every reconnect stacked another concurrent run on top of the ones still going, and disabling Auto-Pathfinding in the UI did not stop runs already in progress.
- `executeRun()` now bails out once at entry and once per target-loop iteration whenever `myGeneration !== this.autoPathfindingGeneration`, so a `stopAutoPathfinding()` call (disable, teardown, or the one a fresh `startAutoPathfinding()` makes on every reconnect) halts a stale run within one target instead of leaving it to run indefinitely.

## Root cause
`startAutoPathfinding()` calls `stopAutoPathfinding()`, which bumps `autoPathfindingGeneration` and clears the jitter/interval timer *handles* — but it has no way to reach an `executeRun()` that is already iterating its target list. That loop only checked `!this.connected`, and spent almost all its time asleep between targets (`await setTimeout(intervalMs)`). Since auto-reconnect nearly always completes within one such sleep, the stale run woke back up, saw `connected === true` again, and kept firing requests — right alongside the new run the reconnect had just started via its own `startAutoPathfinding()` call. Every additional reconnect stacked one more concurrent run, compounding the packet rate over time and explaining why only a container restart (which drops all in-memory closures) stopped it.

#4435 (fix for #4434) added the `autoPathfindingGeneration` counter and closed this same gap for overlapping *timer installation* — two concurrent `startAutoPathfinding()` calls no longer both install a live timer. It never touched the target loop itself, so overlapping *runs* were untouched by that fix, as this issue's reporter correctly diagnosed with reference to the exact lines involved.

## Fix
- `executeRun()` captures `myGeneration` from its enclosing `startAutoPathfinding()` call (already in its closure) and returns immediately if the generation has moved on before it starts.
- Inside the per-target `for` loop, the same check runs at the top of every iteration — which covers immediately after the inter-target sleep, since that's the only place control returns to next. A stale run now stops within one target of a `stopAutoPathfinding()` call instead of continuing until the process restarts.
- This is exactly the primary fix suggested in the issue report. The issue's "better still" suggestion (an abortable sleep via `AbortController`) and "optionally" suggestion (skip restarting pathfinding on reconnect while a run is still active) are both left out for now — the generation guard alone bounds the overlap window to at most one intervalMs tick instead of the previous unbounded growth, which is the actual reported failure mode. Happy to layer on the abortable-sleep improvement separately if it's wanted for the last bit of latency.

## Test plan
- [x] New regression test `src/server/meshcoreManager.autoPathfindingRunCancellation.test.ts`:
  - `stopAutoPathfinding()` mid-loop (disabling the feature) stops the run at its next target instead of only stopping timers.
  - A reconnect racing the inter-target sleep leaves only the new run sending — the stale run never reaches its next target.
  - Both tests verified to **fail without the fix** (extra `discoverContactPath` calls / calls with the stale run's next target key) and **pass with it**.
- [x] Full `meshcoreManager` test suite (52 files / 498 tests) passes.
- [x] `npx tsc --noEmit -p tsconfig.server.json` reports no errors.
- [x] `npm run lint:ci` passes (no ratchet growth; unrelated pre-existing counts improved in a few untouched files from other in-flight work).

---
-- Authored by Roger 🤓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CakFPZr9bGcQeZ7ZCQ9iaL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CakFPZr9bGcQeZ7ZCQ9iaL)_