### PR TITLE
fix(meshcore): allow /dev/serial/by-id and by-path paths for serial connections

### DIFF
--- a/src/server/meshcoreManager.serialPortSanitize.test.ts
+++ b/src/server/meshcoreManager.serialPortSanitize.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression test for MeshCoreManager.sanitizeSerialPort() (#5172).
+ *
+ * The validation regex rejected nested udev symlinks like
+ * /dev/serial/by-id/usb-... and /dev/serial/by-path/pci-..., which is the
+ * recommended stable device path for USB passthrough in Docker/LXC (it
+ * survives replug/reboot renumbering, unlike /dev/ttyACM0).
+ */
+import { describe, expect, it } from 'vitest';
+import { MeshCoreManager } from './meshcoreManager.js';
+
+function sanitize(port: string): string {
+  const m = new MeshCoreManager('test-source');
+  return (m as any).sanitizeSerialPort(port);
+}
+
+describe('MeshCoreManager.sanitizeSerialPort()', () => {
+  it('accepts /dev/serial/by-id/... udev symlinks', () => {
+    const port = '/dev/serial/by-id/usb-Seeed_Studio_XIAO_nRF52840_7142450D89DEE83A-if00';
+    expect(sanitize(port)).toBe(port);
+  });
+
+  it('accepts /dev/serial/by-path/... udev symlinks with colons and dots', () => {
+    const port = '/dev/serial/by-path/pci-0000:00:14.0-usb-0:1:1.0-port0';
+    expect(sanitize(port)).toBe(port);
+  });
+
+  it('still accepts plain device nodes', () => {
+    expect(sanitize('/dev/ttyACM0')).toBe('/dev/ttyACM0');
+    expect(sanitize('/dev/ttyUSB0')).toBe('/dev/ttyUSB0');
+  });
+
+  it('still accepts COM ports and host:port', () => {
+    expect(sanitize('COM3')).toBe('COM3');
+    expect(sanitize('192.168.1.10:4403')).toBe('192.168.1.10:4403');
+  });
+
+  it('still accepts macOS cu. device nodes', () => {
+    expect(sanitize('/dev/cu.usbserial-1410')).toBe('/dev/cu.usbserial-1410');
+  });
+
+  it('rejects paths outside /dev and path traversal', () => {
+    expect(() => sanitize('/etc/passwd')).toThrow('Invalid serial port format');
+    expect(() => sanitize('/dev/../etc/passwd')).toThrow('Invalid serial port format');
+    expect(() => sanitize('')).toThrow('Invalid serial port format');
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2961,8 +2961,11 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
    */
   private sanitizeSerialPort(port: string): string {
     const validPatterns = [
-      /^\/dev\/tty[A-Za-z0-9]+$/,
-      /^\/dev\/[a-zA-Z][a-zA-Z0-9_-]*$/,
+      // Linux device nodes, including nested udev symlinks such as
+      // /dev/serial/by-id/usb-... and /dev/serial/by-path/pci-...
+      // (the recommended stable path for USB passthrough in Docker/LXC,
+      // since it survives replug/reboot unlike /dev/ttyACM0 — #5172).
+      /^\/dev\/[a-zA-Z0-9][a-zA-Z0-9._:-]*(?:\/[a-zA-Z0-9][a-zA-Z0-9._:-]*)*$/,
       /^\/dev\/cu\.[A-Za-z0-9_-]+$/,
       /^COM\d+$/i,
       /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d+$/,


### PR DESCRIPTION
## Summary
- `MeshCoreManager.sanitizeSerialPort()` rejected nested udev symlinks such as `/dev/serial/by-id/usb-...` and `/dev/serial/by-path/pci-...`, throwing `Invalid serial port format`. These paths are the recommended way to reference a USB serial device for Docker/LXC passthrough because they're stable across reboot/replug, unlike `/dev/ttyACM0`, which can be renumbered.
- Widened the `/dev/` validation pattern to allow multiple path segments plus colons/dots (needed for `by-path` PCI addresses like `pci-0000:00:14.0-usb-0:1:1.0-port0`), while still rejecting non-`/dev/` paths and path-traversal segments (e.g. `/dev/../etc/passwd`).
- All other previously-accepted formats (`/dev/ttyACM0`, `/dev/cu.*`, `COM3`, `host:port`) are unaffected.

## Root cause
Reported in #5172: a Seeed XIAO nRF52840 passed through to a Proxmox LXC as `/dev/serial/by-id/usb-Seeed_Studio_XIAO_nRF52840_7142450D89DEE83A-if00` failed every reconnect attempt with `Invalid serial port format`, because the old regex `^\/dev\/[a-zA-Z][a-zA-Z0-9_-]*$` didn't allow any `/` after `/dev/`.

## Test plan
- [x] Added `src/server/meshcoreManager.serialPortSanitize.test.ts` covering `by-id`/`by-path` paths, existing formats (`ttyACM0`, `cu.*`, `COM3`, `host:port`), and rejection of non-`/dev/` paths / traversal.
- [x] `npx vitest run src/server/meshcoreManager` — 501/501 passing.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint:ci` — no new violations.

Fixes #5172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCNq9XPvpaMgBxQAKLnjAR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCNq9XPvpaMgBxQAKLnjAR)_