### PR TITLE
Fix: widen MeshCore snr columns to REAL/DOUBLE (#5175)

### DIFF
--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -181,6 +181,7 @@ import { migration as nodeIdentityMergesMigration, runMigration159Postgres, runM
 import { migration as tracerouteTransportMechanismMigration, runMigration160Postgres, runMigration160Mysql } from '../server/migrations/160_traceroute_transport_mechanism.js';
 import { migration as userPrefsUnreadIndicatorMigration, runMigration161Postgres, runMigration161Mysql } from '../server/migrations/161_user_map_preferences_unread_indicator.js';
 import { migration as privacyDocumentsMigration, runMigration162Postgres, runMigration162Mysql } from '../server/migrations/162_privacy_documents.js';
+import { migration as meshcoreSnrRealMigration, runMigration163Postgres, runMigration163Mysql } from '../server/migrations/163_meshcore_snr_real.js';
 
 // ============================================================================
 // Registry
@@ -2628,4 +2629,20 @@ registry.register({
   sqlite: (db) => privacyDocumentsMigration.up(db),
   postgres: (client) => runMigration162Postgres(client),
   mysql: (pool) => runMigration162Mysql(pool),
+});
+
+// ---------------------------------------------------------------------------
+// Migration 163: widen `meshcore_messages.snr` and `meshcore_heard_repeaters.snr`
+// from INTEGER to REAL/DOUBLE (#5175) — MeshCore SNR is quarter-dB fractional
+// (e.g. -8.25), which PostgreSQL's INTEGER column rejected outright.
+// Idempotent across SQLite / PostgreSQL / MySQL.
+// ---------------------------------------------------------------------------
+
+registry.register({
+  number: 163,
+  name: 'meshcore_snr_real',
+  settingsKey: 'migration_163_meshcore_snr_real',
+  sqlite: (db) => meshcoreSnrRealMigration.up(db),
+  postgres: (client) => runMigration163Postgres(client),
+  mysql: (pool) => runMigration163Mysql(pool),
 });

--- a/src/db/repositories/meshcore.test.ts
+++ b/src/db/repositories/meshcore.test.ts
@@ -333,6 +333,20 @@ describe('MeshCoreRepository — sourceId stamping', () => {
     expect(row.text).toBe('hello');
   });
 
+  it('insertMessage persists fractional snr (#5175 — MeshCore SNR is quarter-dB)', async () => {
+    await repo.insertMessage(
+      { id: 'm-snr', fromPublicKey: 'pk-1', text: 'fractional snr', timestamp: 3000, createdAt: 3000, rssi: -116, snr: -8.25 },
+      'src-a',
+    );
+
+    const row = db.prepare(`SELECT rssi, snr FROM meshcore_messages WHERE id = 'm-snr'`).get() as {
+      rssi: number;
+      snr: number;
+    };
+    expect(row.rssi).toBe(-116);
+    expect(row.snr).toBeCloseTo(-8.25);
+  });
+
   it('insertMessage persists hopCount + routePath and reads them back (#3742)', async () => {
     await repo.insertMessage(
       { id: 'm-route', fromPublicKey: 'pk-1', text: 'relayed', timestamp: 2000, createdAt: 2000, hopCount: 2, routePath: 'a3,7f' },

--- a/src/db/repositories/meshcoreHeardRepeaters.perSource.test.ts
+++ b/src/db/repositories/meshcoreHeardRepeaters.perSource.test.ts
@@ -83,6 +83,24 @@ describe('MeshCoreRepository — heard-repeaters', () => {
     expect(all[0].snr).toBe(7);
   });
 
+  it('persists fractional SNR and keeps the max across quarter-dB values (#5175)', async () => {
+    await repo.recordHeardRepeater({
+      sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', snr: 3.25, heardAt: HEARD_AT,
+    });
+    const merged = await repo.recordHeardRepeater({
+      sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', snr: 7.75, heardAt: HEARD_AT + 1000,
+    });
+    expect(merged.snr).toBeCloseTo(7.75);
+
+    const lower = await repo.recordHeardRepeater({
+      sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', snr: -0.25, heardAt: HEARD_AT + 2000,
+    });
+    expect(lower.snr).toBeCloseTo(7.75); // max retained
+
+    const all = await repo.getHeardRepeatersForMessage('m1', 'src-a');
+    expect(all[0].snr).toBeCloseTo(7.75);
+  });
+
   it('fills in a repeaterName on a later echo when it becomes known', async () => {
     await repo.recordHeardRepeater({
       sourceId: 'src-a', messageId: 'm1', repeaterHash: 'a3', repeaterName: null, snr: 2, heardAt: HEARD_AT,

--- a/src/db/schema/meshcoreHeardRepeaters.ts
+++ b/src/db/schema/meshcoreHeardRepeaters.ts
@@ -15,9 +15,9 @@
  * supports cheap per-message aggregation, and avoids read-modify-write races as
  * multiple echoes stream in.
  */
-import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
-import { pgTable, text as pgText, integer as pgInteger, bigint as pgBigint, serial as pgSerial } from 'drizzle-orm/pg-core';
-import { mysqlTable, varchar as myVarchar, int as myInt, bigint as myBigint } from 'drizzle-orm/mysql-core';
+import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
+import { pgTable, text as pgText, real as pgReal, bigint as pgBigint, serial as pgSerial } from 'drizzle-orm/pg-core';
+import { mysqlTable, varchar as myVarchar, int as myInt, double as myDouble, bigint as myBigint } from 'drizzle-orm/mysql-core';
 
 // ============ SQLite Schema ============
 
@@ -31,8 +31,9 @@ export const meshcoreHeardRepeatersSqlite = sqliteTable('meshcore_heard_repeater
   repeaterHash: text('repeaterHash').notNull(),
   // Resolved repeater contact name (best-effort; null when the hash is unknown).
   repeaterName: text('repeaterName'),
-  // Best (max) SNR observed for this repeater across echoes (nullable).
-  snr: integer('snr'),
+  // Best (max) SNR observed for this repeater across echoes (nullable,
+  // fractional — MeshCore SNR is quarter-dB, e.g. -8.25).
+  snr: real('snr'),
   // When the echo was heard (Unix ms).
   heardAt: integer('heardAt').notNull(),
   createdAt: integer('createdAt').notNull(),
@@ -46,7 +47,7 @@ export const meshcoreHeardRepeatersPostgres = pgTable('meshcore_heard_repeaters'
   messageId: pgText('messageId').notNull(),
   repeaterHash: pgText('repeaterHash').notNull(),
   repeaterName: pgText('repeaterName'),
-  snr: pgInteger('snr'),
+  snr: pgReal('snr'),
   heardAt: pgBigint('heardAt', { mode: 'number' }).notNull(),
   createdAt: pgBigint('createdAt', { mode: 'number' }).notNull(),
 });
@@ -59,7 +60,7 @@ export const meshcoreHeardRepeatersMysql = mysqlTable('meshcore_heard_repeaters'
   messageId: myVarchar('messageId', { length: 64 }).notNull(),
   repeaterHash: myVarchar('repeaterHash', { length: 16 }).notNull(),
   repeaterName: myVarchar('repeaterName', { length: 128 }),
-  snr: myInt('snr'),
+  snr: myDouble('snr'),
   heardAt: myBigint('heardAt', { mode: 'number' }).notNull(),
   createdAt: myBigint('createdAt', { mode: 'number' }).notNull(),
 });

--- a/src/db/schema/meshcoreMessages.ts
+++ b/src/db/schema/meshcoreMessages.ts
@@ -2,9 +2,9 @@
  * Drizzle schema definition for MeshCore messages table
  * Supports SQLite, PostgreSQL, and MySQL
  */
-import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
-import { pgTable, text as pgText, integer as pgInteger, boolean as pgBoolean, bigint as pgBigint } from 'drizzle-orm/pg-core';
-import { mysqlTable, varchar as myVarchar, int as myInt, boolean as myBoolean, bigint as myBigint, text as myText } from 'drizzle-orm/mysql-core';
+import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
+import { pgTable, text as pgText, integer as pgInteger, real as pgReal, boolean as pgBoolean, bigint as pgBigint } from 'drizzle-orm/pg-core';
+import { mysqlTable, varchar as myVarchar, int as myInt, double as myDouble, boolean as myBoolean, bigint as myBigint, text as myText } from 'drizzle-orm/mysql-core';
 
 // ============ SQLite Schema ============
 
@@ -27,9 +27,11 @@ export const meshcoreMessagesSqlite = sqliteTable('meshcore_messages', {
   // Timestamp (Unix ms)
   timestamp: integer('timestamp').notNull(),
 
-  // Signal quality at receive time
+  // Signal quality at receive time. rssi is a plain signed dBm byte
+  // (integer); snr is a quarter-dB LoRa value (fractional, e.g. -8.25) per
+  // the MeshCore companion wire format — see meshcoreCompanionCodec.ts.
   rssi: integer('rssi'),
-  snr: integer('snr'),
+  snr: real('snr'),
   // Routing metadata for received messages (#3742): hop count (from path_len)
   // and the comma-separated relay-hash chain (e.g. "a3,7f,02"). Null = direct/unknown.
   hopCount: integer('hopCount'),
@@ -65,7 +67,7 @@ export const meshcoreMessagesPostgres = pgTable('meshcore_messages', {
   text: pgText('text').notNull(),
   timestamp: pgBigint('timestamp', { mode: 'number' }).notNull(),
   rssi: pgInteger('rssi'),
-  snr: pgInteger('snr'),
+  snr: pgReal('snr'),
   hopCount: pgInteger('hopCount'),
   routePath: pgText('routePath'),
   scopeCode: pgInteger('scopeCode'),
@@ -87,7 +89,7 @@ export const meshcoreMessagesMysql = mysqlTable('meshcore_messages', {
   text: myText('text').notNull(),
   timestamp: myBigint('timestamp', { mode: 'number' }).notNull(),
   rssi: myInt('rssi'),
-  snr: myInt('snr'),
+  snr: myDouble('snr'),
   hopCount: myInt('hopCount'),
   routePath: myText('routePath'),
   scopeCode: myInt('scopeCode'),

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2292,7 +2292,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       if (this.attributedChannelEchoes.has(match.echoKey)) return;
       this.attributedChannelEchoes.set(match.echoKey, now);
 
-      const snr = typeof data.snr === 'number' ? Math.round(data.snr) : null;
+      const snr = typeof data.snr === 'number' ? data.snr : null;
       const heardBy: Array<{ hash: string; name?: string | null; snr?: number | null }> = [];
 
       for (const hash of match.pathHops) {

--- a/src/server/migrations/163_meshcore_snr_real.pgmysql.test.ts
+++ b/src/server/migrations/163_meshcore_snr_real.pgmysql.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Migration 163 — PostgreSQL / MySQL container behaviour (#5175).
+ *
+ * MeshCore SNR is quarter-dB fractional (e.g. -8.25). Both `meshcore_messages`
+ * and `meshcore_heard_repeaters` declared `snr` as a 32-bit INTEGER on
+ * PostgreSQL/MySQL, so a production insert of a real MeshCore message failed
+ * outright on PostgreSQL:
+ *
+ *   error: invalid input syntax for type integer: "-8.25"
+ *
+ * This test builds each table in its pre-163 (INTEGER `snr`) shape — matching
+ * the historical DDL in 001_v37_baseline.ts / 102_create_meshcore_heard_repeaters.ts
+ * — runs migration 163 against it, then round-trips a fractional SNR through
+ * the real Drizzle table object to prove the column actually accepts it.
+ *
+ * **Isolation.** Own PostgreSQL schema, own MySQL database (CLAUDE.md
+ * Multi-Database: two suites creating/dropping the same table name in one test
+ * database is an active race, not a flake).
+ *
+ * A silent skip still reports `success: true`; confirm coverage via
+ * `numPendingTests` in the JSON reporter.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import pg from 'pg';
+import mysql from 'mysql2/promise';
+import { drizzle as drizzlePostgres } from 'drizzle-orm/node-postgres';
+import { drizzle as drizzleMysql } from 'drizzle-orm/mysql2';
+import { eq } from 'drizzle-orm';
+import * as schema from '../../db/schema/index.js';
+import { meshcoreMessagesPostgres, meshcoreMessagesMysql } from '../../db/schema/meshcoreMessages.js';
+import { meshcoreHeardRepeatersPostgres, meshcoreHeardRepeatersMysql } from '../../db/schema/meshcoreHeardRepeaters.js';
+import { runMigration163Postgres, runMigration163Mysql } from './163_meshcore_snr_real.js';
+import { postgresAvailable, mysqlAvailable } from '../../db/repositories/test-utils.js';
+
+const { Pool: PgPool } = pg;
+
+const PG_SCHEMA = 'meshcore_snr_migration_163';
+const MYSQL_DB = 'meshmonitor_test_meshcore_snr_163';
+
+const NOW = 1_800_000_000_000;
+
+describe.skipIf(!postgresAvailable)('migration 163 — PostgreSQL (container)', () => {
+  let pool: InstanceType<typeof PgPool>;
+  let db: ReturnType<typeof drizzlePostgres>;
+
+  beforeAll(async () => {
+    const admin = new PgPool({
+      host: 'localhost', port: 5433, user: 'test', password: 'test', database: 'meshmonitor_test',
+    });
+    await admin.query(`DROP SCHEMA IF EXISTS ${PG_SCHEMA} CASCADE`);
+    await admin.query(`CREATE SCHEMA ${PG_SCHEMA}`);
+    await admin.end();
+
+    pool = new PgPool({
+      host: 'localhost', port: 5433, user: 'test', password: 'test', database: 'meshmonitor_test',
+      options: `-c search_path=${PG_SCHEMA}`,
+    });
+    db = drizzlePostgres(pool, { schema });
+
+    // Pre-163 shape: snr INTEGER, matching the historical baseline DDL.
+    const client = await pool.connect();
+    try {
+      await client.query(`
+        CREATE TABLE meshcore_messages (
+          id TEXT PRIMARY KEY,
+          "fromPublicKey" TEXT NOT NULL,
+          "fromName" TEXT,
+          "toPublicKey" TEXT,
+          text TEXT NOT NULL,
+          timestamp BIGINT NOT NULL,
+          rssi INTEGER,
+          snr INTEGER,
+          "hopCount" INTEGER,
+          "routePath" TEXT,
+          "scopeCode" INTEGER,
+          "scopeName" TEXT,
+          "messageType" TEXT DEFAULT 'text',
+          delivered BOOLEAN DEFAULT false,
+          "deliveredAt" BIGINT,
+          "sourceId" TEXT,
+          "createdAt" BIGINT NOT NULL
+        )
+      `);
+      await client.query(`
+        CREATE TABLE meshcore_heard_repeaters (
+          id SERIAL PRIMARY KEY,
+          "sourceId" TEXT NOT NULL,
+          "messageId" TEXT NOT NULL,
+          "repeaterHash" TEXT NOT NULL,
+          "repeaterName" TEXT,
+          snr INTEGER,
+          "heardAt" BIGINT NOT NULL,
+          "createdAt" BIGINT NOT NULL
+        )
+      `);
+    } finally {
+      client.release();
+    }
+  }, 30_000);
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS ${PG_SCHEMA} CASCADE`);
+      await pool.end();
+    }
+  });
+
+  it('widens meshcore_messages.snr to REAL and accepts a fractional value, and runs twice safely', async () => {
+    const client = await pool.connect();
+    try {
+      await runMigration163Postgres(client);
+      // The ledger normally runs a migration once, but a crash between the
+      // migration and its ledger write re-runs it — idempotency is mandatory.
+      await expect(runMigration163Postgres(client)).resolves.toBeUndefined();
+    } finally {
+      client.release();
+    }
+
+    await db.insert(meshcoreMessagesPostgres).values({
+      id: 'm-163-pg',
+      fromPublicKey: 'pk-1',
+      text: 'fractional snr',
+      timestamp: NOW,
+      rssi: -116,
+      snr: -8.25,
+      createdAt: NOW,
+    });
+    const [row] = await db
+      .select()
+      .from(meshcoreMessagesPostgres)
+      .where(eq(meshcoreMessagesPostgres.id, 'm-163-pg'));
+
+    expect(row.rssi).toBe(-116);
+    expect(row.snr).toBeCloseTo(-8.25);
+  });
+
+  it('widens meshcore_heard_repeaters.snr to REAL and accepts a fractional value', async () => {
+    await db.insert(meshcoreHeardRepeatersPostgres).values({
+      sourceId: 'src-a',
+      messageId: 'm1',
+      repeaterHash: 'a3',
+      snr: 7.75,
+      heardAt: NOW,
+      createdAt: NOW,
+    });
+    const [row] = await db
+      .select()
+      .from(meshcoreHeardRepeatersPostgres)
+      .where(eq(meshcoreHeardRepeatersPostgres.repeaterHash, 'a3'));
+
+    expect(row.snr).toBeCloseTo(7.75);
+  });
+});
+
+describe.skipIf(!mysqlAvailable)('migration 163 — MySQL (container)', () => {
+  let pool: mysql.Pool;
+  let db: ReturnType<typeof drizzleMysql>;
+
+  beforeAll(async () => {
+    const admin = mysql.createPool({
+      host: 'localhost', port: 3307, user: 'root', password: 'root', connectionLimit: 1,
+    });
+    await admin.query(`DROP DATABASE IF EXISTS \`${MYSQL_DB}\``);
+    await admin.query(`CREATE DATABASE \`${MYSQL_DB}\``);
+    await admin.query(`GRANT ALL ON \`${MYSQL_DB}\`.* TO 'test'@'%'`);
+    await admin.query('FLUSH PRIVILEGES');
+    await admin.end();
+
+    pool = mysql.createPool({
+      host: 'localhost', port: 3307, user: 'test', password: 'test', database: MYSQL_DB, connectionLimit: 5,
+    });
+    db = drizzleMysql(pool, { schema, mode: 'default' });
+
+    // Pre-163 shape: snr INT, matching the historical baseline DDL.
+    await pool.query(`
+      CREATE TABLE meshcore_messages (
+        id VARCHAR(64) PRIMARY KEY,
+        fromPublicKey VARCHAR(64) NOT NULL,
+        fromName VARCHAR(64),
+        toPublicKey VARCHAR(64),
+        text TEXT NOT NULL,
+        timestamp BIGINT NOT NULL,
+        rssi INT,
+        snr INT,
+        hopCount INT,
+        routePath TEXT,
+        scopeCode INT,
+        scopeName TEXT,
+        messageType VARCHAR(32) DEFAULT 'text',
+        delivered BOOLEAN DEFAULT false,
+        deliveredAt BIGINT,
+        sourceId VARCHAR(64),
+        createdAt BIGINT NOT NULL
+      )
+    `);
+    await pool.query(`
+      CREATE TABLE meshcore_heard_repeaters (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        sourceId VARCHAR(64) NOT NULL,
+        messageId VARCHAR(64) NOT NULL,
+        repeaterHash VARCHAR(16) NOT NULL,
+        repeaterName VARCHAR(128),
+        snr INT,
+        heardAt BIGINT NOT NULL,
+        createdAt BIGINT NOT NULL
+      )
+    `);
+  }, 30_000);
+
+  afterAll(async () => {
+    if (pool) await pool.end();
+    const admin = mysql.createPool({
+      host: 'localhost', port: 3307, user: 'root', password: 'root', connectionLimit: 1,
+    });
+    await admin.query(`DROP DATABASE IF EXISTS \`${MYSQL_DB}\``);
+    await admin.end();
+  });
+
+  it('widens meshcore_messages.snr to DOUBLE and accepts a fractional value, and runs twice safely', async () => {
+    await runMigration163Mysql(pool);
+    await expect(runMigration163Mysql(pool)).resolves.toBeUndefined();
+
+    await db.insert(meshcoreMessagesMysql).values({
+      id: 'm-163-mysql',
+      fromPublicKey: 'pk-1',
+      text: 'fractional snr',
+      timestamp: NOW,
+      rssi: -116,
+      snr: -8.25,
+      createdAt: NOW,
+    });
+    const [row] = await db
+      .select()
+      .from(meshcoreMessagesMysql)
+      .where(eq(meshcoreMessagesMysql.id, 'm-163-mysql'));
+
+    expect(row.rssi).toBe(-116);
+    expect(row.snr).toBeCloseTo(-8.25);
+  });
+
+  it('widens meshcore_heard_repeaters.snr to DOUBLE and accepts a fractional value', async () => {
+    await db.insert(meshcoreHeardRepeatersMysql).values({
+      sourceId: 'src-a',
+      messageId: 'm1',
+      repeaterHash: 'a3',
+      snr: 7.75,
+      heardAt: NOW,
+      createdAt: NOW,
+    });
+    const [row] = await db
+      .select()
+      .from(meshcoreHeardRepeatersMysql)
+      .where(eq(meshcoreHeardRepeatersMysql.repeaterHash, 'a3'));
+
+    expect(row.snr).toBeCloseTo(7.75);
+  });
+});

--- a/src/server/migrations/163_meshcore_snr_real.ts
+++ b/src/server/migrations/163_meshcore_snr_real.ts
@@ -1,0 +1,97 @@
+/**
+ * Migration 163: widen `meshcore_messages.snr` and `meshcore_heard_repeaters.snr`
+ * from INTEGER to REAL/DOUBLE (issue #5175).
+ *
+ * MeshCore SNR is a quarter-dB LoRa value decoded from the companion wire
+ * format (`[snr:int8 quarter-dB]` divided by 4 — see meshcoreCompanionCodec.ts
+ * and meshcoreManager.ts), so it is routinely fractional (e.g. -8.25, 5.5,
+ * 2.75). Both tables declared `snr` as a 32-bit INTEGER column, which on
+ * PostgreSQL rejects the insert outright:
+ *
+ *   error: invalid input syntax for type integer: "-8.25"
+ *
+ * On MySQL the same insert silently truncates toward zero instead of
+ * erroring; on SQLite INTEGER is dynamic-affinity and already stores the
+ * float as-is, so only PostgreSQL/MySQL need an actual column change.
+ *
+ * `rssi` is unaffected — it's a plain signed dBm byte per the wire format and
+ * stays INTEGER.
+ *
+ * Idempotent across SQLite / PostgreSQL / MySQL (CLAUDE.md migration recipe).
+ */
+import type { Database } from 'better-sqlite3';
+import { logger } from '../../utils/logger.js';
+
+const LABEL = 'Migration 163';
+const COLUMNS: Array<{ table: string; column: string }> = [
+  { table: 'meshcore_messages', column: 'snr' },
+  { table: 'meshcore_heard_repeaters', column: 'snr' },
+];
+
+// ============ SQLite ============
+
+export const migration = {
+  up: (_db: Database): void => {
+    // SQLite columns use dynamic type affinity: an INTEGER-affinity column
+    // stores a REAL value as-is when the conversion would be lossy (e.g.
+    // -8.25), so no schema change is needed here.
+    logger.info(`${LABEL} (SQLite): no-op (INTEGER affinity already stores fractional values)`);
+  },
+};
+
+// ============ PostgreSQL ============
+
+export async function runMigration163Postgres(client: import('pg').PoolClient): Promise<void> {
+  logger.info(`${LABEL} (PostgreSQL): widening meshcore snr columns to REAL...`);
+  for (const { table, column } of COLUMNS) {
+
+    const { rows } = await client.query(
+      `SELECT data_type FROM information_schema.columns
+       WHERE table_name = $1 AND column_name = $2`,
+      [table, column]
+    );
+    const currentType: string | undefined = rows[0]?.data_type?.toLowerCase();
+    if (currentType === undefined) {
+      logger.debug(`${LABEL} (PostgreSQL): ${table}.${column} not found, skipping`);
+      continue;
+    }
+    if (currentType === 'real' || currentType === 'double precision') {
+      logger.debug(`${LABEL} (PostgreSQL): ${table}.${column} already ${currentType}, skipping`);
+      continue;
+    }
+
+    await client.query(`ALTER TABLE ${table} ALTER COLUMN "${column}" TYPE REAL`);
+    logger.info(`${LABEL} (PostgreSQL): ${table}.${column} widened from ${currentType} → REAL`);
+  }
+}
+
+// ============ MySQL ============
+
+export async function runMigration163Mysql(pool: import('mysql2/promise').Pool): Promise<void> {
+  logger.info(`${LABEL} (MySQL): widening meshcore snr columns to DOUBLE...`);
+  const conn = await pool.getConnection();
+  try {
+    for (const { table, column } of COLUMNS) {
+
+      const [rows] = await conn.query(
+        `SELECT DATA_TYPE FROM information_schema.COLUMNS
+         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+        [table, column]
+      );
+      const currentType: string | undefined = (rows as Array<{ DATA_TYPE?: string }>)[0]?.DATA_TYPE?.toLowerCase();
+      if (currentType === undefined) {
+        logger.debug(`${LABEL} (MySQL): ${table}.${column} not found, skipping`);
+        continue;
+      }
+      if (currentType === 'double') {
+        logger.debug(`${LABEL} (MySQL): ${table}.${column} already DOUBLE, skipping`);
+        continue;
+      }
+
+      await conn.query(`ALTER TABLE ${table} MODIFY COLUMN \`${column}\` DOUBLE`);
+      logger.info(`${LABEL} (MySQL): ${table}.${column} widened from ${currentType} → DOUBLE`);
+    }
+  } finally {
+    conn.release();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #5175 — MeshCore text messages with a fractional SNR failed to persist on PostgreSQL with:
```
error: invalid input syntax for type integer: "-8.25"
```

MeshCore SNR is a quarter-dB LoRa value decoded from the companion wire format (`[snr:int8 quarter-dB]` divided by 4 — see `meshcoreCompanionCodec.ts`), so it's routinely fractional (`-8.25`, `5.5`, `2.75`, `-3.5`, all seen in the reporter's logs). Both `meshcore_messages.snr` and the sibling `meshcore_heard_repeaters.snr` were declared `INTEGER`/`pgInteger`/`myInt`, which PostgreSQL enforces strictly. `rssi` is unaffected — it's a plain signed dBm byte per the MeshCore protocol and stays an integer.

- Widened `snr` to `real`/`pgReal`/`myDouble` in `src/db/schema/meshcoreMessages.ts` and `src/db/schema/meshcoreHeardRepeaters.ts`.
- Added migration 163 to `ALTER COLUMN ... TYPE REAL`/`DOUBLE` on PostgreSQL/MySQL (idempotent, information_schema pre-check). SQLite is a documented no-op — `INTEGER` columns there use dynamic type affinity and already store the float value as-is, which is why this only surfaced on Postgres deployments (and why MySQL silently truncated instead of erroring, per its non-strict-mode integer coercion).
- Dropped an unrelated `Math.round(data.snr)` in `meshcoreManager.ts`'s heard-repeater echo handler that was quietly discarding the same fractional precision before it ever reached the (now-fixed) column.
- Historical baseline DDL (`001_v37_baseline.ts`, `102_create_meshcore_heard_repeaters.ts`) is left frozen per the migration recipe — 163 fixes forward rather than rewriting history.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.server.json` — clean
- [x] `npm run lint:ci` — no new ratchet violations
- [x] Targeted suites pass locally (SQLite): `src/db/repositories/meshcore.test.ts`, `src/db/repositories/meshcoreHeardRepeaters.perSource.test.ts`, `src/db/migrations.test.ts`, `src/server/meshcoreManager.channelHeard.test.ts` — added regression tests asserting a fractional `snr` (e.g. `-8.25`) round-trips through both tables and that max-merge on heard-repeater echoes still works with quarter-dB values.
- [x] Broader sweep of every `meshcore*` test file (82 files / 1091 tests) — all green, no regressions from the `Math.round` removal (existing fixtures use whole-number SNR, unaffected).
- [ ] New `src/server/migrations/163_meshcore_snr_real.pgmysql.test.ts` (PostgreSQL + MySQL container suite) — written following the `096`/`162` migration test templates (builds each table in its pre-163 `INTEGER` shape, runs the migration, round-trips a fractional value through the real Drizzle table, asserts idempotency). Could not run locally — no Docker daemon in this session — but will be exercised by CI's PG/MySQL service containers per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXcWGVoQR6h21qvmPfhDGz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXcWGVoQR6h21qvmPfhDGz)_