### PR TITLE
chore(release): bump to 4.16.1-rc1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "meshmonitor-desktop",
   "private": true,
-  "version": "4.16.0",
+  "version": "4.16.1-rc1",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MeshMonitor",
-  "version": "4.16.0",
+  "version": "4.16.1-rc1",
   "identifier": "org.meshmonitor.desktop",
   "build": {
     "beforeBuildCommand": "",

--- a/helm/meshmonitor/Chart.yaml
+++ b/helm/meshmonitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: meshmonitor
 description: A Helm chart for MeshMonitor - Web application for monitoring Meshtastic mesh networks
 type: application
-version: 4.16.0
-appVersion: "4.16.0"
+version: 4.16.1-rc1
+appVersion: "4.16.1-rc1"
 home: https://github.com/Yeraze/meshmonitor
 sources:
   - https://github.com/Yeraze/meshmonitor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshmonitor",
-  "version": "4.16.0",
+  "version": "4.16.1-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshmonitor",
-      "version": "4.16.0",
+      "version": "4.16.1-rc1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshmonitor",
-  "version": "4.16.0",
+  "version": "4.16.1-rc1",
   "description": "Web application for monitoring Meshtastic nodes over IP",
   "license": "BSD-3-Clause",
   "private": true,


### PR DESCRIPTION
## Summary

Version bump for the first release candidate of 4.16.1. Patch-level: every commit merged since `v4.16.0` is a `fix(...)`.

## Changes

All five version files, per CLAUDE.md:

- `package.json`
- `package-lock.json` (regenerated via `npm install --package-lock-only`)
- `helm/meshmonitor/Chart.yaml` (`version` + `appVersion`)
- `desktop/src-tauri/tauri.conf.json`
- `desktop/package.json`

No source changes — 5 files, 7 insertions, 7 deletions, the same shape as the `v4.16.0-rc1` bump.

## What's in 4.16.1

| Issue | Fix | PR |
|---|---|---|
| #5172 | MeshCore serial sources accept `/dev/serial/by-id` and `by-path` paths (Proxmox LXC passthrough) | #5174 |
| #5178 | The Repeater connect path checks the same allow-list, warn-only | #5179 |
| #5175 | MeshCore `snr` widened to REAL/DOUBLE — PostgreSQL rejected `-8.25` outright | #5176 |
| #5170 | In-flight Auto-Pathfinding runs cancel on stop/reconnect instead of stacking | #5171 |
| #5177 | The map centres on the rendered marker, plus a "Spread Nodes" toggle | #5181 |

## Issues Resolved

None directly — this is the release chore.

## Documentation Updates

None needed; no user-facing behaviour changes in this PR itself.

## Testing

Version-only change, no code touched. Carries the `system-test` label per release convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGteQsFhL6o99cqkkee5tc