### PR TITLE
fix(meshcore): check the Repeater serial path too, warn-only (#5178)

### DIFF
--- a/src/server/meshcoreManager.repeaterSerialValidation.test.ts
+++ b/src/server/meshcoreManager.repeaterSerialValidation.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Repeater-mode serial path validation (#5178).
+ *
+ * `connectSerialDirect()` — the Repeater connect path — handed
+ * `config.serialPort` straight to the serialport library, while only
+ * `startNativeBackend()` (Companion) ran it through `sanitizeSerialPort()`. The
+ * two paths therefore disagreed about what a valid serial path is.
+ *
+ * Repeater now runs the same check, but WARN ONLY: the path has never been
+ * validated here, so an unrecognised one (a socat/virtual PTY outside /dev)
+ * connects today and must keep connecting. An odd path is logged, not refused —
+ * the value only ever reaches the serialport library, never a shell.
+ *
+ * The connect attempt never reaches hardware in these tests: the serialport
+ * module is never loaded, so the call fails at the availability check straight
+ * after the path is judged.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MeshCoreManager, ConnectionType } from './meshcoreManager.js';
+import { logger } from '../utils/logger.js';
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+function repeaterManager(serialPort: string): MeshCoreManager {
+  const manager = new MeshCoreManager('src-a');
+  (manager as any).config = {
+    connectionType: ConnectionType.SERIAL,
+    firmwareType: 'repeater',
+    serialPort,
+    baudRate: 115200,
+  };
+  return manager;
+}
+
+/** Drive the Repeater connect path far enough to see how the path was judged. */
+async function connectError(serialPort: string): Promise<string> {
+  try {
+    await (repeaterManager(serialPort) as any).connectSerialDirect();
+    return '<resolved>';
+  } catch (error) {
+    return (error as Error).message;
+  }
+}
+
+/** The text of every warning the connect attempt logged. */
+function warnings(): string[] {
+  return (logger.warn as any).mock.calls.map((c: unknown[]) => String(c[0]));
+}
+
+describe('MeshCore Repeater serial path validation (#5178)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('warns about an unrecognised path but still attempts the connection', async () => {
+    // Past the path check — the failure is the un-loaded serialport module.
+    expect(await connectError('/tmp/ttyV0')).toMatch(/Serial port support not loaded/);
+    expect(warnings().join('\n')).toMatch(/not a recognised device path/);
+  });
+
+  it('stays silent for the paths the Companion path accepts', async () => {
+    for (const port of [
+      '/dev/ttyACM0',
+      '/dev/serial/by-id/usb-Seeed_Studio_XIAO_nRF52840_7142450D89DEE83A-if00',
+      '/dev/serial/by-path/pci-0000:00:14.0-usb-0:2:1.0-port0',
+      'COM3',
+    ]) {
+      expect(await connectError(port)).toMatch(/Serial port support not loaded/);
+    }
+    expect(warnings()).toEqual([]);
+  });
+
+  it('names the offending path in the warning, so a typo is obvious', async () => {
+    await connectError('/dev/ttyACM0 ');
+    expect(warnings().join('\n')).toContain('/dev/ttyACM0 ');
+  });
+
+  it('still reports an unconfigured port distinctly, without a path warning', async () => {
+    expect(await connectError('')).toMatch(/Serial port not configured/);
+    expect(warnings()).toEqual([]);
+  });
+});

--- a/src/server/meshcoreManager.ts
+++ b/src/server/meshcoreManager.ts
@@ -2748,6 +2748,25 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
       throw new Error('Serial port not configured');
     }
 
+    // Check the path against the same allow-list the native/Companion backend
+    // uses (#5178) — but WARN ONLY, never refuse. The Repeater path has never
+    // validated, so a path the allow-list doesn't recognise (a socat/virtual
+    // PTY outside /dev, a symlink in a home directory) connects today.
+    // Rejecting one would break a working deployment for no safety gain: the
+    // value only ever reaches the serialport library, never a shell. So an
+    // unrecognised path is logged and passed through, which still surfaces a
+    // typo early instead of leaving it to whatever serialport reports.
+    const path = this.config.serialPort;
+    try {
+      this.sanitizeSerialPort(path);
+    } catch {
+      logger.warn(
+        `[MeshCore:${this.sourceId}] Serial port "${path}" is not a recognised device path — ` +
+        'connecting anyway. A USB device is normally /dev/ttyACM0 or a stable ' +
+        '/dev/serial/by-id/... name.',
+      );
+    }
+
     if (!SerialPort || !ReadlineParser) {
       throw new Error('Serial port support not loaded');
     }
@@ -2757,7 +2776,7 @@ class MeshCoreManager extends EventEmitter implements ISourceManager {
 
     await new Promise<void>((resolve, reject) => {
       this.serialPort = new SerialPortClass({
-        path: this.config!.serialPort!,
+        path,
         baudRate: this.config!.baudRate || 115200,
       });
 


### PR DESCRIPTION
Fixes #5178. Follow-up to #5174, from the review on that PR.

## Problem

`connectSerialDirect()` — the Repeater-mode connect path — handed `config.serialPort` straight to the serialport library:

```ts
this.serialPort = new SerialPortClass({
  path: this.config!.serialPort!,
  baudRate: this.config!.baudRate || 115200,
});
```

Only `startNativeBackend()` (Companion / native `meshcore.js`) ran `sanitizeSerialPort()`. The two connect paths disagreed about what a valid serial path is, so the same configured value could be rejected on a Companion source and accepted on a Repeater one — and a typo'd Repeater path surfaced only as whatever `serialport` happened to report.

## Fix

The Repeater path now runs the same check — **warn-only, never refuse**:

```
[MeshCore:src-a] Serial port "/tmp/ttyV0" is not a recognised device path — connecting
anyway. A USB device is normally /dev/ttyACM0 or a stable /dev/serial/by-id/... name.
```

Warn-only is deliberate, and it is the part worth reviewing. That path has never validated, so a path the allow-list doesn't recognise — a socat/virtual PTY outside `/dev`, a symlink in a home directory — connects **today**. Refusing it would break a working deployment for no safety gain: the value only ever reaches the serialport library, never a shell. So nothing that connects now stops connecting; the check just surfaces a typo early instead of leaving it to the driver.

The check is placed before the module-availability check, so an odd path is reported as an odd path even where the `serialport` package never loaded.

## Mesh impact

None. A log line on an existing connect path — no packets sent, no timers armed, no notification paths touched.

## Testing

New `src/server/meshcoreManager.repeaterSerialValidation.test.ts` — 4 tests:
- an unrecognised path warns **and still attempts the connection**;
- the paths Companion accepts (`/dev/ttyACM0`, `by-id`, `by-path`, `COM3`) warn about nothing;
- the warning quotes the offending path, so a trailing-space typo is visible;
- an unconfigured port still errors distinctly, with no path warning.

The connect attempt never reaches hardware: the serialport module is never loaded in the test, so the call stops at the availability check right after the path is judged.

- Full Vitest suite: **1242 files passed, 0 failed** (18,617 tests passed, 1,000 skipped — the PG/MySQL container suites; this change touches no schema).
- `npm run lint:ci`: clean (the one FAIL is `dev-dist/registerSW.js`, a gitignored local build artifact CI never sees).
- `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc