### PR TITLE
chore: retire the "refresh the review token on every PR" rule

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -63,39 +63,38 @@ Push the branch using an **explicit branch ref** (this checkout may be shared wi
 git push -u origin <branch-name>
 ```
 
-## Step 3b: Refresh the Claude review token — do this on EVERY PR
+## Step 3b: Do NOT refresh the Claude review token routinely
 
-```bash
-bash ~/Development/homelab/tools/gh-secret.sh
+The repo's `CLAUDE_CODE_OAUTH_TOKEN` secret now holds a **long-lived token**
+minted with `claude setup-token` (2026-09-11). Nothing needs refreshing before a
+PR — skip straight to Step 4.
+
+**Never run `~/Development/homelab/tools/gh-secret.sh` unless asked.** That
+script overwrites the secret with the short-lived credential scraped from
+`~/.claude/.credentials.json`, which rotates and gets revoked — running it now
+*replaces a working token with a broken one*.
+
+If `claude-review` fails, read the failed log before reacting:
+
+```
+API Error: 401 ... "OAuth access token has been revoked."
 ```
 
-Run it **every time you open a PR**, before `gh pr create`. It re-pushes the
-current local Claude credential into the repo's `CLAUDE_CODE_OAUTH_TOKEN`
-secret, which the `claude-review` workflow authenticates with.
-
-That token gets revoked often — three times in a single working session at one
-point. When it is stale, `claude-review` fails with:
-
-```
-API Error: 401 {"type":"error","error":{"type":"authentication_error",
-"message":"OAuth access token has been revoked."}}
-```
-
-which reads as a red CI check on a PR whose code is fine. Refreshing up front
-costs a second and removes the most common source of spurious failures here.
-
-**Do not confuse it with the other `claude-review` failure.** If the log instead
-says:
+means the long-lived token itself was revoked. The fix is for the user to run
+`claude setup-token` and set the secret from its output — you cannot do it, the
+flow is an interactive browser login. Do not reach for `gh-secret.sh`.
 
 ```
 ##[error]Service Unavailable
 ##[error]Failed to resolve action download info.
 ```
 
-that is GitHub failing to serve the action itself — a platform incident, not
-auth. Refreshing the secret does nothing; check
+is GitHub failing to serve the action — a platform incident, not auth. Check
 [githubstatus.com](https://www.githubstatus.com/) and re-run once Actions
-recovers. Always read the failure before reaching for the script.
+recovers.
+
+`claude-review` is advisory: `main` is not branch-protected, so it never blocks
+a merge on its own.
 
 ## Step 4: Create the Pull Request
 

--- a/.claude/commands/epic.md
+++ b/.claude/commands/epic.md
@@ -107,7 +107,7 @@ Once you are satisfied with the work product:
 
 1. Push the branch (`git push origin <branch>` — branch ref, no checkout of main needed).
 2. Create the PR with `/create-pr` (it runs validation and writes the PR body). Reference the epic's issue and phase number.
-3. Monitor with `/ci-monitor` and use the existing processes to resolve findings: it auto-fixes CI failures; a failed Claude Code Review check is usually transient auth (`~/Development/homelab/tools/gh-secret.sh`, then rerun); background CI watchers can lose network — trust the output file's final EXIT line, not the task exit code.
+3. Monitor with `/ci-monitor` and use the existing processes to resolve findings: it auto-fixes CI failures; a failed Claude Code Review check is usually transient — rerun the failed job, and never run `gh-secret.sh` (it would overwrite the repo's long-lived `CLAUDE_CODE_OAUTH_TOKEN` with a revoked short-lived one); it is advisory and never blocks a merge; background CI watchers can lose network — trust the output file's final EXIT line, not the task exit code.
 4. Address review findings by dispatching fixes through the Stage 3/4 loop (commits to the same branch), not by hand-editing.
 5. When CI is green and findings are resolved, **merge via `/merge`** (it fast-forwards local main and cleans up the worktree/branch).
 


### PR DESCRIPTION
## Summary

The repo's `CLAUDE_CODE_OAUTH_TOKEN` secret now holds a **long-lived token** minted with `claude setup-token`. The old standing rule — run `~/Development/homelab/tools/gh-secret.sh` before every `gh pr create` — is now actively harmful: that script pushes the short-lived credential scraped from `~/.claude/.credentials.json`, which rotates and gets revoked, so running it *replaces a working token with a broken one*.

This is not hypothetical. On #5174 the `claude-review` check failed twice with:

```
API Error: 401 {"type":"error","error":{"type":"authentication_error",
"message":"OAuth access token has been revoked."}}
```

Both reruns failed identically because the "fix" had pushed an already-revoked token. Minting a long-lived one resolved it on the next rerun.

## Changes

- **`.claude/commands/create-pr.md`** — Step 3b inverted: from "refresh on EVERY PR" to "do NOT refresh routinely". It now explains what the secret holds, why the script must not be run, and what to do when the long-lived token itself is revoked (only the user can re-mint — `claude setup-token` is an interactive browser login, so an agent must ask rather than try). Keeps the `Service Unavailable` platform-incident signature, and states plainly that `claude-review` is advisory since `main` is not branch-protected.
- **`.claude/commands/epic.md`** — the one-line CI-recovery note updated to match.

## Issues Resolved

None — follow-up to the auth failures observed on #5174.

## Documentation Updates

Both changed files are themselves the documentation. No user-facing docs affected — these are agent command files.

## Testing

No code paths touched; nothing to test. Both files are agent instructions, not shipped code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc