### PR TITLE
fix(apprise): swallow BrokenPipeError when a client disconnects early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- **Bundled Apprise API server no longer logs `BrokenPipeError` tracebacks** — when a notification request took longer to process than the Node client's fetch timeout (or the client otherwise disconnected early), `apprise-api.py` tried to write a response to an already-closed socket and let the resulting `BrokenPipeError` propagate, printing a noisy "Exception occurred during processing of request" traceback to the container log even though the underlying notification had already been dispatched. Response writes now swallow a broken/reset connection instead of raising. (#5184)
+
 ## [4.15.2-rc2] - 2026-08-22
 
 ### Added

--- a/docker/apprise-api.py
+++ b/docker/apprise-api.py
@@ -59,19 +59,33 @@ class AppriseHandler(BaseHTTPRequestHandler):
 
     def send_json_response(self, code, data):
         """Helper to send JSON response"""
-        self.send_response(code)
-        self.send_header('Content-type', 'application/json')
-        self.send_header('Access-Control-Allow-Origin', '*')
-        self.end_headers()
-        self.wfile.write(json.dumps(data).encode())
+        try:
+            self.send_response(code)
+            self.send_header('Content-type', 'application/json')
+            self.send_header('Access-Control-Allow-Origin', '*')
+            self.end_headers()
+            self.wfile.write(json.dumps(data).encode())
+        except (BrokenPipeError, ConnectionResetError):
+            # Caller (e.g. Node's fetch() with an AbortSignal.timeout) gave up
+            # waiting and closed the socket before this response could be
+            # written. The underlying notification may already have been sent
+            # successfully — there is nothing to recover, so drop the response
+            # instead of letting it raise into do_POST/do_GET, where it would
+            # otherwise be treated as a second failure and trigger a retry at
+            # sending an (also doomed) error response, producing the noisy
+            # double traceback in #5184.
+            pass
 
     def do_OPTIONS(self):
         """Handle CORS preflight"""
-        self.send_response(200)
-        self.send_header('Access-Control-Allow-Origin', '*')
-        self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
-        self.end_headers()
+        try:
+            self.send_response(200)
+            self.send_header('Access-Control-Allow-Origin', '*')
+            self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+            self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+            self.end_headers()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
 
     def do_GET(self):
         """Handle GET requests"""

--- a/docker/test_apprise_api.py
+++ b/docker/test_apprise_api.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Regression test for #5184: a client that gives up on a request (e.g. Node's
+fetch() aborting via AbortSignal.timeout) before apprise-api.py finishes
+writing its response must not produce an unhandled BrokenPipeError traceback.
+
+Run directly:  python3 docker/test_apprise_api.py
+Requires the `apprise` package (already a runtime dependency of apprise-api.py).
+"""
+import importlib.util
+import io
+import os
+import socket
+import sys
+import threading
+import time
+import unittest
+from http.server import HTTPServer
+
+MODULE_PATH = os.path.join(os.path.dirname(__file__), 'apprise-api.py')
+
+
+def _load_apprise_api_module():
+    spec = importlib.util.spec_from_file_location('apprise_api_module', MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class ClientDisconnectTest(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load_apprise_api_module()
+        self.server = HTTPServer(('127.0.0.1', 0), self.mod.AppriseHandler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        time.sleep(0.1)
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.thread.join(timeout=2)
+
+    def _post_and_disconnect(self, path, body: bytes):
+        """Send a POST request, then close the socket before reading any
+        response — simulating a fetch() call whose AbortSignal.timeout fired."""
+        req = (
+            f"POST {path} HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{self.port}\r\n"
+            f"Content-Type: application/json\r\n"
+            f"Content-Length: {len(body)}\r\n"
+            f"Connection: close\r\n\r\n"
+        ).encode() + body
+        sock = socket.create_connection(('127.0.0.1', self.port))
+        sock.sendall(req)
+        sock.shutdown(socket.SHUT_RDWR)
+        sock.close()
+
+    def test_disconnect_before_response_does_not_crash_server(self):
+        captured = io.StringIO()
+        orig_stderr = sys.stderr
+        sys.stderr = captured
+        try:
+            # No URLs configured -> handler will try to write a 400 response
+            # to a socket the "client" already closed.
+            self._post_and_disconnect('/notify', b'{"title":"t","body":"b"}')
+            time.sleep(0.3)
+        finally:
+            sys.stderr = orig_stderr
+
+        output = captured.getvalue()
+        self.assertNotIn('Traceback', output, f"Unhandled exception logged:\n{output}")
+        self.assertNotIn('BrokenPipeError', output, f"Unhandled exception logged:\n{output}")
+
+        # Server must still be alive and able to serve a normal request.
+        conn = socket.create_connection(('127.0.0.1', self.port))
+        conn.sendall(b"GET /health HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n")
+        resp = conn.recv(4096)
+        conn.close()
+        self.assertIn(b"200", resp)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fixes noisy `BrokenPipeError` tracebacks logged by the bundled `docker/apprise-api.py` HTTP server (shared by the Docker image and the desktop Apprise sidecar, `desktop/apprise-sidecar/apprise-api.spec`).
- Root cause: `send_json_response` wrote its response unconditionally. When the Node client's `fetch()` call (10s `AbortSignal.timeout` in `appriseNotificationService.ts`) gave up and closed its socket before the response was written — e.g. because Apprise's synchronous, single-threaded `notify()` took longer than 10s fanning out to one or more destinations — the write raised `BrokenPipeError`. That exception escaped `do_POST`'s own `except` block, which then tried to send a *second* (error) response on the same dead socket, failing the same way and producing the doubled traceback reported in the issue. The notification itself had almost certainly already been dispatched — this was purely a noisy response-write failure, not a delivery failure.
- `send_json_response` and `do_OPTIONS` now catch `BrokenPipeError`/`ConnectionResetError` and drop the response instead of letting it propagate.

## Test plan

- [x] Added `docker/test_apprise_api.py`: opens a raw socket, sends a `POST /notify`, then closes the socket before reading any response (simulating an aborted `fetch()`), and asserts no traceback/`BrokenPipeError` is logged and the server continues serving subsequent requests.
- [x] Verified the test **fails** against the pre-fix code (`git stash` the fix and re-run) reproducing the exact traceback from the issue.
- [x] Verified the test **passes** against the fix.
- [x] `python3 -m py_compile docker/apprise-api.py` — syntax OK.

Fixes #5184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VHqjkHWTNcvrGb5K6Qbz5

---
_Generated by [Claude Code](https://claude.ai/code/session_015VHqjkHWTNcvrGb5K6Qbz5)_